### PR TITLE
fix a bug regarding non-combining <LV,T> in hangul shaper

### DIFF
--- a/src/hb-ot-shape-complex-hangul.cc
+++ b/src/hb-ot-shape-complex-hangul.cc
@@ -165,8 +165,8 @@ preprocess_text_hangul (const hb_ot_shape_plan_t *plan,
       bool has_glyph = font->get_glyph (s, 0, &glyph);
       unsigned int lindex = (s - SBase) / NCount;
       unsigned int nindex = (s - SBase) % NCount;
-      unsigned int vindex = nindex / VCount;
-      unsigned int tindex = nindex % VCount;
+      unsigned int vindex = nindex / TCount;
+      unsigned int tindex = nindex % TCount;
 
       if (tindex && has_glyph)
 	goto next; /* <LVT> supported.  Nothing to do. */


### PR DESCRIPTION
- input string: `<U+AC00,U+11F0>`
- expected result: `[uni1100.ljmo05=0+1024|uni1161.vjmo02=0+0|uni11F0.tjmo01=1+0]`, for instance.

After this patch is applied, we now have the expected result.
