### PR TITLE
Fix symbol exporting and libstdc++ linkage of hb-subset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,17 +544,15 @@ if (UNIX OR MINGW)
   # Make symbols link locally
   link_libraries(-Bsymbolic-functions)
 
-  # Make sure we don't link to libstdc++
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Make sure we don't link to libstdc++
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
     set (CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "m") # libm
     set (CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "")
     set_target_properties(harfbuzz PROPERTIES LINKER_LANGUAGE C)
     set_target_properties(harfbuzz-subset PROPERTIES LINKER_LANGUAGE C)
-  endif ()
 
-  # No threadsafe statics as we do it ourselves
-  if (BUILD_SHARED_LIBS)
+    # No threadsafe statics as we do it ourselves
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-threadsafe-statics")
   endif ()
 endif ()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -186,6 +186,7 @@ EXTRA_DIST += harfbuzz-icu.pc.in
 
 if HAVE_GOBJECT
 lib_LTLIBRARIES += libharfbuzz-gobject.la
+libharfbuzz_gobject_la_LINK = $(libharfbuzz_la_LINK)
 libharfbuzz_gobject_la_SOURCES = $(HB_GOBJECT_sources)
 nodist_libharfbuzz_gobject_la_SOURCES = $(HB_GOBJECT_ENUM_sources)
 libharfbuzz_gobject_la_CPPFLAGS = $(libharfbuzz_la_CPPFLAGS) $(GOBJECT_CFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -136,6 +136,7 @@ pkgconfig_DATA = harfbuzz.pc
 EXTRA_DIST += harfbuzz.pc.in
 
 lib_LTLIBRARIES += libharfbuzz-subset.la
+libharfbuzz_subset_la_LINK = $(libharfbuzz_la_LINK)
 libharfbuzz_subset_la_SOURCES = $(HB_SUBSET_sources)
 libharfbuzz_subset_la_CPPFLAGS = $(libharfbuzz_la_CPPFLAGS)
 libharfbuzz_subset_la_LDFLAGS = $(libharfbuzz_la_LDFLAGS)
@@ -172,6 +173,7 @@ HBSOURCES += $(HB_ICU_sources)
 HBHEADERS += $(HB_ICU_headers)
 else
 lib_LTLIBRARIES += libharfbuzz-icu.la
+libharfbuzz_icu_la_LINK = $(libharfbuzz_la_LINK)
 libharfbuzz_icu_la_SOURCES = $(HB_ICU_sources)
 libharfbuzz_icu_la_CPPFLAGS = $(libharfbuzz_la_CPPFLAGS) $(ICU_CFLAGS)
 libharfbuzz_icu_la_LDFLAGS = $(libharfbuzz_la_LDFLAGS)

--- a/src/check-defs.sh
+++ b/src/check-defs.sh
@@ -27,7 +27,7 @@ for def in $defs; do
 		so=$libs/lib${lib}.$suffix
 		if ! test -f "$so"; then continue; fi
 
-		# On mac, C symbols are prefixed with _
+		# On macOS, C symbols are prefixed with _
 		if test $suffix = dylib; then prefix="_"; fi
 
 		EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] .' | grep -v " $prefix"'\(_fini\>\|_init\>\|_fdata\>\|_ftext\>\|_fbss\>\|__bss_start\>\|__bss_start__\>\|__bss_end__\>\|_edata\>\|_end\>\|_bss_end__\>\|__end__\>\|__gcov_flush\>\|llvm_\)' | cut -d' ' -f3`"

--- a/src/check-libstdc++.sh
+++ b/src/check-libstdc++.sh
@@ -21,16 +21,18 @@ else
 fi
 
 tested=false
-for suffix in so dylib; do
-	so=$libs/libharfbuzz.$suffix
-	if ! test -f "$so"; then continue; fi
+for soname in harfbuzz harfbuzz-icu harfbuzz-subset; do
+	for suffix in so dylib; do
+		so=$libs/lib$soname.$suffix
+		if ! test -f "$so"; then continue; fi
 
-	echo "Checking that we are not linking to libstdc++ or libc++"
-	if $LDD $so | grep 'libstdc[+][+]\|libc[+][+]'; then
-		echo "Ouch, linked to libstdc++ or libc++"
-		stat=1
-	fi
-	tested=true
+		echo "Checking that we are not linking to libstdc++ or libc++"
+		if $LDD $so | grep 'libstdc[+][+]\|libc[+][+]'; then
+			echo "Ouch, linked to libstdc++ or libc++"
+			stat=1
+		fi
+		tested=true
+	done
 done
 if ! $tested; then
 	echo "check-libstdc++.sh: libharfbuzz shared library not found; skipping test"

--- a/src/check-symbols.sh
+++ b/src/check-symbols.sh
@@ -17,24 +17,26 @@ fi
 
 echo "Checking that we are not exposing internal symbols"
 tested=false
-for suffix in so dylib; do
-	so=$libs/libharfbuzz.$suffix
-	if ! test -f "$so"; then continue; fi
+for soname in harfbuzz harfbuzz-icu harfbuzz-subset; do
+	for suffix in so dylib; do
+		so=$libs/lib$soname.$suffix
+		if ! test -f "$so"; then continue; fi
 
-	EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] .' | grep -v ' _fini\>\| _init\>\| _fdata\>\| _ftext\>\| _fbss\>\| __bss_start\>\| __bss_start__\>\| __bss_end__\>\| _edata\>\| _end\>\| _bss_end__\>\| __end__\>\| __gcov_flush\>\| ___gcov_flush\>\| llvm_\| _llvm_' | cut -d' ' -f3`"
+		EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] .' | grep -v ' _fini\>\| _init\>\| _fdata\>\| _ftext\>\| _fbss\>\| __bss_start\>\| __bss_start__\>\| __bss_end__\>\| _edata\>\| _end\>\| _bss_end__\>\| __end__\>\| __gcov_flush\>\| ___gcov_flush\>\| llvm_\| _llvm_' | cut -d' ' -f3`"
 
