### PR TITLE
WIP [gobject] Use a identifier-filter

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,6 +9,8 @@ DISTCLEANFILES =
 MAINTAINERCLEANFILES =
 DISTCHECK_CONFIGURE_FLAGS = --enable-introspection
 
+PYTHON = python
+
 # The following warning options are useful for debugging: -Wpadded
 #AM_CXXFLAGS =
 
@@ -185,7 +187,8 @@ DISTCLEANFILES += \
 	$(NULL)
 hb-gobject-enums.%: hb-gobject-enums.%.tmpl $(HBHEADERS)
 	$(AM_V_GEN) $(GLIB_MKENUMS) \
-		--identifier-prefix hb_ --symbol-prefix hb_gobject \
+		--identifier-prefix hb_ \
+		--symbol-prefix hb_gobject \
 		--template $^ | \
 	sed 's/_t_get_type/_get_type/g; s/_T (/ (/g' > "$@" \
 	|| ($(RM) "$@"; false)
@@ -328,11 +331,21 @@ if HAVE_INTROSPECTION
 
 -include $(INTROSPECTION_MAKEFILE)
 INTROSPECTION_GIRS = HarfBuzz-0.0.gir # What does the 0 mean anyway?!
-INTROSPECTION_SCANNER_ARGS = -I$(srcdir) -n hb --identifier-prefix=hb_ --warn-all
 INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir)
 INTROSPECTION_SCANNER_ENV = CC="$(CC)"
+INTROSPECTION_SCANNER_ARGS = \
+	-I$(srcdir) \
+	-n hb \
+	--identifier-prefix=hb_ \
+	--identifier-filter-cmd="$(PYTHON) $(srcdir)/hb-gobject-identfilter.py" \
+	--warn-all \
+	$(NULL)
 
-HarfBuzz-0.0.gir: libharfbuzz.la libharfbuzz-gobject.la
+HarfBuzz-0.0.gir: \
+	libharfbuzz.la \
+	libharfbuzz-gobject.la \
+	hb-gobject-identfilter.py \
+	$(NULL)
 HarfBuzz_0_0_gir_INCLUDES = GObject-2.0
 HarfBuzz_0_0_gir_CFLAGS = \
 	$(INCLUDES) \
@@ -365,6 +378,7 @@ gir_DATA = $(INTROSPECTION_GIRS)
 typelibdir = $(libdir)/girepository-1.0
 typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
 
+EXTRA_DIST += hb-gobject-identfilter.py
 CLEANFILES += $(gir_DATA) $(typelib_DATA)
 
 endif

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -664,7 +664,7 @@ hb_buffer_t::guess_segment_properties (void)
 /* Public API */
 
 /**
- * hb_buffer_create: (Xconstructor)
+ * hb_buffer_create: (constructor)
  *
  * Creates a new #hb_buffer_t with all properties to defaults.
  *

--- a/src/hb-face.cc
+++ b/src/hb-face.cc
@@ -149,7 +149,7 @@ _hb_face_for_data_reference_table (hb_face_t *face HB_UNUSED, hb_tag_t tag, void
 }
 
 /**
- * hb_face_create: (Xconstructor)
+ * hb_face_create: (constructor)
  * @blob: 
  * @index: 
  *

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -399,7 +399,7 @@ static const hb_font_funcs_t _hb_font_funcs_parent = {
 
 
 /**
- * hb_font_funcs_create: (Xconstructor)
+ * hb_font_funcs_create: (constructor)
  *
  * 
  *
@@ -1110,7 +1110,7 @@ hb_font_glyph_from_string (hb_font_t *font,
  */
 
 /**
- * hb_font_create: (Xconstructor)
+ * hb_font_create: (constructor)
  * @face: a face.
  *
  * 

--- a/src/hb-gobject-identfilter.py
+++ b/src/hb-gobject-identfilter.py
@@ -1,0 +1,48 @@
+# -*- Mode: Python; py-indent-offset: 4 -*-
+# vim: tabstop=4 shiftwidth=4 expandtab
+#
+# Copyright (C) 2014 Simon Feltman <sfeltman@gnome.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+# USA
+
+"""
+Script which reads identifiers in the form of "foo_bar_t" from stdin and
+translates them to title case like "FooBar", stripping the "_t" suffix.
+This also adds a special case where a context like identifier with the same
+name as the library is translated into "Context" in GI (useful in situations
+like cairo_t -> Context.
+"""
+
+import sys
+
+
+def ensure_title_case(text):
+    # Strip off "_t" suffix.
+    if text.endswith('_t'):
+        text = text[:-2]
+    if text == 'hb_unicode_funcs': return 'hb_unicodeFuncs'
+    if text == 'hb_unicode_combining_class': return 'hb_unicodeCombiningClass'
+    if text == 'hb_unicode_general_category': return 'hb_unicodeGeneralCategory'
+
+    # Split text on underscores and re-join title casing each part
+    #text = ''.join(part.title() for part in text.split('_'))
+
+    return text
+
+
+if __name__ == '__main__':
+    text = ensure_title_case(sys.stdin.read())
+    sys.stdout.write(text)

--- a/src/hb-set.cc
+++ b/src/hb-set.cc
@@ -31,7 +31,7 @@
 
 
 /**
- * hb_set_create: (Xconstructor)
+ * hb_set_create: (constructor)
  *
  * Return value: (transfer full):
  *

--- a/src/hb-shape-plan.cc
+++ b/src/hb-shape-plan.cc
@@ -95,7 +95,7 @@ hb_shape_plan_plan (hb_shape_plan_t    *shape_plan,
  */
 
 /**
- * hb_shape_plan_create: (Xconstructor)
+ * hb_shape_plan_create: (constructor)
  * @face: 
  * @props: 
  * @user_features: (array length=num_user_features):

--- a/src/hb-unicode.cc
+++ b/src/hb-unicode.cc
@@ -151,7 +151,7 @@ hb_unicode_funcs_get_default (void)
 #endif
 
 /**
- * hb_unicode_funcs_create: (Xconstructor)
+ * hb_unicode_funcs_create: (constructor)
  * @parent: (nullable):
  *
  * 


### PR DESCRIPTION
Based on filter in
https://bugzilla.gnome.org/show_bug.cgi?id=706898

Doesn't quite work.  We now get hb.buffer.buffer_create()
instead of the old hb.buffer_create().  The filter itself
is also crude; not sure what it should do.

This is as much progress as I made tonight.  To be refined.
