### PR TITLE
Add a continuous builder using fswatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if (HB_HAVE_INTROSPECTION)
   set (HB_HAVE_GLIB ON)
 endif ()
 
+option(HB_DISABLE_TEST_PROGS OFF "Do not build some of the test programs, useful for continuous builds")
 option(HB_CHECK OFF "Do a configuration suitable for testing (shared library and enable all options)")
 if (HB_CHECK)
   set (BUILD_SHARED_LIBS ON)
@@ -807,17 +808,18 @@ endif ()
 
 
 ## src/ executables
-foreach (prog main test test-would-substitute test-size-params test-buffer-serialize hb-ot-tag)
-  set (prog_name ${prog})
-  if (${prog_name} STREQUAL "test")
-    # test can not be used as a valid executable name on cmake, lets special case it
-    set (prog_name test-test)
-  endif ()
-  add_executable(${prog_name} ${PROJECT_SOURCE_DIR}/src/${prog}.cc)
-  target_link_libraries(${prog_name} harfbuzz ${THIRD_PARTY_LIBS})
-endforeach ()
-set_target_properties(hb-ot-tag PROPERTIES COMPILE_FLAGS "-DMAIN")
-
+if (NOT HB_DISABLE_TEST_PROGS)
+  foreach (prog main test test-would-substitute test-size-params test-buffer-serialize hb-ot-tag)
+    set (prog_name ${prog})
+    if (${prog_name} STREQUAL "test")
+      # test can not be used as a valid executable name on cmake, lets special case it
+      set (prog_name test-test)
+    endif ()
+    add_executable(${prog_name} ${PROJECT_SOURCE_DIR}/src/${prog}.cc)
+    target_link_libraries(${prog_name} harfbuzz ${THIRD_PARTY_LIBS})
+  endforeach ()
+  set_target_properties(hb-ot-tag PROPERTIES COMPILE_FLAGS "-DMAIN")
+endif ()
 
 ## Tests
 if (UNIX OR MINGW)

--- a/src/dev-run.sh
+++ b/src/dev-run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+for cmd in cmake ninja fswatch; do
+    command -v $cmd >/dev/null 2>&1 || { echo >&2 "This script needs $cmd be installed"; exit 1; }
+done
+
+[ $# = 0 ] && echo Usage: "src/dev-run.sh [FONT-FILE] [TEXT]" && exit
+
+cmake -DHB_CHECK=ON -DHB_DISABLE_TEST_PROGS=ON -Bbuild -H. -GNinja
+ninja -Cbuild
+
+# or "fswatch -0 . -e build/ -e .git"
+find src/ | entr printf '\0' | while read -d "" event; do
+    clear
+    ninja -Cbuild
+    build/hb-shape $@
+    build/hb-view $@
+done
+
+cmake -DHB_CHECK=ON -DHB_DISABLE_TEST_PROGS=OFF -Bbuild -H. -GNinja
+ninja -Cbuild
+CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=8 ninja -Cbuild test

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (HB_HAVE_GLIB)
+if (HB_HAVE_GLIB AND NOT HB_DISABLE_TEST_PROGS)
   file (READ "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.am" MAKEFILEAM)
   extract_make_variable (TEST_PROGS ${MAKEFILEAM})
 


### PR DESCRIPTION
Have a look, uses cmake/ninja/fswatch. I guess we can add more features or anything useful to it. Also feel free to suggest anything about the naming or so.

I tested it with: `src/dev-run.sh "/Library/Fonts/Tahoma.ttf" سََََََََََلام` (don't run it from src/ folder, run it from root of the project, that perhaps should checked by the script also)

Caveat: Doesn't support space on font name and has not a trivial fix apparently other than double quoting.

https://twitter.com/ebraminio/status/965333488969965568

![b](https://user-images.githubusercontent.com/833473/36357073-3f54d44e-150e-11e8-9064-c6f5094536e5.gif)

