### PR TITLE
Make hb_buffer_pre_allocate() allocate exactly requested size

### DIFF
--- a/src/hb-buffer-private.hh
+++ b/src/hb-buffer-private.hh
@@ -177,10 +177,12 @@ struct hb_buffer_t {
 				       unsigned int end);
 
   /* Internal methods */
-  HB_INTERNAL bool enlarge (unsigned int size);
+  HB_INTERNAL bool enlarge (unsigned int size, bool exact);
 
   inline bool ensure (unsigned int size)
-  { return likely (!size || size < allocated) ? true : enlarge (size); }
+  { return likely (!size || size < allocated) ? true : enlarge (size, false); }
+  inline bool ensure_exact (unsigned int size)
+  { return likely (!size || size < allocated) ? true : enlarge (size, true); }
 
   HB_INTERNAL bool make_room_for (unsigned int num_in, unsigned int num_out);
   HB_INTERNAL bool shift_forward (unsigned int count);

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -81,12 +81,12 @@ hb_segment_properties_hash (const hb_segment_properties_t *p)
 /* Internal API */
 
 bool
-hb_buffer_t::enlarge (unsigned int size)
+hb_buffer_t::enlarge (unsigned int size, bool exact)
 {
   if (unlikely (in_error))
     return false;
 
-  unsigned int new_allocated = allocated;
+  unsigned int new_allocated = exact ? size + 1 : allocated;
   hb_glyph_position_t *new_pos = NULL;
   hb_glyph_info_t *new_info = NULL;
   bool separate_out = out_info != info;
@@ -1081,7 +1081,7 @@ hb_buffer_clear_contents (hb_buffer_t *buffer)
 hb_bool_t
 hb_buffer_pre_allocate (hb_buffer_t *buffer, unsigned int size)
 {
-  return buffer->ensure (size);
+  return buffer->ensure_exact (size);
 }
 
 /**


### PR DESCRIPTION
Normally, hb_buffer_t::enlarge() quantizes allocations by calculating
a new allocation size as "current_allocation_size \* 2 + 32".  When
called on an empty buffer (with allocated=0) it will at least allocate
space for 32 characters.

If a caller knows exactly how many characters will ever be written
into the buffer, it is useful if they can use hb_buffer_pre_allocate()
to pre-allocate enough space while avoiding this quantization.  Thus,
modify hb_buffer_pre_allocate()'s behavior to allocate space for the
requested size exactly.  This is implemented using a new argument to
hb_buffer_t::enlarge(), 'exact', which disables the quantization.
