### PR TITLE
Update record-test.sh to the new directory layout

### DIFF
--- a/test/shaping/README.md
+++ b/test/shaping/README.md
@@ -23,18 +23,19 @@ what this does is:
   * If the outputs differ, perhaps it is because the font does not have
     glyph names; it then compares the output of `hb-view` for both fonts.
   * If the outputs differ, recording fails.  Otherwise, it will move the
-    subset font file into `fonts/sha1sum` and name it after its hash,
-    and prints out the test case input, which you can then redirect to
-    an existing or new test file in `tests`, eg.:
+    subset font file into `data/in-house/fonts` and name it after its
+    hash, and print out the test case input, which you can then redirect
+    to an existing or new test file in `data/in-house/tests` using `-o=`,
+    e.g.:
 ```sh
-$ ./hb-unicode-encode 41 42 43 627 | ./record-test.sh ../../util/hb-shape font.ttf >> tests/test-name.test
+$ ./hb-unicode-encode 41 42 43 627 | ./record-test.sh -o=data/in-house/tests/test-name.test ../../util/hb-shape font.ttf
 ```
 
 If you created a new test file, add it to `Makefile.am` so it is run.
 Check that `make check` does indeed run it, and that the test passes.
 When everything looks good, `git add` the new font as well as new
 test file if you created any.  You can see what new files are there
-by running `git status tests fonts/sha1sum`.  And commit!
+by running `git status data/in-house`.  And commit!
 
 *Note!*  Please only add tests using Open Source fonts, preferably under
 OFL or similar license.

--- a/test/shaping/record-test.sh
+++ b/test/shaping/record-test.sh
@@ -2,6 +2,11 @@
 
 dir=`mktemp -d`
 
+out=/dev/stdout
+if test "x${1:0:3}" == 'x-o='; then
+	out=${1:3}
+	shift
+fi
 hb_shape=$1
 shift
 fontfile=$1
@@ -67,8 +72,8 @@ if ! test "x$glyphs" = "x$glyphs_subset"; then
 	echo "$text" | $hb_view $options "$dir/font.subset.ttf" --output-format=png --output-file="$dir/subset.png"
 	if ! cmp "$dir/orig.png" "$dir/subset.png"; then
 		echo "Images differ.  Please inspect $dir/*.png." >&2
-		echo "$glyphs"
-		echo "$glyphs_subset"
+		echo "$glyphs" >> "$out"
+		echo "$glyphs_subset" >> "$out"
 		exit 2
 	fi
 	echo "Yep; all good." >&2
@@ -78,7 +83,7 @@ if ! test "x$glyphs" = "x$glyphs_subset"; then
 fi
 
 sha1sum=`sha1sum "$dir/font.subset.ttf" | cut -d' ' -f1`
-subset="fonts/sha1sum/$sha1sum.ttf"
+subset="data/in-house/fonts/$sha1sum.ttf"
 mv "$dir/font.subset.ttf" "$subset"
 
 # There ought to be an easier way to do this, but it escapes me...
@@ -89,8 +94,12 @@ echo "$glyphs" > "$glyphs_file"
 # Open the "file"s
 exec 3<"$unicodes_file"
 exec 4<"$glyphs_file"
+relative_subset="$subset"
+if test "$out" != "/dev/stdout"; then
+	relative_subset="$(/usr/bin/python -c 'import os, sys; print (os.path.relpath (sys.argv[1], sys.argv[2]))' "$subset" "$(dirname "$out")")"
+fi
 while read uline <&3 && read gline <&4; do
-	echo "$subset:$options:$uline:$gline"
+	echo "$relative_subset:$options:$uline:$gline" >> "$out"
 done
 
 


### PR DESCRIPTION
Since the test directories were reorganized a week ago, record-test.sh was out of date. Maybe there should be a continuous integration test for the test framework. :)