### PR TITLE
link with CoreFoundation when using CoreText

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -429,7 +429,7 @@ if test "x$with_coretext" = "xyes" -o "x$with_coretext" = "xauto"; then
 
 		if $have_coretext; then
 			CORETEXT_CFLAGS=
-			CORETEXT_LIBS="-framework CoreText -framework CoreGraphics"
+			CORETEXT_LIBS="-framework CoreText -framework CoreGraphics -framework CoreFoundation"
 			AC_SUBST(CORETEXT_CFLAGS)
 			AC_SUBST(CORETEXT_LIBS)
 		fi


### PR DESCRIPTION
fix iOS compilation when using CoreText, missing CoreFoundation symbols:
```
Undefined symbols for architecture armv7:
  "_CFArrayAppendValue", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFArrayCreate", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
  "_CFArrayCreateMutable", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFArrayGetCount", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFArrayGetValueAtIndex", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFAttributedStringCreateMutable", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFAttributedStringRemoveAttribute", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFAttributedStringReplaceString", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFAttributedStringSetAttribute", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFDataGetBytePtr", referenced from:
      reference_table(hb_face_t*, unsigned int, void*) in libharfbuzz_la-hb-coretext.o
  "_CFDataGetLength", referenced from:
      reference_table(hb_face_t*, unsigned int, void*) in libharfbuzz_la-hb-coretext.o
  "_CFDictionaryCreate", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFDictionaryGetValue", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFEqual", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFNumberCreate", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFRelease", referenced from:
      _hb_coretext_shaper_face_data_ensure in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shaper_face_data_destroy in libharfbuzz_la-hb-coretext.o
      _hb_coretext_shaper_font_data_ensure in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shaper_font_data_destroy in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
      _hb_coretext_font_create in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
      ...
  "_CFRetain", referenced from:
      _hb_coretext_font_create in libharfbuzz_la-hb-coretext.o
  "_CFStringCompare", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFStringCreateWithCStringNoCopy", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFStringCreateWithCharactersNoCopy", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFStringGetCharacterAtIndex", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_CFStringHasPrefix", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
  "_CFStringHasSuffix", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
  "___CFConstantStringClassReference", referenced from:
      CFString in libharfbuzz_la-hb-coretext.o
      CFString in libharfbuzz_la-hb-coretext.o
      CFString in libharfbuzz_la-hb-coretext.o
      CFString in libharfbuzz_la-hb-coretext.o
      CFString in libharfbuzz_la-hb-coretext.o
      CFString in libharfbuzz_la-hb-coretext.o
  "_kCFAllocatorDefault", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_kCFAllocatorNull", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_kCFBooleanTrue", referenced from:
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_kCFTypeArrayCallBacks", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_kCFTypeDictionaryKeyCallBacks", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
  "_kCFTypeDictionaryValueCallBacks", referenced from:
      __hb_coretext_shaper_font_data_create in libharfbuzz_la-hb-coretext.o
      __hb_coretext_shape in libharfbuzz_la-hb-coretext.o
ld: symbol(s) not found for architecture armv7
```
Can be reproduced with 
```
CPPFLAGS="-arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.1.sdk -miphoneos-version-min=7.0 -O2" CC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc" LD="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld" LDFLAGS="-arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.1.sdk" ./configure --with-coretext --with-glib=no --host=armv7-apple-darwin
```
