### PR TITLE
CMake: hide symbols by default on non-MSVC, define export attribute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 2.8.0)
+# Allow symbol hiding for both static and shared libs.
+cmake_policy(SET CMP0063 NEW)
+
 project(harfbuzz)
 
 enable_testing()
@@ -524,23 +527,19 @@ endif ()
 
 ## Define harfbuzz library
 add_library(harfbuzz ${project_sources} ${project_extra_sources} ${project_headers})
+set_target_properties(harfbuzz PROPERTIES
+  C_VISIBILITY_PRESET hidden
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN TRUE)
 target_link_libraries(harfbuzz ${THIRD_PARTY_LIBS})
-
-if (BUILD_SHARED_LIBS)
-  if (WIN32 AND NOT MINGW)
-    add_definitions("-DHB_EXTERN=__declspec(dllexport) extern")
-  else ()
-    add_definitions("-DHB_EXTERN=__attribute__(( visibility( \"default\" ) )) extern")
-    set_target_properties(harfbuzz PROPERTIES
-      C_VISIBILITY_PRESET hidden
-      CXX_VISIBILITY_PRESET hidden
-      VISIBILITY_INLINES_HIDDEN TRUE)
-  endif ()
-endif ()
 
 ## Define harfbuzz-subset library
 add_library(harfbuzz-subset ${subset_project_sources} ${subset_project_headers})
 add_dependencies(harfbuzz-subset harfbuzz)
+set_target_properties(harfbuzz-subset PROPERTIES
+  C_VISIBILITY_PRESET hidden
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN TRUE)
 target_link_libraries(harfbuzz-subset harfbuzz ${THIRD_PARTY_LIBS})
 
 if (UNIX OR MINGW)
@@ -568,9 +567,21 @@ if (HB_HAVE_GOBJECT)
     ${hb_gobject_headers}
     ${hb_gobject_gen_headers}
   )
+  set_target_properties(harfbuzz-gobject PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN TRUE)
   include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/src)
   add_dependencies(harfbuzz-gobject harfbuzz)
   target_link_libraries(harfbuzz-gobject harfbuzz ${GOBJECT_LIBRARIES} ${THIRD_PARTY_LIBS})
+endif ()
+
+if (BUILD_SHARED_LIBS)
+  if (WIN32 AND NOT MINGW)
+    add_definitions("-DHB_EXTERN=__declspec(dllexport) extern")
+  else ()
+    add_definitions("-DHB_EXTERN=__attribute__(( visibility( \"default\" ) )) extern")
+  endif ()
 endif ()
 
 # On Windows, g-ir-scanner requires a DLL build in order for it to work

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,14 +131,6 @@ if (MSVC)
   add_definitions(-wd4244 -wd4267 -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS)
 endif ()
 
-if (BUILD_SHARED_LIBS)
-  if (WIN32 AND NOT MINGW)
-    add_definitions("-DHB_EXTERN=__declspec(dllexport) extern")
-  else ()
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
-  endif ()
-endif ()
-
 
 ## Detect if we are running inside a distribution or regular repository folder
 # if (EXISTS "${PROJECT_SOURCE_DIR}/ChangeLog")
@@ -533,6 +525,18 @@ endif ()
 ## Define harfbuzz library
 add_library(harfbuzz ${project_sources} ${project_extra_sources} ${project_headers})
 target_link_libraries(harfbuzz ${THIRD_PARTY_LIBS})
+
+if (BUILD_SHARED_LIBS)
+  if (WIN32 AND NOT MINGW)
+    add_definitions("-DHB_EXTERN=__declspec(dllexport) extern")
+  else ()
+    add_definitions("-DHB_EXTERN=__attribute__(( visibility( \"default\" ) )) extern")
+    set_target_properties(harfbuzz PROPERTIES
+      C_VISIBILITY_PRESET hidden
+      CXX_VISIBILITY_PRESET hidden
+      VISIBILITY_INLINES_HIDDEN TRUE)
+  endif ()
+endif ()
 
 ## Define harfbuzz-subset library
 add_library(harfbuzz-subset ${subset_project_sources} ${subset_project_headers})


### PR DESCRIPTION
This change makes sure that non-MSVC builds using CMake properly hide
non-exported functions.

We haven't reached symbol-parity yet though:
Autotools symbol list on my machine: https://paste.fedoraproject.org/paste/VndugIDtEGsXj~UDZJitzw
CMake build symbol list: https://paste.fedoraproject.org/paste/LmK7tRcdWAYAg-Y~BGq1Rw