### PR TITLE
Fix ambiguous overload errors with old compilers

### DIFF
--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -249,7 +249,7 @@ struct ContextualSubtable
       {
 	if (entry->data.markIndex != 0xFFFF)
 	{
-	  const Lookup<GlyphID> &lookup = subs[(unsigned) entry->data.markIndex];
+	  const Lookup<GlyphID> &lookup = subs[entry->data.markIndex];
 	  replacement = lookup.get_value (buffer->info[mark].codepoint, driver->num_glyphs);
 	}
       }
@@ -274,7 +274,7 @@ struct ContextualSubtable
       {
 	if (entry->data.currentIndex != 0xFFFF)
 	{
-	  const Lookup<GlyphID> &lookup = subs[(unsigned) entry->data.currentIndex];
+	  const Lookup<GlyphID> &lookup = subs[entry->data.currentIndex];
 	  replacement = lookup.get_value (buffer->info[idx].codepoint, driver->num_glyphs);
 	}
       }

--- a/src/hb-dsalgs.hh
+++ b/src/hb-dsalgs.hh
@@ -571,8 +571,9 @@ struct hb_array_t
   inline hb_array_t (const hb_array_t &o) : arrayZ (o.arrayZ), len (o.len) {}
   inline hb_array_t (Type *array_, unsigned int len_) : arrayZ (array_), len (len_) {}
 
-  inline Type& operator [] (unsigned int i) const
+  inline Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= len)) return Null(Type);
     return arrayZ[i];
   }

--- a/src/hb-face.cc
+++ b/src/hb-face.cc
@@ -647,8 +647,8 @@ _hb_face_builder_data_reference_blob (hb_face_builder_data_t *data)
   bool is_cff = data->tables.lsearch (HB_TAG ('C','F','F',' ')) || data->tables.lsearch (HB_TAG ('C','F','F','2'));
   hb_tag_t sfnt_tag = is_cff ? OT::OpenTypeFontFile::CFFTag : OT::OpenTypeFontFile::TrueTypeTag;
 
-  Supplier<hb_tag_t>    tags_supplier  (&data->tables[0u].tag, table_count, data->tables.item_size);
-  Supplier<hb_blob_t *> blobs_supplier (&data->tables[0u].blob, table_count, data->tables.item_size);
+  Supplier<hb_tag_t>    tags_supplier  (&data->tables[0].tag, table_count, data->tables.item_size);
+  Supplier<hb_blob_t *> blobs_supplier (&data->tables[0].blob, table_count, data->tables.item_size);
   bool ret = f->serialize_single (&c,
 				  sfnt_tag,
 				  tags_supplier,

--- a/src/hb-machinery.hh
+++ b/src/hb-machinery.hh
@@ -117,8 +117,8 @@ static inline Type& StructAfter(TObject &X)
   enum { min_size = (size) }
 
 #define DEFINE_SIZE_ARRAY(size, array) \
-  DEFINE_COMPILES_ASSERTION ((void) (array)[0u].static_size) \
-  DEFINE_INSTANCE_ASSERTION (sizeof (*this) == (size) + VAR * sizeof ((array)[0u])) \
+  DEFINE_COMPILES_ASSERTION ((void) (array)[0].static_size) \
+  DEFINE_INSTANCE_ASSERTION (sizeof (*this) == (size) + VAR * sizeof ((array)[0])) \
   enum { null_size = (size) }; \
   enum { min_size = (size) }
 

--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -351,14 +351,16 @@ struct UnsizedArrayOf
 
   HB_NO_CREATE_COPY_ASSIGN_TEMPLATE (UnsizedArrayOf, Type);
 
-  inline const Type& operator [] (unsigned int i) const
+  inline const Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     const Type *p = &arrayZ[i];
     if (unlikely (p < arrayZ)) return Null (Type); /* Overflowed. */
     return *p;
   }
