### PR TITLE
Fix reading fonts from stdin

### DIFF
--- a/util/helper-cairo.cc
+++ b/util/helper-cairo.cc
@@ -89,10 +89,16 @@ helper_cairo_create_scaled_font (const font_options_t *font_opts)
       atexit (free_ft_library);
 #endif
     }
-    FT_New_Face (ft_library,
-		 font_opts->font_file,
-		 font_opts->face_index,
-		 &ft_face);
+
+    unsigned int blob_length;
+    const char *blob_data = hb_blob_get_data (font_opts->blob, &blob_length);
+
+    if (FT_New_Memory_Face (ft_library,
+			    (const FT_Byte *) blob_data,
+                            blob_length,
+			    font_opts->face_index,
+			    &ft_face))
+      fail (false, "FT_New_Memory_Face fail");
   }
   if (!ft_face)
   {

--- a/util/options.cc
+++ b/util/options.cc
@@ -643,8 +643,6 @@ font_options_t::get_font (void) const
   if (font)
     return font;
 
-  hb_blob_t *blob = nullptr;
-
   /* Create the blob */
   if (!font_file)
     fail (true, "No font file set");
@@ -663,8 +661,9 @@ font_options_t::get_font (void) const
 	      strerror (errno));
       g_string_append_len (gs, buf, ret);
     }
+    unsigned int len = gs->len;
     char *font_data = g_string_free (gs, false);
-    blob = hb_blob_create (font_data, gs->len,
+    blob = hb_blob_create (font_data, len,
 			   HB_MEMORY_MODE_WRITABLE, font_data,
 			   (hb_destroy_func_t) g_free);
   } else {

--- a/util/options.hh
+++ b/util/options.hh
@@ -455,6 +455,7 @@ struct font_options_t : option_group_t
     font_size_x = font_size_y = default_font_size;
     font_funcs = nullptr;
 
+    blob = nullptr;
     font = nullptr;
 
     add_options (parser);
@@ -471,6 +472,7 @@ struct font_options_t : option_group_t
   hb_font_t *get_font (void) const;
 
   char *font_file;
+  mutable hb_blob_t *blob;
   int face_index;
   hb_variation_t *variations;
   unsigned int num_variations;
@@ -483,7 +485,7 @@ struct font_options_t : option_group_t
   mutable double font_size_y;
   char *font_funcs;
 
-  private:
+private:
   mutable hb_font_t *font;
 };
 


### PR DESCRIPTION
Fixes #1001 

We were passing the font path directly to freetype so rendering
was broken when we are getting the font from stdin.

This fixes it by using FT_New_Memory_Face instead.

This fixes:
* build/util/hb-view /dev/stdin text < font.ttf
* build/util/hb-view - text < font.ttf
* cat font.ttf | build/util/hb-view - text

but this doesn't work on
* cat font.ttf | build/util/hb-view /dev/stdin text

Which I will try to fix separately.