### PR TITLE
Make tracking optout possible using 'trak' ot feature

### DIFF
--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -116,7 +116,8 @@ hb_ot_shape_planner_t::compile (hb_ot_shape_plan_t &plan,
     plan.fallback_mark_positioning = true;
 
   /* Currently we always apply trak. */
-  plan.apply_trak = hb_aat_layout_has_tracking (face);
+  plan.apply_trak = hb_aat_layout_has_tracking (face) &&
+		    plan.map.needs_fallback (HB_TAG ('t','r','a','k'));
 }
 
 
@@ -177,12 +178,15 @@ hb_ot_shape_collect_features (hb_ot_shape_planner_t          *planner,
   /* Random! */
   map->enable_feature (HB_TAG ('r','a','n','d'), F_RANDOM, HB_OT_MAP_MAX_VALUE);
 
-  map->enable_feature (HB_TAG('H','A','R','F'));
+  /* Tracking. */
+  map->enable_feature (HB_TAG ('t','r','a','k'), F_HAS_FALLBACK);
+
+  map->enable_feature (HB_TAG ('H','A','R','F'));
 
   if (planner->shaper->collect_features)
     planner->shaper->collect_features (planner);
 
-  map->enable_feature (HB_TAG('B','U','Z','Z'));
+  map->enable_feature (HB_TAG ('B','U','Z','Z'));
 
   for (unsigned int i = 0; i < ARRAY_LENGTH (common_features); i++)
     map->add_feature (common_features[i]);

--- a/test/shaping/data/in-house/tests/aat-trak.tests
+++ b/test/shaping/data/in-house/tests/aat-trak.tests
@@ -6,3 +6,5 @@
 ../fonts/TestTRAK.ttf:--font-ptem=24:U+0041,U+0042,U+0043:[A.alt=0@-12,0+976|B=1@-12,0+976|C.alt=2@-12,0+976]
 ../fonts/TestTRAK.ttf:--font-ptem=72:U+0041,U+0042,U+0043:[A.alt=0@-50,0+900|B=1@-50,0+900|C.alt=2@-50,0+900]
 ../fonts/TestTRAK.ttf:--font-ptem=144:U+0041,U+0042,U+0043:[A.alt=0@-107,0+786|B=1@-107,0+786|C.alt=2@-107,0+786]
+../fonts/TestTRAK.ttf:--font-ptem=144:U+0041,U+0042,U+0043:[A.alt=0@-107,0+786|B=1@-107,0+786|C.alt=2@-107,0+786]
+../fonts/TestTRAK.ttf:--font-ptem=144 --features=-trak:U+0041,U+0042,U+0043:[A.alt=0+1000|B=1+1000|C.alt=2+1000]


### PR DESCRIPTION
So '--features=-trak' or 'font-feature-settings: 'trak' 0;' can prevent
applying of tracking if used.