-  inline Type& operator [] (unsigned int i)
+  inline Type& operator [] (int i_)
   {
+    unsigned int i = (unsigned int) i_;
     Type *p = &arrayZ[i];
     if (unlikely (p < arrayZ)) return Crap (Type); /* Overflowed. */
     return *p;
@@ -441,14 +443,16 @@ struct UnsizedOffsetArrayOf : UnsizedArrayOf<OffsetTo<Type, OffsetType, has_null
 template <typename Type, typename OffsetType, bool has_null=true>
 struct UnsizedOffsetListOf : UnsizedOffsetArrayOf<Type, OffsetType, has_null>
 {
-  inline const Type& operator [] (unsigned int i) const
+  inline const Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     const OffsetTo<Type, OffsetType, has_null> *p = &this->arrayZ[i];
     if (unlikely (p < this->arrayZ)) return Null (Type); /* Overflowed. */
     return this+*p;
   }
-  inline Type& operator [] (unsigned int i)
+  inline Type& operator [] (int i_)
   {
+    unsigned int i = (unsigned int) i_;
     const OffsetTo<Type, OffsetType, has_null> *p = &this->arrayZ[i];
     if (unlikely (p < this->arrayZ)) return Crap (Type); /* Overflowed. */
     return this+*p;
@@ -501,13 +505,15 @@ struct ArrayOf
 
   HB_NO_CREATE_COPY_ASSIGN_TEMPLATE2 (ArrayOf, Type, LenType);
 
-  inline const Type& operator [] (unsigned int i) const
+  inline const Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= len)) return Null (Type);
     return arrayZ[i];
   }
-  inline Type& operator [] (unsigned int i)
+  inline Type& operator [] (int i_)
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= len)) return Crap (Type);
     return arrayZ[i];
   }
@@ -625,13 +631,15 @@ struct LOffsetLArrayOf : ArrayOf<OffsetTo<Type, HBUINT32>, HBUINT32> {};
 template <typename Type>
 struct OffsetListOf : OffsetArrayOf<Type>
 {
-  inline const Type& operator [] (unsigned int i) const
+  inline const Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= this->len)) return Null (Type);
     return this+this->arrayZ[i];
   }
-  inline const Type& operator [] (unsigned int i)
+  inline const Type& operator [] (int i_)
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= this->len)) return Crap (Type);
     return this+this->arrayZ[i];
   }
@@ -668,13 +676,15 @@ struct HeadlessArrayOf
 
   HB_NO_CREATE_COPY_ASSIGN_TEMPLATE2 (HeadlessArrayOf, Type, LenType);
 
-  inline const Type& operator [] (unsigned int i) const
+  inline const Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= lenP1 || !i)) return Null (Type);
     return arrayZ[i-1];
   }
-  inline Type& operator [] (unsigned int i)
+  inline Type& operator [] (int i_)
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= lenP1 || !i)) return Crap (Type);
     return arrayZ[i-1];
   }
@@ -734,13 +744,15 @@ struct ArrayOfM1
 {
   HB_NO_CREATE_COPY_ASSIGN_TEMPLATE2 (ArrayOfM1, Type, LenType);
 
-  inline const Type& operator [] (unsigned int i) const
+  inline const Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i > lenM1)) return Null (Type);
     return arrayZ[i];
   }
-  inline Type& operator [] (unsigned int i)
+  inline Type& operator [] (int i_)
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i > lenM1)) return Crap (Type);
     return arrayZ[i];
   }
@@ -890,13 +902,15 @@ struct VarSizedBinSearchArrayOf
     return true;
   }
 
-  inline const Type& operator [] (unsigned int i) const
+  inline const Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= get_length ())) return Null (Type);
     return StructAtOffset<Type> (&bytesZ, i * header.unitSize);
   }
-  inline Type& operator [] (unsigned int i)
+  inline Type& operator [] (int i_)
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= get_length ())) return Crap (Type);
     return StructAtOffset<Type> (&bytesZ, i * header.unitSize);
   }

--- a/src/hb-ot-color-cpal-table.hh
+++ b/src/hb-ot-color-cpal-table.hh
@@ -115,7 +115,7 @@ struct CPAL
   inline bool has_data (void) const { return numPalettes; }
 
   inline unsigned int get_size (void) const
-  { return min_size + numPalettes * sizeof (colorRecordIndicesZ[0u]); }
+  { return min_size + numPalettes * sizeof (colorRecordIndicesZ[0]); }
 
   inline unsigned int get_palette_count () const { return numPalettes; }
   inline unsigned int get_color_count () const { return numColors; }

--- a/src/hb-ot-kern-table.hh
+++ b/src/hb-ot-kern-table.hh
@@ -56,7 +56,7 @@ struct KernSubTableFormat3
     if (unlikely (leftC >= leftClassCount || rightC >= rightClassCount))
       return 0;
     unsigned int i = leftC * rightClassCount + rightC;
-    return kernValue[(unsigned) kernIndex[i]];
+    return kernValue[kernIndex[i]];
   }
 
   inline bool apply (AAT::hb_aat_apply_context_t *c) const

