### PR TITLE
Fix build with --coretext on older OS X

### DIFF
--- a/src/hb-coretext.h
+++ b/src/hb-coretext.h
@@ -30,7 +30,7 @@
 #include "hb.h"
 
 #include <TargetConditionals.h>
-#if defined(TARGET_OS_IPHONE)
+#if TARGET_OS_IPHONE
 #  include <CoreText/CoreText.h>
 #  include <CoreGraphics/CoreGraphics.h>
 #else


### PR DESCRIPTION
`TARGET_OS_IPHONE` is defined on all platforms, but its value can be 1 or 0.

I have Mac OS X 10.6, which doesn’t support including CoreText and CoreGraphics headers directly. I don’t know firsthand whether new versions support that, but I trust the comment in #34 that says they do.
