### PR TITLE
Use %zu format specifier for size_t to fix cross platform build

### DIFF
--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -604,7 +604,7 @@ struct cmap
                    + 12 * groups.len; // SequentialMapGroup records
     void *dest = calloc (dest_sz, 1);
     if (unlikely (!dest)) {
-      DEBUG_MSG(SUBSET, nullptr, "Unable to alloc %ld for cmap subset output", dest_sz);
+      DEBUG_MSG(SUBSET, nullptr, "Unable to alloc %zu for cmap subset output", dest_sz);
       return false;
     }
 


### PR DESCRIPTION
Fixes Chromium Android builds, compare
https://ci.chromium.org/buildbot/tryserver.chromium.android/linux_android_rel_ng/491787