### PR TITLE
Fix build with --coretext on iOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,15 +342,30 @@ AC_ARG_WITH(coretext,
 have_coretext=false
 if test "x$with_coretext" = "xyes" -o "x$with_coretext" = "xauto"; then
 	AC_CHECK_TYPE(CTFontRef, have_coretext=true,, [#include <ApplicationServices/ApplicationServices.h>])
+
+	if $have_coretext; then
+		CORETEXT_CFLAGS=
+		CORETEXT_LIBS="-framework ApplicationServices"
+		AC_SUBST(CORETEXT_CFLAGS)
+		AC_SUBST(CORETEXT_LIBS)
+	else
+		# On iOS CoreText and CoreGraphics are stand-alone frameworks
+		if test "x$have_coretext" != "xtrue"; then
+			AC_CHECK_TYPE(CTFontRef, have_coretext=true,, [#include <CoreText/CoreText.h>])
+		fi
+
+		if $have_coretext; then
+			CORETEXT_CFLAGS=
+			CORETEXT_LIBS="-framework CoreText -framework CoreGraphics"
+			AC_SUBST(CORETEXT_CFLAGS)
+			AC_SUBST(CORETEXT_LIBS)
+		fi
+	fi
 fi
 if test "x$with_coretext" = "xyes" -a "x$have_coretext" != "xtrue"; then
 	AC_MSG_ERROR([CoreText support requested but libcoretext not found])
 fi
 if $have_coretext; then
-	CORETEXT_CFLAGS=
-	CORETEXT_LIBS="-framework ApplicationServices"
-	AC_SUBST(CORETEXT_CFLAGS)
-	AC_SUBST(CORETEXT_LIBS)
 	AC_DEFINE(HAVE_CORETEXT, 1, [Have Core Text backend])
 fi
 AM_CONDITIONAL(HAVE_CORETEXT, $have_coretext)

--- a/src/hb-coretext.h
+++ b/src/hb-coretext.h
@@ -29,7 +29,13 @@
 
 #include "hb.h"
 
-#include <ApplicationServices/ApplicationServices.h>
+#include <TargetConditionals.h>
+#if defined(TARGET_OS_IPHONE)
+#  include <CoreText/CoreText.h>
+#  include <CoreGraphics/CoreGraphics.h>
+#else
+#  include <ApplicationServices/ApplicationServices.h>
+#endif
 
 HB_BEGIN_DECLS
 


### PR DESCRIPTION
On iOS CoreText and CoreGraphics are stand-alone frameworks
