### PR TITLE
[ot-layout] Fix nullptr dereference.

### DIFF
--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -195,10 +195,12 @@ _hb_ot_layout_create (hb_face_t *face)
 void
 _hb_ot_layout_destroy (hb_ot_layout_t *layout)
 {
-  for (unsigned int i = 0; i < layout->gsub_lookup_count; i++)
-    layout->gsub_accels[i].fini ();
-  for (unsigned int i = 0; i < layout->gpos_lookup_count; i++)
-    layout->gpos_accels[i].fini ();
+  if (layout->gsub_accels)
+    for (unsigned int i = 0; i < layout->gsub_lookup_count; i++)
+      layout->gsub_accels[i].fini ();
+  if (layout->gpos_accels)
+    for (unsigned int i = 0; i < layout->gpos_lookup_count; i++)
+      layout->gpos_accels[i].fini ();
 
   free (layout->gsub_accels);
   free (layout->gpos_accels);


### PR DESCRIPTION
If the `calloc` for `gsub_accels` or `gpos_accels` fails, then the
unlikely branch afterwards can be taken, which frees up the
`hb_ot_layout_t`, but since those fields can now be `nullptr`, then
we don't want to dereference them.