### PR TITLE
Provide hb-compare-shapers tool

### DIFF
--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -344,7 +344,11 @@ typedef enum {
   /* Buffers with different content_type cannot be meaningfully compared in any
    * further detail.
    */
-  HB_BUFFER_COMPARE_CONTENT_TYPE_MISMATCH = 0x0080
+  HB_BUFFER_COMPARE_CONTENT_TYPE_MISMATCH = 0x0080,
+
+  /* Flag that buffers render visually identically despite different content.
+   */
+  HB_BUFFER_COMPARE_VISUAL_MATCH          = 0x0100
 } hb_buffer_differences_t;
 
 /* Compare the contents of two buffers. */

--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -317,6 +317,41 @@ hb_buffer_deserialize_glyphs (hb_buffer_t *buffer,
 			      hb_font_t *font, /* May be NULL */
 			      hb_buffer_serialize_format_t format);
 
+/*
+ * Compare buffers
+ */
+
+typedef enum {
+  /* We want to know if dottedcircle / .notdef glyphs are present in the reference,
+   * as we may not care so much about other differences in this case.
+   */
+  HB_BUFFER_COMPARE_DOTTED_CIRCLE_PRESENT = 0x0001,
+  HB_BUFFER_COMPARE_NOTDEF_PRESENT        = 0x0002,
+
+  /* If the buffers have the same length, we compare them glyph-by-glyph and report
+   * which aspect(s) of the glyph info/position are different.
+   */
+  HB_BUFFER_COMPARE_CODEPOINT_MISMATCH    = 0x0004,
+  HB_BUFFER_COMPARE_CLUSTER_MISMATCH      = 0x0008,
+  HB_BUFFER_COMPARE_MASK_MISMATCH         = 0x0010,
+  HB_BUFFER_COMPARE_POSITION_MISMATCH     = 0x0020,
+
+  /* For buffers with differing length, the per-glyph comparison is not attempted,
+   * though we do still scan reference for dottedcircle / .notdef glyphs.
+   */
+  HB_BUFFER_COMPARE_LENGTH_MISMATCH       = 0x0040,
+
+  /* Buffers with different content_type cannot be meaningfully compared in any
+   * further detail.
+   */
+  HB_BUFFER_COMPARE_CONTENT_TYPE_MISMATCH = 0x0080
+} hb_buffer_differences_t;
+
+/* Compare the contents of two buffers. */
+hb_buffer_differences_t
+hb_buffers_compare (hb_buffer_t *buffer,
+                    hb_buffer_t *reference,
+                    hb_codepoint_t dotted_circle);
 
 HB_END_DECLS
 

--- a/src/hb-ft.h
+++ b/src/hb-ft.h
@@ -56,6 +56,9 @@ hb_ft_font_set_funcs (hb_font_t *font);
 FT_Face
 hb_ft_font_get_face (hb_font_t *font);
 
+FT_Face
+hb_ft_font_get_new_face (hb_font_t *font);
+
 
 HB_END_DECLS
 

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -48,6 +48,26 @@ hb_view_LDADD = \
 	$(CAIRO_FT_LIBS) \
 	$(NULL)
 bin_PROGRAMS += hb-view
+
+hb_compare_shapers_SOURCES = \
+	hb-compare-shapers.cc \
+	options.cc \
+	options.hh \
+	main-font-text.hh \
+	shape-compare.hh \
+	ansi-print.cc \
+	ansi-print.hh \
+	helper-cairo.cc \
+	helper-cairo.hh \
+	helper-cairo-ansi.cc \
+	helper-cairo-ansi.hh \
+	$(NULL)
+hb_compare_shapers_LDADD = \
+	$(LDADD) \
+	$(CAIRO_LIBS) \
+	$(CAIRO_FT_LIBS) \
+	$(NULL)
+bin_PROGRAMS += hb-compare-shapers
 endif # HAVE_CAIRO_FT
 
 hb_shape_SOURCES = \

