### PR TITLE
Allow optional ZWJ in virama terminated cluster

### DIFF
--- a/src/hb-ot-shape-complex-use-machine.rl
+++ b/src/hb-ot-shape-complex-use-machine.rl
@@ -100,7 +100,7 @@ final_consonants = FAbv* FBlw* FPst* FM?;
 virama_terminated_cluster =
 	(R|CS)? (B | GB) VS?
 	consonant_modifiers
-	H
+	ZWJ?.H.ZWJ?
 ;
 standard_cluster =
 	(R|CS)? (B | GB) VS?


### PR DESCRIPTION
As discussed in https://github.com/harfbuzz/harfbuzz/issues/542
For Newa (and any Indic 3 scripts in the future) ZWJ is needed for virama terminated clusters.