### PR TITLE
Define _POSIX_C_SOURCE only if it is not defined.

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -25,7 +25,11 @@
  */
 
 /* http://www.oracle.com/technetwork/articles/servers-storage-dev/standardheaderfiles-453865.html */
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 199309L
+#error "Do not use _POSIX_C_SOURCE < 199309L."
+#elif !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 199309L
+#endif
 
 #include "hb-private.hh"
 


### PR DESCRIPTION
It considers cases that _POSIX_C_SOURCE is defined for all source files
by compile options in Makefile of a large project.
