### PR TITLE
[aat] Implement lcar and Zapf (incomplete) tables parsing

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -88,7 +88,9 @@ HB_OT_sources = \
 	hb-aat-layout-trak-table.hh \
 	hb-aat-fmtx-table.hh \
 	hb-aat-gcid-table.hh \
+	hb-aat-lcar-table.hh \
 	hb-aat-ltag-table.hh \
+	hb-aat-zapf-table.hh \
 	hb-aat-layout-private.hh \
 	hb-ot-font.cc \
 	hb-ot-layout.cc \

--- a/src/hb-aat-layout-common-private.hh
+++ b/src/hb-aat-layout-common-private.hh
@@ -164,6 +164,12 @@ struct LookupFormat0
     return_trace (arrayZ.sanitize (c, c->num_glyphs));
   }
 
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (arrayZ.sanitize (c, c->num_glyphs, base));
+  }
+
   protected:
   HBUINT16	format;		/* Format identifier--format = 0 */
   UnsizedArrayOf<T>
@@ -171,7 +177,6 @@ struct LookupFormat0
   public:
   DEFINE_SIZE_ARRAY (2, arrayZ);
 };
-
 
 template <typename T>
 struct LookupSegmentSingle
@@ -184,6 +189,12 @@ struct LookupSegmentSingle
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && value.sanitize (c));
+  }
+
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this) && value.sanitize (c, base));
   }
 
   GlyphID	last;		/* Last GlyphID in this segment */
@@ -209,6 +220,12 @@ struct LookupFormat2
   {
     TRACE_SANITIZE (this);
     return_trace (segments.sanitize (c));
+  }
+
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (segments.sanitize (c, base));
   }
 
   protected:
@@ -268,6 +285,12 @@ struct LookupFormat4
     return_trace (segments.sanitize (c, this));
   }
 
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (segments.sanitize (c, base));
+  }
+
   protected:
   HBUINT16	format;		/* Format identifier--format = 2 */
   BinSearchArrayOf<LookupSegmentArray<T> >
@@ -287,6 +310,12 @@ struct LookupSingle
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && value.sanitize (c));
+  }
+
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this) && value.sanitize (c, base));
   }
 
   GlyphID	glyph;		/* Last GlyphID */
@@ -313,6 +342,12 @@ struct LookupFormat6
     return_trace (entries.sanitize (c));
   }
 
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (entries.sanitize (c, this));
+  }
+
   protected:
   HBUINT16	format;		/* Format identifier--format = 6 */
   BinSearchArrayOf<LookupSingle<T> >
@@ -336,6 +371,12 @@ struct LookupFormat8
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && valueArrayZ.sanitize (c, glyphCount));
+  }
+
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this) && valueArrayZ.sanitize (c, glyphCount, base));
   }
 
   protected:
@@ -375,6 +416,20 @@ struct Lookup
     case 4: return_trace (u.format4.sanitize (c));
     case 6: return_trace (u.format6.sanitize (c));
     case 8: return_trace (u.format8.sanitize (c));
+    default:return_trace (true);
+    }
+  }
+
+  inline bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    if (!u.format.sanitize (c)) return_trace (false);
+    switch (u.format) {
+    case 0: return_trace (u.format0.sanitize (c, base));
+    case 2: return_trace (u.format2.sanitize (c, base));
+    //case 4: return_trace (u.format4.sanitize (c, base)); TODO: Enable this
+    case 6: return_trace (u.format6.sanitize (c, base));
+    case 8: return_trace (u.format8.sanitize (c, base));
     default:return_trace (true);
     }
   }

--- a/src/hb-aat-layout.cc
+++ b/src/hb-aat-layout.cc
@@ -37,7 +37,9 @@
 #include "hb-aat-layout-trak-table.hh"
 #include "hb-aat-fmtx-table.hh" // Just so we compile it; unused otherwise.
 #include "hb-aat-gcid-table.hh" // Just so we compile it; unused otherwise.
+#include "hb-aat-lcar-table.hh" // Just so we compile it; unused otherwise.
 #include "hb-aat-ltag-table.hh" // Just so we compile it; unused otherwise.
