### PR TITLE
attempt to offset vertical glyphs (#575) (#485)

### DIFF
--- a/util/helper-cairo.cc
+++ b/util/helper-cairo.cc
@@ -466,7 +466,8 @@ helper_cairo_line_from_buffer (helper_cairo_line_t *l,
 			       const char          *text,
 			       unsigned int         text_len,
 			       int                  scale_bits,
-			       hb_bool_t            utf8_clusters)
+			       hb_bool_t            utf8_clusters,
+			       hb_font_t           *font)
 {
   memset (l, 0, sizeof (*l));
 
@@ -497,6 +498,12 @@ helper_cairo_line_from_buffer (helper_cairo_line_t *l,
   int i;
   for (i = 0; i < (int) l->num_glyphs; i++)
   {
+    if ( HB_DIRECTION_IS_VERTICAL(hb_buffer_get_direction (buffer)) )
+    {
+        hb_font_add_glyph_origin_for_direction( font,
+                            hb_glyph[i].codepoint, HB_DIRECTION_TTB,
+                            &hb_position->x_offset, &hb_position->y_offset);
+    }
     l->glyphs[i].index = hb_glyph[i].codepoint;
     l->glyphs[i].x = scalbn ((double)  hb_position->x_offset + x, scale_bits);
     l->glyphs[i].y = scalbn ((double) -hb_position->y_offset + y, scale_bits);

--- a/util/helper-cairo.hh
+++ b/util/helper-cairo.hh
@@ -81,6 +81,7 @@ helper_cairo_line_from_buffer (helper_cairo_line_t *l,
 			       const char          *text,
 			       unsigned int         text_len,
 			       int                  scale_bits,
-			       hb_bool_t            utf8_clusters);
+			       hb_bool_t            utf8_clusters,
+			       hb_font_t           *font);
 
 #endif

--- a/util/view-cairo.cc
+++ b/util/view-cairo.cc
@@ -78,10 +78,15 @@ view_cairo_t::render (const font_options_t *font_opts)
   /* Setup coordinate system. */
   cairo_translate (cr, view_options.margin.l, view_options.margin.t);
   if (vertical)
+   {
+    // It seems calling hb_font_add_glyph_origin_for_direction()
+    // to offset x_offset and y_offset also have some negative effect
+    // here, try to compensate them based on empirical result.
     cairo_translate (cr,
 		     w /* We stack lines right to left */
-		     -font_height * .5 /* "ascent" for vertical */,
-		     y_sign < 0 ? h : 0);
+		     -font_height,
+		      font_height); 
+   }
   else
    {
     cairo_translate (cr,

--- a/util/view-cairo.hh
+++ b/util/view-cairo.hh
@@ -38,7 +38,7 @@ struct view_cairo_t
 	       : output_options (parser, helper_cairo_supported_formats),
 		 view_options (parser),
 		 direction (HB_DIRECTION_INVALID),
-		 lines (0), scale_bits (0) {}
+		 lines (0), scale_bits (0), font (nullptr) {}
   ~view_cairo_t (void) {
     if (debug)
       cairo_debug_reset_static_data ();
@@ -48,6 +48,7 @@ struct view_cairo_t
   {
     lines = g_array_new (false, false, sizeof (helper_cairo_line_t));
     scale_bits = -font_opts->subpixel_bits;
+    font = hb_font_reference (font_opts->get_font ());
   }
   void new_line (void)
   {
@@ -69,7 +70,7 @@ struct view_cairo_t
   {
     direction = hb_buffer_get_direction (buffer);
     helper_cairo_line_t l;
-    helper_cairo_line_from_buffer (&l, buffer, text, text_len, scale_bits, utf8_clusters);
+    helper_cairo_line_from_buffer (&l, buffer, text, text_len, scale_bits, utf8_clusters, font);
     g_array_append_val (lines, l);
   }
   void finish (hb_buffer_t *buffer, const font_options_t *font_opts)
@@ -85,6 +86,8 @@ struct view_cairo_t
 #else
     g_array_free (lines, TRUE);
 #endif
+    hb_font_destroy (font);
+    font = nullptr;
   }
 
   protected:
@@ -97,6 +100,7 @@ struct view_cairo_t
   hb_direction_t direction; // Remove this, make segment_properties accessible
   GArray *lines;
   int scale_bits;
+  hb_font_t *font;
 };
 
 #endif


### PR DESCRIPTION
This patch would fix incorrect glyph position
highlighted in https://imgur.com/a/I0jJU as well
as in #485. I try to explain my point of view
and would like to know if I'm correct.

Note: for harfbuzz I have do some cairo translate.
In LibreOffice I don't. I don't know why.

Original issue is to fix text offset issue of
vertical writing in LibreOffice (#575)
after LibreOffice update its HarfBuzz from 1.3.3 to 1.4.8. 
I tried to figure out how to use those values empirically.

Y_offset was 0 with HarfBuzz 1.3.3 and has
become -1160 (roughly 1EM upward) after upgrade to
1.4.8, I suspect that the offsets returned by Harfbuzz
are always repect to h_origin:

subtract_glyph_v_origin()
-> get_glyph_v_origin_with_fallback
-> guess_v_origin_minus_h_origin

But underlying renderer might expect positions relative
to the vertical origin. To compensate the result
I try to translate them back by calling
hb_font_add_glyph_origin_for_direction(),
to add the horizontal origin, hence make offset
relative to the v origin.