### PR TITLE
Replace tabs with spaces to avoid misleading indentation.

### DIFF
--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -149,9 +149,9 @@ struct KerxSubTableFormat1
       if (flags & Push)
       {
         if (likely (depth < ARRAY_LENGTH (stack)))
-	  stack[depth++] = buffer->idx;
-	else
-	  depth = 0; /* Probably not what CoreText does, but better? */
+          stack[depth++] = buffer->idx;
+        else
+          depth = 0; /* Probably not what CoreText does, but better? */
       }
 
       if (entry->data.kernActionIndex != 0xFFFF)


### PR DESCRIPTION
clang-tidy's misleading indentation check triggers on these lines
due to mixed tabs and spaces, so fix that so that the check can
be clean.