### PR TITLE
Fix build on older Visual Studio versions

### DIFF
--- a/src/hb-cff-interp-dict-common.hh
+++ b/src/hb-cff-interp-dict-common.hh
@@ -105,7 +105,7 @@ struct DictOpSet : OpSet<Number>
     bool    exp_overflow = false;
     enum Part { INT_PART=0, FRAC_PART, EXP_PART } part = INT_PART;
     enum Nibble { DECIMAL=10, EXP_POS, EXP_NEG, RESERVED, NEG, END };
-    const uint64_t MAX_FRACT = 0xFFFFFFFFFFFFFllu; /* 1^52-1 */
+    const uint64_t MAX_FRACT = 0xFFFFFFFFFFFFFull; /* 1^52-1 */
     const uint32_t MAX_EXP = 0x7FFu; /* 1^11-1 */
 
     double  value = 0.0;

--- a/src/hb-dsalgs.hh
+++ b/src/hb-dsalgs.hh
@@ -306,6 +306,15 @@ template <> struct hb_is_signed<unsigned short> { enum { value = false }; };
 template <> struct hb_is_signed<unsigned int> { enum { value = false }; };
 template <> struct hb_is_signed<unsigned long> { enum { value = false }; };
 
+/* We need to define hb_is_signed for the typedefs we use on pre-Visual Studio 2010
+ * for the int8_t type, since __int8/__int64 is not considered the same as char/long.
+ * The previous lines will suffice for the other types, though.  Note that somehow,
+ * usigned __int8 is considered equal to unsigned char.
+ */
+#if defined (_MSC_VER) && (_MSC_VER < 1600)
+template <> struct hb_is_signed<__int8> { enum { value = true }; };
+#endif
+
 template <typename T> static inline bool
 hb_in_range (T u, T lo, T hi)
 {

--- a/test/api/test-aat-layout.c
+++ b/test/api/test-aat-layout.c
@@ -105,10 +105,11 @@ static void
 test_aat_has (void)
 {
   hb_face_t *morx = hb_test_open_font_file ("fonts/aat-morx.ttf");
+  hb_face_t *trak;
   g_assert (hb_aat_layout_has_substitution (morx));
   hb_face_destroy (morx);
 
-  hb_face_t *trak = hb_test_open_font_file ("fonts/aat-trak.ttf");
+  trak = hb_test_open_font_file ("fonts/aat-trak.ttf");
   g_assert (hb_aat_layout_has_tracking (trak));
   hb_face_destroy (trak);
 }

--- a/test/api/test-subset-cff1.c
+++ b/test/api/test-subset-cff1.c
@@ -235,10 +235,11 @@ test_subset_cff1_expert (void)
   hb_face_t *face_subset = hb_test_open_font_file ("fonts/cff1_expert.2D,F6E9,FB00.otf");
 
   hb_set_t *codepoints = hb_set_create ();
+  hb_face_t *face_test;
   hb_set_add (codepoints, 0x2D);
   hb_set_add (codepoints, 0xF6E9);
   hb_set_add (codepoints, 0xFB00);
-  hb_face_t *face_test = hb_subset_test_create_subset (face, hb_subset_test_create_input (codepoints));
+  face_test = hb_subset_test_create_subset (face, hb_subset_test_create_input (codepoints));
   hb_set_destroy (codepoints);
 
   hb_subset_test_check (face_subset, face_test, HB_TAG ('C','F','F',' '));
@@ -253,10 +254,11 @@ test_subset_cff1_seac (void)
 {
   hb_face_t *face = hb_test_open_font_file ("fonts/cff1_seac.otf");
   hb_face_t *face_subset = hb_test_open_font_file ("fonts/cff1_seac.C0.otf");
+  hb_face_t *face_test;
 
   hb_set_t *codepoints = hb_set_create ();
   hb_set_add (codepoints, 0xC0);  /* Agrave */
-  hb_face_t *face_test = hb_subset_test_create_subset (face, hb_subset_test_create_input (codepoints));
+  face_test = hb_subset_test_create_subset (face, hb_subset_test_create_input (codepoints));
   hb_set_destroy (codepoints);
 
   hb_subset_test_check (face_subset, face_test, HB_TAG ('C','F','F',' '));
@@ -273,10 +275,12 @@ test_subset_cff1_dotsection (void)
   hb_face_t *face_subset = hb_test_open_font_file ("fonts/cff1_dotsect.nohints.otf");
 
   hb_set_t *codepoints = hb_set_create ();
+  hb_subset_input_t *input;
+  hb_face_t *face_test;
   hb_set_add (codepoints, 0x69);  /* i */
-  hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
+  input = hb_subset_test_create_input (codepoints);
   hb_subset_input_set_drop_hints (input, true);
-  hb_face_t *face_test = hb_subset_test_create_subset (face, input);
+  face_test = hb_subset_test_create_subset (face, input);
   hb_set_destroy (codepoints);
 
   hb_subset_test_check (face_subset, face_test, HB_TAG ('C','F','F',' '));


### PR DESCRIPTION
Hi,

This PR attempts to fix builds on pre-2013 Visual Studio by:

-Using 'ull' instead of 'llu' for unsigned long long constants for uint64_t, since pre-2013 Visual Studio does not like llu suffixes.
-Fix the C test programs on variable declarations.
-Add a specialization for hb_is_signed<> for the __int8 type (which is the typedef'ed for int8_t, which somehow the 2008 compiler does not consider equivilant to signed char (unsigned __int8 is considered equivilant to unsigned char, somehow :| )

With blessings, thank you!