### PR TITLE
Hatran script is right-to-left

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -524,6 +524,7 @@ hb_script_get_horizontal_direction (hb_script_t script)
     case HB_SCRIPT_PSALTER_PAHLAVI:
 
     /* Unicode-8.0 additions */
+    case HB_SCRIPT_HATRAN:
     case HB_SCRIPT_OLD_HUNGARIAN:
 
     /* Unicode-9.0 additions */


### PR DESCRIPTION
I just stumbled on this ancient script from Iraq. Apparently HarfBuzz thinks it's left-to-right, but it turns out:

"Hatran is written from right to left horizontally"

http://www.unicode.org/L2/L2012/12312-n4324-hatran.pdf

This script was added with Unicode 8.0.

Also this spreadsheet (referenced in an inline comment in the source code) has it as RTL: http://goo.gl/x9ilM

