### PR TITLE
[morx] Only insert glyphs at mark when a mark has been set before

### DIFF
--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -592,6 +592,7 @@ struct InsertionSubtable
 			     hb_aat_apply_context_t *c_) :
 	ret (false),
 	c (c_),
+	mark_set (false),
 	mark (0),
 	insertionAction (table+table->insertionAction) {}
 
@@ -607,7 +608,7 @@ struct InsertionSubtable
       hb_buffer_t *buffer = driver->buffer;
       unsigned int flags = entry->flags;
 
-      if (entry->data.markedInsertIndex != 0xFFFF)
+      if (entry->data.markedInsertIndex != 0xFFFF && mark_set)
       {
 	unsigned int count = (flags & MarkedInsertCount);
 	unsigned int start = entry->data.markedInsertIndex;
@@ -668,7 +669,10 @@ struct InsertionSubtable
       }
 
       if (flags & SetMark)
+      {
+	mark_set = true;
 	mark = buffer->out_len;
+      }
 
       return true;
     }
@@ -677,6 +681,7 @@ struct InsertionSubtable
     bool ret;
     private:
     hb_aat_apply_context_t *c;
+    bool mark_set;
     unsigned int mark;
     const UnsizedArrayOf<GlyphID> &insertionAction;
   };


### PR DESCRIPTION
This reverts commit f4072e8cb81072cd6d51a2607efedb76c02e7db1.
https://github.com/harfbuzz/harfbuzz/issues/1195