### PR TITLE
Fix Travis build on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
         - ./autogen.sh
         - ./configure $CONFIGURE_OPTS --with-coretext
         - make
-        - make check || (cat `find -name '*.log'` && false)
+        - make check || (cat `find . -name '*.log'` && false)
 
 notifications:
   irc: "irc.freenode.org#harfbuzz"

--- a/src/check-defs.sh
+++ b/src/check-defs.sh
@@ -27,10 +27,10 @@ for def in $defs; do
 		so=$libs/lib${lib}.$suffix
 		if ! test -f "$so"; then continue; fi
 
-		EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] .' | grep -v ' _fini\>\| _init\>\| _fdata\>\| _ftext\>\| _fbss\>\| __bss_start\>\| __bss_start__\>\| __bss_end__\>\| _edata\>\| _end\>\| _bss_end__\>\| __end__\>\| __gcov_flush\>\| llvm_' | cut -d' ' -f3`"
-
 		# On mac, C symbols are prefixed with _
 		if test $suffix = dylib; then prefix="_"; fi
+
+		EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] .' | grep -v " $prefix"'\(_fini\>\|_init\>\|_fdata\>\|_ftext\>\|_fbss\>\|__bss_start\>\|__bss_start__\>\|__bss_end__\>\|_edata\>\|_end\>\|_bss_end__\>\|__end__\>\|__gcov_flush\>\|llvm_\)' | cut -d' ' -f3`"
 
 		if test -f "$so"; then
 


### PR DESCRIPTION
Travis builds on macOS have been failing lately because check-defs.sh does not fully ignore the prefix “_” when comparing symbol lists. When the test fails, Travis does not print the log, because it tries to run find with a syntax that does not work on macOS.