### PR TITLE
src/hb-blob.cc: Fix mmap functionality with UWP.

### DIFF
--- a/src/hb.hh
+++ b/src/hb.hh
@@ -237,7 +237,9 @@ struct _hb_alignof
 #    undef _WIN32_WINNT
 #  endif
 #  ifndef _WIN32_WINNT
-#    define _WIN32_WINNT 0x0600
+#    if !defined(WINAPI_FAMILY) || !(WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+#      define _WIN32_WINNT 0x0600
+#    endif
 #  endif
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN 1


### PR DESCRIPTION
CreateFileW, GetFileSize, CreateFileMapping, MapViewOfFile are not available with UWP builds.
This patch adds in their UWP counterparts.

hb.hh was also slightly modified as when compiling UWP, setting _WIN32_WINNT to an earlier windows version prevents certain UWP functions from being exposed. There are different SDKs for each targeted windows WinRT/UWP version so _WIN32_WINNT  should not be set.