--- a/util/hb-compare-shapers.cc
+++ b/util/hb-compare-shapers.cc
@@ -1,0 +1,268 @@
+#include "main-font-text.hh"
+#include "shape-compare.hh"
+#include "hb-ft.h"
+
+struct output_buffer_t
+{
+  output_buffer_t (option_parser_t *parser)
+		  : options (parser,
+			     g_strjoinv ("/", (gchar**) hb_buffer_serialize_list_formats ())),
+		    format (parser),
+		    gs (NULL),
+		    line_no (0),
+		    font (NULL) {}
+
+  void init (const font_options_t *font_opts)
+  {
+    options.get_file_handle ();
+    gs = g_string_new (NULL);
+    line_no = 0;
+    font = hb_font_reference (font_opts->get_font ());
+    memset (&stats, 0, sizeof (stats));
+
+    if (!options.output_format)
+      output_format = HB_BUFFER_SERIALIZE_FORMAT_TEXT;
+    else
+      output_format = hb_buffer_serialize_format_from_string (options.output_format, -1);
+    if (!hb_buffer_serialize_format_to_string (output_format))
+    {
+      if (options.explicit_output_format)
+	fail (false, "Unknown output format `%s'; supported formats are: %s",
+	      options.output_format, options.supported_formats);
+      else
+	/* Just default to TEXT if not explicitly requested and the
+	 * file extension is not recognized. */
+	output_format = HB_BUFFER_SERIALIZE_FORMAT_TEXT;
+    }
+
+    unsigned int flags = HB_BUFFER_SERIALIZE_FLAG_DEFAULT;
+    if (!format.show_glyph_names)
+      flags |= HB_BUFFER_SERIALIZE_FLAG_NO_GLYPH_NAMES;
+    if (!format.show_clusters)
+      flags |= HB_BUFFER_SERIALIZE_FLAG_NO_CLUSTERS;
+    if (!format.show_positions)
+      flags |= HB_BUFFER_SERIALIZE_FLAG_NO_POSITIONS;
+    format_flags = (hb_buffer_serialize_flags_t) flags;
+  }
+  void new_line (void)
+  {
+    g_string_set_size (gs, 0);
+    line_no++;
+  }
+  void consume_text (hb_buffer_t  *buffer,
+		     const char   *text,
+		     unsigned int  text_len,
+		     hb_bool_t     utf8_clusters)
+  {
+    format.serialize_buffer_of_text (buffer, line_no, text, text_len, font, gs);
+  }
+  void shape_failed (hb_buffer_t  *buffer,
+		     const char   *text,
+		     unsigned int  text_len,
+		     hb_bool_t     utf8_clusters)
+  {
+    format.serialize_message (line_no, "msg: test shaper failed", gs);
+  }
+  void ref_shape_failed (hb_buffer_t  *buffer,
+		     const char   *text,
+		     unsigned int  text_len,
+		     hb_bool_t     utf8_clusters)
+  {
+    format.serialize_message (line_no, "msg: reference shaper failed", gs);
+  }
+  void visual_match ()
+  {
+    format.serialize_message (line_no, "msg: visual match", gs);
+  }
+  void consume_glyphs (hb_buffer_t  *buffer,
+		       const char   *text,
+		       unsigned int  text_len,
+		       hb_bool_t     utf8_clusters)
+  {
+    format.serialize_buffer_of_glyphs (buffer, line_no, text, text_len, font,
+				       output_format, format_flags, gs);
+  }
+  void dump_image (GString *image_data, int image_num)
+  {
+    if (!options.output_file)
+      return;
+    GString *name = g_string_new (0);
+    g_string_printf (name, "%s.%d.image%d.png",
+                     options.output_file,
+                     line_no,
+                     image_num);
+    FILE *f = fopen (name->str, "wb");
+    if (f) {
+      fwrite (image_data->str, image_data->len, 1, f);
+      fclose (f);
+    }
+    g_string_free (name, true);
+  }
+  void report_differences (hb_buffer_differences_t diffs)
+  {
+    if (diffs & HB_BUFFER_COMPARE_LENGTH_MISMATCH)
+      format.serialize_message (line_no, "diff: L", gs);
+    else if (diffs & HB_BUFFER_COMPARE_CODEPOINT_MISMATCH)
+      format.serialize_message (line_no, "diff: G", gs);
+    else if (diffs & HB_BUFFER_COMPARE_POSITION_MISMATCH)
+      format.serialize_message (line_no, "diff: P", gs);
+    else if (diffs & HB_BUFFER_COMPARE_CLUSTER_MISMATCH)
+      format.serialize_message (line_no, "diff: C", gs);
+    if (diffs & HB_BUFFER_COMPARE_VISUAL_MATCH)
+      format.serialize_message (line_no, "note: visual match", gs);
+    if (diffs & HB_BUFFER_COMPARE_NOTDEF_PRESENT)
+      format.serialize_message (line_no, "note: .notdef", gs);
+    if (diffs & HB_BUFFER_COMPARE_DOTTED_CIRCLE_PRESENT)
+      format.serialize_message (line_no, "note: dottedcircle", gs);
+  }
+  void collect_stats (hb_buffer_differences_t diffs)
+  {
+    unsigned int *counters;
+    if (diffs & HB_BUFFER_COMPARE_LENGTH_MISMATCH)
+      counters = stats.length;
+    else if (diffs & HB_BUFFER_COMPARE_CODEPOINT_MISMATCH)
+      counters = stats.glyph;
+    else if (diffs & HB_BUFFER_COMPARE_POSITION_MISMATCH)
+      counters = stats.position;
+    else if (diffs & HB_BUFFER_COMPARE_CLUSTER_MISMATCH)
+      counters = stats.cluster;
+    else
+      counters = stats.match;
+    counters[0]++;
+    if (diffs & HB_BUFFER_COMPARE_VISUAL_MATCH)
+      counters[1]++;
+    else if (diffs & HB_BUFFER_COMPARE_DOTTED_CIRCLE_PRESENT)
+      counters[2]++;
+    else if (diffs & HB_BUFFER_COMPARE_NOTDEF_PRESENT)
+      counters[3]++;
+  }
+  void report_summary ()
+  {
+    fprintf (options.fp, "summary: Total    %d\n", stats.match[0] + stats.length[0] + stats.glyph[0] + stats.position[0] + stats.cluster[0]);
+    fprintf (options.fp, "summary: Match    %d\n", stats.match[0]);
+    fprintf (options.fp, "summary: Length   %d (%d/%d/%d)\n", stats.length[0], stats.length[1], stats.length[2], stats.length[3]);
+    fprintf (options.fp, "summary: Glyph    %d (%d/%d/%d)\n", stats.glyph[0], stats.glyph[1], stats.glyph[2], stats.glyph[3]);
+    fprintf (options.fp, "summary: Position %d (%d/%d/%d)\n", stats.position[0], stats.position[1], stats.position[2], stats.position[3]);
+    fprintf (options.fp, "summary: Cluster  %d (%d/%d/%d)\n", stats.cluster[0], stats.cluster[1], stats.cluster[2], stats.cluster[3]);
+  }
+  void finish_line ()
+  {
+    fprintf (options.fp, "%s", gs->str);
+  }
+  void finish (const font_options_t *font_opts)
+  {
+    report_summary ();
+    hb_font_destroy (font);
+    g_string_free (gs, true);
+    gs = NULL;
+    font = NULL;
+  }
+  void get_surface_size (cairo_scaled_font_t *scaled_font,
+                         helper_cairo_line_t *line,
+                         hb_direction_t direction,
+                         const view_options_t *view_opts,
+                         double *w, double *h);
+  GString *render_to_png (helper_cairo_line_t *line,
+                          hb_direction_t direction,
+                          const font_options_t *font_opts,
+                          const view_options_t *view_options);
+
+  protected:
+  output_options_t options;
+  format_options_t format;
+
+  struct {
+    unsigned int length[4];
+    unsigned int glyph[4];
+    unsigned int position[4];
+    unsigned int cluster[4];
+    unsigned int match[4];
+  } stats;
+
+  GString *gs;
+  unsigned int line_no;
+  hb_font_t *font;
+  hb_buffer_serialize_format_t output_format;
+  hb_buffer_serialize_flags_t format_flags;
+};
+
+void
+output_buffer_t::get_surface_size (cairo_scaled_font_t *scaled_font,
+                                   helper_cairo_line_t *line,
+                                   hb_direction_t direction,
+                                   const view_options_t *view_opts,
+                                   double *w, double *h)
+{
+  cairo_font_extents_t font_extents;
+
+  cairo_scaled_font_extents (scaled_font, &font_extents);
+
+  bool vertical = HB_DIRECTION_IS_VERTICAL (direction);
+  (vertical ? *w : *h) = font_extents.height;
+  (vertical ? *h : *w) = 0;
+  double x_advance, y_advance;
+  line->get_advance (&x_advance, &y_advance);
+  if (vertical)
+    *h = y_advance;
+  else
+    *w = x_advance;
+  *w += view_opts->margin.l + view_opts->margin.r;
+  *h += view_opts->margin.t + view_opts->margin.b;
+}
+
+// returns a string containing the rendering of the line
+GString *
+output_buffer_t::render_to_png (helper_cairo_line_t *line,
+                                hb_direction_t direction,
+                                const font_options_t *font_opts,
+                                const view_options_t *view_opts)
+{
+  cairo_scaled_font_t *scaled_font = helper_cairo_create_scaled_font (font_opts, view_opts->font_size);
+
+  double width, height;
+  get_surface_size (scaled_font, line, direction, view_opts, &width, &height);
+
+  GString *rval = g_string_new (NULL);
+
+  const char *save_output_format = options.output_format;
+  options.output_format = "png";
+  cairo_t *cr = helper_cairo_create_context (width, height, view_opts, &options, rval);
+  options.output_format = save_output_format;
+  cairo_set_scaled_font (cr, scaled_font);
+  cairo_scaled_font_destroy (scaled_font);
+
+  bool vertical = HB_DIRECTION_IS_VERTICAL (direction);
+  int v = vertical ? 1 : 0;
+  int h = vertical ? 0 : 1;
+  cairo_font_extents_t font_extents;
+  cairo_font_extents (cr, &font_extents);
+  cairo_translate (cr, view_opts->margin.l, view_opts->margin.t);
+  double descent;
+  if (vertical)
+    descent = font_extents.height * 1.5;
+  else
+    descent = font_extents.height - font_extents.ascent;
+  cairo_translate (cr, v * descent, h * -descent);
+
+  cairo_translate (cr, v * -font_extents.height, h * font_extents.height);
+
+  if (line->num_clusters)
+    cairo_show_text_glyphs (cr,
+			    line->utf8, line->utf8_len,
+			    line->glyphs, line->num_glyphs,
+			    line->clusters, line->num_clusters,
+			    line->cluster_flags);
+  else
+    cairo_show_glyphs (cr, line->glyphs, line->num_glyphs);
+
+  helper_cairo_destroy_context (cr);
+
+  return rval;
+}
+
+int
+main (int argc, char **argv)
+{
+  main_font_text_t<shape_compare_t<output_buffer_t> > driver;
+  return driver.main (argc, argv);
+}

