### PR TITLE
fix for issue #1447: unhandled opcode in name_op_to_index

### DIFF
--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -656,7 +656,7 @@ struct NameDictValues
   static inline enum NameDictValIndex name_op_to_index (OpCode op)
   {
     switch (op) {
-      default:
+      default: // can't happen - just make some compiler happy
       case OpCode_version:
 	return version;
       case OpCode_Notice:
@@ -673,7 +673,9 @@ struct NameDictValues
 	return postscript;
       case OpCode_FontName:
 	return fontName;
-      }
+      case OpCode_BaseFontName:
+	return baseFontName;
+    }
   }
 
   unsigned int  values[ValCount];


### PR DESCRIPTION
Added case for OpCode_BaseFontName. This opcode is in CFF spec but practically unused.
Added a comment for the default case which can't be hit by only two callers of this function `name_op_to_index`.