### PR TITLE
Allow trailing non-numeric characters in --unicodes

### DIFF
--- a/util/options.cc
+++ b/util/options.cc
@@ -340,8 +340,10 @@ parse_unicodes (const char *name G_GNUC_UNUSED,
 
   while (s && *s)
   {
-    while (*s && strchr ("<+>{},;&#\\xXuUnNiI\n\t", *s))
+    while (*s && strchr ("<+>{},;&#\\xXuUnNiI\n\t\v\f\r ", *s))
       s++;
+    if (!*s)
+      break;
 
     errno = 0;
     hb_codepoint_t u = strtoul (s, &p, 16);


### PR DESCRIPTION
I have often removed the last code point from the argument to `--unicodes` without removing the preceding separator (e.g. `65,67` to `65,`), resulting in an error.