### PR TITLE
[subset] Caclculate head table checksum adjustment

### DIFF
--- a/src/hb-ot-head-table.hh
+++ b/src/hb-ot-head-table.hh
@@ -43,6 +43,8 @@ namespace OT {
 
 struct head
 {
+  friend struct OffsetTable;
+
   static const hb_tag_t tableTag	= HB_OT_TAG_head;
 
   inline unsigned int get_upem (void) const

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -198,6 +198,8 @@ _hb_subset_face_reference_table (hb_face_t *face, hb_tag_t tag, void *user_data)
   return nullptr;
 }
 
+/* TODO: Move this to hb-face.h and rename to hb_face_builder_create()
+ * with hb_face_builder_add_table(). */
 hb_face_t *
 hb_subset_face_create (void)
 {


### PR DESCRIPTION
Test still fails, because we do not serialize tables in the same
order that fonttools subsetter does.