--- a/src/hb-ot-layout-gpos-table.hh
+++ b/src/hb-ot-layout-gpos-table.hh
@@ -625,8 +625,8 @@ struct PairSet
   inline bool intersects (const hb_set_t *glyphs,
 			  const ValueFormat *valueFormats) const
   {
-    unsigned int len1 = valueFormats[0u].get_len ();
-    unsigned int len2 = valueFormats[1u].get_len ();
+    unsigned int len1 = valueFormats[0].get_len ();
+    unsigned int len2 = valueFormats[1].get_len ();
     unsigned int record_size = HBUINT16::static_size * (1 + len1 + len2);
 
     const PairValueRecord *record = &firstPairValueRecord;
@@ -644,8 +644,8 @@ struct PairSet
 			      const ValueFormat *valueFormats) const
   {
     TRACE_COLLECT_GLYPHS (this);
-    unsigned int len1 = valueFormats[0u].get_len ();
-    unsigned int len2 = valueFormats[1u].get_len ();
+    unsigned int len1 = valueFormats[0].get_len ();
+    unsigned int len2 = valueFormats[1].get_len ();
     unsigned int record_size = HBUINT16::static_size * (1 + len1 + len2);
 
     const PairValueRecord *record = &firstPairValueRecord;
@@ -658,8 +658,8 @@ struct PairSet
   {
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
-    unsigned int len1 = valueFormats[0u].get_len ();
-    unsigned int len2 = valueFormats[1u].get_len ();
+    unsigned int len1 = valueFormats[0].get_len ();
+    unsigned int len2 = valueFormats[1].get_len ();
     unsigned int record_size = HBUINT16::static_size * (1 + len1 + len2);
 
     unsigned int count = len;
@@ -681,8 +681,8 @@ struct PairSet
       else
       {
 	/* Note the intentional use of "|" instead of short-circuit "||". */
-	if (valueFormats[0u].apply_value (c, this, &record->values[0u], buffer->cur_pos()) |
-	    valueFormats[1u].apply_value (c, this, &record->values[len1], buffer->pos[pos]))
+	if (valueFormats[0].apply_value (c, this, &record->values[0], buffer->cur_pos()) |
+	    valueFormats[1].apply_value (c, this, &record->values[len1], buffer->pos[pos]))
 	  buffer->unsafe_to_break (buffer->idx, pos + 1);
 	if (len2)
 	  pos++;
@@ -698,7 +698,7 @@ struct PairSet
   {
     const void *base;
     const ValueFormat *valueFormats;
-    unsigned int len1; /* valueFormats[0u].get_len() */
+    unsigned int len1; /* valueFormats[0].get_len() */
     unsigned int stride; /* 1 + len1 + len2 */
   };
 
@@ -713,8 +713,8 @@ struct PairSet
 
     unsigned int count = len;
     const PairValueRecord *record = &firstPairValueRecord;
-    return_trace (closure->valueFormats[0u].sanitize_values_stride_unsafe (c, closure->base, &record->values[0u], count, closure->stride) &&
-		  closure->valueFormats[1u].sanitize_values_stride_unsafe (c, closure->base, &record->values[closure->len1], count, closure->stride));
+    return_trace (closure->valueFormats[0].sanitize_values_stride_unsafe (c, closure->base, &record->values[0], count, closure->stride) &&
+		  closure->valueFormats[1].sanitize_values_stride_unsafe (c, closure->base, &record->values[closure->len1], count, closure->stride));
   }
 
   protected:
@@ -781,8 +781,8 @@ struct PairPosFormat1
 
     if (!c->check_struct (this)) return_trace (false);
 
-    unsigned int len1 = valueFormat[0u].get_len ();
-    unsigned int len2 = valueFormat[1u].get_len ();
+    unsigned int len1 = valueFormat[0].get_len ();
+    unsigned int len2 = valueFormat[1].get_len ();
     PairSet::sanitize_closure_t closure =
     {
       this,
@@ -799,10 +799,10 @@ struct PairPosFormat1
   OffsetTo<Coverage>
 		coverage;		/* Offset to Coverage table--from
 					 * beginning of subtable */
-  ValueFormat	valueFormat[2u];	/* [0u] Defines the types of data in
+  ValueFormat	valueFormat[2];		/* [0] Defines the types of data in
 					 * ValueRecord1--for the first glyph
 					 * in the pair--may be zero (0) */
-					/* [1u] Defines the types of data in
+					/* [1] Defines the types of data in
 					 * ValueRecord2--for the second glyph
 					 * in the pair--may be zero (0) */
   OffsetArrayOf<PairSet>
@@ -885,7 +885,7 @@ struct PairPosFormat2
     return_trace (c->check_range ((const void *) values,
 				  count,
 				  record_size) &&
-		  valueFormat1.sanitize_values_stride_unsafe (c, this, &values[0u], count, stride) &&
+		  valueFormat1.sanitize_values_stride_unsafe (c, this, &values[0], count, stride) &&
 		  valueFormat2.sanitize_values_stride_unsafe (c, this, &values[len1], count, stride));
   }
 

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -1672,7 +1672,7 @@ struct ContextFormat3
 {
   inline bool intersects (const hb_set_t *glyphs) const
   {
-    if (!(this+coverageZ[0u]).intersects (glyphs))
+    if (!(this+coverageZ[0]).intersects (glyphs))
       return false;
 
     struct ContextClosureLookupContext lookup_context = {
@@ -1687,7 +1687,7 @@ struct ContextFormat3
   inline void closure (hb_closure_context_t *c) const
   {
     TRACE_CLOSURE (this);
-    if (!(this+coverageZ[0u]).intersects (c->glyphs))
+    if (!(this+coverageZ[0]).intersects (c->glyphs))
       return;
 
     const LookupRecord *lookupRecord = &StructAfter<LookupRecord> (coverageZ.as_array (glyphCount));
@@ -1704,7 +1704,7 @@ struct ContextFormat3
   inline void collect_glyphs (hb_collect_glyphs_context_t *c) const
   {
     TRACE_COLLECT_GLYPHS (this);
-    (this+coverageZ[0u]).add_coverage (c->input);
+    (this+coverageZ[0]).add_coverage (c->input);
 
     const LookupRecord *lookupRecord = &StructAfter<LookupRecord> (coverageZ.as_array (glyphCount));
     struct ContextCollectGlyphsLookupContext lookup_context = {
@@ -1731,12 +1731,12 @@ struct ContextFormat3
   }
 
   inline const Coverage &get_coverage (void) const
-  { return this+coverageZ[0u]; }
+  { return this+coverageZ[0]; }
 
   inline bool apply (hb_ot_apply_context_t *c) const
   {
     TRACE_APPLY (this);
-    unsigned int index = (this+coverageZ[0u]).get_coverage (c->buffer->cur().codepoint);
+    unsigned int index = (this+coverageZ[0]).get_coverage (c->buffer->cur().codepoint);
     if (likely (index == NOT_COVERED)) return_trace (false);
 
     const LookupRecord *lookupRecord = &StructAfter<LookupRecord> (coverageZ.as_array (glyphCount));
@@ -1759,7 +1759,7 @@ struct ContextFormat3
     TRACE_SANITIZE (this);
     if (!c->check_struct (this)) return_trace (false);
     unsigned int count = glyphCount;
-    if (!count) return_trace (false); /* We want to access coverageZ[0u] freely. */
+    if (!count) return_trace (false); /* We want to access coverageZ[0] freely. */
     if (!c->check_array (coverageZ.arrayZ, count)) return_trace (false);
     for (unsigned int i = 0; i < count; i++)
       if (!coverageZ[i].sanitize (c, this)) return_trace (false);
@@ -1838,7 +1838,7 @@ static inline bool chain_context_intersects (const hb_set_t *glyphs,
 {
   return intersects_array (glyphs,
 			   backtrackCount, backtrack,
-			   lookup_context.funcs.intersects, lookup_context.intersects_data[0u])
+			   lookup_context.funcs.intersects, lookup_context.intersects_data[0])
       && intersects_array (glyphs,
 			   inputCount ? inputCount - 1 : 0, input,
 			   lookup_context.funcs.intersects, lookup_context.intersects_data[1])

--- a/src/hb-vector.hh
+++ b/src/hb-vector.hh
@@ -78,14 +78,16 @@ struct hb_vector_t
   inline const Type * arrayZ (void) const
   { return arrayZ_ ? arrayZ_ : static_array; }
 
-  inline Type& operator [] (unsigned int i)
+  inline Type& operator [] (int i_)
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= len))
       return Crap (Type);
     return arrayZ()[i];
   }
-  inline const Type& operator [] (unsigned int i) const
+  inline const Type& operator [] (int i_) const
   {
+    unsigned int i = (unsigned int) i_;
     if (unlikely (i >= len))
       return Null(Type);
     return arrayZ()[i];


### PR DESCRIPTION
Testing ground to see how to better fix old-gcc's ambiguous-overload errors:
```
    hb-ot-vorg-table.hh:96: error: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second:
    hb-vector.hh:87: note: candidate 1: const Type& hb_vector_t<Type, PreallocedCount>::operator[](unsigned int) const [with Type = OT::VertOriginMetric, unsigned int PreallocedCount = 8u]
    hb-ot-vorg-table.hh:96: note: candidate 2: operator[](const T*, int) <built-in>
```