### PR TITLE
Add -Werror=unused-function check to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ language: cpp
 env:
   global:
     - CPPFLAGS=""
-    - CFLAGS="-Werror --coverage"
-    - CXXFLAGS="-Werror -Wno-deprecated-register --coverage" # glib uses register and clang raises a warning
+    - CFLAGS="-Werror -Werror=unused-function --coverage"
+    - CXXFLAGS="-Werror -Werror=unused-function -Wno-deprecated-register --coverage" # glib uses register and clang raises a warning
     - LDFLAGS="--coverage"
     - CONFIGURE_OPTS="--with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2"
     - NOCONFIGURE=1

--- a/src/hb-aat-layout.cc
+++ b/src/hb-aat-layout.cc
@@ -89,19 +89,19 @@ _get_trak (hb_face_t *face, hb_blob_t **blob = nullptr)
   return trak;
 }
 
-static inline void
-_hb_aat_layout_create (hb_face_t *face)
-{
-  OT::Sanitizer<AAT::morx> sanitizer;
-  sanitizer.set_num_glyphs (face->get_num_glyphs ());
-  hb_blob_t *morx_blob = sanitizer.sanitize (face->reference_table (HB_AAT_TAG_MORX));
-  OT::Sanitizer<AAT::morx>::lock_instance (morx_blob);
+// static inline void
+// _hb_aat_layout_create (hb_face_t *face)
+// {
+//   OT::Sanitizer<AAT::morx> sanitizer;
+//   sanitizer.set_num_glyphs (face->get_num_glyphs ());
+//   hb_blob_t *morx_blob = sanitizer.sanitize (face->reference_table (HB_AAT_TAG_MORX));
+//   OT::Sanitizer<AAT::morx>::lock_instance (morx_blob);
 
-  if (0)
-  {
-    OT::Sanitizer<AAT::Lookup<OT::GlyphID> >::lock_instance (morx_blob)->get_value (1, face->get_num_glyphs ());
-  }
-}
+//   if (0)
+//   {
+//     OT::Sanitizer<AAT::Lookup<OT::GlyphID> >::lock_instance (morx_blob)->get_value (1, face->get_num_glyphs ());
+//   }
+// }
 
 void
 hb_aat_layout_substitute (hb_font_t *font, hb_buffer_t *buffer)

--- a/test/api/test-set.c
+++ b/test/api/test-set.c
@@ -121,15 +121,16 @@ test_set_basic (void)
   hb_set_destroy (s);
 }
 
-static inline void
-print_set (hb_set_t *s)
-{
-  hb_codepoint_t next;
-  printf ("{");
-  for (next = HB_SET_VALUE_INVALID; hb_set_next (s, &next); )
-    printf ("%d, ", next);
-  printf ("}\n");
-}
+
+// static inline void
+// print_set (hb_set_t *s)
+// {
+//   hb_codepoint_t next;
+//   printf ("{");
+//   for (next = HB_SET_VALUE_INVALID; hb_set_next (s, &next); )
+//     printf ("%d, ", next);
+//   printf ("}\n");
+// }
 
 static void
 test_set_algebra (void)


### PR DESCRIPTION
Hopefully to fix #807, if Chromium's builders have that mercy that our strict clang bots have! (interestingly no change was needed on gcc builders even with the addition of the flag)