### PR TITLE
Switch from using custom version.xml to using gtkdocentities.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -501,7 +501,6 @@ test/shaping/data/Makefile
 test/shaping/data/in-house/Makefile
 test/shaping/data/text-rendering-tests/Makefile
 docs/Makefile
-docs/version.xml
 ])
 
 AC_OUTPUT

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -80,8 +80,7 @@ content_files=	\
 	usermanual-hello-harfbuzz.xml \
 	usermanual-install-harfbuzz.xml \
 	usermanual-opentype-features.xml \
-	usermanual-what-is-harfbuzz.xml \
-	version.xml
+	usermanual-what-is-harfbuzz.xml
 
 # SGML files where gtk-doc abbrevations (#GtkWidget) are expanded
 # These files must be listed here *and* in content_files
@@ -101,10 +100,6 @@ endif
 
 # This includes the standard gtk-doc make rules, copied by gtkdocize.
 include $(top_srcdir)/gtk-doc.make
-
-# Other files to distribute
-# e.g. EXTRA_DIST += version.xml.in
-EXTRA_DIST += version.xml.in
 
 # Files not to distribute
 # for --rebuild-types in $(SCAN_OPTIONS), e.g. $(DOC_MODULE).types

--- a/docs/harfbuzz-docs.xml
+++ b/docs/harfbuzz-docs.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
                "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" [
   <!ENTITY % local.common.attrib "xmlns:xi  CDATA  #FIXED 'http://www.w3.org/2003/XInclude'">
-  <!ENTITY version SYSTEM "version.xml">
+  <!ENTITY % gtkdocentities SYSTEM "xml/gtkdocentities.ent">
+  %gtkdocentities;
 ]>
 <book id="index">
   <bookinfo>
@@ -53,7 +54,7 @@
   <part>
     <partinfo>
       <releaseinfo>
-        This document is for HarfBuzz &version;.
+        This document is for HarfBuzz &package_version;.
         <!--The latest version of this documentation can be found on-line at
         <ulink role="online-location" url="http://[SERVER]/libharfbuzz/index.html">http://[SERVER]/libharfbuzz/</ulink>.-->
       </releaseinfo>


### PR DESCRIPTION
`docs/xml/gtkdocentities.ent` is already created by `gtkdoc.make`
and contains the version number among other things. We can just
generate this single file and use it.