### PR TITLE
Fix for CMake 3.0 and below

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,7 +493,7 @@ file(WRITE "${PROJECT_BINARY_DIR}/try_compile_intel_atomic_primitives.c"
 ")
 try_compile(HB_HAVE_INTEL_ATOMIC_PRIMITIVES
   ${PROJECT_BINARY_DIR}/try_compile_intel_atomic_primitives
-  SOURCES ${PROJECT_BINARY_DIR}/try_compile_intel_atomic_primitives.c)
+  ${PROJECT_BINARY_DIR}/try_compile_intel_atomic_primitives.c)
 if (HB_HAVE_INTEL_ATOMIC_PRIMITIVES)
   add_definitions(-DHAVE_INTEL_ATOMIC_PRIMITIVES)
 endif ()
@@ -509,7 +509,7 @@ file(WRITE "${PROJECT_BINARY_DIR}/try_compile_solaris_atomic_ops.c"
 ")
 try_compile(HB_HAVE_SOLARIS_ATOMIC_OPS
   ${PROJECT_BINARY_DIR}/try_compile_solaris_atomic_ops
-  SOURCES ${PROJECT_BINARY_DIR}/try_compile_solaris_atomic_ops.c)
+  ${PROJECT_BINARY_DIR}/try_compile_solaris_atomic_ops.c)
 if (HB_HAVE_SOLARIS_ATOMIC_OPS)
   add_definitions(-DHAVE_SOLARIS_ATOMIC_OPS)
 endif ()


### PR DESCRIPTION
This is a trivial change that fixes compilation in CMake 2.8.

The "SOURCES" option to `try_compile` is not available in the stated minimum CMake version 2.8.  However, it is only necessary if more than once source file needs to be compiled, which isn't the case here.