### PR TITLE
fix various GCC 8.1.X function pointer warnings

### DIFF
--- a/src/hb-debug.hh
+++ b/src/hb-debug.hh
@@ -173,7 +173,7 @@ _hb_debug_msg_va (const char *what,
 
   fprintf (stderr, "\n");
 }
-template <> inline void
+template <> inline void HB_PRINTF_FUNC(7, 0)
 _hb_debug_msg_va<0> (const char *what HB_UNUSED,
 		     const void *obj HB_UNUSED,
 		     const char *func HB_UNUSED,
@@ -192,7 +192,7 @@ _hb_debug_msg (const char *what,
 	       int level_dir,
 	       const char *message,
 	       ...) HB_PRINTF_FUNC(7, 8);
-template <int max_level> static inline void
+template <int max_level> static inline void HB_PRINTF_FUNC(7, 8)
 _hb_debug_msg (const char *what,
 	       const void *obj,
 	       const char *func,
@@ -216,7 +216,7 @@ _hb_debug_msg<0> (const char *what HB_UNUSED,
 		  int level_dir HB_UNUSED,
 		  const char *message HB_UNUSED,
 		  ...) HB_PRINTF_FUNC(7, 8);
-template <> inline void
+template <> inline void HB_PRINTF_FUNC(7, 8)
 _hb_debug_msg<0> (const char *what HB_UNUSED,
 		  const void *obj HB_UNUSED,
 		  const char *func HB_UNUSED,

--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -49,8 +49,8 @@ struct hb_set_t
 
   struct page_t
   {
-    inline void init0 (void) { memset (&v, 0, sizeof (v)); }
-    inline void init1 (void) { memset (&v, 0xff, sizeof (v)); }
+    inline void init0 (void) { memset (reinterpret_cast<char*>(&v), 0, sizeof (v)); }
+    inline void init1 (void) { memset (reinterpret_cast<char*>(&v), 0xff, sizeof (v)); }
 
     inline unsigned int len (void) const
     { return ARRAY_LENGTH_CONST (v); }


### PR DESCRIPTION
Hi, and thanks for all the work on HarfBuzz.
I've been working to reduce warnings from the latest GCC, which is fairly strict.
This patch fixes some function parameter / template and other issues.
It'd be great if you consider accepting it.
