### PR TITLE
[dwrite] Use new again and enable the build on msys2 bots

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,11 +20,11 @@ environment:
 
 
     - compiler: msys2
-      MINGW_PREFIX: /c/msys2/mingw64/
+      MINGW_PREFIX: /mingw64
       MINGW_CHOST: x86_64-w64-mingw32
       MSYS2_ARCH: x86_64
     - compiler: msys2
-      MINGW_PREFIX: /c/msys2/mingw32/
+      MINGW_PREFIX: /mingw32
       MINGW_CHOST: i686-w64-mingw32
       MSYS2_ARCH: i686
 
@@ -44,7 +44,8 @@ build_script:
   - 'if "%compiler%"=="msvc" if not "%platform%"=="ARM" ctest --output-on-failure -C %configuration%'
 
   - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-$MSYS2_ARCH-{freetype,cairo,icu,gettext,gobject-introspection,gcc,gcc-libs,glib2,graphite2,pkg-config,python2}"'
-  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh --with-uniscribe --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2 --build=%MINGW_CHOST% --host=%MINGW_CHOST% --prefix=%MINGW_PREFIX%; make; make check || .ci/fail.sh"'
+  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "curl https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-headers/include/dwrite_1.h?format=raw > %MINGW_PREFIX%/%MINGW_CHOST%/include/dwrite_1.h"'
+  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; ./autogen.sh --with-uniscribe --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2 --with-directwrite --build=%MINGW_CHOST% --host=%MINGW_CHOST% --prefix=%MINGW_PREFIX%; make; make check || .ci/fail.sh"'
 
 cache:
   - c:\tools\vcpkg\installed\


### PR DESCRIPTION
#884 fixed most of the GCC compile issues, this enables it on msys2 bots.

<s>The way I am checking validity of headers may don't seem good. The issue is msys2 and mingw-w64 headers are not complete and I am checking that using that `#ifdef`. I proposed a fix to upstream also but that can take years to have here so I am applying this workaround.</s> this now just downloads the needed header

Also applied https://github.com/harfbuzz/harfbuzz/pull/884#discussion_r174845362 now that it doesn't have any other hb-directwrite.cc perhaps should be separated but don't know if worths to