### PR TITLE
update simple shaping example (closes #298)

### DIFF
--- a/docs/usermanual-getting-started.xml
+++ b/docs/usermanual-getting-started.xml
@@ -157,7 +157,8 @@
     </orderedlist>
     <programlisting language="C">
       #include &lt;hb-ft.h&gt;
-      FT_New_Face(ft_library, font_path, index, &amp;face)
+      FT_New_Face(ft_library, font_path, index, &amp;face);
+      FT_Set_Char_Size(face, 0, 1000, 0, 0);
       hb_font_t *font = hb_ft_font_create(face);
     </programlisting>
     <orderedlist numeration="arabic">


### PR DESCRIPTION
add call to `FT_Set_Char_Size`, otherwise default size remains at `0`, and glyph positions come back as `0` too