### PR TITLE
Cosmetic and minor changes

### DIFF
--- a/src/hb-buffer-serialize.cc
+++ b/src/hb-buffer-serialize.cc
@@ -440,8 +440,8 @@ hb_bool_t
 hb_buffer_deserialize_glyphs (hb_buffer_t *buffer,
 			      const char *buf,
 			      int buf_len, /* -1 means nul-terminated */
-			      const char **end_ptr, /* May be nullptr */
-			      hb_font_t *font, /* May be nullptr */
+			      const char **end_ptr, /* May be NULL */
+			      hb_font_t *font, /* May be NULL */
 			      hb_buffer_serialize_format_t format)
 {
   const char *end;

--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -709,9 +709,9 @@ struct VariationSelectorRecord
 
   HBUINT24	varSelector;	/* Variation selector. */
   LOffsetTo<DefaultUVS>
-		defaultUVS;	/* Offset to Default UVS Table. May be 0. */
+		defaultUVS;	/* Offset to Default UVS Table.  May be 0. */
   LOffsetTo<NonDefaultUVS>
-		nonDefaultUVS;	/* Offset to Non-Default UVS Table. May be 0. */
+		nonDefaultUVS;	/* Offset to Non-Default UVS Table.  May be 0. */
   public:
   DEFINE_SIZE_STATIC (11);
 };

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -473,7 +473,7 @@ struct FeatureParamsCharacterVariants
 					 * specifies a string (or strings,
 					 * for multiple languages) for a
 					 * user-interface label for this
