### PR TITLE
Cleanup Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,17 +16,7 @@
 
 LOCAL_PATH:= $(call my-dir)
 
-#############################################################
-#   build the harfbuzz library
-#
-
-include $(CLEAR_VARS)
-
-LOCAL_ARM_MODE := arm
-
-LOCAL_MODULE_TAGS := optional
-
-LOCAL_SRC_FILES:= \
+HARFBUZZ_SRC_FILES = \
 	src/hb-blob.cc \
 	src/hb-buffer-serialize.cc \
 	src/hb-buffer.cc \
@@ -53,7 +43,20 @@ LOCAL_SRC_FILES:= \
 	src/hb-ot-shape-complex-sea.cc \
 	src/hb-ot-shape-complex-thai.cc \
 	src/hb-ot-shape-normalize.cc \
-	src/hb-ot-shape-fallback.cc \
+	src/hb-ot-shape-fallback.cc
+
+#############################################################
+#   build the harfbuzz library
+#
+
+include $(CLEAR_VARS)
+
+LOCAL_ARM_MODE := arm
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SRC_FILES:= \
+	$(HARFBUZZ_SRC_FILES) \
 	src/hb-icu.cc
 
 LOCAL_CPP_EXTENSION := .cc
@@ -84,38 +87,11 @@ include $(CLEAR_VARS)
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES:= \
-	src/hb-blob.cc \
-	src/hb-buffer-serialize.cc \
-	src/hb-buffer.cc \
-	src/hb-common.cc \
-	src/hb-fallback-shape.cc \
-	src/hb-face.cc \
-	src/hb-font.cc \
-	src/hb-ot-tag.cc \
-	src/hb-set.cc \
-	src/hb-shape.cc \
-	src/hb-shape-plan.cc \
-	src/hb-shaper.cc \
-	src/hb-tt-font.cc \
-	src/hb-unicode.cc \
-	src/hb-warning.cc \
-	src/hb-ot-layout.cc \
-	src/hb-ot-map.cc \
-	src/hb-ot-shape.cc \
-	src/hb-ot-shape-complex-arabic.cc \
-	src/hb-ot-shape-complex-default.cc \
-	src/hb-ot-shape-complex-indic.cc \
-	src/hb-ot-shape-complex-indic-table.cc \
-	src/hb-ot-shape-complex-myanmar.cc \
-	src/hb-ot-shape-complex-sea.cc \
-	src/hb-ot-shape-complex-thai.cc \
-	src/hb-ot-shape-normalize.cc \
-	src/hb-ot-shape-fallback.cc \
+	$(HARFBUZZ_SRC_FILES) \
 	src/hb-ucdn.cc \
-  src/hb-ucdn/ucdn.c
+	src/hb-ucdn/ucdn.c
 
 LOCAL_CPP_EXTENSION     := .cc
-LOCAL_SHARED_LIBRARIES  := 
 LOCAL_STATIC_LIBRARIES  := libft2
 LOCAL_C_INCLUDES        := \
   $(LOCAL_PATH)/src \


### PR DESCRIPTION
- use common src files for both static and shared libs
- remove empty LOCAL_SHARED_LIBRARIES
