### PR TITLE
Provide cmake module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -491,6 +491,7 @@ AC_CONFIG_FILES([
 Makefile
 src/Makefile
 src/hb-version.h
+src/harfbuzz-config.cmake
 src/hb-ucdn/Makefile
 util/Makefile
 test/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -154,7 +154,9 @@ pkginclude_HEADERS = $(HBHEADERS)
 nodist_pkginclude_HEADERS = $(HBNODISTHEADERS)
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = harfbuzz.pc
-EXTRA_DIST += harfbuzz.pc.in
+cmakedir = $(libdir)/cmake/harfbuzz
+cmake_DATA = harfbuzz-config.cmake
+EXTRA_DIST += harfbuzz.pc.in harfbuzz-config.cmake.in
 
 lib_LTLIBRARIES += libharfbuzz-subset.la
 libharfbuzz_subset_la_SOURCES = $(HB_SUBSET_sources)

--- a/src/harfbuzz-config.cmake.in
+++ b/src/harfbuzz-config.cmake.in
@@ -1,0 +1,9 @@
+add_library(harfbuzz::harfbuzz UNKNOWN IMPORTED)
+
+set(prefix "@prefix@")
+set(exec_prefix "@exec_prefix@")
+
+set_target_properties(harfbuzz::harfbuzz PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "@includedir@/harfbuzz"
+  IMPORTED_LOCATION "@libdir@/harfbuzz"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "harfbuzz")


### PR DESCRIPTION
Done the very bare minimum one, can be extended later for `harfbuzz-icu` `harfbuzz-gobject` and add version variables. See https://github.com/GNOME/libxml2/commit/fa23ac1a796877621a21b8470f2c491d995a5151 for example