### PR TITLE
wrap definition of free_langs() with HAVE_ATEXIT

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -234,6 +234,7 @@ struct hb_language_item_t {
 
 static hb_language_item_t *langs;
 
+#ifdef HAVE_ATEXIT
 static inline
 void free_langs (void)
 {
@@ -244,6 +245,7 @@ void free_langs (void)
     langs = next;
   }
 }
+#endif
 
 static hb_language_item_t *
 lang_find_or_insert (const char *key)


### PR DESCRIPTION
...to avoid an unused function warning; see mozilla bug https://bugzilla.mozilla.org/show_bug.cgi?id=984081.