--- a/util/hb-ot-shape-closure.cc
+++ b/util/hb-ot-shape-closure.cc
@@ -63,7 +63,8 @@ struct shape_closure_consumer_t : option_group_t
 		     const char   *text,
 		     unsigned int  text_len,
 		     const char   *text_before,
-		     const char   *text_after)
+		     const char   *text_after,
+		     const font_options_t *font_opts)
   {
     hb_set_clear (glyphs);
     shaper.shape_closure (text, text_len, font, buffer, glyphs);

--- a/util/helper-cairo.hh
+++ b/util/helper-cairo.hh
@@ -40,8 +40,9 @@ extern const char helper_cairo_supported_formats[];
 
 cairo_t *
 helper_cairo_create_context (double w, double h,
-			     view_options_t *view_opts,
-			     output_options_t *out_opts);
+			     const view_options_t *view_opts,
+			     output_options_t *out_opts,
+			     GString *out_string);
 
 void
 helper_cairo_destroy_context (cairo_t *cr);

--- a/util/main-font-text.hh
+++ b/util/main-font-text.hh
@@ -61,7 +61,7 @@ struct main_font_text_t
     unsigned int text_len;
     const char *text;
     while ((text = input.get_line (&text_len)))
-      consumer.consume_line (buffer, text, text_len, input.text_before, input.text_after);
+      consumer.consume_line (buffer, text, text_len, input.text_before, input.text_after, &font_opts);
     hb_buffer_destroy (buffer);
 
     consumer.finish (&font_opts);