-	prefix=`basename "$so" | sed 's/libharfbuzz/hb/; s/-/_/g; s/[.].*//'`
+		prefix=`basename "$so" | sed 's/libharfbuzz/hb/; s/-/_/g; s/[.].*//'`
 
-	# On mac, C symbols are prefixed with _
-	if test $suffix = dylib; then prefix="_$prefix"; fi
+		# On macOS, C symbols are prefixed with _
+		if test $suffix = dylib; then prefix="_$prefix"; fi
 
-	echo "Processing $so"
-	if echo "$EXPORTED_SYMBOLS" | grep -v "^${prefix}_"; then
-		echo "Ouch, internal symbols exposed"
-		stat=1
-	fi
+		echo "Processing $so"
+		if echo "$EXPORTED_SYMBOLS" | grep -v "^${prefix}\(_\|$\)"; then
+			echo "Ouch, internal symbols exposed"
+			stat=1
+		fi
 
-	tested=true
+		tested=true
+	done
 done
 if ! $tested; then
 	echo "check-symbols.sh: no shared library found; skipping test"

--- a/src/hb-subset-glyf.cc
+++ b/src/hb-subset-glyf.cc
@@ -29,7 +29,7 @@
 #include "hb-set.h"
 #include "hb-subset-glyf.hh"
 
-bool
+HB_INTERNAL bool
 _calculate_glyf_and_loca_prime_size (const OT::glyf::accelerator_t &glyf,
                                      hb_set_t *glyph_ids,
                                      unsigned int *glyf_size /* OUT */,
@@ -55,7 +55,7 @@ _calculate_glyf_and_loca_prime_size (const OT::glyf::accelerator_t &glyf,
   return true;
 }
 
-bool
+HB_INTERNAL bool
 _write_glyf_and_loca_prime (const OT::glyf::accelerator_t &glyf,
                             const char                    *glyf_data,
                             const hb_set_t                *glyph_ids,
@@ -89,7 +89,7 @@ _write_glyf_and_loca_prime (const OT::glyf::accelerator_t &glyf,
   return true;
 }
 
-bool
+HB_INTERNAL bool
 _hb_subset_glyf_and_loca (const OT::glyf::accelerator_t  &glyf,
                           const char                     *glyf_data,
                           hb_set_t                       *glyphs_to_retain,

--- a/src/hb-subset-glyf.hh
+++ b/src/hb-subset-glyf.hh
@@ -31,7 +31,7 @@
 
 #include "hb-subset-plan.hh"
 
-bool
+HB_INTERNAL bool
 hb_subset_glyf_and_loca (hb_subset_plan_t *plan,
                          hb_face_t        *face,
                          hb_blob_t       **glyf_prime /* OUT */,

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -47,7 +47,7 @@ hb_subset_plan_new_gid_for_old_id(hb_subset_plan_t *plan,
   return false;
 }
 
-hb_set_t *
+HB_INTERNAL hb_set_t *
 glyph_ids_to_retain (hb_face_t *face,
                      hb_set_t  *codepoints)
 {

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -40,20 +40,20 @@ struct hb_subset_plan_t {
 
 typedef struct hb_subset_plan_t hb_subset_plan_t;
 
-hb_subset_plan_t *
+HB_INTERNAL hb_subset_plan_t *
 hb_subset_plan_create (hb_face_t           *face,
                        hb_subset_profile_t *profile,
                        hb_subset_input_t   *input);
 
-hb_bool_t
+HB_INTERNAL hb_bool_t
 hb_subset_plan_new_gid_for_old_id(hb_subset_plan_t *plan,
                                   hb_codepoint_t old_gid,
                                   hb_codepoint_t *new_gid /* OUT */);
 
-hb_subset_plan_t *
+HB_INTERNAL hb_subset_plan_t *
 hb_subset_plan_get_empty ();
 
-void
+HB_INTERNAL void
 hb_subset_plan_destroy (hb_subset_plan_t *plan);
 
 #endif /* HB_SUBSET_PLAN_HH */

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -108,7 +108,7 @@ hb_subset_input_destroy(hb_subset_input_t *subset_input)
 }
 
 template<typename TableType>
-hb_bool_t
+HB_INTERNAL hb_bool_t
 subset (hb_subset_plan_t *plan, hb_face_t *source, hb_face_t *dest)
 {
     OT::Sanitizer<TableType> sanitizer;

--- a/src/hb-ucdn/Makefile.am
+++ b/src/hb-ucdn/Makefile.am
@@ -4,6 +4,17 @@ noinst_LTLIBRARIES = libhb-ucdn.la
 
 include Makefile.sources
 
+if OS_WIN32
+libhb_ucdn_la_LINK = $(CXXLINK)
+else
+# Use a C linker for GCC, not C++; Don't link to libstdc++
+if HAVE_GCC
+libhb_ucdn_la_LINK = $(LINK)
+else
+libhb_ucdn_la_LINK = $(CXXLINK)
+endif
+endif
+
 libhb_ucdn_la_SOURCES = $(LIBHB_UCDN_sources)
 libhb_ucdn_la_CPPFLAGS = \
 	-I$(top_srcdir) \


### PR DESCRIPTION
Fixes #767.

TODO:
* src/check-defs.sh
* libharfbuzz_gobject_la_LINK = $(libharfbuzz_la_LINK)
* Separate -icu and -subset on CMake also.