### PR TITLE
[test] Fix printing subprocess error messages

### DIFF
--- a/test/shaping/run-tests.py
+++ b/test/shaping/run-tests.py
@@ -9,7 +9,7 @@ def cmd(command):
 	p = subprocess.Popen (
 		command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 	p.wait ()
-	print (p.stderr.read (), end="") # file=sys.stderr
+	print (p.stderr.read ().decode ("utf-8").strip ()) # file=sys.stderr
 	return p.stdout.read ().decode ("utf-8").strip (), p.returncode
 
 


### PR DESCRIPTION
Decode the string as Python 3 returns bytes string, and also don’t assume that it ends with a new line.