### PR TITLE
HB_TAG_MAX: switched from 2^32-1 (UINT_MAX) to 2^31-1 (INT_MAX)

### DIFF
--- a/src/hb-common.h
+++ b/src/hb-common.h
@@ -94,7 +94,7 @@ typedef uint32_t hb_tag_t;
 #define HB_UNTAG(tag)   ((uint8_t)((tag)>>24)), ((uint8_t)((tag)>>16)), ((uint8_t)((tag)>>8)), ((uint8_t)(tag))
 
 #define HB_TAG_NONE HB_TAG(0,0,0,0)
-#define HB_TAG_MAX HB_TAG(0xff,0xff,0xff,0xff)
+#define HB_TAG_MAX HB_TAG(0x7f,0xff,0xff,0xff)
 
 /* len=-1 means str is NUL-terminated. */
 hb_tag_t


### PR DESCRIPTION
An error occurs when building with clang — HB_TAG_MAX value doesn't fit into the `value` field of struct GEnumValue:
hb-gobject-enums.cc:289:11: error: constant expression evaluates to 4294967295 which cannot be narrowed to type 'gint' (aka 'int')
      [-Wc++11-narrowing]
        { _HB_SCRIPT_MAX_VALUE, "_HB_SCRIPT_MAX_VALUE", "-hb-script-max-value" },
          ^~~~~~~~~~~~~~~~~~~~
hb-gobject-enums.cc:289:11: note: override this message by inserting an explicit cast
        { _HB_SCRIPT_MAX_VALUE, "_HB_SCRIPT_MAX_VALUE", "-hb-script-max-value" },
          ^~~~~~~~~~~~~~~~~~~~
          static_cast<gint>(  )
