### PR TITLE
Fix hb-buffer logic error

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -1933,7 +1933,7 @@ hb_buffer_diff (hb_buffer_t *buffer,
       result |= HB_BUFFER_DIFF_FLAG_CODEPOINT_MISMATCH;
     if (buf_info->cluster != ref_info->cluster)
       result |= HB_BUFFER_DIFF_FLAG_CLUSTER_MISMATCH;
-    if ((buf_info->mask & HB_GLYPH_FLAG_DEFINED) & (ref_info->mask & HB_GLYPH_FLAG_DEFINED) != (ref_info->mask & HB_GLYPH_FLAG_DEFINED))
+    if (((buf_info->mask & HB_GLYPH_FLAG_DEFINED) & (ref_info->mask & HB_GLYPH_FLAG_DEFINED)) != (ref_info->mask & HB_GLYPH_FLAG_DEFINED))
       result |= HB_BUFFER_DIFF_FLAG_GLYPH_FLAGS_MISMATCH;
     if (contains && ref_info->codepoint == dottedcircle_glyph)
       result |= HB_BUFFER_DIFF_FLAG_DOTTED_CIRCLE_PRESENT;


### PR DESCRIPTION
Clang complains about this,
https://github.com/harfbuzz/harfbuzz/commit/54e6efadd6a30587736858d3fb497ed4e5e5f252#diff-d4fe75bc0a3a13a3f3bf3e0f810de372
And this is this what it could mean I guess.

https://travis-ci.org/harfbuzz/harfbuzz/jobs/337930723#L2218