### PR TITLE
Skip binary search early

### DIFF
--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -724,9 +724,16 @@ struct SortedArrayOf : ArrayOf<Type, LenType>
   template <typename SearchType>
   inline int bsearch (const SearchType &x) const
   {
+    int max = (int) this->len - 1;
+    /* Special case, should be between 0.7% to 3% while formatting text. */
+    if (max == 0) {
+      return this->arrayZ[0].cmp (x);
+    }
+
     /* Hand-coded bsearch here since this is in the hot inner loop. */
     const Type *arr = this->arrayZ;
-    int min = 0, max = (int) this->len - 1;
+    int min = 0;
+
     while (min <= max)
     {
       int mid = ((unsigned int) min + (unsigned int) max) / 2;


### PR DESCRIPTION
Even though it is a rare case (between 0.7% to 4% while performing text shaping), by performing an early skip of binary search and special casing for arrays of a single element, we can make hb-shape
between 3x to almost 4x faster.

So for x86 it was an 3.3x boost for latin without regressions for complex scripts (actually was 2% improvement).

For ARM, the results were even better: 3.8x boost for little cores (A53) and 3.6x boost for big cores (A72).

We still have some failing tests to fix (around 13%) before landing.
