### PR TITLE
Make some of implicit header uses explicit

### DIFF
--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -29,6 +29,7 @@
 
 #include "hb-open-type-private.hh"
 #include "hb-aat-layout-common-private.hh"
+#include "hb-ot-layout-common-private.hh"
 
 /*
  * morx -- Extended Glyph Metamorphosis

--- a/src/hb-aat-layout-trak-table.hh
+++ b/src/hb-aat-layout-trak-table.hh
@@ -29,6 +29,7 @@
 #define HB_AAT_LAYOUT_TRAK_TABLE_HH
 
 #include "hb-aat-layout-common-private.hh"
+#include "hb-ot-layout-private.hh"
 #include "hb-open-type-private.hh"
 
 /*

--- a/src/hb-ot-hdmx-table.hh
+++ b/src/hb-ot-hdmx-table.hh
@@ -28,6 +28,7 @@
 #define HB_OT_HDMX_TABLE_HH
 
 #include "hb-open-type-private.hh"
+#include "hb-subset-plan.hh"
 
 /*
  * hdmx -- Horizontal Device Metrics

--- a/src/hb-ot-hmtx-table.hh
+++ b/src/hb-ot-hmtx-table.hh
@@ -31,6 +31,7 @@
 #include "hb-ot-hhea-table.hh"
 #include "hb-ot-os2-table.hh"
 #include "hb-ot-var-hvar-table.hh"
+#include "hb-subset-plan.hh"
 
 /*
  * hmtx -- Horizontal Metrics

--- a/src/hb-ot-os2-table.hh
+++ b/src/hb-ot-os2-table.hh
@@ -29,6 +29,7 @@
 
 #include "hb-open-type-private.hh"
 #include "hb-ot-os2-unicode-ranges.hh"
+#include "hb-subset-plan.hh"
 
 namespace OT {
 

--- a/src/hb-ot-post-table.hh
+++ b/src/hb-ot-post-table.hh
@@ -29,6 +29,7 @@
 
 #include "hb-open-type-private.hh"
 #include "hb-dsalgs.hh"
+#include "hb-subset-plan.hh"
 
 #define HB_STRING_ARRAY_NAME format1_names
 #define HB_STRING_ARRAY_LIST "hb-ot-post-macroman.hh"


### PR DESCRIPTION
Splitted from #950 and #986 IIRC Chromium had a policy about this encouraging it,
not sure about automated way to detect and add them but for now lets have the needed
ones of them.