### PR TITLE
Verbose fail when something is wrong with hb-shape/hb-view input font file

### DIFF
--- a/util/options.cc
+++ b/util/options.cc
@@ -671,6 +671,17 @@ font_options_t::get_font (void) const
     blob = hb_blob_create_from_file (font_file);
   }
 
+  if (hb_blob_get_length (blob) == 0)
+    fail (false, "No such file or directory, or is empty");
+
+  unsigned int face_count = hb_face_count (blob);
+
+  if (face_count == 0)
+    fail (false, "Not a font file"); // most likely
+
+  if (face_index > face_count)
+    fail (false, "The requested font index wasn't available in the file");
+
   /* Create the face */
   hb_face_t *face = hb_face_create (blob, face_index);
   hb_blob_destroy (blob);


### PR DESCRIPTION
Fixes #1058 

In addition to check whether it exists or isn't empty or checks if the input file is a font, which is something not used to happen before.