-					 * feature. (May be nullptr.) */
+					 * feature. (May be NULL.) */
   NameID	featUITooltipTextNameID;/* The ‘name’ table name ID that
 					 * specifies a string (or strings,
 					 * for multiple languages) that an
@@ -483,7 +483,7 @@ struct FeatureParamsCharacterVariants
   NameID	sampleTextNameID;	/* The ‘name’ table name ID that
 					 * specifies sample text that
 					 * illustrates the effect of this
-					 * feature. (May be nullptr.) */
+					 * feature. (May be NULL.) */
   HBUINT16	numNamedParameters;	/* Number of named parameters. (May
 					 * be zero.) */
   NameID	firstParamUILabelNameID;/* The first ‘name’ table name ID

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -214,10 +214,10 @@ struct hb_collect_glyphs_context_t :
   unsigned int debug_depth;
 
   hb_collect_glyphs_context_t (hb_face_t *face_,
-			       hb_set_t  *glyphs_before, /* OUT. May be nullptr */
-			       hb_set_t  *glyphs_input,  /* OUT. May be nullptr */
-			       hb_set_t  *glyphs_after,  /* OUT. May be nullptr */
-			       hb_set_t  *glyphs_output, /* OUT. May be nullptr */
+			       hb_set_t  *glyphs_before, /* OUT.  May be NULL */
+			       hb_set_t  *glyphs_input,  /* OUT.  May be NULL */
+			       hb_set_t  *glyphs_after,  /* OUT.  May be NULL */
+			       hb_set_t  *glyphs_output, /* OUT.  May be NULL */
 			       unsigned int nesting_level_left_ = HB_MAX_NESTING_LEVEL) :
 			      face (face_),
 			      before (glyphs_before ? glyphs_before : hb_set_get_empty ()),

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -322,7 +322,7 @@ hb_ot_layout_table_get_script_tags (hb_face_t    *face,
 				    hb_tag_t      table_tag,
 				    unsigned int  start_offset,
 				    unsigned int *script_count /* IN/OUT */,
-				    hb_tag_t     *script_tags /* OUT */)
+				    hb_tag_t     *script_tags  /* OUT */)
 {
   const OT::GSUBGPOS &g = get_gsubgpos_table (face, table_tag);
 
@@ -383,7 +383,7 @@ hb_ot_layout_table_select_script (hb_face_t      *face,
 				  hb_tag_t        table_tag,
 				  unsigned int    script_count,
 				  const hb_tag_t *script_tags,
-				  unsigned int   *script_index /* OUT */,
+				  unsigned int   *script_index  /* OUT */,
 				  hb_tag_t       *chosen_script /* OUT */)
 {
   static_assert ((OT::Index::NOT_FOUND_INDEX == HB_OT_LAYOUT_NO_SCRIPT_INDEX), "");
@@ -433,7 +433,7 @@ hb_ot_layout_table_get_feature_tags (hb_face_t    *face,
 				     hb_tag_t      table_tag,
 				     unsigned int  start_offset,
 				     unsigned int *feature_count /* IN/OUT */,
-				     hb_tag_t     *feature_tags /* OUT */)
+				     hb_tag_t     *feature_tags  /* OUT */)
 {
   const OT::GSUBGPOS &g = get_gsubgpos_table (face, table_tag);
 
@@ -469,7 +469,7 @@ hb_ot_layout_script_get_language_tags (hb_face_t    *face,
 				       unsigned int  script_index,
 				       unsigned int  start_offset,
 				       unsigned int *language_count /* IN/OUT */,
-				       hb_tag_t     *language_tags /* OUT */)
+				       hb_tag_t     *language_tags  /* OUT */)
 {
   const OT::Script &s = get_gsubgpos_table (face, table_tag).get_script (script_index);
 
@@ -574,7 +574,7 @@ hb_ot_layout_language_get_feature_indexes (hb_face_t    *face,
 					   unsigned int  script_index,
 					   unsigned int  language_index,
 					   unsigned int  start_offset,
-					   unsigned int *feature_count /* IN/OUT */,
+					   unsigned int *feature_count   /* IN/OUT */,
 					   unsigned int *feature_indexes /* OUT */)
 {
   const OT::GSUBGPOS &g = get_gsubgpos_table (face, table_tag);
@@ -590,7 +590,7 @@ hb_ot_layout_language_get_feature_tags (hb_face_t    *face,
 					unsigned int  language_index,
 					unsigned int  start_offset,
 					unsigned int *feature_count /* IN/OUT */,
-					hb_tag_t     *feature_tags /* OUT */)
+					hb_tag_t     *feature_tags  /* OUT */)
 {
   const OT::GSUBGPOS &g = get_gsubgpos_table (face, table_tag);
   const OT::LangSys &l = g.get_script (script_index).get_lang_sys (language_index);
@@ -644,7 +644,7 @@ hb_ot_layout_feature_get_lookups (hb_face_t    *face,
 				  hb_tag_t      table_tag,
 				  unsigned int  feature_index,
 				  unsigned int  start_offset,
-				  unsigned int *lookup_count /* IN/OUT */,
+				  unsigned int *lookup_count   /* IN/OUT */,
 				  unsigned int *lookup_indexes /* OUT */)
 {
   return hb_ot_layout_feature_with_variations_get_lookups (face,
@@ -872,10 +872,10 @@ void
 hb_ot_layout_lookup_collect_glyphs (hb_face_t    *face,
 				    hb_tag_t      table_tag,
 				    unsigned int  lookup_index,
-				    hb_set_t     *glyphs_before, /* OUT. May be nullptr */
-				    hb_set_t     *glyphs_input,  /* OUT. May be nullptr */
-				    hb_set_t     *glyphs_after,  /* OUT. May be nullptr */
-				    hb_set_t     *glyphs_output  /* OUT. May be nullptr */)
+				    hb_set_t     *glyphs_before, /* OUT.  May be NULL */
+				    hb_set_t     *glyphs_input,  /* OUT.  May be NULL */
+				    hb_set_t     *glyphs_after,  /* OUT.  May be NULL */
+				    hb_set_t     *glyphs_output  /* OUT.  May be NULL */)
 {
   if (unlikely (!hb_ot_shaper_face_data_ensure (face))) return;
 
@@ -1073,11 +1073,11 @@ hb_ot_layout_position_finish_offsets (hb_font_t *font, hb_buffer_t *buffer)
  **/
 hb_bool_t
 hb_ot_layout_get_size_params (hb_face_t    *face,
-			      unsigned int *design_size,       /* OUT.  May be nullptr */
-			      unsigned int *subfamily_id,      /* OUT.  May be nullptr */
-			      unsigned int *subfamily_name_id, /* OUT.  May be nullptr */
-			      unsigned int *range_start,       /* OUT.  May be nullptr */
-			      unsigned int *range_end          /* OUT.  May be nullptr */)
+			      unsigned int *design_size,       /* OUT.  May be NULL */
+			      unsigned int *subfamily_id,      /* OUT.  May be NULL */
+			      unsigned int *subfamily_name_id, /* OUT.  May be NULL */
+			      unsigned int *range_start,       /* OUT.  May be NULL */
+			      unsigned int *range_end          /* OUT.  May be NULL */)
 {
   const OT::GPOS &gpos = _get_gpos (face);
   const hb_tag_t tag = HB_TAG ('s','i','z','e');
@@ -1092,26 +1092,22 @@ hb_ot_layout_get_size_params (hb_face_t    *face,
 
       if (params.designSize)
       {
-#define PARAM(a, A) if (a) *a = params.A
-	PARAM (design_size, designSize);
-	PARAM (subfamily_id, subfamilyID);
-	PARAM (subfamily_name_id, subfamilyNameID);
-	PARAM (range_start, rangeStart);
-	PARAM (range_end, rangeEnd);
-#undef PARAM
+	if (design_size) *design_size = params.designSize;
+	if (subfamily_id) *subfamily_id = params.subfamilyID;
+	if (subfamily_name_id) *subfamily_name_id = params.subfamilyNameID;
+	if (range_start) *range_start = params.rangeStart;
+	if (range_end) *range_end = params.rangeEnd;
 
 	return true;
       }
     }
   }
 
-#define PARAM(a, A) if (a) *a = 0
-  PARAM (design_size, designSize);
-  PARAM (subfamily_id, subfamilyID);
-  PARAM (subfamily_name_id, subfamilyNameID);
-  PARAM (range_start, rangeStart);
-  PARAM (range_end, rangeEnd);
-#undef PARAM
+  if (design_size) *design_size = 0;
+  if (subfamily_id) *subfamily_id = 0;
+  if (subfamily_name_id) *subfamily_name_id = 0;
+  if (range_start) *range_start = 0;
+  if (range_end) *range_end = 0;
 
   return false;
 }
@@ -1141,14 +1137,14 @@ hb_ot_layout_get_size_params (hb_face_t    *face,
  * Since: REPLACEME
  **/
 hb_bool_t
-hb_ot_layout_feature_get_name_ids (hb_face_t      *face,
-				   hb_tag_t        table_tag,
-				   unsigned int    feature_index,
-				   hb_name_id_t   *label_id,             /* OUT.  May be NULL */
-				   hb_name_id_t   *tooltip_id,           /* OUT.  May be NULL */
-				   hb_name_id_t   *sample_id,            /* OUT.  May be NULL */
-				   unsigned int   *num_named_parameters, /* OUT.  May be NULL */
-				   hb_name_id_t   *first_param_id        /* OUT.  May be NULL */)
+hb_ot_layout_feature_get_name_ids (hb_face_t    *face,
+				   hb_tag_t      table_tag,
+				   unsigned int  feature_index,
+				   hb_name_id_t *label_id,             /* OUT.  May be NULL */
+				   hb_name_id_t *tooltip_id,           /* OUT.  May be NULL */
+				   hb_name_id_t *sample_id,            /* OUT.  May be NULL */
+				   unsigned int *num_named_parameters, /* OUT.  May be NULL */
+				   hb_name_id_t *first_param_id        /* OUT.  May be NULL */)
 {
   const OT::GSUBGPOS &g = get_gsubgpos_table (face, table_tag);
 
@@ -1162,34 +1158,32 @@ hb_ot_layout_feature_get_name_ids (hb_face_t      *face,
       feature_params.get_stylistic_set_params (feature_tag);
     if (&ss_params != &Null (OT::FeatureParamsStylisticSet)) /* ssXX */
     {
-#define PARAM(a, A) if (a) *a = A
-      PARAM(label_id, ss_params.uiNameID);
+      if (label_id) *label_id = ss_params.uiNameID;
       // ssXX features don't have the rest
-      PARAM(tooltip_id, HB_NAME_ID_INVALID);
-      PARAM(sample_id, HB_NAME_ID_INVALID);
-      PARAM(num_named_parameters, 0);
-      PARAM(first_param_id, HB_NAME_ID_INVALID);
+      if (tooltip_id) *tooltip_id = HB_NAME_ID_INVALID;
+      if (sample_id) *sample_id = HB_NAME_ID_INVALID;
+      if (num_named_parameters) *num_named_parameters = 0;
+      if (first_param_id) *first_param_id = HB_NAME_ID_INVALID;
       return true;
     }
     const OT::FeatureParamsCharacterVariants& cv_params =
       feature_params.get_character_variants_params (feature_tag);
     if (&cv_params != &Null (OT::FeatureParamsCharacterVariants)) /* cvXX */
     {
-      PARAM(label_id, cv_params.featUILableNameID);
-      PARAM(tooltip_id, cv_params.featUITooltipTextNameID);
-      PARAM(sample_id, cv_params.sampleTextNameID);
-      PARAM(num_named_parameters, cv_params.numNamedParameters);
-      PARAM(first_param_id, cv_params.firstParamUILabelNameID);
+      if (label_id) *label_id = cv_params.featUILableNameID;
+      if (tooltip_id) *tooltip_id = cv_params.featUITooltipTextNameID;
+      if (sample_id) *sample_id = cv_params.sampleTextNameID;
+      if (num_named_parameters) *num_named_parameters = cv_params.numNamedParameters;
+      if (first_param_id) *first_param_id = cv_params.firstParamUILabelNameID;
       return true;
     }
   }
 
-  PARAM(label_id, HB_NAME_ID_INVALID);
-  PARAM(tooltip_id, HB_NAME_ID_INVALID);
-  PARAM(sample_id, HB_NAME_ID_INVALID);
-  PARAM(num_named_parameters, 0);
-  PARAM(first_param_id, HB_NAME_ID_INVALID);
-#undef PARAM
+  if (label_id) *label_id = HB_NAME_ID_INVALID;
+  if (tooltip_id) *tooltip_id = HB_NAME_ID_INVALID;
+  if (sample_id) *sample_id = HB_NAME_ID_INVALID;
+  if (num_named_parameters) *num_named_parameters = 0;
+  if (first_param_id) *first_param_id = HB_NAME_ID_INVALID;
   return false;
 }
 
@@ -1232,23 +1226,16 @@ hb_ot_layout_feature_get_characters (hb_face_t      *face,
 
   const OT::FeatureParamsCharacterVariants& cv_params =
     feature_params.get_character_variants_params(feature_tag);
-  if (&cv_params != &Null (OT::FeatureParamsCharacterVariants))
+
+  unsigned int len = 0;
+  if (char_count && characters && start_offset < cv_params.characters.len)
   {
-    unsigned int len = 0;
-    if (char_count && characters && start_offset < cv_params.characters.len)
-    {
-      len = MIN (cv_params.characters.len - start_offset, *char_count);
-      for (unsigned int i = 0; i < len; ++i)
-        characters[i] = cv_params.characters[start_offset + i];
-    }
-#define PARAM(a, A) if (a) *a = A
-    PARAM(char_count, len);
-    return cv_params.characters.len;
+    len = MIN (cv_params.characters.len - start_offset, *char_count);
+    for (unsigned int i = 0; i < len; ++i)
+      characters[i] = cv_params.characters[start_offset + i];
   }
-  PARAM(char_count, 0);
-  PARAM(characters, 0);
-#undef PARAM
-  return 0;
+  if (char_count) *char_count = len;
+  return cv_params.characters.len;
 }
 
 

--- a/src/hb-ot-layout.h
+++ b/src/hb-ot-layout.h
@@ -216,10 +216,10 @@ HB_EXTERN void
 hb_ot_layout_lookup_collect_glyphs (hb_face_t    *face,
 				    hb_tag_t      table_tag,
 				    unsigned int  lookup_index,
-				    hb_set_t     *glyphs_before, /* OUT. May be NULL */
-				    hb_set_t     *glyphs_input,  /* OUT. May be NULL */
-				    hb_set_t     *glyphs_after,  /* OUT. May be NULL */
-				    hb_set_t     *glyphs_output  /* OUT. May be NULL */);
+				    hb_set_t     *glyphs_before, /* OUT.  May be NULL */
+				    hb_set_t     *glyphs_input,  /* OUT.  May be NULL */
+				    hb_set_t     *glyphs_after,  /* OUT.  May be NULL */
+				    hb_set_t     *glyphs_output  /* OUT.  May be NULL */);
 
 #ifdef HB_NOT_IMPLEMENTED
 typedef struct
@@ -331,15 +331,16 @@ hb_ot_layout_get_size_params (hb_face_t    *face,
 			      unsigned int *range_start,       /* OUT.  May be NULL */
 			      unsigned int *range_end          /* OUT.  May be NULL */);
 
+
 HB_EXTERN hb_bool_t
-hb_ot_layout_feature_get_name_ids (hb_face_t      *face,
-				   hb_tag_t        table_tag,
-				   unsigned int    feature_index,
-				   hb_name_id_t   *label_id             /* OUT.  May be NULL */,
-				   hb_name_id_t   *tooltip_id           /* OUT.  May be NULL */,
-				   hb_name_id_t   *sample_id            /* OUT.  May be NULL */,
-				   unsigned int   *num_named_parameters /* OUT.  May be NULL */,
-				   hb_name_id_t   *first_param_id       /* OUT.  May be NULL */);
+hb_ot_layout_feature_get_name_ids (hb_face_t    *face,
+				   hb_tag_t      table_tag,
+				   unsigned int  feature_index,
+				   hb_name_id_t *label_id             /* OUT.  May be NULL */,
+				   hb_name_id_t *tooltip_id           /* OUT.  May be NULL */,
+				   hb_name_id_t *sample_id            /* OUT.  May be NULL */,
+				   unsigned int *num_named_parameters /* OUT.  May be NULL */,
+				   hb_name_id_t *first_param_id       /* OUT.  May be NULL */);
 
 
 HB_EXTERN unsigned int

--- a/src/hb-ot-math-table.hh
+++ b/src/hb-ot-math-table.hh
@@ -50,7 +50,7 @@ struct MathValueRecord
   protected:
   HBINT16			value;		/* The X or Y value in design units */
   OffsetTo<Device>	deviceTable;	/* Offset to the device table - from the
-					 * beginning of parent table. May be nullptr.
+					 * beginning of parent table.  May be NULL.
 					 * Suggested format for device table is 1. */
 
   public:
@@ -318,7 +318,7 @@ struct MathKernInfoRecord
 
   protected:
   /* Offset to MathKern table for each corner -
-   * from the beginning of MathKernInfo table. May be nullptr. */
+   * from the beginning of MathKernInfo table.  May be NULL. */
   OffsetTo<MathKern> mathKern[4];
 
   public:
@@ -401,7 +401,7 @@ struct MathGlyphInfo
    * from the beginning of MathGlyphInfo table. When the left or right glyph of
    * a box is an extended shape variant, the (ink) box (and not the default
    * position defined by values in MathConstants table) should be used for
-   * vertical positioning purposes. May be nullptr.. */
+   * vertical positioning purposes.  May be NULL.. */
   OffsetTo<Coverage> extendedShapeCoverage;
 
    /* Offset to MathKernInfo table -
@@ -570,7 +570,7 @@ struct MathGlyphConstruction
 
   protected:
   /* Offset to MathGlyphAssembly table for this shape - from the beginning of
-     MathGlyphConstruction table. May be nullptr. */
+     MathGlyphConstruction table.  May be NULL. */
   OffsetTo<MathGlyphAssembly>	  glyphAssembly;
 
   /* MathGlyphVariantRecords for alternative variants of the glyphs. */

--- a/src/hb-ot-name.h
+++ b/src/hb-ot-name.h
@@ -48,7 +48,6 @@ typedef unsigned int hb_name_id_t;
  **/
 #define HB_NAME_ID_INVALID 0xFFFF
 
-
 HB_END_DECLS
 
 #endif /* HB_OT_NAME_H */

--- a/src/hb-ot-shape-complex.hh
+++ b/src/hb-ot-shape-complex.hh
@@ -69,7 +69,7 @@ struct hb_ot_complex_shaper_t
   /* collect_features()
    * Called during shape_plan().
    * Shapers should use plan->map to add their features and callbacks.
-   * May be nullptr.
+   * May be NULL.
    */
   void (*collect_features) (hb_ot_shape_planner_t *plan);
 
@@ -77,7 +77,7 @@ struct hb_ot_complex_shaper_t
    * Called during shape_plan().
    * Shapers should use plan->map to override features and add callbacks after
    * common features are added.
-   * May be nullptr.
+   * May be NULL.
    */
   void (*override_features) (hb_ot_shape_planner_t *plan);
 
@@ -93,7 +93,7 @@ struct hb_ot_complex_shaper_t
    * Called when the shape_plan is being destroyed.
    * plan->data is passed here for destruction.
    * If nullptr is returned, means a plan failure.
-   * May be nullptr.
+   * May be NULL.
    */
   void (*data_destroy) (void *data);
 
@@ -101,7 +101,7 @@ struct hb_ot_complex_shaper_t
   /* preprocess_text()
    * Called during shape().
    * Shapers can use to modify text before shaping starts.
-   * May be nullptr.
+   * May be NULL.
    */
   void (*preprocess_text) (const hb_ot_shape_plan_t *plan,
 			   hb_buffer_t              *buffer,
@@ -110,7 +110,7 @@ struct hb_ot_complex_shaper_t
   /* postprocess_glyphs()
    * Called during shape().
    * Shapers can use to modify glyphs after shaping ends.
-   * May be nullptr.
+   * May be NULL.
    */
   void (*postprocess_glyphs) (const hb_ot_shape_plan_t *plan,
 			      hb_buffer_t              *buffer,
@@ -121,7 +121,7 @@ struct hb_ot_complex_shaper_t
 
   /* decompose()
    * Called during shape()'s normalization.
-   * May be nullptr.
+   * May be NULL.
    */
   bool (*decompose) (const hb_ot_shape_normalize_context_t *c,
 		     hb_codepoint_t  ab,
@@ -130,7 +130,7 @@ struct hb_ot_complex_shaper_t
 
   /* compose()
    * Called during shape()'s normalization.
-   * May be nullptr.
+   * May be NULL.
    */
   bool (*compose) (const hb_ot_shape_normalize_context_t *c,
 		   hb_codepoint_t  a,
@@ -141,7 +141,7 @@ struct hb_ot_complex_shaper_t
    * Called during shape().
    * Shapers should use map to get feature masks and set on buffer.
    * Shapers may NOT modify characters.
-   * May be nullptr.
+   * May be NULL.
    */
   void (*setup_masks) (const hb_ot_shape_plan_t *plan,
 		       hb_buffer_t              *buffer,
@@ -156,7 +156,7 @@ struct hb_ot_complex_shaper_t
   /* reorder_marks()
    * Called during shape().
    * Shapers can use to modify ordering of combining marks.
-   * May be nullptr.
+   * May be NULL.
    */
   void (*reorder_marks) (const hb_ot_shape_plan_t *plan,
 			 hb_buffer_t              *buffer,


### PR DESCRIPTION
Feel free to request to separated patches for them and to remove the ones you disagree with.

The changes on `hb_ot_layout_get_size_params` and `hb_ot_layout_feature_get_*` need more careful watching but no functional change anyway. Also changes `hb_ot_layout_feature_get_characters` to relying on null pool.

Once you said [offline] why the use of nullptr on headers so normalizing on the whole project, or maybe I shouldn't do that on public headers only.