### PR TITLE
Correctly show documentation build status

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -531,7 +531,7 @@ Platform shapers (not normally needed):
 	DirectWrite:		${have_directwrite}
 
 Other features:
-	Documentation:		${have_gtk_doc}
+	Documentation:		${enable_gtk_doc}
 	GObject bindings:	${have_gobject}
 	Introspection:		${have_introspection}
 ])


### PR DESCRIPTION
Correctly show if building documentation is enabled or not in configure summary.

Fixes https://github.com/harfbuzz/harfbuzz/issues/741