### PR TITLE
Few fixes for Visual Studio builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,6 +696,8 @@ if (HB_HAVE_INTROSPECTION)
       -DHB_H_IN
       -DHB_OT_H
       -DHB_OT_H_IN
+      -DHB_AAT_H
+      -DHB_AAT_H_IN
       -DHB_GOBJECT_H
       -DHB_GOBJECT_H_IN
       -DHB_EXTERN=

--- a/test/api/hb-test.h
+++ b/test/api/hb-test.h
@@ -287,10 +287,11 @@ hb_test_open_font_file (const char *font_path)
 #endif
 
   hb_blob_t *blob = hb_blob_create_from_file (path);
+  hb_face_t *face;
   if (hb_blob_get_length (blob) == 0)
     g_error ("Font %s not found.", path);
 
-  hb_face_t *face = hb_face_create (blob, 0);
+  face = hb_face_create (blob, 0);
   hb_blob_destroy (blob);
 
   g_free (path);

--- a/test/api/test-aat-layout.c
+++ b/test/api/test-aat-layout.c
@@ -116,6 +116,7 @@ test_aat_has (void)
 int
 main (int argc, char **argv)
 {
+  unsigned int status;
   hb_test_init (&argc, &argv);
 
   hb_test_add (test_aat_get_feature_types);
@@ -124,7 +125,7 @@ main (int argc, char **argv)
 
   face = hb_test_open_font_file ("fonts/aat-feat.ttf");
   sbix = hb_test_open_font_file ("fonts/chromacheck-sbix.ttf");
-  unsigned int status = hb_test_run ();
+  status = hb_test_run ();
   hb_face_destroy (sbix);
   hb_face_destroy (face);
   return status;

--- a/test/api/test-font.c
+++ b/test/api/test-font.c
@@ -400,6 +400,7 @@ test_fontfuncs_parallels (void)
   hb_font_t *font0;
   hb_font_t *font1;
   hb_font_t *font2;
+  hb_codepoint_t glyph;
 
   blob = hb_blob_create (test_data, sizeof (test_data), HB_MEMORY_MODE_READONLY, NULL, NULL);
   face = hb_face_create (blob, 0);
@@ -424,7 +425,6 @@ test_fontfuncs_parallels (void)
   hb_font_funcs_destroy (ffuncs2);
 
   /* Just test that calling get_nominal_glyph doesn't infinite-loop. */
-  hb_codepoint_t glyph;
   hb_font_get_nominal_glyph (font2, 0x0020u, &glyph);
 
   hb_font_destroy (font2);

--- a/test/api/test-map.c
+++ b/test/api/test-map.c
@@ -31,11 +31,12 @@ static void
 test_map_basic (void)
 {
   hb_map_t *empty = hb_map_get_empty ();
+  hb_map_t *m;
   g_assert (hb_map_is_empty (empty));
   g_assert (!hb_map_allocation_successful (empty));
   hb_map_destroy (empty);
 
-  hb_map_t *m = hb_map_create ();
+  m = hb_map_create ();
   g_assert (hb_map_allocation_successful (m));
   g_assert (hb_map_is_empty (m));
 
@@ -68,11 +69,12 @@ test_map_userdata (void)
 
   hb_user_data_key_t key[2];
   int *data = (int *) malloc (sizeof (int));
+  int *data2;
   *data = 3123;
   hb_map_set_user_data (m, &key[0], data, free, TRUE);
   g_assert_cmpint (*((int *) hb_map_get_user_data (m, &key[0])), ==, 3123);
 
-  int *data2 = (int *) malloc (sizeof (int));
+  data2 = (int *) malloc (sizeof (int));
   *data2 = 6343;
   hb_map_set_user_data (m, &key[0], data2, free, FALSE);
   g_assert_cmpint (*((int *) hb_map_get_user_data (m, &key[0])), ==, 3123);
@@ -86,10 +88,11 @@ static void
 test_map_refcount (void)
 {
   hb_map_t *m = hb_map_create ();
+  hb_map_t *m2;
   hb_map_set (m, 213, 223);
   g_assert_cmpint (hb_map_get (m, 213), ==, 223);
 
-  hb_map_t *m2 = hb_map_reference (m);
+  m2 = hb_map_reference (m);
   hb_map_destroy (m);
 
   /* We copied its reference so it is still usable after one destroy */

--- a/test/api/test-ot-color.c
+++ b/test/api/test-ot-color.c
@@ -317,6 +317,7 @@ test_hb_ot_color_glyph_get_layers (void)
 {
   hb_ot_color_layer_t layers[1];
   unsigned int count = 1;
+  unsigned int num_layers;
 
   g_assert_cmpuint (hb_ot_color_glyph_get_layers (cpal_v1, 0, 0,
 						  NULL, NULL), ==, 0);
@@ -325,7 +326,6 @@ test_hb_ot_color_glyph_get_layers (void)
   g_assert_cmpuint (hb_ot_color_glyph_get_layers (cpal_v1, 2, 0,
 						  NULL, NULL), ==, 2);
 
-  unsigned int num_layers;
   num_layers = hb_ot_color_glyph_get_layers (cpal_v1, 2, 0, &count, layers);
 
   g_assert_cmpuint (num_layers, ==, 2);
@@ -382,13 +382,14 @@ static void
 test_hb_ot_color_svg (void)
 {
   hb_blob_t *blob;
+  unsigned int length;
+  const char *data;
 
   blob = hb_ot_color_glyph_reference_svg (svg, 0);
   g_assert (hb_blob_get_length (blob) == 0);
 
   blob = hb_ot_color_glyph_reference_svg (svg, 1);
-  unsigned int length;
-  const char *data = hb_blob_get_data (blob, &length);
+  data = hb_blob_get_data (blob, &length);
   g_assert_cmpuint (length, ==, 146);
   g_assert (strncmp (data, "<?xml", 4) == 0);
   g_assert (strncmp (data + 140, "</svg>", 5) == 0);
@@ -406,6 +407,7 @@ test_hb_ot_color_png (void)
   unsigned int length;
   const char *data;
   hb_glyph_extents_t extents;
+  hb_font_t *cbdt_font;
 
   /* sbix */
   hb_font_t *sbix_font;
@@ -431,7 +433,6 @@ test_hb_ot_color_png (void)
   hb_font_destroy (sbix_font);
 
   /* cbdt */
-  hb_font_t *cbdt_font;
   cbdt_font = hb_font_create (cbdt);
   blob = hb_ot_color_glyph_reference_png (cbdt_font, 0);
   g_assert (hb_blob_get_length (blob) == 0);

--- a/test/api/test-ot-face.c
+++ b/test/api/test-ot-face.c
@@ -37,17 +37,19 @@ test_face (hb_face_t *face,
 	   hb_codepoint_t cp)
 {
   hb_font_t *font = hb_font_create (face);
+  hb_set_t *set;
+  hb_codepoint_t g;
+  hb_position_t x, y;
+  char buf[5] = {0};
+  unsigned int len;
+  hb_glyph_extents_t extents;
   hb_ot_font_set_funcs (font);
 
-  hb_set_t *set = hb_set_create ();
+  set = hb_set_create ();
   hb_face_collect_unicodes (face, set);
   hb_face_collect_variation_selectors (face, set);
   hb_face_collect_variation_unicodes (face, cp, set);
 
-  hb_codepoint_t g;
-  hb_position_t x, y;
-  hb_glyph_extents_t extents;
-  char buf[5] = {0};
   hb_font_get_nominal_glyph (font, cp, &g);
   hb_font_get_variation_glyph (font, cp, cp, &g);
   hb_font_get_glyph_h_advance (font, cp);
@@ -86,7 +88,7 @@ test_face (hb_face_t *face,
   hb_ot_math_get_min_connector_overlap (font, HB_DIRECTION_RTL);
   hb_ot_math_get_glyph_assembly (font, cp, HB_DIRECTION_BTT, 0, NULL, NULL, NULL);
 
-  unsigned int len = sizeof (buf);
+  len = sizeof (buf);
   hb_ot_name_list_names (face, NULL);
   hb_ot_name_get_utf8 (face, cp, NULL, &len, buf);
   hb_ot_name_get_utf16 (face, cp, NULL, NULL, NULL);

--- a/test/api/test-ot-name.c
+++ b/test/api/test-ot-name.c
@@ -34,6 +34,14 @@ test_ot_layout_feature_get_name_ids_and_characters (void)
 {
   hb_tag_t cv01 = HB_TAG ('c','v','0','1');
   unsigned int feature_index;
+  unsigned int num_named_parameters;
+  hb_ot_name_id_t label_id;
+  hb_ot_name_id_t tooltip_id;
+  hb_ot_name_id_t sample_id;
+  hb_ot_name_id_t first_param_id;
+  hb_codepoint_t characters[100];
+  unsigned int char_count = 100;
+  unsigned int all_chars;
   if (!hb_ot_layout_language_find_feature (face,
 					   HB_OT_TAG_GSUB,
 					   0,
@@ -42,11 +50,6 @@ test_ot_layout_feature_get_name_ids_and_characters (void)
 					   &feature_index))
      g_error ("Failed to find feature index");
 
-  hb_ot_name_id_t label_id;
-  hb_ot_name_id_t tooltip_id;
-  hb_ot_name_id_t sample_id;
-  unsigned int num_named_parameters;
-  hb_ot_name_id_t first_param_id;
   if (!hb_ot_layout_feature_get_name_ids (face, HB_OT_TAG_GSUB, feature_index,
 					  &label_id, &tooltip_id, &sample_id,
 					  &num_named_parameters, &first_param_id))
@@ -58,10 +61,6 @@ test_ot_layout_feature_get_name_ids_and_characters (void)
   g_assert_cmpint (num_named_parameters, ==, 2);
   g_assert_cmpint (first_param_id, ==, 259);
 
-  hb_codepoint_t characters[100];
-  unsigned int char_count = 100;
-
-  unsigned int all_chars;
   all_chars = hb_ot_layout_feature_get_characters (face, HB_OT_TAG_GSUB, feature_index,
 						   0, &char_count, characters);
 
@@ -76,14 +75,16 @@ test_ot_name (void)
 {
   unsigned int num_entries;
   const hb_ot_name_entry_t *entries;
-  entries = hb_ot_name_list_names (face, &num_entries);
-  g_assert_cmpuint (12, ==, num_entries);
-  hb_ot_name_id_t name_id = entries[3].name_id;
-  g_assert_cmpuint (3, ==, name_id);
-  hb_language_t lang = entries[3].language;
-  g_assert_cmpstr (hb_language_to_string (lang), ==, "en");
+  hb_ot_name_id_t name_id;
+  hb_language_t lang;
   char text[10];
   unsigned int text_size = 10;
+  entries = hb_ot_name_list_names (face, &num_entries);
+  g_assert_cmpuint (12, ==, num_entries);
+  name_id = entries[3].name_id;
+  g_assert_cmpuint (3, ==, name_id);
+  lang = entries[3].language;
+  g_assert_cmpstr (hb_language_to_string (lang), ==, "en");
   g_assert_cmpuint (27, ==, hb_ot_name_get_utf8 (face, name_id, lang, &text_size, text));
   g_assert_cmpuint (9, ==, text_size);
   g_assert_cmpstr (text, ==, "FontForge");
@@ -92,13 +93,14 @@ test_ot_name (void)
 int
 main (int argc, char **argv)
 {
+  unsigned int status;
   g_test_init (&argc, &argv, NULL);
 
   hb_test_add (test_ot_layout_feature_get_name_ids_and_characters);
   hb_test_add (test_ot_name);
 
   face = hb_test_open_font_file ("fonts/cv01.otf");
-  unsigned int status = hb_test_run ();
+  status = hb_test_run ();
   hb_face_destroy (face);
   return status;
 }

--- a/test/api/test-ot-tag.c
+++ b/test/api/test-ot-tag.c
@@ -202,11 +202,11 @@ test_language_two_way (const char *tag_s, const char *lang_s)
 {
   hb_language_t lang = hb_language_from_string (lang_s, -1);
   hb_tag_t tag = hb_tag_from_string (tag_s, -1);
+  hb_tag_t tag2;
+  unsigned int count = 1;
 
   g_test_message ("Testing language %s <-> tag %s", lang_s, tag_s);
 
-  hb_tag_t tag2;
-  unsigned int count = 1;
   hb_ot_tags_from_script_and_language (HB_SCRIPT_INVALID,
 				       lang,
 				       NULL, NULL, &count, &tag2);
@@ -223,11 +223,11 @@ test_tag_from_language (const char *tag_s, const char *lang_s)
 {
   hb_language_t lang = hb_language_from_string (lang_s, -1);
   hb_tag_t tag = hb_tag_from_string (tag_s, -1);
+  hb_tag_t tag2;
+  unsigned int count = 1;
 
   g_test_message ("Testing language %s -> tag %s", lang_s, tag_s);
 
-  hb_tag_t tag2;
-  unsigned int count = 1;
   hb_ot_tags_from_script_and_language (HB_SCRIPT_INVALID,
 				       lang,
 				       NULL, NULL, &count, &tag2);
@@ -467,9 +467,10 @@ test_tags (hb_script_t  script,
   unsigned int i;
   hb_tag_t *script_tags = malloc (script_count * sizeof (hb_tag_t));
   hb_tag_t *language_tags = malloc (language_count * sizeof (hb_tag_t));
+  hb_language_t lang;
   g_assert (script_tags);
   g_assert (language_tags);
-  hb_language_t lang = hb_language_from_string (lang_s, -1);
+  lang = hb_language_from_string (lang_s, -1);
   va_start (expected_tags, expected_language_count);
 
   hb_ot_tags_from_script_and_language (script, lang, &script_count, script_tags, &language_count, language_tags);


### PR DESCRIPTION
Hi,

This updates the flags passed to g-ir-scanner in the CMake build files so that it won't complain about not including the headers correctly, and updates the test programs (in C) to declare variables at the top of the block, so that things will continue to build properly.

With blessings, thank you!