### PR TITLE
[CFF] minimized assert usage

### DIFF
--- a/src/hb-ot-cff-common.hh
+++ b/src/hb-ot-cff-common.hh
@@ -51,7 +51,7 @@ inline unsigned int calcOffSize(unsigned int dataSize)
     size++;
     offset >>= 8;
   }
-  assert (size <= 4);
+  /* format does not support size > 4; caller should handle it as an error */
   return size;
 }
 

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -211,7 +211,8 @@ struct Encoding {
 	hb_codepoint_t code = code_ranges[i].code;
 	for (int left = (int)code_ranges[i].glyph; left >= 0; left--)
 	  fmt0->codes[glyph++].set (code++);
-	assert ((glyph <= 0x100) && (code <= 0x100));
+	if (unlikely (!((glyph <= 0x100) && (code <= 0x100))))
+	  return_trace (false);
       }
     }
     else
@@ -221,7 +222,8 @@ struct Encoding {
       fmt1->nRanges.set (code_ranges.len);
       for (unsigned int i = 0; i < code_ranges.len; i++)
       {
-	assert ((code_ranges[i].code <= 0xFF) && (code_ranges[i].glyph <= 0xFF));
+	if (unlikely (!((code_ranges[i].code <= 0xFF) && (code_ranges[i].glyph <= 0xFF))))
+	  return_trace (false);
 	fmt1->ranges[i].first.set (code_ranges[i].code);
 	fmt1->ranges[i].nLeft.set (code_ranges[i].glyph);
       }
@@ -490,7 +492,8 @@ struct Charset {
       if (unlikely (fmt1 == nullptr)) return_trace (false);
       for (unsigned int i = 0; i < sid_ranges.len; i++)
       {
-	assert (sid_ranges[i].glyph <= 0xFF);
+      	if (unlikely (!(sid_ranges[i].glyph <= 0xFF)))
+	  return_trace (false);
 	fmt1->ranges[i].first.set (sid_ranges[i].code);
 	fmt1->ranges[i].nLeft.set (sid_ranges[i].glyph);
       }
@@ -501,7 +504,8 @@ struct Charset {
       if (unlikely (fmt2 == nullptr)) return_trace (false);
       for (unsigned int i = 0; i < sid_ranges.len; i++)
       {
-	assert (sid_ranges[i].glyph <= 0xFFFF);
+      	if (unlikely (!(sid_ranges[i].glyph <= 0xFFFF)))
+	  return_trace (false);
 	fmt2->ranges[i].first.set (sid_ranges[i].code);
 	fmt2->ranges[i].nLeft.set (sid_ranges[i].glyph);
       }

--- a/src/hb-subset-cff-common.cc
+++ b/src/hb-subset-cff-common.cc
@@ -100,8 +100,9 @@ hb_plan_subset_cff_fdselect (const hb_vector_t<hb_codepoint_t> &glyphs,
       hb_codepoint_t  fd = CFF_UNDEF_CODE;
       while (set->next (&fd))
 	fdmap.add (fd);
-      assert (fdmap.get_count () == subset_fd_count);
       hb_set_destroy (set);
+      if (unlikely (fdmap.get_count () != subset_fd_count))
+      	return false;
     }
 
     /* update each font dict index stored as "code" in fdselect_ranges */
@@ -112,7 +113,8 @@ hb_plan_subset_cff_fdselect (const hb_vector_t<hb_codepoint_t> &glyphs,
   /* determine which FDSelect format is most compact */
   if (subset_fd_count > 0xFF)
   {
-    assert (src.format == 4);
+    if (unlikely (src.format != 4))
+      return false;
     subset_fdselect_format = 4;
     subset_fdselect_size = FDSelect::min_size + FDSelect4::min_size + FDSelect4_Range::static_size * num_ranges + HBUINT32::static_size;
   }

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -578,7 +578,6 @@ struct SubrRemap : Remap
   inline int biased_num (unsigned int old_num) const
   {
     hb_codepoint_t new_num = (*this)[old_num];
-    assert (new_num != CFF_UNDEF_CODE);
     return (int)new_num - bias;
   }
 

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -112,7 +112,11 @@ struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
       const BlendArg &arg = env.argStack[i];
       if (arg.blending ())
       {
-	assert ((arg.numValues > 0) && (env.argStack.get_count () >= arg.numValues));
+      	if (unlikely (!((arg.numValues > 0) && (env.argStack.get_count () >= arg.numValues))))
+      	{
+	  env.set_error ();
+	  return;
+	}
 	flatten_blends (arg, i, env, param);
 	i += arg.numValues;
       }
@@ -133,8 +137,12 @@ struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
     for (unsigned int j = 0; j < arg.numValues; j++)
     {
       const BlendArg &arg1 = env.argStack[i + j];
-      assert (arg1.blending () && (arg.numValues == arg1.numValues) && (arg1.valueIndex == j) &&
-	      (arg1.deltas.len == env.get_region_count ()));
+      if (unlikely (!((arg1.blending () && (arg.numValues == arg1.numValues) && (arg1.valueIndex == j) &&
+	      (arg1.deltas.len == env.get_region_count ())))))
+      {
+      	env.set_error ();
+      	return;
+      }
       encoder.encode_num (arg1);
     }
     /* flatten deltas for each value */


### PR DESCRIPTION
Minimized usage of `assert()` in CFF code, either by:

(1) handle a failure condition as an error if it may ever happen with bad/unexpected input
(2) removed, if a failure shouldn't happen and cannot be easily handled as an error
(3) leave assert, if a failure shouldn't happen