### PR TITLE
Optimize harfbuzz big integer conversions

### DIFF
--- a/src/hb-machinery.hh
+++ b/src/hb-machinery.hh
@@ -691,6 +691,10 @@ struct BEInt<Type, 2>
   }
   inline operator Type (void) const
   {
+#if defined(__GNUC__) || defined(__clang__)
+    struct __attribute__((packed)) packed_uint16_t { uint16_t v; };
+    return __builtin_bswap16(((packed_uint16_t *) this)->v);
+#endif
     return (v[0] <<  8)
          + (v[1]      );
   }

--- a/src/hb-machinery.hh
+++ b/src/hb-machinery.hh
@@ -692,8 +692,10 @@ struct BEInt<Type, 2>
   inline operator Type (void) const
   {
 #if defined(__GNUC__) || defined(__clang__)
+    /* Spoon-feed the compiler a big-endian integer with alignment 1.
+     * https://github.com/harfbuzz/harfbuzz/pull/1398 */
     struct __attribute__((packed)) packed_uint16_t { uint16_t v; };
-    return __builtin_bswap16(((packed_uint16_t *) this)->v);
+    return __builtin_bswap16 (((packed_uint16_t *) this)->v);
 #endif
     return (v[0] <<  8)
          + (v[1]      );


### PR DESCRIPTION
Profiling showed that type conversions were adding considerable cycles in time
spent doing text shaping.

The idea is to optimize it using native processor instructions to help Blink
layout performance.

NOT for commit: still needs further testing on ARM (i.e. unaligned loads) and handling other OS-es (only tested on Linux).