### PR TITLE
Automake 1.11 fix

### DIFF
--- a/docs/reference/Makefile.am
+++ b/docs/reference/Makefile.am
@@ -92,7 +92,7 @@ include $(top_srcdir)/gtk-doc.make
 
 # Other files to distribute
 # e.g. EXTRA_DIST += version.xml.in
-EXTRA_DIST += version.xml.in
+EXTRA_DIST = version.xml.in
 
 # Files not to distribute
 # for --rebuild-types in $(SCAN_OPTIONS), e.g. $(DOC_MODULE).types


### PR DESCRIPTION
When built with automake 1.11, HarfBuzz configure breaks with an error:

```
docs/reference/Makefile.am:95: EXTRA_DIST must be set with `=' before using `+='
```

This apparently fixes the problem.
