### PR TITLE
Add pre-opentype font pages detection code

### DIFF
--- a/src/hb-ot-os2-table.hh
+++ b/src/hb-ot-os2-table.hh
@@ -125,6 +125,24 @@ struct os2
     *max_cp = max;
   }
 
+  enum font_page_t {
+    HEBREW_FONT_PAGE		= 0xB100, // Hebrew Windows 3.1 font page
+    SIMP_ARABIC_FONT_PAGE	= 0xB200, // Simplified Arabic Windows 3.1 font page
+    TRAD_ARABIC_FONT_PAGE	= 0xB300, // Traditional Arabic Windows 3.1 font page
+    OEM_ARABIC_FONT_PAGE	= 0xB400, // OEM Arabic Windows 3.1 font page
+    SIMP_FARSI_FONT_PAGE	= 0xBA00, // Simplified Farsi Windows 3.1 font page
+    TRAD_FARSI_FONT_PAGE	= 0xBB00, // Traditional Farsi Windows 3.1 font page
+    THAI_FONT_PAGE		= 0xDE00  // Thai Windows 3.1 font page
+  };
+
+  // https://github.com/Microsoft/Font-Validator/blob/520aaae/OTFontFileVal/val_OS2.cs#L644-L681
+  inline font_page_t get_font_page () const
+  {
+    if (version != 0)
+      return (font_page_t) 0;
+    return (font_page_t) (fsSelection & 0xFF00);
+  }
+
   public:
   HBUINT16	version;
 


### PR DESCRIPTION
As @khaledhosny cool finding on https://github.com/harfbuzz/harfbuzz/pull/981#issuecomment-381714131 this is the way uniscribe understands those fonts. Thanks Khaled! The patch is related to #681 issue.