### PR TITLE
hb-unicode.cc: Workaround a Visual Studio 2010 x64 optimization bug

### DIFF
--- a/src/hb-unicode.cc
+++ b/src/hb-unicode.cc
@@ -32,6 +32,13 @@
 
 #include "hb-unicode.hh"
 
+/* Workaround a Visual Studio 2010 x64 optimization bug */
+#if (defined (_M_X64) || defined (_M_AMD64)) && (defined (_MSC_VER) && (_MSC_VER >= 1600) && (_MSC_VER < 1700))
+#define HB_WORKAROUND_VS10_X64_OPT_BUG strtod ("10", nullptr);
+#else
+#define HB_WORKAROUND_VS10_X64_OPT_BUG
+#endif
+
 
 /**
  * SECTION: hb-unicode
@@ -302,6 +309,7 @@ hb_unicode_funcs_get_user_data (hb_unicode_funcs_t *ufuncs,
 void
 hb_unicode_funcs_make_immutable (hb_unicode_funcs_t *ufuncs)
 {
+  HB_WORKAROUND_VS10_X64_OPT_BUG
   if (hb_object_is_immutable (ufuncs))
     return;
 


### PR DESCRIPTION
Hi,

This PR attempts to workaround an optimization bug in the Visual Studio 2010 x64 compiler, where the resulting binaries will crash unless compiler optimizations are disabled for the build (i.e. changing "/O2 /Ob1" to "/Od").

This does so by inserting a pointless line that is used only on Visual Studio 2010 x64 builds in hb_unicode_funcs_make_immutable() (which calls an inline function hb_object_is_immutable() in hb-object.hh), so that the optimizer will not do something weird here.

Call stack (before the updates here) for references, where this issue is exhibited when running the test-unicode test program (among other test programs as well):

harfbuzz.dll!hb_unicode_funcs_make_immutable(hb_unicode_funcs_t * ufuncs) line 305 C++
harfbuzz.dll!hb_unicode_funcs_create(hb_unicode_funcs_t * parent) line 172 C++
harfbuzz.dll!hb_ucdn_unicode_funcs_lazy_loader_t::create() line 236 C++
harfbuzz.dll!hb_ucdn_get_unicode_funcs() line 268 C++
test-unicode.exe!main(int argc, char * * argv) line 799 C
test-unicode.exe!__tmainCRTStartup() line 555 C

With blessings, thank you!