--- a/util/options.hh
+++ b/util/options.hh
@@ -152,6 +152,7 @@ struct shape_options_t : option_group_t
     features = NULL;
     num_features = 0;
     shapers = NULL;
+    reference_shaper = NULL;
     utf8_clusters = false;
     normalize_glyphs = false;
     num_iterations = 1;
@@ -162,6 +163,7 @@ struct shape_options_t : option_group_t
   {
     free (features);
     g_strfreev (shapers);
+    g_strfreev (reference_shaper);
   }
 
   void add_options (option_parser_t *parser);
@@ -214,6 +216,14 @@ struct shape_options_t : option_group_t
     return res;
   }
 
+  hb_bool_t shape_reference (hb_font_t *font, hb_buffer_t *buffer)
+  {
+    hb_bool_t res = hb_shape_full (font, buffer, features, num_features, reference_shaper);
+    if (normalize_glyphs)
+      hb_buffer_normalize_glyphs (buffer);
+    return res;
+  }
+
   void shape_closure (const char *text, int text_len,
 		      hb_font_t *font, hb_buffer_t *buffer,
 		      hb_set_t *glyphs)
@@ -237,6 +247,7 @@ struct shape_options_t : option_group_t
   hb_feature_t *features;
   unsigned int num_features;
   char **shapers;
