### PR TITLE
Remove some use of Crap in hb-set.

### DIFF
--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -669,7 +669,7 @@ struct hb_set_t
 	return nullptr;
 
       pages[map.index].init0 ();
-      memmove (&page_map[i + 1], &page_map[i], (page_map.len - 1 - i) * sizeof (page_map[0]));
+      memmove (&page_map[i] + 1, &page_map[i], (page_map.len - 1 - i) * sizeof (page_map[0]));
       page_map[i] = map;
     }
     return &pages[page_map[i].index];


### PR DESCRIPTION
When hb_set_t::page_for_insert needs to insert at the end of the page_map
it ends up evaluating '&page_map[i + 1]' which has hb_vector return an
lvalue of a Crap so that nothing can be moved to its address. This turns
into issues with ThreadSanitizer on Crap when two threads modify different
hb_set_t instances. This can be avoided by using '&page_map[i] + 1'
instead.