### PR TITLE
[aat/ltag] Implement the table parsing

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -82,7 +82,9 @@ HB_OT_sources = \
 	hb-aat-layout.cc \
 	hb-aat-layout-common-private.hh \
 	hb-aat-layout-ankr-table.hh \
+	hb-aat-layout-fmtx-table.hh \
 	hb-aat-layout-kerx-table.hh \
+	hb-aat-layout-ltag-table.hh \
 	hb-aat-layout-morx-table.hh \
 	hb-aat-layout-trak-table.hh \
 	hb-aat-layout-private.hh \

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -31,7 +31,7 @@
 #include "hb-open-type-private.hh"
 #include "hb-aat-layout-common-private.hh"
 
-#define HB_AAT_TAG_KERX HB_TAG('k','e','r','x')
+#define HB_AAT_TAG_kerx HB_TAG('k','e','r','x')
 
 
 namespace AAT {
@@ -284,7 +284,7 @@ struct SubtableGlyphCoverageArray
 
 struct kerx
 {
-  static const hb_tag_t tableTag = HB_AAT_TAG_KERX;
+  static const hb_tag_t tableTag = HB_AAT_TAG_kerx;
 
   inline bool apply (hb_aat_apply_context_t *c, const AAT::ankr *ankr) const
   {

--- a/src/hb-aat-layout-ltag-table.hh
+++ b/src/hb-aat-layout-ltag-table.hh
@@ -22,46 +22,59 @@
  * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
  */
 
-#ifndef HB_AAT_LAYOUT_FMTX_TABLE_HH
-#define HB_AAT_LAYOUT_FMTX_TABLE_HH
+#ifndef HB_AAT_LAYOUT_LTAG_TABLE_HH
+#define HB_AAT_LAYOUT_LTAG_TABLE_HH
 
 #include "hb-aat-layout-common-private.hh"
 
-#define HB_AAT_TAG_fmtx HB_TAG('f','m','t','x')
+#define HB_AAT_TAG_ltag HB_TAG('l','t','a','g')
 
 
 namespace AAT {
 
+struct FTStringRange
+{
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this) &&
+      tag (base).sanitize (c, length));
+  }
+
+  protected:
+  OffsetTo<UnsizedArrayOf<HBUINT8> >
+		tag;	/* Offset from the start of the table to
+			   the beginning of the string */
+  HBUINT16	length;	/* String length (in bytes) */
+  public:
+  DEFINE_SIZE_STATIC (4);
+};
 
 /*
- * fmtx -- Font metrics
+ * ltag -- Language tags
  */
 
-struct fmtx
+struct ltag
 {
-  static const hb_tag_t tableTag = HB_AAT_TAG_fmtx;
+  static const hb_tag_t tableTag = HB_AAT_TAG_ltag;
 
   inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
-    return_trace (c->check_struct (this));
+    return_trace (c->check_struct (this) &&
+      tagRanges.sanitize (c, this));
   }
 
-  FixedVersion<>version;		/* Version (set to 0x00020000). */
-  HBUINT32	glyphIndex;		/* The glyph whose points represent the metrics. */
-  HBUINT8	horizontalBefore;	/* Point number for the horizontal ascent. */
-  HBUINT8	horizontalAfter;	/* Point number for the horizontal descent. */
-  HBUINT8	horizontalCaretHead;	/* Point number for the horizontal caret head. */
-  HBUINT8	horizontalCaretBase;	/* Point number for the horizontal caret base. */
-  HBUINT8	verticalBefore;		/* Point number for the vertical ascent. */
-  HBUINT8	verticalAfter;		/* Point number for the vertical descent. */
-  HBUINT8	verticalCaretHead;	/* Point number for the vertical caret head. */
-  HBUINT8	verticalCaretBase;	/* Point number for the vertical caret base. */
+  protected:
+  HBUINT32	version;/* Table version; currently 1 */
+  HBUINT32	flags;	/* Table flags; currently none defined */
+  ArrayOf<FTStringRange, HBUINT32>
+  	tagRanges;	/* Range for each tag's string */
   public:
-  DEFINE_SIZE_STATIC (16);
+  DEFINE_SIZE_ARRAY (12, tagRanges);
 };
 
 } /* namespace AAT */
 
 
