### PR TITLE
Do not enforce a native direction of RTL for Old Hungarian

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -531,7 +531,6 @@ hb_script_get_horizontal_direction (hb_script_t script)
 
     /* Unicode-8.0 additions */
     case HB_SCRIPT_HATRAN:
-    case HB_SCRIPT_OLD_HUNGARIAN:
 
     /* Unicode-9.0 additions */
     case HB_SCRIPT_ADLAM:
@@ -545,6 +544,7 @@ hb_script_get_horizontal_direction (hb_script_t script)
 
 
     /* https://github.com/harfbuzz/harfbuzz/issues/1000 */
+    case HB_SCRIPT_OLD_HUNGARIAN:
     case HB_SCRIPT_OLD_ITALIC:
     case HB_SCRIPT_RUNIC:
 


### PR DESCRIPTION
Old Hungarian, like Runic, can be written in either direction and often ligates letters.