### PR TITLE
[ci] Add a build only apple-gcc-4.2 i686 bot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,18 @@ jobs:
       - run: make 2>&1 | grep -v -e '^/var/folders/*' -e '^[[:space:]]*\.section' -e '^[[:space:]]*\^[[:space:]]*~*'
       - run: make check || .ci/fail.sh
 
+  macos-notest-apple-gcc-i686-4.2:
+    macos:
+      xcode: "8.3.3"
+    steps:
+      - checkout
+      - run: brew update-reset
+      - run: brew install wget pkg-config libtool ragel
+      - run: wget https://packages.macports.org/apple-gcc42/apple-gcc42-5666.3_15+universal.darwin_15.i386-x86_64.tbz2 && tar zxvf apple-gcc42-5666.3_15+universal.darwin_15.i386-x86_64.tbz2
+      - run: CPP=$PWD/opt/local/bin/i686-apple-darwin15-cpp-apple-4.2.1 CC=$PWD/opt/local/bin/i686-apple-darwin15-gcc-apple-4.2.1 CXX=$PWD/opt/local/bin/i686-apple-darwin15-g++-apple-4.2.1 ./autogen.sh
+      # Ignoring assembler complains, https://stackoverflow.com/a/39867021
+      - run: make 2>&1 | grep -v -e '^/var/folders/*' -e '^[[:space:]]*\.section' -e '^[[:space:]]*\^[[:space:]]*~*'
+
   distcheck:
     docker:
       - image: ubuntu:17.10
@@ -178,6 +190,7 @@ workflows:
     jobs:
       # macOS
       - macos-llvm-gcc-4.2
+      - macos-notest-apple-gcc-i686-4.2
 
       # both autotools and cmake
       - distcheck


### PR DESCRIPTION
Apple GCC 4.2 is somehow last of its kind as Apple was shipping this GCC build along the OS but after that migrated to llvm's clang. As a 32bit GCC 4.2 bot was needed for https://github.com/harfbuzz/harfbuzz/issues/901#issuecomment-375925315 I went for it. I checked that It reproduces the issue #901 also