### PR TITLE
Fix compilation error caused by  _POSIX_C_SOURCE on FreeBSD

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -26,7 +26,7 @@
 
 /* http://www.oracle.com/technetwork/articles/servers-storage-dev/standardheaderfiles-453865.html */
 #ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200809L
 #endif
 
 #include "hb-private.hh"


### PR DESCRIPTION
FreeBSD libc assumes setting `_POSIX_C_SOURCE` to any POSIX version released before 1999 means disabling C99 support, which causes compilation error because many functions are not declared.

```
CXX      libharfbuzz_la-hb-blob.lo
In file included from /home/lantw44/gnome/source/harfbuzz/src/hb-blob.cc:32:
In file included from /home/lantw44/gnome/source/harfbuzz/src/hb-private.hh:43:
/usr/include/c++/v1/math.h:640:39: error: use of undeclared identifier 'fabsf'; did you mean 'fabs'?
abs(float __lcpp_x) _NOEXCEPT {return fabsf(__lcpp_x);}
                                      ^
/usr/include/math.h:255:8: note: 'fabs' declared here
double  fabs(double) __pure2;
        ^
In file included from /home/lantw44/gnome/source/harfbuzz/src/hb-blob.cc:32:
In file included from /home/lantw44/gnome/source/harfbuzz/src/hb-private.hh:43:
/usr/include/c++/v1/math.h:648:45: error: use of undeclared identifier 'fabsl'; did you mean 'fabs'?
abs(long double __lcpp_x) _NOEXCEPT {return fabsl(__lcpp_x);}
                                            ^
/usr/include/math.h:255:8: note: 'fabs' declared here
double  fabs(double) __pure2;
        ^
In file included from /home/lantw44/gnome/source/harfbuzz/src/hb-blob.cc:32:
In file included from /home/lantw44/gnome/source/harfbuzz/src/hb-private.hh:43:
/usr/include/c++/v1/math.h:654:91: error: use of undeclared identifier 'acosf'; did you mean 'acos'?
inline _LIBCPP_INLINE_VISIBILITY float       acos(float __lcpp_x) _NOEXCEPT       {return acosf(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:654:46: note: 'acos' declared here
inline _LIBCPP_INLINE_VISIBILITY float       acos(float __lcpp_x) _NOEXCEPT       {return acosf(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:655:91: error: use of undeclared identifier 'acosl'; did you mean 'acos'?
inline _LIBCPP_INLINE_VISIBILITY long double acos(long double __lcpp_x) _NOEXCEPT {return acosl(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:655:46: note: 'acos' declared here
inline _LIBCPP_INLINE_VISIBILITY long double acos(long double __lcpp_x) _NOEXCEPT {return acosl(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:666:91: error: use of undeclared identifier 'asinf'; did you mean 'asin'?
inline _LIBCPP_INLINE_VISIBILITY float       asin(float __lcpp_x) _NOEXCEPT       {return asinf(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:666:46: note: 'asin' declared here
inline _LIBCPP_INLINE_VISIBILITY float       asin(float __lcpp_x) _NOEXCEPT       {return asinf(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:667:91: error: use of undeclared identifier 'asinl'; did you mean 'asin'?
inline _LIBCPP_INLINE_VISIBILITY long double asin(long double __lcpp_x) _NOEXCEPT {return asinl(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:667:46: note: 'asin' declared here
inline _LIBCPP_INLINE_VISIBILITY long double asin(long double __lcpp_x) _NOEXCEPT {return asinl(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:678:91: error: use of undeclared identifier 'atanf'; did you mean 'atan'?
inline _LIBCPP_INLINE_VISIBILITY float       atan(float __lcpp_x) _NOEXCEPT       {return atanf(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:678:46: note: 'atan' declared here
inline _LIBCPP_INLINE_VISIBILITY float       atan(float __lcpp_x) _NOEXCEPT       {return atanf(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:679:91: error: use of undeclared identifier 'atanl'; did you mean 'atan'?
inline _LIBCPP_INLINE_VISIBILITY long double atan(long double __lcpp_x) _NOEXCEPT {return atanl(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:679:46: note: 'atan' declared here
inline _LIBCPP_INLINE_VISIBILITY long double atan(long double __lcpp_x) _NOEXCEPT {return atanl(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:690:114: error: use of undeclared identifier 'atan2f'; did you mean 'atan2'?
inline _LIBCPP_INLINE_VISIBILITY float       atan2(float __lcpp_y, float __lcpp_x) _NOEXCEPT             {return atan2f(__lcpp_y, __lcpp_x);}
                                                                                                                 ^
/usr/include/c++/v1/math.h:690:46: note: 'atan2' declared here
inline _LIBCPP_INLINE_VISIBILITY float       atan2(float __lcpp_y, float __lcpp_x) _NOEXCEPT             {return atan2f(__lcpp_y, __lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:691:114: error: use of undeclared identifier 'atan2l'; did you mean 'atan2'?
inline _LIBCPP_INLINE_VISIBILITY long double atan2(long double __lcpp_y, long double __lcpp_x) _NOEXCEPT {return atan2l(__lcpp_y, __lcpp_x);}
                                                                                                                 ^
/usr/include/c++/v1/math.h:691:46: note: 'atan2' declared here
inline _LIBCPP_INLINE_VISIBILITY long double atan2(long double __lcpp_y, long double __lcpp_x) _NOEXCEPT {return atan2l(__lcpp_y, __lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:713:91: error: use of undeclared identifier 'ceilf'; did you mean 'ceil'?
inline _LIBCPP_INLINE_VISIBILITY float       ceil(float __lcpp_x) _NOEXCEPT       {return ceilf(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:713:46: note: 'ceil' declared here
inline _LIBCPP_INLINE_VISIBILITY float       ceil(float __lcpp_x) _NOEXCEPT       {return ceilf(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:714:91: error: use of undeclared identifier 'ceill'; did you mean 'ceil'?
inline _LIBCPP_INLINE_VISIBILITY long double ceil(long double __lcpp_x) _NOEXCEPT {return ceill(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:714:46: note: 'ceil' declared here
inline _LIBCPP_INLINE_VISIBILITY long double ceil(long double __lcpp_x) _NOEXCEPT {return ceill(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:725:90: error: use of undeclared identifier 'cosf'
inline _LIBCPP_INLINE_VISIBILITY float       cos(float __lcpp_x) _NOEXCEPT       {return cosf(__lcpp_x);}
                                                                                         ^
/usr/include/c++/v1/math.h:726:90: error: use of undeclared identifier 'cosl'
inline _LIBCPP_INLINE_VISIBILITY long double cos(long double __lcpp_x) _NOEXCEPT {return cosl(__lcpp_x);}
                                                                                         ^
/usr/include/c++/v1/math.h:737:91: error: use of undeclared identifier 'coshf'; did you mean 'cosh'?
inline _LIBCPP_INLINE_VISIBILITY float       cosh(float __lcpp_x) _NOEXCEPT       {return coshf(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:737:46: note: 'cosh' declared here
inline _LIBCPP_INLINE_VISIBILITY float       cosh(float __lcpp_x) _NOEXCEPT       {return coshf(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:738:91: error: use of undeclared identifier 'coshl'; did you mean 'cosh'?
inline _LIBCPP_INLINE_VISIBILITY long double cosh(long double __lcpp_x) _NOEXCEPT {return coshl(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:738:46: note: 'cosh' declared here
inline _LIBCPP_INLINE_VISIBILITY long double cosh(long double __lcpp_x) _NOEXCEPT {return coshl(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:749:90: error: use of undeclared identifier 'expf'; did you mean 'exp'?
inline _LIBCPP_INLINE_VISIBILITY float       exp(float __lcpp_x) _NOEXCEPT       {return expf(__lcpp_x);}
                                                                                         ^
/usr/include/c++/v1/math.h:749:46: note: 'exp' declared here
inline _LIBCPP_INLINE_VISIBILITY float       exp(float __lcpp_x) _NOEXCEPT       {return expf(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:750:90: error: use of undeclared identifier 'expl'; did you mean 'exp'?
inline _LIBCPP_INLINE_VISIBILITY long double exp(long double __lcpp_x) _NOEXCEPT {return expl(__lcpp_x);}
                                                                                         ^
/usr/include/c++/v1/math.h:750:46: note: 'exp' declared here
inline _LIBCPP_INLINE_VISIBILITY long double exp(long double __lcpp_x) _NOEXCEPT {return expl(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:761:91: error: use of undeclared identifier 'fabsf'; did you mean 'fabs'?
inline _LIBCPP_INLINE_VISIBILITY float       fabs(float __lcpp_x) _NOEXCEPT       {return fabsf(__lcpp_x);}
                                                                                          ^
/usr/include/c++/v1/math.h:761:46: note: 'fabs' declared here
inline _LIBCPP_INLINE_VISIBILITY float       fabs(float __lcpp_x) _NOEXCEPT       {return fabsf(__lcpp_x);}
                                             ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```