### PR TITLE
CMake: Policy 0063 must be enabled to have hidden inline visibility on static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 2.8.0)
+cmake_policy(SET CMP0063 NEW)
+
 project(harfbuzz)
 
 enable_testing()


### PR DESCRIPTION
Tested with `cmake -E make_directory build && cmake -E chdir build cmake .. && cmake --build build --config Release` and `cmake -E remove_directory build && cmake -E make_directory build && cmake -E chdir build cmake -DBUILD_SHARED_LIBS=ON .. && cmake --build build --config Release`