### PR TITLE
[subset] Do not compare ttx progress output in the tests

### DIFF
--- a/test/subset/run-tests.py
+++ b/test/subset/run-tests.py
@@ -80,6 +80,7 @@ def run_test(test, should_check_ots):
 def run_ttx(file):
 	print ("ttx %s" % file)
 	cli_args = ["ttx",
+		    "-q",
 		    "-o-",
 		    file]
 	return cmd(cli_args)


### PR DESCRIPTION
The subset test suite fails all test due to path miss matches.

The test suite log states

```
../../../util/hb-subset --font-file=.../test/subset/data/fonts/Roboto-Regular.abc.ttf --output-file=/tmp/tmpZMWZq2/Roboto-Regular.abc.def
ault.61.ttf-subset.ttf --unicodes=61
---
+++
@@ -1,4 +1,4 @@
-Dumping ".../test/subset/data/expected/basics/Roboto-Regular.abc.default.61.ttf" to "-"...
+Dumping "/tmp/tmpZMWZq2/Roboto-Regular.abc.default.61.ttf-subset.ttf" to "-"...
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.0">

ERROR: ttx for expected and actual does not match.
Test State:
  test.font_path    .../test/subset/data/fonts/Roboto-Regular.abc.ttf
  test.profile_path .../test/subset/data/profiles/default.txt
  test.unicodes     61
  expected_file     .../test/subset/data/expected/basics/Roboto-Regular.abc.default.61.ttf
```

If I'm correct, then the issue is that also ttx progress output is compared (the "Dumping ..." part) and this output contains the path of the files being compared.

This pull request fixes this issue by supplying -q (be quite; No messages will be written to stdout about what is being done.) to the command line of ttx.
