### PR TITLE
[COLR/CPAL] Provide enough helpers for rasterization

### DIFF
--- a/src/hb-ot-cpal-table.hh
+++ b/src/hb-ot-cpal-table.hh
@@ -42,12 +42,15 @@ namespace OT {
 
 struct ColorRecord
 {
+  friend struct CPAL;
+
   inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (true);
   }
 
+  protected:
   HBUINT8 blue;
   HBUINT8 green;
   HBUINT8 red;
@@ -74,14 +77,14 @@ struct CPALV1Tail
   inline hb_ot_color_palette_flags_t
   get_palette_flags (const void *base, unsigned int palette) const
   {
-    const HBUINT32* flags = (const HBUINT32*) (const void*) &paletteFlags (base);
+    const HBUINT32* flags = &paletteFlags (base);
     return (hb_ot_color_palette_flags_t) (uint32_t) flags[palette];
   }
 
   inline unsigned int
   get_palette_name_id (const void *base, unsigned int palette) const
   {
-    const HBUINT16* name_ids = (const HBUINT16*) (const void*) &paletteLabel (base);
+    const HBUINT16* name_ids = &paletteLabel (base);
     return name_ids[palette];
   }
 
@@ -148,9 +151,18 @@ struct CPAL
     return numPalettes;
   }
 
+  inline void get_color_record (int palette_index, uint8_t &r, uint8_t &g,
+                                              uint8_t &b, uint8_t &a) const
+  {
+    // We should check if palette_index is in range as it is not done on COLR sanitization
+    r = colorRecords[palette_index].red;
+    g = colorRecords[palette_index].green;
+    b = colorRecords[palette_index].blue;
+    a = colorRecords[palette_index].alpha;
+  }
+
   protected:
   HBUINT16	version;
-
   /* Version 0 */
   HBUINT16	numPaletteEntries;
   HBUINT16	numPalettes;


### PR DESCRIPTION
It works with something like this:

```C
  const OT::COLR &colr = _get_colr(font->face);
  const OT::CPAL &cpal = _get_cpal(font->face);

  FT_Face ftface = hb_ft_font_get_face (font);
  for (unsigned int I = 0; I < buffer->len; ++i)
  {
    hb_codepoint_t code_point = buffer->info[i].codepoint;

    FT_Load_Glyph (ftface, code_point, FT_LOAD_DEFAULT);
    FT_GlyphSlot slot = ftface->glyph;
    FT_Render_Glyph (slot, FT_RENDER_MODE_NORMAL);

    int width = slot->bitmap.width;
    int height = slot->bitmap.rows;
    int left = slot->bitmap_left;
    int top = slot->bitmap_top;

    unsigned char* image = (unsigned char*) calloc (width * height * 16, sizeof(char));

    unsigned int first_layer_index, num_layers;
    if (colr.get_base_glyph_record (code_point, first_layer_index, num_layers))
    {
      for (unsigned int j = 0; j < num_layers; ++j)
      {
        hb_codepoint_t glyph_id;
        unsigned int palette_index;
        colr.get_layer_record(first_layer_index + j, glyph_id, palette_index);

        uint8_t r, g, b, a;
        cpal.get_color_record(palette_index, r, g, b, a);

        FT_Load_Glyph(ftface, glyph_id, FT_LOAD_DEFAULT);
        FT_Render_Glyph(slot, FT_RENDER_MODE_NORMAL);

        drawBitmap(&slot->bitmap,
          slot->bitmap_left - left,
          top - slot->bitmap_top,
          image, width, height,
          r, g, b, a);
      }
    }
  }
```