### PR TITLE
Guard free_static function definitions with macro

### DIFF
--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -417,7 +417,9 @@ hb_ft_get_font_h_extents (hb_font_t *font HB_UNUSED,
   return true;
 }
 
+#ifdef HB_USE_ATEXIT
 static void free_static_ft_funcs (void);
+#endif
 
 static struct hb_ft_font_funcs_lazy_loader_t : hb_font_funcs_lazy_loader_t<hb_ft_font_funcs_lazy_loader_t>
 {
@@ -682,8 +684,9 @@ hb_ft_font_create_referenced (FT_Face ft_face)
   return hb_ft_font_create (ft_face, _hb_ft_face_destroy);
 }
 
-
+#ifdef HB_USE_ATEXIT
 static void free_static_ft_library (void);
+#endif
 
 static struct hb_ft_library_lazy_loader_t : hb_lazy_loader_t<hb_remove_ptr_t<FT_Library>::value,
 							     hb_ft_library_lazy_loader_t>

--- a/src/hb-glib.cc
+++ b/src/hb-glib.cc
@@ -366,8 +366,9 @@ hb_glib_unicode_decompose_compatibility (hb_unicode_funcs_t *ufuncs HB_UNUSED,
 }
 
 
-
+#ifdef HB_USE_ATEXIT
 static void free_static_glib_funcs (void);
+#endif
 
 static struct hb_glib_unicode_funcs_lazy_loader_t : hb_unicode_funcs_lazy_loader_t<hb_glib_unicode_funcs_lazy_loader_t>
 {

--- a/src/hb-icu.cc
+++ b/src/hb-icu.cc
@@ -343,8 +343,9 @@ hb_icu_unicode_decompose_compatibility (hb_unicode_funcs_t *ufuncs HB_UNUSED,
   return utf32_len;
 }
 
-
+#ifdef HB_USE_ATEXIT
 static void free_static_icu_funcs (void);
+#endif
 
 static struct hb_icu_unicode_funcs_lazy_loader_t : hb_unicode_funcs_lazy_loader_t<hb_icu_unicode_funcs_lazy_loader_t>
 {

--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -226,8 +226,9 @@ hb_ot_get_font_v_extents (hb_font_t *font,
   return ot_font->v_metrics.has_font_extents;
 }
 
-
+#ifdef HB_USE_ATEXIT
 static void free_static_ot_funcs (void);
+#endif
 
 static struct hb_ot_font_funcs_lazy_loader_t : hb_font_funcs_lazy_loader_t<hb_ot_font_funcs_lazy_loader_t>
 {

--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -46,8 +46,10 @@
  * contains the output glyphs and their positions.
  **/
 
-
+#ifdef HB_USE_ATEXIT
 static void free_static_shaper_list (void);
+#endif
+
 static const char *nil_shaper_list[] = {nullptr};
 
 static struct hb_shaper_list_lazy_loader_t : hb_lazy_loader_t<const char *,

--- a/src/hb-shaper.cc
+++ b/src/hb-shaper.cc
@@ -35,8 +35,9 @@ static const hb_shaper_pair_t all_shapers[] = {
 #undef HB_SHAPER_IMPLEMENT
 };
 
-
+#ifdef HB_USE_ATEXIT
 static void free_static_shapers (void);
+#endif
 
 static struct hb_shapers_lazy_loader_t : hb_lazy_loader_t<const hb_shaper_pair_t,
 							  hb_shapers_lazy_loader_t>


### PR DESCRIPTION
Add HB_USE_ATEXIT macros around free_static function definitions to
avoid unused function compiler warnings/errors.