+#include "hb-aat-zapf-table.hh" // Just so we compile it; unused otherwise.
 
 /*
  * morx/kerx/trak

--- a/src/hb-aat-lcar-table.hh
+++ b/src/hb-aat-lcar-table.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2018  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#ifndef HB_AAT_LCAR_TABLE_HH
+#define HB_AAT_LCAR_TABLE_HH
+
+#include "hb-aat-layout-common-private.hh"
+
+#define HB_AAT_TAG_lcar HB_TAG('l','c','a','r')
+
+
+namespace AAT {
+
+/*
+ * lcar -- Ligature caret
+ * https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6lcar.html
+ */
+
+struct lcar
+{
+  static const hb_tag_t tableTag = HB_AAT_TAG_lcar;
+
+  inline bool sanitize (hb_sanitize_context_t *c) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this) && lookup.sanitize (c, this));
+  }
+
+  protected:
+  FixedVersion<>version;	/* Version number of the ligature caret table */
+  HBUINT16	format;		/* Format of the ligature caret table. */
+  Lookup<OffsetTo<ArrayOf<HBINT16> > >
+		lookup;		/* data Lookup table associating glyphs */
+  public:
+  DEFINE_SIZE_MIN (8);
+};
+
+} /* namespace AAT */
+
+
+#endif /* HB_AAT_LCAR_TABLE_HH */

--- a/src/hb-aat-zapf-table.hh
+++ b/src/hb-aat-zapf-table.hh
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2018  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#ifndef HB_AAT_LCAR_TABLE_HH
+#define HB_AAT_LCAR_TABLE_HH
+
+#include "hb-aat-layout-common-private.hh"
+
+#define HB_AAT_TAG_Zapf HB_TAG('Z','a','p','f')
+
+
+namespace AAT {
+
+struct ZapfGlyphIdentifier
+{
+  HBUINT8	kind;	/* What kind of identifier this is */
+  HBUINT8	data[var];	/* Identifier data */
+};
+
+struct ZapfGlyphInfo
+{
+  Offset<HBUINT32>
+	groupOffset;	/* Byte offset from start of extraInfo to the GlyphGroup or
+			 * GlyphGroupOffsetArray for this glyph, or 0xFFFFFFFF if none */
+  Offset<HBUINT32>
+	featOffset;	/* Byte offset from start of extraInfo to FeatureInfo
+			 * for this glyph, or 0xFFFFFFFF if none */
+  HBUINT8	flags;
+  ArrayOf<HBUINT16, HBUINT8>
+	unicodes;	/* Unicode code points for this glyph (if any) */
+  ArrayOf<ZapfGlyphIdentifier, HBUINT16>
+	glyphIDs;	/* GlyphIdentifiers for this glyph (if any) */
+  //(UInt8	padding2[1..3]	If needed, to pad to 32-bit alignment before next GlyphInfo in the array)
+};
+
+/*
+ * Zapf -- Hermann Zapf -- contains information about the individual glyphs in the font
+ * https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6Zapf.html
+ */
+
+struct Zapf
+{
+  static const hb_tag_t tableTag = HB_AAT_TAG_Zapf;
+
+  inline bool sanitize (hb_sanitize_context_t *c) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (c->check_struct (this) && lookup.sanitize (c, this));
+  }
+
+  protected:
+  HBUINT16	version;	/* Set to 2 */
+  HBUINT16	reserved;	/* 0 */
+  Lookup<LOffsetTo<ZapfGlyphInfo> >
+		lookup;		/* Offset from start of table to start of extra info space
+				 * (added to groupOffset and featOffset in GlyphInfo) */
+  public:
+  DEFINE_SIZE_MIN (8);
+};
+
+} /* namespace AAT */
+
+
+#endif /* HB_AAT_LCAR_TABLE_HH */


### PR DESCRIPTION
Created to be closed and archived. Related to #907 #919 but is incomplete.

"src/hb-aat-layout-common-private.hh" changes was needed for both lcar and Zapf but didn't apply the changes `LookupFormat4` because it was different.