### PR TITLE
Few fixes for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,7 +574,7 @@ if (HB_HAVE_GOBJECT)
 endif ()
 
 if (BUILD_SHARED_LIBS AND WIN32 AND NOT MINGW)
-  add_definitions("-DHB_EXTERN=__declspec(dllexport) extern")
+  add_definitions("-DHB_DLL_EXPORT")
 endif ()
 
 # On Windows, g-ir-scanner requires a DLL build in order for it to work
@@ -772,6 +772,11 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/harfbuzz
   )
   if (HB_BUILD_UTILS)
+    if (WIN32 AND BUILD_SHARED_LIBS)
+      install(TARGETS harfbuzz-subset
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      )
+    endif ()
     install(TARGETS hb-view
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -39,6 +39,10 @@
 #define _POSIX_C_SOURCE 200809L
 #endif
 
+#if defined (_MSC_VER) && defined (HB_DLL_EXPORT)
+#define HB_EXTERN __declspec (dllexport) extern
+#endif
+
 #include "hb.h"
 #define HB_H_IN
 #ifdef HAVE_OT
@@ -178,8 +182,10 @@ struct _hb_alignof
 # if !defined(HB_NO_VISIBILITY) && !defined(__MINGW32__) && !defined(__CYGWIN__) && !defined(_MSC_VER) && !defined(__SUNPRO_CC)
 #  define HB_INTERNAL __attribute__((__visibility__("hidden")))
 # elif defined(__MINGW32__)
-   /* We use -export-symbols on mingw32, since it does not support visibility
-    * attribute. */
+   /* We use -export-symbols on mingw32, since it does not support visibility attributes. */
+#  define HB_INTERNAL
+# elif defined (_MSC_VER) && defined (HB_DLL_EXPORT)
+   /* We do not try to export internal symbols on Visual Studio */
 #  define HB_INTERNAL
 #else
 #  define HB_INTERNAL

--- a/test/api/test-collect-unicodes.c
+++ b/test/api/test-collect-unicodes.c
@@ -32,10 +32,11 @@ test_collect_unicodes_format4 (void)
 {
   hb_face_t *face = hb_subset_test_open_font("fonts/Roboto-Regular.abc.format4.ttf");
   hb_set_t *codepoints = hb_set_create();
+  hb_codepoint_t cp;
 
   hb_face_collect_unicodes (face, codepoints);
 
-  hb_codepoint_t cp = HB_SET_VALUE_INVALID;
+  cp = HB_SET_VALUE_INVALID;
   g_assert (hb_set_next (codepoints, &cp));
   g_assert_cmpuint (0x61, ==, cp);
   g_assert (hb_set_next (codepoints, &cp));
@@ -53,10 +54,11 @@ test_collect_unicodes_format12 (void)
 {
   hb_face_t *face = hb_subset_test_open_font("fonts/Roboto-Regular.abc.format12.ttf");
   hb_set_t *codepoints = hb_set_create();
+  hb_codepoint_t cp;
 
   hb_face_collect_unicodes (face, codepoints);
 
-  hb_codepoint_t cp = HB_SET_VALUE_INVALID;
+  cp = HB_SET_VALUE_INVALID;
   g_assert (hb_set_next (codepoints, &cp));
   g_assert_cmpuint (0x61, ==, cp);
   g_assert (hb_set_next (codepoints, &cp));
@@ -74,10 +76,11 @@ test_collect_unicodes (void)
 {
   hb_face_t *face = hb_subset_test_open_font("fonts/Roboto-Regular.abc.ttf");
   hb_set_t *codepoints = hb_set_create();
+  hb_codepoint_t cp;
 
   hb_face_collect_unicodes (face, codepoints);
 
-  hb_codepoint_t cp = HB_SET_VALUE_INVALID;
+  cp = HB_SET_VALUE_INVALID;
   g_assert (hb_set_next (codepoints, &cp));
   g_assert_cmpuint (0x61, ==, cp);
   g_assert (hb_set_next (codepoints, &cp));

--- a/test/api/test-subset-glyf.c
+++ b/test/api/test-subset-glyf.c
@@ -105,16 +105,18 @@ test_subset_glyf_with_gsub (void)
 {
   hb_face_t *face_fil = hb_subset_test_open_font ("fonts/Roboto-Regular.gsub.fil.ttf");
   hb_face_t *face_fi = hb_subset_test_open_font ("fonts/Roboto-Regular.gsub.fi.ttf");
+  hb_subset_input_t *input;
+  hb_face_t *face_subset;
 
   hb_set_t *codepoints = hb_set_create();
   hb_set_add (codepoints, 102); // f
   hb_set_add (codepoints, 105); // i
 
-  hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
+  input = hb_subset_test_create_input (codepoints);
   hb_set_destroy (codepoints);
   hb_subset_input_set_drop_layout (input, false);
 
-  hb_face_t *face_subset = hb_subset_test_create_subset (face_fil, input);
+  face_subset = hb_subset_test_create_subset (face_fil, input);
 
   hb_subset_test_check (face_fi, face_subset, HB_TAG ('g','l','y','f'));
   hb_subset_test_check (face_fi, face_subset, HB_TAG ('l','o','c', 'a'));
@@ -130,16 +132,18 @@ test_subset_glyf_without_gsub (void)
 {
   hb_face_t *face_fil = hb_subset_test_open_font ("fonts/Roboto-Regular.gsub.fil.ttf");
   hb_face_t *face_fi = hb_subset_test_open_font ("fonts/Roboto-Regular.nogsub.fi.ttf");
+  hb_subset_input_t *input;
+  hb_face_t *face_subset;
 
   hb_set_t *codepoints = hb_set_create();
   hb_set_add (codepoints, 102); // f
   hb_set_add (codepoints, 105); // i
 
-  hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
+  input = hb_subset_test_create_input (codepoints);
   hb_set_destroy (codepoints);
   hb_subset_input_set_drop_layout (input, true);
 
-  hb_face_t *face_subset = hb_subset_test_create_subset (face_fil, input);
+  face_subset = hb_subset_test_create_subset (face_fil, input);
 
   hb_subset_test_check (face_fi, face_subset, HB_TAG ('g','l','y','f'));
   hb_subset_test_check (face_fi, face_subset, HB_TAG ('l','o','c', 'a'));
@@ -233,16 +237,19 @@ test_subset_glyf_strip_hints_invalid (void)
     '3', '@', '_', '%', '&', ')', '*', '$', '!'
   };
   unsigned int i;
+  hb_subset_input_t *input;
+  hb_face_t *face_subset;
+
   for (i = 0; i < sizeof (text) / sizeof (hb_codepoint_t); i++)
   {
     hb_set_add (codepoints, text[i]);
   }
 
-  hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
+  input = hb_subset_test_create_input (codepoints);
   hb_subset_input_set_drop_hints (input, true);
   hb_set_destroy (codepoints);
 
-  hb_face_t *face_subset = hb_subset_test_create_subset (face, input);
+  face_subset = hb_subset_test_create_subset (face, input);
   g_assert (face_subset);
   g_assert (face_subset == hb_face_get_empty ());
 

--- a/test/api/test-subset-hdmx.c
+++ b/test/api/test-subset-hdmx.c
@@ -76,11 +76,13 @@ test_subset_hdmx_invalid (void)
 
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
   hb_set_t *codepoints = hb_subset_input_unicode_set (input);
+  hb_face_t *subset;
+
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'b');
   hb_set_add (codepoints, 'c');
 
-  hb_face_t *subset = hb_subset (face, input);
+  subset = hb_subset (face, input);
   g_assert (subset);
   g_assert (subset == hb_face_get_empty ());
 
@@ -96,11 +98,13 @@ test_subset_hdmx_fails_sanitize (void)
 
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
   hb_set_t *codepoints = hb_subset_input_unicode_set (input);
+  hb_face_t *subset;
+
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'b');
   hb_set_add (codepoints, 'c');
 
-  hb_face_t *subset = hb_subset (face, input);
+  subset = hb_subset (face, input);
   g_assert (subset);
   g_assert (subset == hb_face_get_empty ());
 

--- a/test/api/test-subset-hmtx.c
+++ b/test/api/test-subset-hmtx.c
@@ -154,6 +154,7 @@ static void
 test_subset_invalid_hmtx (void)
 {
   hb_face_t *face = hb_subset_test_open_font("fonts/crash-e4e0bb1458a91b692eba492c907ae1f94e635480");
+  hb_face_t *subset;
 
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
   hb_set_t *codepoints = hb_subset_input_unicode_set (input);
@@ -161,7 +162,7 @@ test_subset_invalid_hmtx (void)
   hb_set_add (codepoints, 'b');
   hb_set_add (codepoints, 'c');
 
-  hb_face_t *subset = hb_subset (face, input);
+  subset = hb_subset (face, input);
   g_assert (subset);
   g_assert (subset == hb_face_get_empty ());
 

--- a/test/api/test-subset-post.c
+++ b/test/api/test-subset-post.c
@@ -34,11 +34,12 @@ test_post_drops_glyph_names (void)
 {
   hb_face_t *face_full = hb_subset_test_open_font ("fonts/Mplus1p-Regular.660E,6975,73E0,5EA6,8F38,6E05.ttf");
   hb_face_t *face_subset = hb_subset_test_open_font ("fonts/Mplus1p-Regular.660E.ttf");
+  hb_face_t *face_full_subset;
 
   hb_set_t *codepoints = hb_set_create ();
   hb_set_add (codepoints, 0x660E);
 
-  hb_face_t *face_full_subset = hb_subset_test_create_subset (face_full, hb_subset_test_create_input (codepoints));
+  face_full_subset = hb_subset_test_create_subset (face_full, hb_subset_test_create_input (codepoints));
   hb_set_destroy (codepoints);
 
   hb_subset_test_check (face_subset, face_full_subset, HB_TAG ('p','o','s','t'));

--- a/test/api/test-subset-vmtx.c
+++ b/test/api/test-subset-vmtx.c
@@ -48,11 +48,12 @@ test_subset_vmtx_simple_subset (void)
 {
   hb_face_t *face_full = hb_subset_test_open_font ("fonts/Mplus1p-Regular.660E,6975,73E0,5EA6,8F38,6E05.ttf");
   hb_face_t *face_subset = hb_subset_test_open_font ("fonts/Mplus1p-Regular.660E.ttf");
+  hb_face_t *face_full_subset;
 
   hb_set_t *codepoints = hb_set_create ();
   hb_set_add (codepoints, 0x660E);
 
-  hb_face_t *face_full_subset = hb_subset_test_create_subset (face_full, hb_subset_test_create_input (codepoints));
+  face_full_subset = hb_subset_test_create_subset (face_full, hb_subset_test_create_input (codepoints));
   hb_set_destroy (codepoints);
 
   check_num_vmetrics(face_full_subset, 1); /* nothing has same width */
@@ -67,6 +68,7 @@ static void
 test_subset_vmtx_noop (void)
 {
   hb_face_t *face_full = hb_subset_test_open_font ("fonts/Mplus1p-Regular.660E,6975,73E0,5EA6,8F38,6E05.ttf");
+  hb_face_t *face_full_subset;
 
   hb_set_t *codepoints = hb_set_create();
   hb_set_add (codepoints, 0x660E);
@@ -75,7 +77,7 @@ test_subset_vmtx_noop (void)
   hb_set_add (codepoints, 0x5EA6);
   hb_set_add (codepoints, 0x8F38);
   hb_set_add (codepoints, 0x6E05);
-  hb_face_t *face_full_subset = hb_subset_test_create_subset (face_full, hb_subset_test_create_input (codepoints));
+  face_full_subset = hb_subset_test_create_subset (face_full, hb_subset_test_create_input (codepoints));
   hb_set_destroy (codepoints);
 
   check_num_vmetrics(face_full_subset, 1); /* all have the same width */

--- a/test/api/test-subset.c
+++ b/test/api/test-subset.c
@@ -36,11 +36,13 @@ test_subset_32_tables (void)
 
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
   hb_set_t *codepoints = hb_subset_input_unicode_set (input);
+  hb_face_t *subset;
+
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'b');
   hb_set_add (codepoints, 'c');
 
-  hb_face_t *subset = hb_subset (face, input);
+  subset = hb_subset (face, input);
   g_assert (subset);
   g_assert (subset != hb_face_get_empty ());
 
@@ -56,11 +58,13 @@ test_subset_no_inf_loop (void)
 
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
   hb_set_t *codepoints = hb_subset_input_unicode_set (input);
+  hb_face_t *subset;
+
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'b');
   hb_set_add (codepoints, 'c');
 
-  hb_face_t *subset = hb_subset (face, input);
+  subset = hb_subset (face, input);
   g_assert (subset);
   g_assert (subset == hb_face_get_empty ());
 
@@ -76,11 +80,13 @@ test_subset_crash (void)
 
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
   hb_set_t *codepoints = hb_subset_input_unicode_set (input);
+  hb_face_t *subset;
+
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'b');
   hb_set_add (codepoints, 'c');
 
-  hb_face_t *subset = hb_subset (face, input);
+  subset = hb_subset (face, input);
   g_assert (subset);
   g_assert (subset == hb_face_get_empty ());
 


### PR DESCRIPTION
Hi,

There are some fixes that are needed for Visual Studio builds when:
-We are building the tools and we are building HarfBuzz as a DLL, as Visual Studio does not support GCC visibility attributes as well.
-Building the test-subset* sources on older Visual Studio, as some variables are not at the top of the block.

This PR is for the fixes that are needed.

With blessings, thank you!