### PR TITLE
Add compiler check for -Bsymbolic-functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,7 +544,11 @@ target_link_libraries(harfbuzz-subset harfbuzz ${THIRD_PARTY_LIBS})
 
 if (UNIX OR MINGW)
   # Make symbols link locally
-  link_libraries(-Bsymbolic-functions)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-Bsymbolic-functions CXX_SUPPORTS_FLAG_BSYMB_FUNCS)
+  if(CXX_SUPPORTS_FLAG_BSYMB_FUNCS)
+    link_libraries(-Bsymbolic-functions)
+  endif()  
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Make sure we don't link to libstdc++


### PR DESCRIPTION
Fix for reported issue 883 - [Build Fails on QNX](https://github.com/harfbuzz/harfbuzz/issues/883)