-#endif /* HB_AAT_LAYOUT_FMTX_TABLE_HH */
+#endif /* HB_AAT_LAYOUT_LTAG_TABLE_HH */

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -30,7 +30,7 @@
 #include "hb-open-type-private.hh"
 #include "hb-aat-layout-common-private.hh"
 
-#define HB_AAT_TAG_MORX HB_TAG('m','o','r','x')
+#define HB_AAT_TAG_morx HB_TAG('m','o','r','x')
 
 
 namespace AAT {
@@ -677,7 +677,7 @@ struct Chain
 
 struct morx
 {
-  static const hb_tag_t tableTag = HB_AAT_TAG_MORX;
+  static const hb_tag_t tableTag = HB_AAT_TAG_morx;
 
   inline void apply (hb_aat_apply_context_t *c) const
   {

--- a/src/hb-aat-layout-trak-table.hh
+++ b/src/hb-aat-layout-trak-table.hh
@@ -31,7 +31,7 @@
 #include "hb-aat-layout-common-private.hh"
 #include "hb-open-type-private.hh"
 
-#define HB_AAT_TAG_TRAK HB_TAG('t','r','a','k')
+#define HB_AAT_TAG_trak HB_TAG('t','r','a','k')
 
 
 namespace AAT {
@@ -135,7 +135,7 @@ struct TrackData
 
 struct trak
 {
-  static const hb_tag_t tableTag = HB_AAT_TAG_TRAK;
+  static const hb_tag_t tableTag = HB_AAT_TAG_trak;
 
   inline bool sanitize (hb_sanitize_context_t *c) const
   {

--- a/src/hb-aat-layout.cc
+++ b/src/hb-aat-layout.cc
@@ -33,6 +33,7 @@
 #include "hb-aat-layout-ankr-table.hh"
 #include "hb-aat-layout-fmtx-table.hh" // Just so we compile it; unused otherwise.
 #include "hb-aat-layout-kerx-table.hh"
+#include "hb-aat-layout-ltag-table.hh" // Just so we compile it; unused otherwise.
 #include "hb-aat-layout-morx-table.hh"
 #include "hb-aat-layout-trak-table.hh"
 
@@ -111,7 +112,7 @@ _get_trak (hb_face_t *face, hb_blob_t **blob = nullptr)
 // {
 //   OT::Sanitizer<AAT::morx> sanitizer;
 //   sanitizer.set_num_glyphs (face->get_num_glyphs ());
-//   hb_blob_t *morx_blob = sanitizer.sanitize (face->reference_table (HB_AAT_TAG_MORX));
+//   hb_blob_t *morx_blob = sanitizer.sanitize (face->reference_table (HB_AAT_TAG_morx));
 //   OT::Sanitizer<AAT::morx>::lock_instance (morx_blob);
 
 //   if (0)


### PR DESCRIPTION
Related to #905. Here is the list of the fonts and their tag numbers and values, we don't need deferring tags sanitization to runtime as they are very low, 

```
1 en /Library/Fonts/Kefa.ttc
1 pl /Library/Fonts/BigCaslon.ttf
1 fa /Library/Fonts/Al Nile.ttc
1 fa /Library/Fonts/Muna.ttc
1 fa /Library/Fonts/Farah.ttc
1 fa /Library/Fonts/Diwan Kufi.ttc
1 zh-Hant /Library/Fonts/Skia.ttf
1 fa /Library/Fonts/Beirut.ttc
1 fa /Library/Fonts/Sana.ttc
1 fa /Library/Fonts/Al Tarikh.ttc
```

Which matches `ftxdumperfuser` dump results also.