### PR TITLE
gen-def.py: pass headers as arguments so that msys2 can convert posix paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -836,7 +836,7 @@ if (UNIX OR MINGW)
     # generate harfbuzz.def after build completion
     string(REPLACE ";" " " space_separated_headers "${project_headers}")
     add_custom_command(TARGET harfbuzz POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E env "headers=${space_separated_headers}" python ${PROJECT_SOURCE_DIR}/src/gen-def.py ${PROJECT_BINARY_DIR}/harfbuzz.def
+      COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/src/gen-def.py ${PROJECT_BINARY_DIR}/harfbuzz.def ${space_separated_headers}
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src)
 
     add_test(NAME check-static-inits.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -834,9 +834,8 @@ set_target_properties(hb-ot-tag PROPERTIES COMPILE_FLAGS "-DMAIN")
 if (UNIX OR MINGW)
   if (BUILD_SHARED_LIBS)
     # generate harfbuzz.def after build completion
-    string(REPLACE ";" " " space_separated_headers "${project_headers}")
     add_custom_command(TARGET harfbuzz POST_BUILD
-      COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/src/gen-def.py ${PROJECT_BINARY_DIR}/harfbuzz.def ${space_separated_headers}
+      COMMAND "${PYTHON_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/src/gen-def.py ${PROJECT_BINARY_DIR}/harfbuzz.def ${project_headers}
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src)
 
     add_test(NAME check-static-inits.sh

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -277,13 +277,13 @@ endif
 check: $(DEF_FILES) # For check-symbols.sh
 CLEANFILES += $(DEF_FILES)
 harfbuzz.def: $(HBHEADERS) $(HBNODISTHEADERS)
-	$(AM_V_GEN) headers="$^" $(srcdir)/gen-def.py "$@"
+	$(AM_V_GEN) $(srcdir)/gen-def.py "$@" $^
 harfbuzz-subset.def: $(HB_SUBSET_headers)
-	$(AM_V_GEN) headers="$^" $(srcdir)/gen-def.py "$@"
+	$(AM_V_GEN) $(srcdir)/gen-def.py "$@" $^
 harfbuzz-icu.def: $(HB_ICU_headers)
-	$(AM_V_GEN) headers="$^" $(srcdir)/gen-def.py "$@"
+	$(AM_V_GEN) $(srcdir)/gen-def.py "$@" $^
 harfbuzz-gobject.def: $(HB_GOBJECT_headers)
-	$(AM_V_GEN) headers="$^" $(srcdir)/gen-def.py "$@"
+	$(AM_V_GEN) $(srcdir)/gen-def.py "$@" $^
 
 
 GENERATORS = \

--- a/src/gen-def.py
+++ b/src/gen-def.py
@@ -4,8 +4,14 @@ from __future__ import print_function, division, absolute_import
 
 import io, os, re, sys
 
+if len (sys.argv) < 3:
+	sys.exit("usage: gen-def.py harfbuzz.def hb.h [hb-blob.h hb-buffer.h ...]")
+
+output_file = sys.argv[1]
+header_paths = sys.argv[2:]
+
 headers_content = []
-for h in os.environ["headers"].split (' '):
+for h in header_paths:
 	if h.endswith (".h"):
 		with io.open (h, encoding='utf-8') as f: headers_content.append (f.read ())
 
@@ -13,7 +19,7 @@ result = """EXPORTS
 %s
 LIBRARY lib%s-0.dll""" % (
 	"\n".join (sorted (re.findall (r"^hb_\w+(?= \()", "\n".join (headers_content), re.M))),
-	sys.argv[1].replace ('.def', '')
+	output_file.replace ('.def', '')
 )
 
-with open (sys.argv[1], "w") as f: f.write (result)
+with open (output_file, "w") as f: f.write (result)


### PR DESCRIPTION
When one is not using the msys2 python to run the `gen-def.py` script, the header files that are passed in as environment variable cannot be found:

https://ci.appveyor.com/project/fonttools/ttfautohint-py/build/1.0.65/job/rkremny4jjid9nl2#L803

This is because msys2 shell and GNU make use POSIX paths (e.g. `/c/Users/clupo/...`) whereas non-msys2 python.exe uses native Windows paths (e.g. `C:\Users\clupo\...`).

Msys2 will automatically convert command line arguments (but not environment variables) from POSIX to Windows paths when calling a native win32 executable, so we need to pass the header paths as arguments instead of environment variables.

This way the gen-def.py script can support both mingw python running in an MSYS2 shell, and native win32 python.

This is required for building the embedded libttfautohint.dll (statically linked to libharfbuzz) that ships with https://github.com/fonttools/ttfautohint-py (python bindings for the ttfautohint library).

In the build environment for ttfautohint-py, we must use the regular Windows python.exe instead of the msys2 one, so the gen-def.py script should be able to run on the former as well as the latter.

Here is a build of ttfautohint-py that passes after applying the batch below:
https://ci.appveyor.com/project/fonttools/ttfautohint-py/build/1.0.68/job/ty4jqbncx04289uo