### PR TITLE
Added caching into hb_ft_get_glyph_h_advance function.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -464,6 +464,18 @@ AM_CONDITIONAL(HAVE_CORETEXT, $have_coretext)
 
 dnl ===========================================================================
 
+AC_ARG_ENABLE(h_advance_cache,
+	[AS_HELP_STRING([--enable-h_advance_cache=@<:@yes/no@:>@],
+			[Use cache for hb_ft_get_glyph_h_advance @<:@default=no@:>@])],
+			[with_h_advance_cache=true],
+			[with_h_advance_cache=false])
+
+if $with_h_advance_cache; then
+	AC_DEFINE(USE_H_ADVANCE_CACHE, 1, [Use cache for hb_ft_get_glyph_h_advance])
+fi
+
+dnl ===========================================================================
+
 AC_CACHE_CHECK([for Intel atomic primitives], hb_cv_have_intel_atomic_primitives, [
 	hb_cv_have_intel_atomic_primitives=false
 	AC_TRY_LINK([

--- a/src/hb-cache-private.hh
+++ b/src/hb-cache-private.hh
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2012  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Behdad Esfahbod
+ */
+
+#ifndef HB_CACHE_PRIVATE_HH
+#define HB_CACHE_PRIVATE_HH
+
+#include "hb-private.hh"
+
+
+/* Implements a lock-free cache for int->int functions. */
+
+template <unsigned int key_bits, unsigned int value_bits, unsigned int cache_bits>
+struct hb_cache_t
+{
+  static_assert ((key_bits >= cache_bits), "");
+  static_assert ((key_bits + value_bits - cache_bits <= 8 * sizeof (unsigned int)), "");
+
+  inline void clear (void)
+  {
+    memset (values, 255, sizeof (values));
+  }
+
+  inline bool get (unsigned int key, unsigned int *value)
+  {
+    unsigned int k = key & ((1u<<cache_bits)-1);
+    unsigned int v = values[k];
+    if ((v >> value_bits) != (key >> cache_bits))
+      return false;
+    *value = v & ((1u<<value_bits)-1);
+    return true;
+  }
+
+  inline bool set (unsigned int key, unsigned int value)
+  {
+    if (unlikely ((key >> key_bits) || (value >> value_bits)))
+      return false; /* Overflows */
+    unsigned int k = key & ((1u<<cache_bits)-1);
+    unsigned int v = ((key>>cache_bits)<<value_bits) | value;
+    values[k] = v;
+    return true;
+  }
+
+  private:
+  unsigned int values[1u<<cache_bits];
+};
+
+typedef hb_cache_t<21, 16, 8> hb_cmap_cache_t;
+typedef hb_cache_t<16, 24, 8> hb_advance_cache_t;
+
+
+#endif /* HB_CACHE_PRIVATE_HH */

--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -34,6 +34,10 @@
 
 #include "hb-font-private.hh"
 
+#if USE_H_ADVANCE_CACHE
+#include "hb-cache-private.hh"
+#endif
+
 #include FT_ADVANCES_H
 #include FT_MULTIPLE_MASTERS_H
 #include FT_TRUETYPE_TABLES_H
@@ -65,6 +69,9 @@
 struct hb_ft_font_t
 {
   FT_Face ft_face;
+#if USE_H_ADVANCE_CACHE
+  mutable hb_advance_cache_t advance_cache;
+#endif
   int load_flags;
   bool symbol; /* Whether selected cmap is symbol cmap. */
   bool unref; /* Whether to destroy ft_face when done. */
@@ -83,7 +90,9 @@ _hb_ft_font_create (FT_Face ft_face, bool symbol, bool unref)
   ft_font->unref = unref;
 
   ft_font->load_flags = FT_LOAD_DEFAULT | FT_LOAD_NO_HINTING;
-
+#if USE_H_ADVANCE_CACHE
+  ft_font->advance_cache.clear();
+#endif
   return ft_font;
 }
 
@@ -218,8 +227,21 @@ hb_ft_get_glyph_h_advance (hb_font_t *font,
   const hb_ft_font_t *ft_font = (const hb_ft_font_t *) font_data;
   FT_Fixed v;
 
+#if USE_H_ADVANCE_CACHE
+  unsigned int cv;
+  if (ft_font->advance_cache.get(glyph, &cv) == false) {
+    if (unlikely (FT_Get_Advance (ft_font->ft_face, glyph, ft_font->load_flags, &v))) {
+      return 0;
+    } else {
+      ft_font->advance_cache.set(glyph, v);
+    }
+  } else {
+    v = cv;
+  }
+#else
   if (unlikely (FT_Get_Advance (ft_font->ft_face, glyph, ft_font->load_flags, &v)))
     return 0;
+#endif
 
   if (font->x_scale < 0)
     v = -v;


### PR DESCRIPTION
Added caching mentioned in #651. 

In our tests hb_shape time decreased from 260ms to 10ms. 

I have almost no experience with autoconf, please check if it's correct.