### PR TITLE
Apply reviews of hb_ot_layout_get_feature_name_ids

### DIFF
--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1134,34 +1134,32 @@ hb_ot_layout_get_feature_name_ids (hb_face_t      *face,
       feature_params.get_stylistic_set_params (feature);
     if (&ss_params != &Null (OT::FeatureParamsStylisticSet)) /* ssXX */
     {
-#define PARAM(a, A) if (a) *a = A
-      PARAM(label_id, ss_params.uiNameID);
+      if (label_id) *label_id = ss_params.uiNameID;
       // ssXX features don't have the rest
-      PARAM(tooltip_id, 0);
-      PARAM(sample_id, 0);
-      PARAM(num_named_parameters, 0);
-      PARAM(first_param_id, 0);
+      if (tooltip_id) *tooltip_id = HB_NO_NAME_ID;
+      if (sample_id) *sample_id = HB_NO_NAME_ID;
+      if (num_named_parameters) *num_named_parameters = 0;
+      if (first_param_id) *first_param_id = HB_NO_NAME_ID;
       return true;
     }
     const OT::FeatureParamsCharacterVariants& cv_params =
       feature_params.get_character_variants_params (feature);
     if (&cv_params != &Null (OT::FeatureParamsCharacterVariants)) /* cvXX */
     {
-      PARAM(label_id, cv_params.featUILableNameID);
-      PARAM(tooltip_id, cv_params.featUITooltipTextNameID);
-      PARAM(sample_id, cv_params.sampleTextNameID);
-      PARAM(num_named_parameters, cv_params.numNamedParameters);
-      PARAM(first_param_id, cv_params.firstParamUILabelNameID);
+      if (label_id) *label_id = cv_params.featUILableNameID;
+      if (tooltip_id) *tooltip_id = cv_params.featUITooltipTextNameID;
+      if (sample_id) *sample_id = cv_params.sampleTextNameID;
+      if (num_named_parameters) *num_named_parameters = cv_params.numNamedParameters;
+      if (first_param_id) *first_param_id = cv_params.firstParamUILabelNameID;
       return true;
     }
   }
 
-  PARAM(label_id, 0);
-  PARAM(tooltip_id, 0);
-  PARAM(sample_id, 0);
-  PARAM(num_named_parameters, 0);
-  PARAM(first_param_id, 0);
-#undef PARAM
+  if (label_id) *label_id = HB_NO_NAME_ID;
+  if (tooltip_id) *tooltip_id = HB_NO_NAME_ID;
+  if (sample_id) *sample_id = HB_NO_NAME_ID;
+  if (num_named_parameters) *num_named_parameters = 0;
+  if (first_param_id) *first_param_id = HB_NO_NAME_ID;
   return false;
 }
 

--- a/src/hb-ot-layout.h
+++ b/src/hb-ot-layout.h
@@ -329,6 +329,8 @@ hb_ot_layout_get_size_params (hb_face_t    *face,
 			      unsigned int *range_start,       /* OUT.  May be NULL */
 			      unsigned int *range_end          /* OUT.  May be NULL */);
 
+#define HB_NO_NAME_ID 0xFFFF
+
 HB_EXTERN hb_bool_t
 hb_ot_layout_get_feature_name_ids (hb_face_t      *face,
 				   hb_tag_t        feature,


### PR DESCRIPTION
Remained things,
* "What we want however is DEFINE_NULL_DATA for the two FeatureParams types in this change to use 0xFFFF instead of zero bytes." (If I figure out how)
* Bringing back hb_ot_layout_get_feature_characters (If someone create a test font for it)
