### PR TITLE
[aat] First dig on 'trak'

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -82,8 +82,9 @@ HB_FALLBACK_sources = \
 HB_OT_sources = \
 	hb-aat-layout.cc \
 	hb-aat-layout-common-private.hh \
-	hb-aat-layout-kerx-table.hh \
 	hb-aat-layout-morx-table.hh \
+	hb-aat-layout-kerx-table.hh \
+	hb-aat-layout-trak-table.hh \
 	hb-aat-layout-private.hh \
 	hb-ot-font.cc \
 	hb-ot-layout.cc \

--- a/src/hb-aat-layout-trak-table.hh
+++ b/src/hb-aat-layout-trak-table.hh
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2018  Google, Inc.
+ * Copyright © 2018  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Behdad Esfahbod
+ */
+
+#ifndef HB_AAT_LAYOUT_TRAK_TABLE_HH
+#define HB_AAT_LAYOUT_TRAK_TABLE_HH
+
+#include "hb-aat-layout-common-private.hh"
+#include "hb-open-type-private.hh"
+
+#define HB_AAT_TAG_trak HB_TAG('t','r','a','k')
+
+
+namespace AAT {
+
+
+struct TrackTableEntry
+{
+  inline bool sanitize (hb_sanitize_context_t *c) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this));
+  }
+
+  protected:
+  Fixed	track;	/* Track value for this record. */
+  HBUINT16	nameIndex;	/* The 'name' table index for this track */
+  HBUINT16  offset;	/* Offset from start of tracking table to per-size tracking values for this track. */
+
+  public:
+  DEFINE_SIZE_MIN (8);
+};
+
+struct TrackData
+{
+  inline bool sanitize (hb_sanitize_context_t *c) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this));
+  }
+
+  protected:
+  HBUINT16	nTracks;	/* Number of separate tracks included in this table. */
+  HBUINT16	nSizes;	/* Number of point sizes included in this table. */
+  OffsetTo<UnsizedArrayOf<Fixed>, HBUINT32> sizeTable;
+  TrackTableEntry	trackTable[VAR];	/* Array[nSizes] of size values. */
+
+  public:
+  DEFINE_SIZE_MIN (8);
+};
+
+struct trak
+{
+  static const hb_tag_t tableTag = HB_AAT_TAG_trak;
+
+  inline bool sanitize (hb_sanitize_context_t *c) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this));
+  }
+
+  protected:
+  FixedVersion<>version;		/* Version of the tracking table--currently
+					 * 0x00010000u for version 1.0. */
+  HBUINT16	format; /* Format of the tracking table */
+  OffsetTo<TrackData, HBUINT16>	horizOffset;	/* TrackData for horizontal text */
+  OffsetTo<TrackData, HBUINT16>	vertOffset;	/* TrackData for vertical text */
+  HBUINT16	reserved;	/* Reserved. Set to 0. */
+
+  public:
+  DEFINE_SIZE_MIN (12);
+};
+
+} /* namespace AAT */
+
+
+#endif /* HB_AAT_LAYOUT_TRAK_TABLE_HH */

--- a/src/hb-aat-layout.cc
+++ b/src/hb-aat-layout.cc
@@ -30,8 +30,9 @@
 #include "hb-ot-layout-gsubgpos-private.hh"
 
 #include "hb-aat-layout-private.hh"
-#include "hb-aat-layout-kerx-table.hh"
 #include "hb-aat-layout-morx-table.hh"
+#include "hb-aat-layout-kerx-table.hh"
+#include "hb-aat-layout-trak-table.hh"
 
 /*
  * mort/morx

--- a/src/hb-ot-layout-private.hh
+++ b/src/hb-ot-layout-private.hh
@@ -131,8 +131,9 @@ namespace OT {
 }
 
 namespace AAT {
-  struct kerx;
   struct morx;
+  struct kerx;
+  struct trak;
 }
 
 struct hb_ot_layout_lookup_accelerator_t
@@ -170,8 +171,9 @@ struct hb_ot_layout_t
   OT::hb_lazy_table_loader_t<struct OT::MATH> math;
   OT::hb_lazy_table_loader_t<struct OT::fvar> fvar;
   OT::hb_lazy_table_loader_t<struct OT::avar> avar;
-  OT::hb_lazy_table_loader_t<struct AAT::kerx> kerx;
   OT::hb_lazy_table_loader_t<struct AAT::morx> morx;
+  OT::hb_lazy_table_loader_t<struct AAT::kerx> kerx;
+  OT::hb_lazy_table_loader_t<struct AAT::trak> trak;
 
   unsigned int gsub_lookup_count;
   unsigned int gpos_lookup_count;


### PR DESCRIPTION
Sorry that this is not that useful and obviously is erroneous, be careful when developing it. Based on Apple's [specification](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html) and [trak.js](https://github.com/devongovett/fontkit/blob/aat-kern/src/tables/trak.js)