### PR TITLE
Include unistd.h independently from sys/mman.h

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -33,10 +33,11 @@
 #include "hb-debug.hh"
 #include "hb-blob-private.hh"
 
-#ifdef HAVE_SYS_MMAN_H
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */
+
+#ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */
 

--- a/test/api/test-blob.c
+++ b/test/api/test-blob.c
@@ -32,10 +32,11 @@
 
 # define TEST_MMAP 1
 
-#ifdef HAVE_SYS_MMAN_H
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */
+
+#ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */
 


### PR DESCRIPTION
Helps this compile:
CC=arm-vita-eabi-gcc CXX=arm-vita-eabi-g++ ../configure --host=arm-vita-eabi

I guess we have to deal with the not presence of unistd.h also sometime.