### PR TITLE
[hb-ft] Fix build when Multiple Master font support is disabled in freetype

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -354,6 +354,7 @@ if $have_freetype; then
 	save_libs=$LIBS
 	LIBS="$LIBS $FREETYPE_LIBS"
 	AC_CHECK_FUNCS(FT_Get_Var_Blend_Coordinates)
+	AC_CHECK_FUNCS(FT_Set_Var_Blend_Coordinates)
 	LIBS=$save_libs
 fi
 AM_CONDITIONAL(HAVE_FREETYPE, $have_freetype)

--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -747,6 +747,7 @@ hb_ft_font_set_funcs (hb_font_t *font)
     FT_Set_Transform (ft_face, &matrix, nullptr);
   }
 
+#ifdef HAVE_FT_SET_VAR_BLEND_COORDINATES
   unsigned int num_coords;
   const int *coords = hb_font_get_var_coords_normalized (font, &num_coords);
   if (num_coords)
@@ -760,6 +761,7 @@ hb_ft_font_set_funcs (hb_font_t *font)
       free (ft_coords);
     }
   }
+#endif
 
   ft_face->generic.data = blob;
   ft_face->generic.finalizer = (FT_Generic_Finalizer) _release_blob;

--- a/util/helper-cairo.cc
+++ b/util/helper-cairo.cc
@@ -103,6 +103,7 @@ helper_cairo_create_scaled_font (const font_options_t *font_opts)
   }
   else
   {
+#ifdef HAVE_FT_SET_VAR_BLEND_COORDINATES
     unsigned int num_coords;
     const int *coords = hb_font_get_var_coords_normalized (font, &num_coords);
     if (num_coords)
@@ -116,6 +117,7 @@ helper_cairo_create_scaled_font (const font_options_t *font_opts)
 	free (ft_coords);
       }
     }
+#endif
 
     cairo_face = cairo_ft_font_face_create_for_ft_face (ft_face, 0);
   }


### PR DESCRIPTION
FT_Set_Var_Blend_Coordinates() is not available when "Multiple Master font interface" is disabled in freetype's modules.cfg