### PR TITLE
[CFF] Refix oss-fuzz 11714: set_blends (PR #1458)

### DIFF
--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -576,7 +576,7 @@ struct ArgStack : Stack<ARG, 513>
     return true;
   }
 
-  inline const hb_array_t<const ARG> &get_subarray (unsigned int start) const
+  inline hb_array_t<const ARG> get_subarray (unsigned int start) const
   {
     return S::elements.sub_array (start);
   }

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -576,6 +576,11 @@ struct ArgStack : Stack<ARG, 513>
     return true;
   }
 
+  inline const hb_array_t<const ARG> &get_subarray (unsigned int start) const
+  {
+    return S::elements.sub_array (start);
+  }
+
   private:
   typedef Stack<ARG, 513> S;
 };

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -237,6 +237,12 @@ struct CFF2CSOpSet : CSOpSet<BlendArg, OPSET, CFF2CSInterpEnv, PARAM, PATH>
     n = env.argStack.pop_uint ();
     /* copy the blend values into blend array of the default values */
     unsigned int start = env.argStack.get_count () - ((k+1) * n);
+    /* let an obvious error case fail, but note CFF2 spec doesn't forbid n==0 */
+    if (unlikely (start > env.argStack.get_count ()))
+    {
+      env.set_error ();
+      return;
+    }
     for (unsigned int i = 0; i < n; i++)
     {
       const hb_array_t<const BlendArg>	blends = env.argStack.get_subarray (start + n + (i * k));

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -52,7 +52,7 @@ struct BlendArg : Number
   inline void set_real (double v) { reset_blends (); Number::set_real (v); }
 
   inline void set_blends (unsigned int numValues_, unsigned int valueIndex_,
-			  unsigned int numBlends, const BlendArg *blends_)
+			  unsigned int numBlends, const hb_array_t<const BlendArg> &blends_)
   {
     numValues = numValues_;
     valueIndex = valueIndex_;
@@ -235,15 +235,13 @@ struct CFF2CSOpSet : CSOpSet<BlendArg, OPSET, CFF2CSInterpEnv, PARAM, PATH>
     env.process_blend ();
     k = env.get_region_count ();
     n = env.argStack.pop_uint ();
-    if (unlikely (env.argStack.get_count () < ((k+1) * n)))
-    {
-      env.set_error ();
-      return;
-    }
     /* copy the blend values into blend array of the default values */
     unsigned int start = env.argStack.get_count () - ((k+1) * n);
     for (unsigned int i = 0; i < n; i++)
-      env.argStack[start + i].set_blends (n, i, k, &env.argStack[start + n + (i * k)]);
+    {
+      const hb_array_t<const BlendArg>	&blends = env.argStack.get_subarray (start + n + (i * k));
+      env.argStack[start + i].set_blends (n, i, k, blends);
+    }
 
     /* pop off blend values leaving default values now adorned with blend values */
     env.argStack.pop (k * n);

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -239,7 +239,7 @@ struct CFF2CSOpSet : CSOpSet<BlendArg, OPSET, CFF2CSInterpEnv, PARAM, PATH>
     unsigned int start = env.argStack.get_count () - ((k+1) * n);
     for (unsigned int i = 0; i < n; i++)
     {
-      const hb_array_t<const BlendArg>	&blends = env.argStack.get_subarray (start + n + (i * k));
+      const hb_array_t<const BlendArg>	blends = env.argStack.get_subarray (start + n + (i * k));
       env.argStack[start + i].set_blends (n, i, k, blends);
     }
 


### PR DESCRIPTION
`set_bends` now takes a sub-array of blend values so that it can’t crash.
The original error check is tweaked and still used to let an error case fail early when arguments on stack too short.

Tested against the minimized test case with and without the error check.
