### PR TITLE
Fix test-multithread build on FreeBSD

### DIFF
--- a/test/api/test-multithread.c
+++ b/test/api/test-multithread.c
@@ -37,6 +37,8 @@ static const char *text = "طرح‌نَما";
 static const char *path =
 #if defined(__linux__)
 		"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+#elif defined(__FreeBSD__)
+		"/usr/local/share/fonts/dejavu/DejaVuSans.ttf";
 #elif defined(_WIN32) || defined(_WIN64)
 		"C:\\Windows\\Fonts\\tahoma.ttf";
 #elif __APPLE__


### PR DESCRIPTION
Add the default font path used by FreeBSD ports.

This fixes compilation error on FreeBSD:
```
  CC       test_multithread-test-multithread.o
/home/lantw44/gnome/source/harfbuzz/test/api/test-multithread.c:46:1: error: expected expression
static int num_threads = 30;
^
/home/lantw44/gnome/source/harfbuzz/test/api/test-multithread.c:108:32: error: use of undeclared identifier 'num_threads'
  pthread_t *threads = calloc (num_threads, sizeof (pthread_t));
                               ^
/home/lantw44/gnome/source/harfbuzz/test/api/test-multithread.c:109:35: error: use of undeclared identifier 'num_threads'
  hb_buffer_t **buffers = calloc (num_threads, sizeof (hb_buffer_t *));
                                  ^
/home/lantw44/gnome/source/harfbuzz/test/api/test-multithread.c:113:19: error: use of undeclared identifier 'num_threads'
  for (i = 0; i < num_threads; i++)
                  ^
/home/lantw44/gnome/source/harfbuzz/test/api/test-multithread.c:123:19: error: use of undeclared identifier 'num_threads'
  for (i = 0; i < num_threads; i++)
                  ^
/home/lantw44/gnome/source/harfbuzz/test/api/test-multithread.c:137:5: error: use of undeclared identifier 'num_threads'
    num_threads = atoi (argv[1]);
    ^
6 errors generated.
```

I am not sure whether this is the best fix. The path of the font can be changed by the user, and this test will still be broken for other operating systems such as OpenBSD.