### PR TITLE
remove clang warning 'private field 'xxx' is not used

### DIFF
--- a/src/hb-open-type-private.hh
+++ b/src/hb-open-type-private.hh
@@ -592,7 +592,7 @@ struct LONGDATETIME
     TRACE_SANITIZE (this);
     return TRACE_RETURN (likely (c->check_struct (this)));
   }
-  private:
+  protected:
   LONG major;
   ULONG minor;
   public:


### PR DESCRIPTION
This will also fix firefox bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=776085
