### PR TITLE
Documentation for HB_GLYPH_FLAG_UNSAFE_TO_BREAK.

### DIFF
--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -71,9 +71,15 @@ typedef struct hb_glyph_info_t {
   hb_var_int_t   var2;
 } hb_glyph_info_t;
 
+/**
+ * hb_glyph_flags_t:
+ * @HB_GLYPH_FLAG_UNSAFE_TO_BREAK: If this glyph is split from the previous logical glyph
+ *                                 then both sides should be re-shaped.
+ */
 typedef enum { /*< flags >*/
   HB_GLYPH_FLAG_UNSAFE_TO_BREAK		= 0x00000001,
 
+  /*< private >*/
   HB_GLYPH_FLAG_DEFINED			= 0x00000001 /* OR of all defined flags */
 } hb_glyph_flags_t;
 


### PR DESCRIPTION
HB_GLYPH_FLAG_UNSAFE_TO_BREAK means that the glyph with this flag is somehow affected by the previous logical glyph (the previous index in the buffer if ltr and the next index if the buffer is rtl). If these two glyphs are separated by a break (line or otherwise) then the underlying text should be re-shaped on both sides up to corresponding position in the text of some glyph not marked with this flag.