### PR TITLE
Apply needed fixes of previous changes

### DIFF
--- a/util/options.cc
+++ b/util/options.cc
@@ -670,16 +670,8 @@ font_options_t::get_font (void) const
     blob = hb_blob_create_from_file (font_file);
   }
 
-  if (hb_blob_get_length (blob) == 0)
-    fail (false, "No such file or directory, or is empty");
-
-  unsigned int face_count = hb_face_count (blob);
-
-  if (face_count == 0)
-    fail (false, "Not a font file"); // most likely
-
-  if (face_index > face_count)
-    fail (false, "The requested font index wasn't available in the file");
+  if (blob == hb_blob_get_empty ())
+    fail (false, "No such file or directory");
 
   /* Create the face */
   hb_face_t *face = hb_face_create (blob, face_index);

--- a/util/options.hh
+++ b/util/options.hh
@@ -485,7 +485,7 @@ struct font_options_t : option_group_t
   mutable double font_size_y;
   char *font_funcs;
 
-private:
+  private:
   mutable hb_font_t *font;
 };
 


### PR DESCRIPTION
Fixes these TBRs [1](https://github.com/harfbuzz/harfbuzz/pull/1059#issuecomment-397912812), [2](https://github.com/harfbuzz/harfbuzz/pull/1060#discussion_r195945045)

> Humm. I'm leaning towards changing the API to return NULL if file does not exist. Or, better, check if blob == hb_blob_get_empty (), instead of checking length being zero.

So should I both check if `blob == hb_blob_get_empty ()` and NULL?

> On the creation side, obviously, make it return nil blob only on error.

So you like to change [this](https://github.com/harfbuzz/harfbuzz/blob/1.7.7/src/hb-blob.cc#L609) to NULL and check for that here?