### PR TITLE
HarfBuzz 1.7.1 and later don't compile on AIX with xlC (#655)

### DIFF
--- a/src/hb-ot-shape-complex-arabic-fallback.hh
+++ b/src/hb-ot-shape-complex-arabic-fallback.hh
@@ -77,7 +77,7 @@ arabic_fallback_synthesize_lookup_single (const hb_ot_shape_plan_t *plan HB_UNUS
 
   /* Bubble-sort or something equally good!
    * May not be good-enough for presidential candidate interviews, but good-enough for us... */
-  hb_stable_sort (&glyphs[0], num_glyphs, OT::GlyphID::cmp, &substitutes[0]);
+  hb_stable_sort (&glyphs[0], num_glyphs, (int(*)(const OT::GlyphID*, const OT::GlyphID *)) OT::GlyphID::cmp, &substitutes[0]);
 
   OT::Supplier<OT::GlyphID> glyphs_supplier      (glyphs, num_glyphs);
   OT::Supplier<OT::GlyphID> substitutes_supplier (substitutes, num_glyphs);
@@ -126,7 +126,7 @@ arabic_fallback_synthesize_lookup_ligature (const hb_ot_shape_plan_t *plan HB_UN
     first_glyphs_indirection[num_first_glyphs] = first_glyph_idx;
     num_first_glyphs++;
   }
-  hb_stable_sort (&first_glyphs[0], num_first_glyphs, OT::GlyphID::cmp, &first_glyphs_indirection[0]);
+  hb_stable_sort (&first_glyphs[0], num_first_glyphs, (int(*)(const OT::GlyphID*, const OT::GlyphID *)) OT::GlyphID::cmp, &first_glyphs_indirection[0]);
 
   /* Now that the first-glyphs are sorted, walk again, populate ligatures. */
   for (unsigned int i = 0; i < num_first_glyphs; i++)


### PR DESCRIPTION
This pull request fixes #655 

There's a compiler bug in xlC 12 & 13 which prevents xlC from selecting the correct version of the overloaded 'cmp(..)' method from struct IntType (defined in hb-open-type-private.hh) in the two functions  'arabic_fallback_synthesize_lookup_single(..)' and 'arabic_fallback_synthesize_lookup_ligature(..)' (defined in hb-ot-shape-complex-arabic-fallback.hh).

The fix is quite easy. Instead of writing:

```
hb_stable_sort (&glyphs[0], num_glyphs, OT::GlyphID::cmp, &substitutes[0]);
```

we can help the compiler by casting 'OT::GlyphID::cmp' to the correct overloaded version of 'cmp(..'):

```
hb_stable_sort (&glyphs[0], num_glyphs, (int(*)(const OT::GlyphID*, const OT::GlyphID *)) OT::GlyphID::cmp, &substitutes[0]);
```
This issue has been fixed in the OpenJDK project after the integration of the new HarfBuzz version 1.7.1 (see [JDK-8193515: AIX: new Harfbuzz 1.7.1 version fails to compile with xlC](https://bugs.openjdk.java.net/browse/JDK-8193515)), but it would be great if we could bring this fix upstream to avoid problems when updatating to newer HarfBuzz version in the future.
