### PR TITLE
[cmake] Don't hide symbols by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
 cmake_minimum_required(VERSION 2.8.0)
-# Allow symbol hiding for both static and shared libs.
-cmake_policy(SET CMP0063 NEW)
-
 project(harfbuzz)
 
 enable_testing()
@@ -528,8 +525,6 @@ endif ()
 ## Define harfbuzz library
 add_library(harfbuzz ${project_sources} ${project_extra_sources} ${project_headers})
 set_target_properties(harfbuzz PROPERTIES
-  C_VISIBILITY_PRESET hidden
-  CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN TRUE)
 target_link_libraries(harfbuzz ${THIRD_PARTY_LIBS})
 
@@ -537,8 +532,6 @@ target_link_libraries(harfbuzz ${THIRD_PARTY_LIBS})
 add_library(harfbuzz-subset ${subset_project_sources} ${subset_project_headers})
 add_dependencies(harfbuzz-subset harfbuzz)
 set_target_properties(harfbuzz-subset PROPERTIES
-  C_VISIBILITY_PRESET hidden
-  CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN TRUE)
 target_link_libraries(harfbuzz-subset harfbuzz ${THIRD_PARTY_LIBS})
 
@@ -568,20 +561,14 @@ if (HB_HAVE_GOBJECT)
     ${hb_gobject_gen_headers}
   )
   set_target_properties(harfbuzz-gobject PROPERTIES
-    C_VISIBILITY_PRESET hidden
-    CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN TRUE)
   include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/src)
   add_dependencies(harfbuzz-gobject harfbuzz)
   target_link_libraries(harfbuzz-gobject harfbuzz ${GOBJECT_LIBRARIES} ${THIRD_PARTY_LIBS})
 endif ()
 
-if (BUILD_SHARED_LIBS)
-  if (WIN32 AND NOT MINGW)
-    add_definitions("-DHB_EXTERN=__declspec(dllexport) extern")
-  else ()
-    add_definitions("-DHB_EXTERN=__attribute__(( visibility( \"default\" ) )) extern")
-  endif ()
+if (BUILD_SHARED_LIBS AND WIN32 AND NOT MINGW)
+  add_definitions("-DHB_EXTERN=__declspec(dllexport) extern")
 endif ()
 
 # On Windows, g-ir-scanner requires a DLL build in order for it to work


### PR DESCRIPTION
but keep use of cmake idiomatic way of making inlines hidden. Partially reverts #886 but keeps the good part.