+  char **reference_shaper;
   hb_bool_t utf8_clusters;
   hb_bool_t normalize_glyphs;
   unsigned int num_iterations;
@@ -392,6 +403,10 @@ struct format_options_t : option_group_t
 				 GString      *gs);
   void serialize_message (unsigned int  line_no,
 			  const char   *msg,
+			  GString      *gs);
+  void serialize_message_2 (unsigned int  line_no,
+			  const char   *msg1,
+			  const char   *msg2,
 			  GString      *gs);
   void serialize_buffer_of_glyphs (hb_buffer_t  *buffer,
 				   unsigned int  line_no,

--- a/util/shape-compare.hh
+++ b/util/shape-compare.hh
@@ -1,0 +1,134 @@
+#include "options.hh"
+#include "helper-cairo.hh"
+
+#ifndef HB_SHAPE_COMPARE_HH
+#define HB_SHAPE_COMPARE_HH
+
+
+template <typename output_t>
+struct shape_compare_t
+{
+  shape_compare_t (option_parser_t *parser)
+		  : failed (false),
+		    shaper (parser),
+		    output (parser),
+		    font (NULL),
+		    view_options (parser) {}
+
+  void init (const font_options_t *font_opts)
+  {
+    font = hb_font_reference (font_opts->get_font ());
+    ref_buffer = hb_buffer_create ();
+    output.init (font_opts);
+    failed = false;
+    ref_failed = false;
+    if (!hb_font_get_glyph (font, 0x25cc, 0, &dotted_circle))
+      dotted_circle = (hb_codepoint_t) -1;
+    scale = double (view_options.font_size) / hb_face_get_upem (hb_font_get_face (font));
+  }
+
+  void consume_line (hb_buffer_t  *buffer,
+		     const char   *text,
+		     unsigned int  text_len,
+		     const char   *text_before,
+		     const char   *text_after,
+		     const font_options_t *font_opts)
+  {
+    output.new_line ();
+
+    shaper.populate_buffer (buffer, text, text_len, text_before, text_after);
+    shaper.populate_buffer (ref_buffer, text, text_len, text_before, text_after);
+
+    output.consume_text (buffer, text, text_len, shaper.utf8_clusters);
+
+    if (!shaper.shape (font, buffer)) {
+      failed = true;
+      hb_buffer_set_length (buffer, 0);
+    }
+
+    if (!shaper.shape_reference (font, ref_buffer)) {
+      ref_failed = true;
+      hb_buffer_set_length (ref_buffer, 0);
+    }
+
+    hb_buffer_differences_t diffs = hb_buffers_compare (buffer, ref_buffer, dotted_circle);
+
+    if (diffs & (HB_BUFFER_COMPARE_CODEPOINT_MISMATCH |
+                 HB_BUFFER_COMPARE_CLUSTER_MISMATCH |
+                 HB_BUFFER_COMPARE_POSITION_MISMATCH |
+                 HB_BUFFER_COMPARE_LENGTH_MISMATCH)) {
+      output.consume_glyphs (buffer, text, text_len, shaper.utf8_clusters);
+      output.consume_glyphs (ref_buffer, text, text_len, shaper.utf8_clusters);
+
+      GString *test_image = NULL;
+      GString *reference_image = NULL;
+
+      if (failed)
+        output.shape_failed (buffer, text, text_len, shaper.utf8_clusters);
+      else {
+        helper_cairo_line_t l;
+        helper_cairo_line_from_buffer (&l, buffer, text, text_len, scale, shaper.utf8_clusters);
+        test_image = output.render_to_png (&l, hb_buffer_get_direction (buffer), font_opts, &view_options);
+        l.finish ();
+      }
+      if (ref_failed)
+        output.ref_shape_failed (ref_buffer, text, text_len, shaper.utf8_clusters);
+      else {
+        helper_cairo_line_t l;
+        helper_cairo_line_from_buffer (&l, ref_buffer, text, text_len, scale, shaper.utf8_clusters);
+        reference_image = output.render_to_png (&l, hb_buffer_get_direction (ref_buffer), font_opts, &view_options);
+        l.finish ();
+      }
+
+      if (test_image && reference_image) {
+        if (test_image->len != reference_image->len ||
+            memcmp(test_image->str, reference_image->str, test_image->len)) {
+          output.dump_image (test_image, 1);
+          output.dump_image (reference_image, 2);
+        }
+        else {
+          diffs = (hb_buffer_differences_t) (diffs | HB_BUFFER_COMPARE_VISUAL_MATCH);
+          output.dump_image (test_image, 1);
+        }
+      }
+
+      if (test_image)
+	g_string_free (test_image, true);
+      if (reference_image)
+	g_string_free (reference_image, true);
+
+      output.report_differences (diffs);
+
+      output.finish_line ();
+    }
+
+    output.collect_stats (diffs);
+  }
+
+  void finish (const font_options_t *font_opts)
+  {
+    output.finish (font_opts);
+    hb_font_destroy (font);
+    hb_buffer_destroy (ref_buffer);
+    font = NULL;
+  }
+
+  public:
+  bool failed;
+  bool ref_failed;
+
+  protected:
+  shape_options_t shaper;
+  view_options_t view_options;
+  output_t output;
+
+  hb_font_t *font;
+  hb_buffer_t *ref_buffer;
+  hb_codepoint_t dotted_circle;
+
+  // for rendering
+  double scale;
+};
+
+
+#endif

--- a/util/shape-consumer.hh
+++ b/util/shape-consumer.hh
@@ -49,7 +49,8 @@ struct shape_consumer_t
 		     const char   *text,
 		     unsigned int  text_len,
 		     const char   *text_before,
-		     const char   *text_after)
+		     const char   *text_after,
+		     const font_options_t *font_opts)
   {
     output.new_line ();
 

--- a/util/view-cairo.cc
+++ b/util/view-cairo.cc
@@ -57,7 +57,7 @@ view_cairo_t::render (const font_options_t *font_opts)
   cairo_scaled_font_t *scaled_font = helper_cairo_create_scaled_font (font_opts, view_options.font_size);
   double w, h;
   get_surface_size (scaled_font, &w, &h);
-  cairo_t *cr = helper_cairo_create_context (w, h, &view_options, &output_options);
+  cairo_t *cr = helper_cairo_create_context (w, h, &view_options, &output_options, NULL);
   cairo_set_scaled_font (cr, scaled_font);
   cairo_scaled_font_destroy (scaled_font);
 


### PR DESCRIPTION
These are the patches I'm using to generate the uniscribe-vs-harfbuzz comparisons - would be nice to integrate this to master sometime.
