### PR TITLE
Use __aarch64__ for 64-bit ARM detection, not __arm64__

### DIFF
--- a/src/hb-atomic-private.hh
+++ b/src/hb-atomic-private.hh
@@ -82,7 +82,7 @@ typedef int32_t hb_atomic_int_t;
 #if (MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_4 || __IPHONE_VERSION_MIN_REQUIRED >= 20100)
 #define hb_atomic_ptr_cmpexch(P,O,N)	OSAtomicCompareAndSwapPtrBarrier ((void *) (O), (void *) (N), (void **) (P))
 #else
-#if __ppc64__ || __x86_64__ || __arm64__
+#if __ppc64__ || __x86_64__ || __aarch64__
 #define hb_atomic_ptr_cmpexch(P,O,N)    OSAtomicCompareAndSwap64Barrier ((int64_t) (O), (int64_t) (N), (int64_t*) (P))
 #else
 #define hb_atomic_ptr_cmpexch(P,O,N)    OSAtomicCompareAndSwap32Barrier ((int32_t) (O), (int32_t) (N), (int32_t*) (P))


### PR DESCRIPTION
Many GCC versions don't define __arm64__.
Also, only most recent upstream versions of CLANG/LLVM define __arm64__.
__aarch64__ is generally the safest choice.
