### PR TITLE
Fix build with CoreText on OS X 10.7 and earlier

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -168,6 +168,10 @@ create_ct_font (CGFontRef cg_font, CGFloat font_size)
   if (CFStringHasPrefix (cg_postscript_name, CFSTR (".SFNSText")) ||
       CFStringHasPrefix (cg_postscript_name, CFSTR (".SFNSDisplay")))
   {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1080
+# define kCTFontUIFontSystem kCTFontSystemFontType
+# define kCTFontUIFontEmphasizedSystem kCTFontEmphasizedSystemFontType
+#endif
     CTFontUIFontType font_type = kCTFontUIFontSystem;
     if (CFStringHasSuffix (cg_postscript_name, CFSTR ("-Bold")))
       font_type = kCTFontUIFontEmphasizedSystem;
@@ -206,7 +210,18 @@ create_ct_font (CGFontRef cg_font, CGFloat font_size)
       return ct_font;
   }
 
-  CFURLRef original_url = (CFURLRef)CTFontCopyAttribute(ct_font, kCTFontURLAttribute);
+  CFURLRef original_url = NULL;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+  ATSFontRef atsFont;
+  FSRef fsref;
+  OSStatus status;
+  atsFont = CTFontGetPlatformFont (ct_font, NULL);
+  status = ATSFontGetFileReference (atsFont, &fsref);
+  if (status == noErr)
+    original_url = CFURLCreateFromFSRef (NULL, &fsref);
+#else
+  original_url = (CFURLRef) CTFontCopyAttribute (ct_font, kCTFontURLAttribute);
+#endif
 
   /* Create font copy with cascade list that has LastResort first; this speeds up CoreText
    * font fallback which we don't need anyway. */
@@ -225,7 +240,15 @@ create_ct_font (CGFontRef cg_font, CGFloat font_size)
        * system locations that we cannot access from the sandboxed renderer
        * process in Blink. This can be detected by the new file URL location
        * that the newly found font points to. */
-      CFURLRef new_url = (CFURLRef) CTFontCopyAttribute (new_ct_font, kCTFontURLAttribute);
+      CFURLRef new_url = NULL;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+      atsFont = CTFontGetPlatformFont (new_ct_font, NULL);
+      status = ATSFontGetFileReference (atsFont, &fsref);
+      if (status == noErr)
+        new_url = CFURLCreateFromFSRef (NULL, &fsref);
+#else
+      new_url = (CFURLRef) CTFontCopyAttribute (new_ct_font, kCTFontURLAttribute);
+#endif
       // Keep reconfigured font if URL cannot be retrieved (seems to be the case
       // on Mac OS 10.12 Sierra), speculative fix for crbug.com/625606
       if (!original_url || !new_url || CFEqual (original_url, new_url)) {
@@ -944,6 +967,9 @@ resize_and_retry:
 
       int level = HB_DIRECTION_IS_FORWARD (buffer->props.direction) ? 0 : 1;
       CFNumberRef level_number = CFNumberCreate (kCFAllocatorDefault, kCFNumberIntType, &level);
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+      extern const CFStringRef kCTTypesetterOptionForcedEmbeddingLevel;
+#endif
       CFDictionaryRef options = CFDictionaryCreate (kCFAllocatorDefault,
 						    (const void **) &kCTTypesetterOptionForcedEmbeddingLevel,
 						    (const void **) &level_number,


### PR DESCRIPTION
Hi, I'm the maintainer of harfbuzz in MacPorts. I was recently asked to enable CoreText support for harfbuzz in MacPorts. In attempting to do so, I found that although CoreText was introduced in Mac OS X 10.5, harfbuzz's CoreText support doesn't work there:

```
hb-coretext.cc: In function “const __CTFont* create_ct_font(CGFont*, CGFloat)”:
hb-coretext.cc:171: error: “kCTFontUIFontSystem” was not declared in this scope
hb-coretext.cc:173: error: “kCTFontUIFontEmphasizedSystem” was not declared in this scope
hb-coretext.cc:209: error: “kCTFontURLAttribute” was not declared in this scope
hb-coretext.cc: In function “hb_bool_t _hb_coretext_shape(hb_shape_plan_t*, hb_font_t*, hb_buffer_t*, const hb_feature_t*, unsigned int)”:
hb-coretext.cc:948: error: “kCTTypesetterOptionForcedEmbeddingLevel” was not declared in this scope
```

According to Apple documentation, `kCTTypesetterOptionForcedEmbeddingLevel` was introduced in 10.5, so I'm not sure why on 10.5 it says it's not declared, but here is someone else's patch for that:

https://github.com/jralls/gtk-osx-build/blob/master/patches/harfbuzz-kCTTypesetterOptionForcedEmbeddingLevel-Leopard.patch

`kCTFontURLAttribute` was introduced in 10.6; I found and adapted some compatibility code I found for that.

`kCTFontUIFontSystem` and `kCTFontUIFontEmphasizedSystem` were introduced in 10.8, as new names for older constants that existed before. So on older systems, I defined these new constants to the old ones.

This builds for me now with `--with-coretext` on 10.5 and later and the test suite passes, though I wasn't sure if the tests cover the CoreText functionality.