### PR TITLE
CoreText: fix iOS build

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -210,7 +210,7 @@ create_ct_font (CGFontRef cg_font, CGFloat font_size)
   }
 
   CFURLRef original_url = nullptr;
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+#if !TARGET_OS_IPHONE && MAC_OS_X_VERSION_MIN_REQUIRED < 1060
   ATSFontRef atsFont;
   FSRef fsref;
   OSStatus status;
@@ -240,7 +240,7 @@ create_ct_font (CGFontRef cg_font, CGFloat font_size)
        * process in Blink. This can be detected by the new file URL location
        * that the newly found font points to. */
       CFURLRef new_url = nullptr;
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+#if !TARGET_OS_IPHONE && MAC_OS_X_VERSION_MIN_REQUIRED < 1060
       atsFont = CTFontGetPlatformFont (new_ct_font, NULL);
       status = ATSFontGetFileReference (atsFont, &fsref);
       if (status == noErr)


### PR DESCRIPTION
1.7.6 builds fine for iOS (cross-compilation on macOS).
1.7.7 version introduced a new call to CoreText 'CTFontGetPlatformFont' in file src/hb-coretext.cc
This function 'CTFontGetPlatformFont' is not available on iOS (only on macOS):
https://developer.apple.com/documentation/coretext/1510544-ctfontgetplatformfont

From 1.7.7 to 1.9.0, harfbuzz can not be build for iOS for this reason.
The commit based on 1.9.0 version goes back to old code path of the 1.7.6 :
Is it the right way to fix the iOS build ?

For your information, we have also a patch to support arm64 architecture on iOS in our build environment:
```--- config.sub	2014-11-03 15:12:46.000000000 +0100
+++ config.sub	2014-11-03 15:11:32.000000000 +0100
@@ -253,7 +253,7 @@
 	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
 	| am33_2.0 \
 	| arc | arceb \
-	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm] \
+	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm]  | arm64 \
 	| avr | avr32 \
 	| be32 | be64 \
 	| bfin \
@@ -367,7 +367,7 @@
 	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
 	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
 	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
+	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* | arm64-* \
 	| avr-* | avr32-* \
 	| be32-* | be64-* \
 	| bfin-* | bs2000-* \```

Command line used to build in our build environment:
```CPPFLAGS='-arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk -miphoneos-version-min=7.0 -O2'
LD=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld
PKG_CONFIG_LIBDIR=/Users/jbnoel/devel/.sx/iosframeworks/arm64/lib/pkgconfig
LDFLAGS='-arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk'
CC=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
PKG_CONFIG_DIR=''
RANLIB=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib
CXXFLAGS='-arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk -miphoneos-version-min=7.0 -O2 -stdlib=libc++'
CXX=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
AS=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/as
AR=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar
LIBTOOL=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool
CFLAGS='-arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk -miphoneos-version-min=7.0 -O2'
STRIP=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip
PKG_CONFIG_PATH='' NM=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/nm

./configure --with-freetype=yes --with-glib=no --enable-shared=no --enable-static=yes --bindir=/tmp/build/useless/arm64/bin --datarootdir=/tmp/build/useless/arm64/share --with-icu=no --with-cairo=no --with-gobject=no --with-coretext --build=x86_64 --host=arm64-apple-darwin --prefix=/Users/jbnoel/devel/.sx/pacman-builds/arm64-swift_4.1.2-ios-xcode9/harfbuzz/pkg/harfbuzz

make -j8```