### PR TITLE
Actual py3 compatibility making on gen-* scripts

### DIFF
--- a/src/gen-arabic-table.py
+++ b/src/gen-arabic-table.py
@@ -9,7 +9,7 @@ if len (sys.argv) != 4:
 	print ("usage: ./gen-arabic-table.py ArabicShaping.txt UnicodeData.txt Blocks.txt", file=sys.stderr)
 	sys.exit (1)
 
-files = [file (x) for x in sys.argv[1:]]
+files = [open (x) for x in sys.argv[1:]]
 
 headers = [[files[0].readline (), files[0].readline ()], [files[2].readline (), files[2].readline ()]]
 headers.append (["UnicodeData.txt does not have a header."])
@@ -229,9 +229,7 @@ def print_shaping_table(f):
 	print (" } ligatures[%d];" % max_i)
 	print ("} ligature_table[] =")
 	print ("{")
-	keys = ligas.keys ()
-	keys.sort ()
-	for first in keys:
+	for first in sorted (ligas.keys ()):
 
 		print ("  { 0x%04Xu, {" % (first))
 		for liga in ligas[first]:

--- a/src/gen-indic-table.py
+++ b/src/gen-indic-table.py
@@ -32,7 +32,7 @@ ALLOWED_BLOCKS = [
 	'Myanmar Extended-A',
 ]
 
-files = [file (x) for x in sys.argv[1:]]
+files = [open (x) for x in sys.argv[1:]]
 
 headers = [[f.readline () for i in range (2)] for f in files]
 
@@ -133,8 +133,7 @@ what = ["INDIC_SYLLABIC_CATEGORY", "INDIC_MATRA_CATEGORY"]
 what_short = ["ISC", "IMC"]
 for i in range (2):
 	print ()
-	vv = values[i].keys ()
-	vv.sort ()
+	vv = sorted (values[i].keys ())
 	for v in vv:
 		v_no_and = v.replace ('_And_', '_')
 		if v in short[i]:
@@ -180,8 +179,7 @@ def print_block (block, start, end, data):
 	if block:
 		last_block = block
 
-uu = data.keys ()
-uu.sort ()
+uu = sorted (data.keys ())
 
 last = -100000
 num = 0
@@ -228,7 +226,7 @@ print ("hb_indic_get_categories (hb_codepoint_t u)")
 print ("{")
 print ("  switch (u >> %d)" % page_bits)
 print ("  {")
-pages = set([u>>page_bits for u in starts+ends+singles.keys()])
+pages = set ([u>>page_bits for u in starts+ends+list (singles.keys ())])
 for p in sorted(pages):
 	print ("    case 0x%0Xu:" % p)
 	for u,d in singles.items ():
@@ -249,8 +247,7 @@ print ()
 print ("#undef _")
 for i in range (2):
 	print
-	vv = values[i].keys ()
-	vv.sort ()
+	vv = sorted (values[i].keys ())
 	for v in vv:
 		print ("#undef %s_%s" %
 			(what_short[i], short[i][v]))

--- a/src/gen-use-table.py
+++ b/src/gen-use-table.py
@@ -10,7 +10,7 @@ if len (sys.argv) != 5:
 
 BLACKLISTED_BLOCKS = ["Thai", "Lao", "Tibetan"]
 
-files = [file (x) for x in sys.argv[1:]]
+files = [open (x) for x in sys.argv[1:]]
 
 headers = [[f.readline () for i in range (2)] for j,f in enumerate(files) if j != 2]
 headers.append (["UnicodeData.txt does not have a header."])
@@ -126,6 +126,11 @@ property_names = [
 	'Overstruck',
 ]
 
+try:
+	basestring
+except NameError:
+	basestring = str
+
 class PropertyValue(object):
 	def __init__(self, name_):
 		self.name = name_
@@ -135,6 +140,8 @@ class PropertyValue(object):
 		return self.name == (other if isinstance(other, basestring) else other.name)
 	def __ne__(self, other):
 		return not (self == other)
+	def __hash__(self):
+		return hash(str(self))
 
 property_values = {}
 
@@ -398,8 +405,7 @@ def print_block (block, start, end, data):
 	if block:
 		last_block = block
 
-uu = data.keys ()
-uu.sort ()
+uu = sorted (data.keys ())
 
 last = -100000
 num = 0

--- a/test/shaping/hb_test_tools.py
+++ b/test/shaping/hb_test_tools.py
@@ -514,7 +514,7 @@ class FileHelpers:
 	def open_file_or_stdin (f):
 		if f == '-':
 			return sys.stdin
-		return file (f)
+		return open (f)
 
 
 class Manifest:
@@ -533,7 +533,7 @@ class Manifest:
 		if os.path.isdir (s):
 
 			try:
-				m = file (os.path.join (s, "MANIFEST"))
+				m = open (os.path.join (s, "MANIFEST"))
 				items = [x.strip () for x in m.readlines ()]
 				for f in items:
 					for p in Manifest.read (os.path.join (s, f)):


### PR DESCRIPTION
This is tested on both py2 and py3. There is no difference between the previous version and the current on python2 but on python3 currently there is just a minor difference. This time I changed shebangs for my python3 testing. The generated files on this commit are by python2 by running this command,

`make -Cbuild/src arabic-table indic-table use-table && mv build/src/*.{cc,hh} src/`

for my out-of-tree build.