### PR TITLE
Fix iOS builds

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -210,7 +210,7 @@ create_ct_font (CGFontRef cg_font, CGFloat font_size)
   }
 
   CFURLRef original_url = nullptr;
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+#if !TARGET_OS_IPHONE && MAC_OS_X_VERSION_MIN_REQUIRED < 1060
   ATSFontRef atsFont;
   FSRef fsref;
   OSStatus status;
@@ -240,7 +240,7 @@ create_ct_font (CGFontRef cg_font, CGFloat font_size)
        * process in Blink. This can be detected by the new file URL location
        * that the newly found font points to. */
       CFURLRef new_url = nullptr;
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+#if !TARGET_OS_IPHONE && MAC_OS_X_VERSION_MIN_REQUIRED < 1060
       atsFont = CTFontGetPlatformFont (new_ct_font, NULL);
       status = ATSFontGetFileReference (atsFont, &fsref);
       if (status == noErr)


### PR DESCRIPTION
Some of the older macOS CoreText code does not work with the current iOS SDKs, and since I believe `MAC_OS_X_VERSION_MIN_REQUIRED` evaluates to 0 on an iOS build, it falls into the older code rather than using the newer APIs. Thanks!