### PR TITLE
[aat] Implement gcid table parsing

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -87,6 +87,7 @@ HB_OT_sources = \
 	hb-aat-layout-morx-table.hh \
 	hb-aat-layout-trak-table.hh \
 	hb-aat-fmtx-table.hh \
+	hb-aat-gcid-table.hh \
 	hb-aat-ltag-table.hh \
 	hb-aat-layout-private.hh \
 	hb-ot-font.cc \

--- a/src/hb-aat-gcid-table.hh
+++ b/src/hb-aat-gcid-table.hh
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2018  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#ifndef HB_AAT_GCID_TABLE_HH
+#define HB_AAT_GCID_TABLE_HH
+
+#include "hb-aat-layout-common-private.hh"
+
+#define HB_AAT_TAG_gcid HB_TAG('g','c','i','d')
+
+
+namespace AAT {
+
+/*
+ * gcid -- Glyphs CIDs
+ * https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gcid.html
+ */
+
+struct gcid
+{
+  static const hb_tag_t tableTag = HB_AAT_TAG_gcid;
+
+  inline bool sanitize (hb_sanitize_context_t *c) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this) && CIDs.sanitize (c));
+  }
+
+  protected:
+  HBUINT16	version;	/* Version number (set to 0) */
+  HBUINT16	format;		/* Data format (set to 0) */
+  HBUINT32	size;		/* Size of the table, including header */
+  HBUINT16	registry;	/* The registry ID */
+  uint8_t	registryName[64];
+				/* The registry name in ASCII */
+  HBUINT16	order;		/* The order ID */
+  uint8_t	orderName[64];	/* The order name in ASCII */
+  HBUINT16	supplementVersion;
+				/* The supplement version */
+  ArrayOf<HBUINT16>
+		CIDs;		/* The CIDs for the glyphs in the font,
+				 * starting with glyph 0. If a glyph does not correspond
+				 * to a CID in the identified collection, 0xFFFF is used.
+				 * This should not exceed the number of glyphs in the font. */
+  public:
+  DEFINE_SIZE_ARRAY (144, CIDs);
+};
+
+} /* namespace AAT */
+
+
+#endif /* HB_AAT_GCID_TABLE_HH */

--- a/src/hb-aat-layout.cc
+++ b/src/hb-aat-layout.cc
@@ -36,6 +36,7 @@
 #include "hb-aat-layout-morx-table.hh"
 #include "hb-aat-layout-trak-table.hh"
 #include "hb-aat-fmtx-table.hh" // Just so we compile it; unused otherwise.
+#include "hb-aat-gcid-table.hh" // Just so we compile it; unused otherwise.
 #include "hb-aat-ltag-table.hh" // Just so we compile it; unused otherwise.
 
 /*


### PR DESCRIPTION
Fixes #914. The implementation is manually tested with Sierra's Apple Gothic, the table is removed from High Sierra however and no other macOS font has it. Unlike other implemented tables probably useful only for historical reasons :)