### PR TITLE
CFF renaming

### DIFF
--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -309,6 +309,8 @@ struct byte_str_t : hb_ubytes_t
   byte_str_t (const hb_ubytes_t &ub)	/* conversion from hb_ubytes_t */
     : hb_ubytes_t (ub) {}
   
+  void init (void) { str(); }
+  
   /* sub-string */
   byte_str_t sub_str (unsigned int offset, unsigned int len_) const
   { return byte_str_t (hb_ubytes_t::sub_array (offset, len_)); }
@@ -325,7 +327,7 @@ struct byte_str_ref_t
 
   void init ()
   {
-    str = byte_str_t ();
+    str.init ();
     offset = 0;
     error = false;
   }

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -217,37 +217,37 @@ inline unsigned int OpCode_Size (op_code_t op) { return Is_OpCode_ESC (op) ? 2: 
 
 struct number_t
 {
-  void init () { set_real (0.0); }
-  void fini () {}
+  inline void init () { set_real (0.0); }
+  inline void fini () {}
 
-  void set_int (int v)       { value = (double) v; }
-  int to_int () const        { return (int) value; }
+  inline void set_int (int v)		{ value = (double) v; }
+  inline int to_int () const		{ return (int) value; }
 
-  void set_fixed (int32_t v) { value = v / 65536.0; }
-  int32_t to_fixed () const  { return (int32_t) (value * 65536.0); }
+  inline void set_fixed (int32_t v)	{ value = v / 65536.0; }
+  inline int32_t to_fixed () const	{ return (int32_t) (value * 65536.0); }
 
-  void set_real (double v)	 { value = v; }
-  double to_real () const    { return value; }
+  inline void set_real (double v)	{ value = v; }
+  inline double to_real () const	{ return value; }
 
-  int ceil () const          { return (int) ::ceil (value); }
-  int floor () const         { return (int) ::floor (value); }
+  inline int ceil () const		{ return (int) ::ceil (value); }
+  inline int floor () const		{ return (int) ::floor (value); }
 
-  bool in_int_range () const
+  inline bool in_int_range () const
   { return ((double) (int16_t) to_int () == value); }
 
-  bool operator > (const number_t &n) const
+  inline bool operator > (const number_t &n) const
   { return value > n.to_real (); }
 
-  bool operator < (const number_t &n) const
+  inline bool operator < (const number_t &n) const
   { return n > *this; }
 
-  bool operator >= (const number_t &n) const
+  inline bool operator >= (const number_t &n) const
   { return !(*this < n); }
 
-  bool operator <= (const number_t &n) const
+  inline bool operator <= (const number_t &n) const
   { return !(*this > n); }
 
-  const number_t &operator += (const number_t &n)
+  inline const number_t &operator += (const number_t &n)
   {
     set_real (to_real () + n.to_real ());
 
@@ -263,7 +263,7 @@ struct UnsizedByteStr : UnsizedArrayOf <HBUINT8>
 {
   // encode 2-byte int (Dict/CharString) or 4-byte int (Dict)
   template <typename INTTYPE, int minVal, int maxVal>
-  static bool serialize_int (hb_serialize_context_t *c, op_code_t intOp, int value)
+  static inline bool serialize_int (hb_serialize_context_t *c, op_code_t intOp, int value)
   {
     TRACE_SERIALIZE (this);
 
@@ -281,10 +281,10 @@ struct UnsizedByteStr : UnsizedArrayOf <HBUINT8>
     return_trace (true);
   }
 
-  static bool serialize_int4 (hb_serialize_context_t *c, int value)
+  static inline bool serialize_int4 (hb_serialize_context_t *c, int value)
   { return serialize_int<HBUINT32, 0, 0x7FFFFFFF> (c, OpCode_longintdict, value); }
 
-  static bool serialize_int2 (hb_serialize_context_t *c, int value)
+  static inline bool serialize_int2 (hb_serialize_context_t *c, int value)
   { return serialize_int<HBUINT16, 0, 0x7FFF> (c, OpCode_shortint, value); }
 
   /* Defining null_size allows a Null object may be created. Should be safe because:
@@ -300,49 +300,48 @@ struct UnsizedByteStr : UnsizedArrayOf <HBUINT8>
 /* Holder of a section of byte string within a CFFIndex entry */
 struct byte_str_t : hb_ubytes_t
 {
-  byte_str_t ()
+  inline byte_str_t ()
     : hb_ubytes_t () {}
-  byte_str_t (const UnsizedByteStr& s, unsigned int l)
+  inline byte_str_t (const UnsizedByteStr& s, unsigned int l)
     : hb_ubytes_t ((const unsigned char*)&s, l) {}
-  byte_str_t (const unsigned char *s, unsigned int l)
+  inline byte_str_t (const unsigned char *s, unsigned int l)
     : hb_ubytes_t (s, l) {}
-  byte_str_t (const hb_ubytes_t &ub)	/* conversion from hb_ubytes_t */
+  inline byte_str_t (const hb_ubytes_t &ub)	/* conversion from hb_ubytes_t */
     : hb_ubytes_t (ub) {}
   
   /* sub-string */
-  byte_str_t sub_str (unsigned int offset, unsigned int len_) const
+  inline byte_str_t sub_str (unsigned int offset, unsigned int len_) const
   { return byte_str_t (hb_ubytes_t::sub_array (offset, len_)); }
 
-  bool check_limit (unsigned int offset, unsigned int count) const
+  inline bool check_limit (unsigned int offset, unsigned int count) const
   { return (offset + count <= len); }
 };
 
 /* A byte string associated with the current offset and an error condition */
 struct byte_str_ref_t
 {
-  byte_str_ref_t ()
-  { init (); }
+  inline byte_str_ref_t ()	{ init (); }
 
-  void init ()
+  inline void init ()
   {
     str = byte_str_t ();
     offset = 0;
     error = false;
   }
 
-  void fini () {}
+  inline void fini () {}
 
-  byte_str_ref_t (const byte_str_t &str_, unsigned int offset_ = 0)
+  inline byte_str_ref_t (const byte_str_t &str_, unsigned int offset_ = 0)
     : str (str_), offset (offset_), error (false) {}
 
-  void reset (const byte_str_t &str_, unsigned int offset_ = 0)
+  inline void reset (const byte_str_t &str_, unsigned int offset_ = 0)
   {
     str = str_;
     offset = offset_;
     error = false;
   }
 
-  const unsigned char& operator [] (int i) {
+  inline const unsigned char& operator [] (int i) {
     if (unlikely ((unsigned int)(offset + i) >= str.len))
     {
       set_error ();
@@ -353,16 +352,16 @@ struct byte_str_ref_t
   }
 
   /* Conversion to byte_str_t */
-  operator byte_str_t () const { return str.sub_str (offset, str.len - offset); }
+  inline operator byte_str_t () const { return str.sub_str (offset, str.len - offset); }
 
-  byte_str_t sub_str (unsigned int offset_, unsigned int len_) const
+  inline byte_str_t sub_str (unsigned int offset_, unsigned int len_) const
   { return str.sub_str (offset_, len_); }
 
-  bool avail (unsigned int count=1) const
+  inline bool avail (unsigned int count=1) const
   {
     return (!in_error () && str.check_limit (offset, count));
   }
-  void inc (unsigned int count=1)
+  inline void inc (unsigned int count=1)
   {
     if (likely (!in_error () && (offset <= str.len) && (offset + count <= str.len)))
     {
@@ -375,8 +374,8 @@ struct byte_str_ref_t
     }
   }
 
-  void set_error ()      { error = true; }
-  bool in_error () const { return error; }
+  inline void set_error ()      { error = true; }
+  inline bool in_error () const { return error; }
 
   byte_str_t       str;
   unsigned int  offset; /* beginning of the sub-string within str */
@@ -391,7 +390,7 @@ typedef hb_vector_t<byte_str_t> byte_str_array_t;
 template <typename ELEM, int LIMIT>
 struct stack_t
 {
-  void init ()
+  inline void init ()
   {
     error = false;
     count = 0;
@@ -401,18 +400,18 @@ struct stack_t
       elements[i].init ();
   }
 
-  void fini ()
+  inline void fini ()
   {
     elements.fini_deep ();
   }
 
-  ELEM& operator [] (unsigned int i)
+  inline ELEM& operator [] (unsigned int i)
   {
     if (unlikely (i >= count)) set_error ();
     return elements[i];
   }
 
-  void push (const ELEM &v)
+  inline void push (const ELEM &v)
   {
     if (likely (count < elements.len))
       elements[count++] = v;
@@ -420,7 +419,7 @@ struct stack_t
       set_error ();
   }
 
-  ELEM &push ()
+  inline ELEM &push ()
   {
     if (likely (count < elements.len))
       return elements[count++];
@@ -431,7 +430,7 @@ struct stack_t
     }
   }
 
-  ELEM& pop ()
+  inline ELEM& pop ()
   {
     if (likely (count > 0))
       return elements[--count];
@@ -442,7 +441,7 @@ struct stack_t
     }
   }
 
-  void pop (unsigned int n)
+  inline void pop (unsigned int n)
   {
     if (likely (count >= n))
       count -= n;
@@ -450,7 +449,7 @@ struct stack_t
       set_error ();
   }
 
-  const ELEM& peek ()
+  inline const ELEM& peek ()
   {
     if (likely (count > 0))
       return elements[count-1];
@@ -461,7 +460,7 @@ struct stack_t
     }
   }
 
-  void unpop ()
+  inline void unpop ()
   {
     if (likely (count < elements.len))
       count++;
@@ -469,13 +468,13 @@ struct stack_t
       set_error ();
   }
 
-  void clear () { count = 0; }
+  inline void clear () { count = 0; }
 
-  bool in_error () const { return (error || elements.in_error ()); }
-  void set_error ()      { error = true; }
+  inline bool in_error () const { return (error || elements.in_error ()); }
+  inline void set_error ()	{ error = true; }
 
-  unsigned int get_count () const { return count; }
-  bool is_empty () const { return count == 0; }
+  inline unsigned int get_count () const { return count; }
+  inline bool is_empty () const { return count == 0; }
 
   static const unsigned int kSizeLimit = LIMIT;
 
@@ -489,29 +488,29 @@ struct stack_t
 template <typename ARG=number_t>
 struct arg_stack_t : stack_t<ARG, 513>
 {
-  void push_int (int v)
+  inline void push_int (int v)
   {
     ARG &n = S::push ();
     n.set_int (v);
   }
 
-  void push_fixed (int32_t v)
+  inline void push_fixed (int32_t v)
   {
     ARG &n = S::push ();
     n.set_fixed (v);
   }
 
-  void push_real (double v)
+  inline void push_real (double v)
   {
     ARG &n = S::push ();
     n.set_real (v);
   }
 
-  ARG& pop_num () { return this->pop (); }
+  inline ARG& pop_num () { return this->pop (); }
 
-  int pop_int ()  { return this->pop ().to_int (); }
+  inline int pop_int ()  { return this->pop ().to_int (); }
 
-  unsigned int pop_uint ()
+  inline unsigned int pop_uint ()
   {
     int i = pop_int ();
     if (unlikely (i < 0))
@@ -522,13 +521,13 @@ struct arg_stack_t : stack_t<ARG, 513>
     return (unsigned)i;
   }
 
-  void push_longint_from_substr (byte_str_ref_t& str_ref)
+  inline void push_longint_from_substr (byte_str_ref_t& str_ref)
   {
     push_int ((str_ref[0] << 24) | (str_ref[1] << 16) | (str_ref[2] << 8) | (str_ref[3]));
     str_ref.inc (4);
   }
 
-  bool push_fixed_from_substr (byte_str_ref_t& str_ref)
+  inline bool push_fixed_from_substr (byte_str_ref_t& str_ref)
   {
     if (unlikely (!str_ref.avail (4)))
       return false;
@@ -537,7 +536,7 @@ struct arg_stack_t : stack_t<ARG, 513>
     return true;
   }
 
-  hb_array_t<const ARG> get_subarray (unsigned int start) const
+  inline hb_array_t<const ARG> get_subarray (unsigned int start) const
   {
     return S::elements.sub_array (start);
   }
@@ -549,8 +548,8 @@ struct arg_stack_t : stack_t<ARG, 513>
 /* an operator prefixed by its operands in a byte string */
 struct op_str_t
 {
-  void init () {}
-  void fini () {}
+  inline void init () {}
+  inline void fini () {}
 
   op_code_t  op;
   byte_str_t str;
@@ -560,7 +559,7 @@ struct op_str_t
 struct op_serializer_t
 {
   protected:
-  bool copy_opstr (hb_serialize_context_t *c, const op_str_t& opstr) const
+  inline bool copy_opstr (hb_serialize_context_t *c, const op_str_t& opstr) const
   {
     TRACE_SERIALIZE (this);
 
@@ -574,14 +573,14 @@ struct op_serializer_t
 template <typename VAL>
 struct parsed_values_t
 {
-  void init ()
+  inline void init ()
   {
     opStart = 0;
     values.init ();
   }
-  void fini () { values.fini_deep (); }
+  inline void fini () { values.fini_deep (); }
 
-  void add_op (op_code_t op, const byte_str_ref_t& str_ref = byte_str_ref_t ())
+  inline void add_op (op_code_t op, const byte_str_ref_t& str_ref = byte_str_ref_t ())
   {
     VAL *val = values.push ();
     val->op = op;
@@ -589,7 +588,7 @@ struct parsed_values_t
     opStart = str_ref.offset;
   }
 
-  void add_op (op_code_t op, const byte_str_ref_t& str_ref, const VAL &v)
+  inline void add_op (op_code_t op, const byte_str_ref_t& str_ref, const VAL &v)
   {
     VAL *val = values.push (v);
     val->op = op;
@@ -597,16 +596,16 @@ struct parsed_values_t
     opStart = str_ref.offset;
   }
 
-  bool has_op (op_code_t op) const
+  inline bool has_op (op_code_t op) const
   {
     for (unsigned int i = 0; i < get_count (); i++)
       if (get_value (i).op == op) return true;
     return false;
   }
 
-  unsigned get_count () const { return values.len; }
-  const VAL &get_value (unsigned int i) const { return values[i]; }
-  const VAL &operator [] (unsigned int i) const { return get_value (i); }
+  inline unsigned get_count () const { return values.len; }
+  inline const VAL &get_value (unsigned int i) const { return values[i]; }
+  inline const VAL &operator [] (unsigned int i) const { return get_value (i); }
 
   unsigned int       opStart;
   hb_vector_t<VAL>   values;
@@ -615,20 +614,20 @@ struct parsed_values_t
 template <typename ARG=number_t>
 struct interp_env_t
 {
-  void init (const byte_str_t &str_)
+  inline void init (const byte_str_t &str_)
   {
     str_ref.reset (str_);
     argStack.init ();
     error = false;
   }
-  void fini () { argStack.fini (); }
+  inline void fini () { argStack.fini (); }
 
-  bool in_error () const
+  inline bool in_error () const
   { return error || str_ref.in_error () || argStack.in_error (); }
 
-  void set_error () { error = true; }
+  inline void set_error () { error = true; }
 
-  op_code_t fetch_op ()
+  inline op_code_t fetch_op ()
   {
     op_code_t  op = OpCode_Invalid;
     if (unlikely (!str_ref.avail ()))
@@ -644,22 +643,22 @@ struct interp_env_t
     return op;
   }
 
-  const ARG& eval_arg (unsigned int i)
+  inline const ARG& eval_arg (unsigned int i)
   {
     return argStack[i];
   }
 
-  ARG& pop_arg ()
+  inline ARG& pop_arg ()
   {
     return argStack.pop ();
   }
 
-  void pop_n_args (unsigned int n)
+  inline void pop_n_args (unsigned int n)
   {
     argStack.pop (n);
   }
 
-  void clear_args ()
+  inline void clear_args ()
   {
     pop_n_args (argStack.get_count ());
   }
@@ -675,7 +674,7 @@ typedef interp_env_t<> num_interp_env_t;
 template <typename ARG=number_t>
 struct opset_t
 {
-  static void process_op (op_code_t op, interp_env_t<ARG>& env)
+  static inline void process_op (op_code_t op, interp_env_t<ARG>& env)
   {
     switch (op) {
       case OpCode_shortint:
@@ -713,9 +712,9 @@ struct opset_t
 template <typename ENV>
 struct interpreter_t {
 
-  ~interpreter_t() { fini (); }
+  inline ~interpreter_t() { fini (); }
 
-  void fini () { env.fini (); }
+  inline void fini () { env.fini (); }
 
   ENV env;
 };

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -215,7 +215,7 @@ inline unsigned int OpCode_Size (OpCode op) { return Is_OpCode_ESC (op) ? 2: 1; 
 #define OpCode_Invalid		0xFFFFu
 
 
-struct Number
+struct number_t
 {
   void init () { set_real (0.0); }
   void fini () {}
@@ -235,19 +235,19 @@ struct Number
   bool in_int_range () const
   { return ((double) (int16_t) to_int () == value); }
 
-  bool operator > (const Number &n) const
+  bool operator > (const number_t &n) const
   { return value > n.to_real (); }
 
-  bool operator < (const Number &n) const
+  bool operator < (const number_t &n) const
   { return n > *this; }
 
-  bool operator >= (const Number &n) const
+  bool operator >= (const number_t &n) const
   { return !(*this < n); }
 
-  bool operator <= (const Number &n) const
+  bool operator <= (const number_t &n) const
   { return !(*this > n); }
 
-  const Number &operator += (const Number &n)
+  const number_t &operator += (const number_t &n)
   {
     set_real (to_real () + n.to_real ());
 
@@ -389,7 +389,7 @@ typedef hb_vector_t<byte_str_t> byte_str_array_t;
 
 /* stack */
 template <typename ELEM, int LIMIT>
-struct Stack
+struct stack_t
 {
   void init ()
   {
@@ -486,8 +486,8 @@ struct Stack
 };
 
 /* argument stack */
-template <typename ARG=Number>
-struct ArgStack : Stack<ARG, 513>
+template <typename ARG=number_t>
+struct arg_stack_t : stack_t<ARG, 513>
 {
   void push_int (int v)
   {
@@ -543,11 +543,11 @@ struct ArgStack : Stack<ARG, 513>
   }
 
   private:
-  typedef Stack<ARG, 513> S;
+  typedef stack_t<ARG, 513> S;
 };
 
 /* an operator prefixed by its operands in a byte string */
-struct OpStr
+struct op_str_t
 {
   void init () {}
   void fini () {}
@@ -557,10 +557,10 @@ struct OpStr
 };
 
 /* base of OP_SERIALIZER */
-struct OpSerializer
+struct op_serializer_t
 {
   protected:
-  bool copy_opstr (hb_serialize_context_t *c, const OpStr& opstr) const
+  bool copy_opstr (hb_serialize_context_t *c, const op_str_t& opstr) const
   {
     TRACE_SERIALIZE (this);
 
@@ -572,7 +572,7 @@ struct OpSerializer
 };
 
 template <typename VAL>
-struct ParsedValues
+struct parsed_values_t
 {
   void init ()
   {
@@ -612,8 +612,8 @@ struct ParsedValues
   hb_vector_t<VAL>   values;
 };
 
-template <typename ARG=Number>
-struct InterpEnv
+template <typename ARG=number_t>
+struct interp_env_t
 {
   void init (const byte_str_t &str_)
   {
@@ -665,17 +665,17 @@ struct InterpEnv
   }
 
   byte_str_ref_t    str_ref;
-  ArgStack<ARG> argStack;
+  arg_stack_t<ARG> argStack;
   protected:
   bool	  error;
 };
 
-typedef InterpEnv<> NumInterpEnv;
+typedef interp_env_t<> num_interp_env_t;
 
-template <typename ARG=Number>
-struct OpSet
+template <typename ARG=number_t>
+struct opset_t
 {
-  static void process_op (OpCode op, InterpEnv<ARG>& env)
+  static void process_op (OpCode op, interp_env_t<ARG>& env)
   {
     switch (op) {
       case OpCode_shortint:
@@ -711,9 +711,9 @@ struct OpSet
 };
 
 template <typename ENV>
-struct Interpreter {
+struct interpreter_t {
 
-  ~Interpreter() { fini (); }
+  ~interpreter_t() { fini (); }
 
   void fini () { env.fini (); }
 

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -309,8 +309,6 @@ struct byte_str_t : hb_ubytes_t
   byte_str_t (const hb_ubytes_t &ub)	/* conversion from hb_ubytes_t */
     : hb_ubytes_t (ub) {}
   
-  void init (void) { str(); }
-  
   /* sub-string */
   byte_str_t sub_str (unsigned int offset, unsigned int len_) const
   { return byte_str_t (hb_ubytes_t::sub_array (offset, len_)); }
@@ -327,7 +325,7 @@ struct byte_str_ref_t
 
   void init ()
   {
-    str.init ();
+    str = byte_str_t ();
     offset = 0;
     error = false;
   }

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -217,37 +217,37 @@ inline unsigned int OpCode_Size (op_code_t op) { return Is_OpCode_ESC (op) ? 2: 
 
 struct number_t
 {
-  inline void init () { set_real (0.0); }
-  inline void fini () {}
+  void init () { set_real (0.0); }
+  void fini () {}
 
-  inline void set_int (int v)		{ value = (double) v; }
-  inline int to_int () const		{ return (int) value; }
+  void set_int (int v)       { value = (double) v; }
+  int to_int () const        { return (int) value; }
 
-  inline void set_fixed (int32_t v)	{ value = v / 65536.0; }
-  inline int32_t to_fixed () const	{ return (int32_t) (value * 65536.0); }
+  void set_fixed (int32_t v) { value = v / 65536.0; }
+  int32_t to_fixed () const  { return (int32_t) (value * 65536.0); }
 
-  inline void set_real (double v)	{ value = v; }
-  inline double to_real () const	{ return value; }
+  void set_real (double v)	 { value = v; }
+  double to_real () const    { return value; }
 
-  inline int ceil () const		{ return (int) ::ceil (value); }
-  inline int floor () const		{ return (int) ::floor (value); }
+  int ceil () const          { return (int) ::ceil (value); }
+  int floor () const         { return (int) ::floor (value); }
 
-  inline bool in_int_range () const
+  bool in_int_range () const
   { return ((double) (int16_t) to_int () == value); }
 
-  inline bool operator > (const number_t &n) const
+  bool operator > (const number_t &n) const
   { return value > n.to_real (); }
 
-  inline bool operator < (const number_t &n) const
+  bool operator < (const number_t &n) const
   { return n > *this; }
 
-  inline bool operator >= (const number_t &n) const
+  bool operator >= (const number_t &n) const
   { return !(*this < n); }
 
-  inline bool operator <= (const number_t &n) const
+  bool operator <= (const number_t &n) const
   { return !(*this > n); }
 
-  inline const number_t &operator += (const number_t &n)
+  const number_t &operator += (const number_t &n)
   {
     set_real (to_real () + n.to_real ());
 
@@ -263,7 +263,7 @@ struct UnsizedByteStr : UnsizedArrayOf <HBUINT8>
 {
   // encode 2-byte int (Dict/CharString) or 4-byte int (Dict)
   template <typename INTTYPE, int minVal, int maxVal>
-  static inline bool serialize_int (hb_serialize_context_t *c, op_code_t intOp, int value)
+  static bool serialize_int (hb_serialize_context_t *c, op_code_t intOp, int value)
   {
     TRACE_SERIALIZE (this);
 
@@ -281,10 +281,10 @@ struct UnsizedByteStr : UnsizedArrayOf <HBUINT8>
     return_trace (true);
   }
 
-  static inline bool serialize_int4 (hb_serialize_context_t *c, int value)
+  static bool serialize_int4 (hb_serialize_context_t *c, int value)
   { return serialize_int<HBUINT32, 0, 0x7FFFFFFF> (c, OpCode_longintdict, value); }
 
-  static inline bool serialize_int2 (hb_serialize_context_t *c, int value)
+  static bool serialize_int2 (hb_serialize_context_t *c, int value)
   { return serialize_int<HBUINT16, 0, 0x7FFF> (c, OpCode_shortint, value); }
 
   /* Defining null_size allows a Null object may be created. Should be safe because:
@@ -300,48 +300,49 @@ struct UnsizedByteStr : UnsizedArrayOf <HBUINT8>
 /* Holder of a section of byte string within a CFFIndex entry */
 struct byte_str_t : hb_ubytes_t
 {
-  inline byte_str_t ()
+  byte_str_t ()
     : hb_ubytes_t () {}
-  inline byte_str_t (const UnsizedByteStr& s, unsigned int l)
+  byte_str_t (const UnsizedByteStr& s, unsigned int l)
     : hb_ubytes_t ((const unsigned char*)&s, l) {}
-  inline byte_str_t (const unsigned char *s, unsigned int l)
+  byte_str_t (const unsigned char *s, unsigned int l)
     : hb_ubytes_t (s, l) {}
-  inline byte_str_t (const hb_ubytes_t &ub)	/* conversion from hb_ubytes_t */
+  byte_str_t (const hb_ubytes_t &ub)	/* conversion from hb_ubytes_t */
     : hb_ubytes_t (ub) {}
   
   /* sub-string */
-  inline byte_str_t sub_str (unsigned int offset, unsigned int len_) const
+  byte_str_t sub_str (unsigned int offset, unsigned int len_) const
   { return byte_str_t (hb_ubytes_t::sub_array (offset, len_)); }
 
-  inline bool check_limit (unsigned int offset, unsigned int count) const
+  bool check_limit (unsigned int offset, unsigned int count) const
   { return (offset + count <= len); }
 };
 
 /* A byte string associated with the current offset and an error condition */
 struct byte_str_ref_t
 {
-  inline byte_str_ref_t ()	{ init (); }
+  byte_str_ref_t ()
+  { init (); }
 
-  inline void init ()
+  void init ()
   {
     str = byte_str_t ();
     offset = 0;
     error = false;
   }
 
-  inline void fini () {}
+  void fini () {}
 
-  inline byte_str_ref_t (const byte_str_t &str_, unsigned int offset_ = 0)
+  byte_str_ref_t (const byte_str_t &str_, unsigned int offset_ = 0)
     : str (str_), offset (offset_), error (false) {}
 
-  inline void reset (const byte_str_t &str_, unsigned int offset_ = 0)
+  void reset (const byte_str_t &str_, unsigned int offset_ = 0)
   {
     str = str_;
     offset = offset_;
     error = false;
   }
 
-  inline const unsigned char& operator [] (int i) {
+  const unsigned char& operator [] (int i) {
     if (unlikely ((unsigned int)(offset + i) >= str.len))
     {
       set_error ();
@@ -352,16 +353,16 @@ struct byte_str_ref_t
   }
 
   /* Conversion to byte_str_t */
-  inline operator byte_str_t () const { return str.sub_str (offset, str.len - offset); }
+  operator byte_str_t () const { return str.sub_str (offset, str.len - offset); }
 
-  inline byte_str_t sub_str (unsigned int offset_, unsigned int len_) const
+  byte_str_t sub_str (unsigned int offset_, unsigned int len_) const
   { return str.sub_str (offset_, len_); }
 
-  inline bool avail (unsigned int count=1) const
+  bool avail (unsigned int count=1) const
   {
     return (!in_error () && str.check_limit (offset, count));
   }
-  inline void inc (unsigned int count=1)
+  void inc (unsigned int count=1)
   {
     if (likely (!in_error () && (offset <= str.len) && (offset + count <= str.len)))
     {
@@ -374,8 +375,8 @@ struct byte_str_ref_t
     }
   }
 
-  inline void set_error ()      { error = true; }
-  inline bool in_error () const { return error; }
+  void set_error ()      { error = true; }
+  bool in_error () const { return error; }
 
   byte_str_t       str;
   unsigned int  offset; /* beginning of the sub-string within str */
@@ -390,7 +391,7 @@ typedef hb_vector_t<byte_str_t> byte_str_array_t;
 template <typename ELEM, int LIMIT>
 struct stack_t
 {
-  inline void init ()
+  void init ()
   {
     error = false;
     count = 0;
@@ -400,18 +401,18 @@ struct stack_t
       elements[i].init ();
   }
 
-  inline void fini ()
+  void fini ()
   {
     elements.fini_deep ();
   }
 
-  inline ELEM& operator [] (unsigned int i)
+  ELEM& operator [] (unsigned int i)
   {
     if (unlikely (i >= count)) set_error ();
     return elements[i];
   }
 
-  inline void push (const ELEM &v)
+  void push (const ELEM &v)
   {
     if (likely (count < elements.len))
       elements[count++] = v;
@@ -419,7 +420,7 @@ struct stack_t
       set_error ();
   }
 
-  inline ELEM &push ()
+  ELEM &push ()
   {
     if (likely (count < elements.len))
       return elements[count++];
@@ -430,7 +431,7 @@ struct stack_t
     }
   }
 
-  inline ELEM& pop ()
+  ELEM& pop ()
   {
     if (likely (count > 0))
       return elements[--count];
@@ -441,7 +442,7 @@ struct stack_t
     }
   }
 
-  inline void pop (unsigned int n)
+  void pop (unsigned int n)
   {
     if (likely (count >= n))
       count -= n;
@@ -449,7 +450,7 @@ struct stack_t
       set_error ();
   }
 
-  inline const ELEM& peek ()
+  const ELEM& peek ()
   {
     if (likely (count > 0))
       return elements[count-1];
@@ -460,7 +461,7 @@ struct stack_t
     }
   }
 
-  inline void unpop ()
+  void unpop ()
   {
     if (likely (count < elements.len))
       count++;
@@ -468,13 +469,13 @@ struct stack_t
       set_error ();
   }
 
-  inline void clear () { count = 0; }
+  void clear () { count = 0; }
 
-  inline bool in_error () const { return (error || elements.in_error ()); }
-  inline void set_error ()	{ error = true; }
+  bool in_error () const { return (error || elements.in_error ()); }
+  void set_error ()      { error = true; }
 
-  inline unsigned int get_count () const { return count; }
-  inline bool is_empty () const { return count == 0; }
+  unsigned int get_count () const { return count; }
+  bool is_empty () const { return count == 0; }
 
   static const unsigned int kSizeLimit = LIMIT;
 
@@ -488,29 +489,29 @@ struct stack_t
 template <typename ARG=number_t>
 struct arg_stack_t : stack_t<ARG, 513>
 {
-  inline void push_int (int v)
+  void push_int (int v)
   {
     ARG &n = S::push ();
     n.set_int (v);
   }
 
-  inline void push_fixed (int32_t v)
+  void push_fixed (int32_t v)
   {
     ARG &n = S::push ();
     n.set_fixed (v);
   }
 
-  inline void push_real (double v)
+  void push_real (double v)
   {
     ARG &n = S::push ();
     n.set_real (v);
   }
 
-  inline ARG& pop_num () { return this->pop (); }
+  ARG& pop_num () { return this->pop (); }
 
-  inline int pop_int ()  { return this->pop ().to_int (); }
+  int pop_int ()  { return this->pop ().to_int (); }
 
-  inline unsigned int pop_uint ()
+  unsigned int pop_uint ()
   {
     int i = pop_int ();
     if (unlikely (i < 0))
@@ -521,13 +522,13 @@ struct arg_stack_t : stack_t<ARG, 513>
     return (unsigned)i;
   }
 
-  inline void push_longint_from_substr (byte_str_ref_t& str_ref)
+  void push_longint_from_substr (byte_str_ref_t& str_ref)
   {
     push_int ((str_ref[0] << 24) | (str_ref[1] << 16) | (str_ref[2] << 8) | (str_ref[3]));
     str_ref.inc (4);
   }
 
-  inline bool push_fixed_from_substr (byte_str_ref_t& str_ref)
+  bool push_fixed_from_substr (byte_str_ref_t& str_ref)
   {
     if (unlikely (!str_ref.avail (4)))
       return false;
@@ -536,7 +537,7 @@ struct arg_stack_t : stack_t<ARG, 513>
     return true;
   }
 
-  inline hb_array_t<const ARG> get_subarray (unsigned int start) const
+  hb_array_t<const ARG> get_subarray (unsigned int start) const
   {
     return S::elements.sub_array (start);
   }
@@ -548,8 +549,8 @@ struct arg_stack_t : stack_t<ARG, 513>
 /* an operator prefixed by its operands in a byte string */
 struct op_str_t
 {
-  inline void init () {}
-  inline void fini () {}
+  void init () {}
+  void fini () {}
 
   op_code_t  op;
   byte_str_t str;
@@ -559,7 +560,7 @@ struct op_str_t
 struct op_serializer_t
 {
   protected:
-  inline bool copy_opstr (hb_serialize_context_t *c, const op_str_t& opstr) const
+  bool copy_opstr (hb_serialize_context_t *c, const op_str_t& opstr) const
   {
     TRACE_SERIALIZE (this);
 
@@ -573,14 +574,14 @@ struct op_serializer_t
 template <typename VAL>
 struct parsed_values_t
 {
-  inline void init ()
+  void init ()
   {
     opStart = 0;
     values.init ();
   }
-  inline void fini () { values.fini_deep (); }
+  void fini () { values.fini_deep (); }
 
-  inline void add_op (op_code_t op, const byte_str_ref_t& str_ref = byte_str_ref_t ())
+  void add_op (op_code_t op, const byte_str_ref_t& str_ref = byte_str_ref_t ())
   {
     VAL *val = values.push ();
     val->op = op;
@@ -588,7 +589,7 @@ struct parsed_values_t
     opStart = str_ref.offset;
   }
 
-  inline void add_op (op_code_t op, const byte_str_ref_t& str_ref, const VAL &v)
+  void add_op (op_code_t op, const byte_str_ref_t& str_ref, const VAL &v)
   {
     VAL *val = values.push (v);
     val->op = op;
@@ -596,16 +597,16 @@ struct parsed_values_t
     opStart = str_ref.offset;
   }
 
-  inline bool has_op (op_code_t op) const
+  bool has_op (op_code_t op) const
   {
     for (unsigned int i = 0; i < get_count (); i++)
       if (get_value (i).op == op) return true;
     return false;
   }
 
-  inline unsigned get_count () const { return values.len; }
-  inline const VAL &get_value (unsigned int i) const { return values[i]; }
-  inline const VAL &operator [] (unsigned int i) const { return get_value (i); }
+  unsigned get_count () const { return values.len; }
+  const VAL &get_value (unsigned int i) const { return values[i]; }
+  const VAL &operator [] (unsigned int i) const { return get_value (i); }
 
   unsigned int       opStart;
   hb_vector_t<VAL>   values;
@@ -614,20 +615,20 @@ struct parsed_values_t
 template <typename ARG=number_t>
 struct interp_env_t
 {
-  inline void init (const byte_str_t &str_)
+  void init (const byte_str_t &str_)
   {
     str_ref.reset (str_);
     argStack.init ();
     error = false;
   }
-  inline void fini () { argStack.fini (); }
+  void fini () { argStack.fini (); }
 
-  inline bool in_error () const
+  bool in_error () const
   { return error || str_ref.in_error () || argStack.in_error (); }
 
-  inline void set_error () { error = true; }
+  void set_error () { error = true; }
 
-  inline op_code_t fetch_op ()
+  op_code_t fetch_op ()
   {
     op_code_t  op = OpCode_Invalid;
     if (unlikely (!str_ref.avail ()))
@@ -643,22 +644,22 @@ struct interp_env_t
     return op;
   }
 
-  inline const ARG& eval_arg (unsigned int i)
+  const ARG& eval_arg (unsigned int i)
   {
     return argStack[i];
   }
 
-  inline ARG& pop_arg ()
+  ARG& pop_arg ()
   {
     return argStack.pop ();
   }
 
-  inline void pop_n_args (unsigned int n)
+  void pop_n_args (unsigned int n)
   {
     argStack.pop (n);
   }
 
-  inline void clear_args ()
+  void clear_args ()
   {
     pop_n_args (argStack.get_count ());
   }
@@ -674,7 +675,7 @@ typedef interp_env_t<> num_interp_env_t;
 template <typename ARG=number_t>
 struct opset_t
 {
-  static inline void process_op (op_code_t op, interp_env_t<ARG>& env)
+  static void process_op (op_code_t op, interp_env_t<ARG>& env)
   {
     switch (op) {
       case OpCode_shortint:
@@ -712,9 +713,9 @@ struct opset_t
 template <typename ENV>
 struct interpreter_t {
 
-  inline ~interpreter_t() { fini (); }
+  ~interpreter_t() { fini (); }
 
-  inline void fini () { env.fini (); }
+  void fini () { env.fini (); }
 
   ENV env;
 };

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -302,6 +302,8 @@ struct byte_str_t : hb_ubytes_t
 {
   byte_str_t ()
     : hb_ubytes_t () {}
+  byte_str_t (const byte_str_t &bs)
+    : hb_ubytes_t (bs) {}
   byte_str_t (const UnsizedByteStr& s, unsigned int l)
     : hb_ubytes_t ((const unsigned char*)&s, l) {}
   byte_str_t (const unsigned char *s, unsigned int l)

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -315,7 +315,7 @@ struct byte_str_t : hb_ubytes_t
   ~byte_str_t () {}
   
   /* Copy assignment operator */
-  byte_str_t &operator=(byte_str_t &bs)
+  byte_str_t &operator=(const byte_str_t &bs)
   {
     return *this; /* test */
   }

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -30,7 +30,7 @@ namespace CFF {
 
 using namespace OT;
 
-typedef unsigned int OpCode;
+typedef unsigned int op_code_t;
 
 
 /* === Dict operators === */
@@ -88,11 +88,11 @@ typedef unsigned int OpCode;
 
 /* Two byte escape operators 12, (0-41) */
 #define OpCode_ESC_Base		256
-#define Make_OpCode_ESC(byte2)	((OpCode)(OpCode_ESC_Base + (byte2)))
+#define Make_OpCode_ESC(byte2)	((op_code_t)(OpCode_ESC_Base + (byte2)))
 
-inline OpCode Unmake_OpCode_ESC (OpCode op)  { return (OpCode)(op - OpCode_ESC_Base); }
-inline bool Is_OpCode_ESC (OpCode op) { return op >= OpCode_ESC_Base; }
-inline unsigned int OpCode_Size (OpCode op) { return Is_OpCode_ESC (op) ? 2: 1; }
+inline op_code_t Unmake_OpCode_ESC (op_code_t op)  { return (op_code_t)(op - OpCode_ESC_Base); }
+inline bool Is_OpCode_ESC (op_code_t op) { return op >= OpCode_ESC_Base; }
+inline unsigned int OpCode_Size (op_code_t op) { return Is_OpCode_ESC (op) ? 2: 1; }
 
 #define OpCode_Copyright	Make_OpCode_ESC(0) /* CFF Top */
 #define OpCode_isFixedPitch	Make_OpCode_ESC(1) /* CFF Top (false) */
@@ -263,7 +263,7 @@ struct UnsizedByteStr : UnsizedArrayOf <HBUINT8>
 {
   // encode 2-byte int (Dict/CharString) or 4-byte int (Dict)
   template <typename INTTYPE, int minVal, int maxVal>
-  static bool serialize_int (hb_serialize_context_t *c, OpCode intOp, int value)
+  static bool serialize_int (hb_serialize_context_t *c, op_code_t intOp, int value)
   {
     TRACE_SERIALIZE (this);
 
@@ -552,7 +552,7 @@ struct op_str_t
   void init () {}
   void fini () {}
 
-  OpCode  op;
+  op_code_t  op;
   byte_str_t str;
 };
 
@@ -581,7 +581,7 @@ struct parsed_values_t
   }
   void fini () { values.fini_deep (); }
 
-  void add_op (OpCode op, const byte_str_ref_t& str_ref = byte_str_ref_t ())
+  void add_op (op_code_t op, const byte_str_ref_t& str_ref = byte_str_ref_t ())
   {
     VAL *val = values.push ();
     val->op = op;
@@ -589,7 +589,7 @@ struct parsed_values_t
     opStart = str_ref.offset;
   }
 
-  void add_op (OpCode op, const byte_str_ref_t& str_ref, const VAL &v)
+  void add_op (op_code_t op, const byte_str_ref_t& str_ref, const VAL &v)
   {
     VAL *val = values.push (v);
     val->op = op;
@@ -597,7 +597,7 @@ struct parsed_values_t
     opStart = str_ref.offset;
   }
 
-  bool has_op (OpCode op) const
+  bool has_op (op_code_t op) const
   {
     for (unsigned int i = 0; i < get_count (); i++)
       if (get_value (i).op == op) return true;
@@ -628,12 +628,12 @@ struct interp_env_t
 
   void set_error () { error = true; }
 
-  OpCode fetch_op ()
+  op_code_t fetch_op ()
   {
-    OpCode  op = OpCode_Invalid;
+    op_code_t  op = OpCode_Invalid;
     if (unlikely (!str_ref.avail ()))
       return OpCode_Invalid;
-    op = (OpCode)(unsigned char)str_ref[0];
+    op = (op_code_t)(unsigned char)str_ref[0];
     if (op == OpCode_escape) {
       if (unlikely (!str_ref.avail ()))
 	return OpCode_Invalid;
@@ -675,7 +675,7 @@ typedef interp_env_t<> num_interp_env_t;
 template <typename ARG=number_t>
 struct opset_t
 {
-  static void process_op (OpCode op, interp_env_t<ARG>& env)
+  static void process_op (op_code_t op, interp_env_t<ARG>& env)
   {
     switch (op) {
       case OpCode_shortint:

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -302,23 +302,12 @@ struct byte_str_t : hb_ubytes_t
 {
   byte_str_t ()
     : hb_ubytes_t () {}
-  byte_str_t (const byte_str_t &bs)
-    : hb_ubytes_t (bs) {}
   byte_str_t (const UnsizedByteStr& s, unsigned int l)
     : hb_ubytes_t ((const unsigned char*)&s, l) {}
   byte_str_t (const unsigned char *s, unsigned int l)
     : hb_ubytes_t (s, l) {}
   byte_str_t (const hb_ubytes_t &ub)	/* conversion from hb_ubytes_t */
     : hb_ubytes_t (ub) {}
-
-  /* Destructor */
-  ~byte_str_t () {}
-  
-  /* Copy assignment operator */
-  byte_str_t &operator=(const byte_str_t &bs)
-  {
-    return *this; /* test */
-  }
   
   /* sub-string */
   byte_str_t sub_str (unsigned int offset, unsigned int len_) const

--- a/src/hb-cff-interp-common.hh
+++ b/src/hb-cff-interp-common.hh
@@ -310,6 +310,15 @@ struct byte_str_t : hb_ubytes_t
     : hb_ubytes_t (s, l) {}
   byte_str_t (const hb_ubytes_t &ub)	/* conversion from hb_ubytes_t */
     : hb_ubytes_t (ub) {}
+
+  /* Destructor */
+  ~byte_str_t () {}
+  
+  /* Copy assignment operator */
+  byte_str_t &operator=(byte_str_t &bs)
+  {
+    return *this; /* test */
+  }
   
   /* sub-string */
   byte_str_t sub_str (unsigned int offset, unsigned int len_) const

--- a/src/hb-cff-interp-cs-common.hh
+++ b/src/hb-cff-interp-cs-common.hh
@@ -41,7 +41,7 @@ enum cs_type_t {
 
 struct call_context_t
 {
-  inline void init (const byte_str_ref_t substr_=byte_str_ref_t (), cs_type_t type_=CSType_CharString, unsigned int subr_num_=0)
+  void init (const byte_str_ref_t substr_=byte_str_ref_t (), cs_type_t type_=CSType_CharString, unsigned int subr_num_=0)
   {
     str_ref = substr_;
     type = type_;
@@ -62,7 +62,7 @@ struct call_stack_t : stack_t<call_context_t, kMaxCallLimit> {};
 template <typename SUBRS>
 struct biased_subrs_t
 {
-  inline void init (const SUBRS &subrs_)
+  void init (const SUBRS &subrs_)
   {
     subrs = &subrs_;
     unsigned int  nSubrs = get_count ();
@@ -74,12 +74,12 @@ struct biased_subrs_t
       bias = 32768;
   }
 
-  inline void fini () {}
+  void fini () {}
 
-  inline unsigned int get_count () const { return (subrs == nullptr)? 0: subrs->count; }
-  inline unsigned int get_bias () const { return bias; }
+  unsigned int get_count () const { return (subrs == nullptr)? 0: subrs->count; }
+  unsigned int get_bias () const { return bias; }
 
-  inline byte_str_t operator [] (unsigned int index) const
+  byte_str_t operator [] (unsigned int index) const
   {
     if (unlikely ((subrs == nullptr) || index >= subrs->count))
       return Null(byte_str_t);
@@ -94,22 +94,22 @@ struct biased_subrs_t
 
 struct point_t
 {
-  inline void init ()
+  void init ()
   {
     x.init ();
     y.init ();
   }
 
-  inline void set_int (int _x, int _y)
+  void set_int (int _x, int _y)
   {
     x.set_int (_x);
     y.set_int (_y);
   }
 
-  inline void move_x (const number_t &dx) { x += dx; }
-  inline void move_y (const number_t &dy) { y += dy; }
-  inline void move (const number_t &dx, const number_t &dy) { move_x (dx); move_y (dy); }
-  inline void move (const point_t &d) { move_x (d.x); move_y (d.y); }
+  void move_x (const number_t &dx) { x += dx; }
+  void move_y (const number_t &dy) { y += dy; }
+  void move (const number_t &dx, const number_t &dy) { move_x (dx); move_y (dy); }
+  void move (const point_t &d) { move_x (d.x); move_y (d.y); }
 
   number_t  x;
   number_t  y;
@@ -118,7 +118,7 @@ struct point_t
 template <typename ARG, typename SUBRS>
 struct cs_interp_env_t : interp_env_t<ARG>
 {
-  inline void init (const byte_str_t &str, const SUBRS &globalSubrs_, const SUBRS &localSubrs_)
+  void init (const byte_str_t &str, const SUBRS &globalSubrs_, const SUBRS &localSubrs_)
   {
     interp_env_t<ARG>::init (str);
 
@@ -132,7 +132,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     globalSubrs.init (globalSubrs_);
     localSubrs.init (localSubrs_);
   }
-  inline void fini ()
+  void fini ()
   {
     interp_env_t<ARG>::fini ();
 
@@ -141,12 +141,12 @@ struct cs_interp_env_t : interp_env_t<ARG>
     localSubrs.fini ();
   }
 
-  inline bool in_error () const
+  bool in_error () const
   {
     return callStack.in_error () || SUPER::in_error ();
   }
 
-  inline bool popSubrNum (const biased_subrs_t<SUBRS>& biasedSubrs, unsigned int &subr_num)
+  bool popSubrNum (const biased_subrs_t<SUBRS>& biasedSubrs, unsigned int &subr_num)
   {
     int n = SUPER::argStack.pop_int ();
     n += biasedSubrs.get_bias ();
@@ -157,7 +157,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     return true;
   }
 
-  inline void callSubr (const biased_subrs_t<SUBRS>& biasedSubrs, cs_type_t type)
+  void callSubr (const biased_subrs_t<SUBRS>& biasedSubrs, cs_type_t type)
   {
     unsigned int subr_num;
 
@@ -174,7 +174,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     SUPER::str_ref = context.str_ref;
   }
 
-  inline void returnFromSubr ()
+  void returnFromSubr ()
   {
     if (unlikely (SUPER::str_ref.in_error ()))
       SUPER::set_error ();
@@ -182,7 +182,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     SUPER::str_ref = context.str_ref;
   }
 
-  inline void determine_hintmask_size ()
+  void determine_hintmask_size ()
   {
     if (!seen_hintmask)
     {
@@ -192,14 +192,14 @@ struct cs_interp_env_t : interp_env_t<ARG>
     }
   }
 
-  inline void set_endchar (bool endchar_flag_) { endchar_flag = endchar_flag_; }
-  inline bool is_endchar () const { return endchar_flag; }
+  void set_endchar (bool endchar_flag_) { endchar_flag = endchar_flag_; }
+  bool is_endchar () const { return endchar_flag; }
 
-  inline const number_t &get_x () const { return pt.x; }
-  inline const number_t &get_y () const { return pt.y; }
-  inline const point_t &get_pt () const { return pt; }
+  const number_t &get_x () const { return pt.x; }
+  const number_t &get_y () const { return pt.y; }
+  const point_t &get_pt () const { return pt; }
 
-  inline void moveto (const point_t &pt_ ) { pt = pt_; }
+  void moveto (const point_t &pt_ ) { pt = pt_; }
 
   public:
   call_context_t   context;
@@ -210,7 +210,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
   unsigned int  hstem_count;
   unsigned int  vstem_count;
   unsigned int  hintmask_size;
-  call_stack_t	callStack;
+  call_stack_t	    callStack;
   biased_subrs_t<SUBRS>   globalSubrs;
   biased_subrs_t<SUBRS>   localSubrs;
 
@@ -223,32 +223,32 @@ struct cs_interp_env_t : interp_env_t<ARG>
 template <typename ENV, typename PARAM>
 struct path_procs_null_t
 {
-  static inline void rmoveto (ENV &env, PARAM& param) {}
-  static inline void hmoveto (ENV &env, PARAM& param) {}
-  static inline void vmoveto (ENV &env, PARAM& param) {}
-  static inline void rlineto (ENV &env, PARAM& param) {}
-  static inline void hlineto (ENV &env, PARAM& param) {}
-  static inline void vlineto (ENV &env, PARAM& param) {}
-  static inline void rrcurveto (ENV &env, PARAM& param) {}
-  static inline void rcurveline (ENV &env, PARAM& param) {}
-  static inline void rlinecurve (ENV &env, PARAM& param) {}
-  static inline void vvcurveto (ENV &env, PARAM& param) {}
-  static inline void hhcurveto (ENV &env, PARAM& param) {}
-  static inline void vhcurveto (ENV &env, PARAM& param) {}
-  static inline void hvcurveto (ENV &env, PARAM& param) {}
-  static inline void moveto (ENV &env, PARAM& param, const point_t &pt) {}
-  static inline void line (ENV &env, PARAM& param, const point_t &pt1) {}
-  static inline void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3) {}
-  static inline void hflex (ENV &env, PARAM& param) {}
-  static inline void flex (ENV &env, PARAM& param) {}
-  static inline void hflex1 (ENV &env, PARAM& param) {}
-  static inline void flex1 (ENV &env, PARAM& param) {}
+  static void rmoveto (ENV &env, PARAM& param) {}
+  static void hmoveto (ENV &env, PARAM& param) {}
+  static void vmoveto (ENV &env, PARAM& param) {}
+  static void rlineto (ENV &env, PARAM& param) {}
+  static void hlineto (ENV &env, PARAM& param) {}
+  static void vlineto (ENV &env, PARAM& param) {}
+  static void rrcurveto (ENV &env, PARAM& param) {}
+  static void rcurveline (ENV &env, PARAM& param) {}
+  static void rlinecurve (ENV &env, PARAM& param) {}
+  static void vvcurveto (ENV &env, PARAM& param) {}
+  static void hhcurveto (ENV &env, PARAM& param) {}
+  static void vhcurveto (ENV &env, PARAM& param) {}
+  static void hvcurveto (ENV &env, PARAM& param) {}
+  static void moveto (ENV &env, PARAM& param, const point_t &pt) {}
+  static void line (ENV &env, PARAM& param, const point_t &pt1) {}
+  static void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3) {}
+  static void hflex (ENV &env, PARAM& param) {}
+  static void flex (ENV &env, PARAM& param) {}
+  static void hflex1 (ENV &env, PARAM& param) {}
+  static void flex1 (ENV &env, PARAM& param) {}
 };
 
 template <typename ARG, typename OPSET, typename ENV, typename PARAM, typename PATH=path_procs_null_t<ENV, PARAM> >
 struct cs_opset_t : opset_t<ARG>
 {
-  static inline void process_op (op_code_t op, ENV &env, PARAM& param)
+  static void process_op (op_code_t op, ENV &env, PARAM& param)
   {
     switch (op) {
 
@@ -370,19 +370,19 @@ struct cs_opset_t : opset_t<ARG>
     }
   }
 
-  static inline void process_hstem (op_code_t op, ENV &env, PARAM& param)
+  static void process_hstem (op_code_t op, ENV &env, PARAM& param)
   {
     env.hstem_count += env.argStack.get_count () / 2;
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static inline void process_vstem (op_code_t op, ENV &env, PARAM& param)
+  static void process_vstem (op_code_t op, ENV &env, PARAM& param)
   {
     env.vstem_count += env.argStack.get_count () / 2;
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static inline void process_hintmask (op_code_t op, ENV &env, PARAM& param)
+  static void process_hintmask (op_code_t op, ENV &env, PARAM& param)
   {
     env.determine_hintmask_size ();
     if (likely (env.str_ref.avail (env.hintmask_size)))
@@ -392,15 +392,15 @@ struct cs_opset_t : opset_t<ARG>
     }
   }
 
-  static inline void process_post_flex (op_code_t op, ENV &env, PARAM& param)
+  static void process_post_flex (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static inline void check_width (op_code_t op, ENV &env, PARAM& param)
+  static void check_width (op_code_t op, ENV &env, PARAM& param)
   {}
 
-  static inline void process_post_move (op_code_t op, ENV &env, PARAM& param)
+  static void process_post_move (op_code_t op, ENV &env, PARAM& param)
   {
     if (!env.seen_moveto)
     {
@@ -410,27 +410,27 @@ struct cs_opset_t : opset_t<ARG>
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static inline void process_post_path (op_code_t op, ENV &env, PARAM& param)
+  static void process_post_path (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static inline void flush_args_and_op (op_code_t op, ENV &env, PARAM& param)
+  static void flush_args_and_op (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args (env, param);
     OPSET::flush_op (op, env, param);
   }
 
-  static inline void flush_args (ENV &env, PARAM& param)
+  static void flush_args (ENV &env, PARAM& param)
   {
     env.pop_n_args (env.argStack.get_count ());
   }
 
-  static inline void flush_op (op_code_t op, ENV &env, PARAM& param)
+  static void flush_op (op_code_t op, ENV &env, PARAM& param)
   {
   }
 
-  static inline void flush_hintmask (op_code_t op, ENV &env, PARAM& param)
+  static void flush_hintmask (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
@@ -460,7 +460,7 @@ struct cs_opset_t : opset_t<ARG>
 template <typename PATH, typename ENV, typename PARAM>
 struct path_procs_t
 {
-  static inline void rmoveto (ENV &env, PARAM& param)
+  static void rmoveto (ENV &env, PARAM& param)
   {
     point_t pt1 = env.get_pt ();
     const number_t &dy = env.pop_arg ();
@@ -469,21 +469,21 @@ struct path_procs_t
     PATH::moveto (env, param, pt1);
   }
 
-  static inline void hmoveto (ENV &env, PARAM& param)
+  static void hmoveto (ENV &env, PARAM& param)
   {
     point_t pt1 = env.get_pt ();
     pt1.move_x (env.pop_arg ());
     PATH::moveto (env, param, pt1);
   }
 
-  static inline void vmoveto (ENV &env, PARAM& param)
+  static void vmoveto (ENV &env, PARAM& param)
   {
     point_t pt1 = env.get_pt ();
     pt1.move_y (env.pop_arg ());
     PATH::moveto (env, param, pt1);
   }
 
-  static inline void rlineto (ENV &env, PARAM& param)
+  static void rlineto (ENV &env, PARAM& param)
   {
     for (unsigned int i = 0; i + 2 <= env.argStack.get_count (); i += 2)
     {
@@ -493,7 +493,7 @@ struct path_procs_t
     }
   }
 
-  static inline void hlineto (ENV &env, PARAM& param)
+  static void hlineto (ENV &env, PARAM& param)
   {
     point_t pt1;
     unsigned int i = 0;
@@ -513,7 +513,7 @@ struct path_procs_t
     }
   }
 
-  static inline void vlineto (ENV &env, PARAM& param)
+  static void vlineto (ENV &env, PARAM& param)
   {
     point_t pt1;
     unsigned int i = 0;
@@ -533,7 +533,7 @@ struct path_procs_t
     }
   }
 
-  static inline void rrcurveto (ENV &env, PARAM& param)
+  static void rrcurveto (ENV &env, PARAM& param)
   {
     for (unsigned int i = 0; i + 6 <= env.argStack.get_count (); i += 6)
     {
@@ -547,7 +547,7 @@ struct path_procs_t
     }
   }
 
-  static inline void rcurveline (ENV &env, PARAM& param)
+  static void rcurveline (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
     for (; i + 6 <= env.argStack.get_count (); i += 6)
@@ -568,7 +568,7 @@ struct path_procs_t
     }
   }
 
-  static inline void rlinecurve (ENV &env, PARAM& param)
+  static void rlinecurve (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
     unsigned int line_limit = (env.argStack.get_count () % 6);
@@ -590,7 +590,7 @@ struct path_procs_t
     }
   }
 
-  static inline void vvcurveto (ENV &env, PARAM& param)
+  static void vvcurveto (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
     point_t pt1 = env.get_pt ();
@@ -608,7 +608,7 @@ struct path_procs_t
     }
   }
 
-  static inline void hhcurveto (ENV &env, PARAM& param)
+  static void hhcurveto (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
     point_t pt1 = env.get_pt ();
@@ -626,7 +626,7 @@ struct path_procs_t
     }
   }
 
-  static inline void vhcurveto (ENV &env, PARAM& param)
+  static void vhcurveto (ENV &env, PARAM& param)
   {
     point_t pt1, pt2, pt3;
     unsigned int i = 0;
@@ -687,7 +687,7 @@ struct path_procs_t
     }
   }
 
-  static inline void hvcurveto (ENV &env, PARAM& param)
+  static void hvcurveto (ENV &env, PARAM& param)
   {
     point_t pt1, pt2, pt3;
     unsigned int i = 0;
@@ -749,16 +749,16 @@ struct path_procs_t
   }
 
   /* default actions to be overridden */
-  static inline void moveto (ENV &env, PARAM& param, const point_t &pt)
+  static void moveto (ENV &env, PARAM& param, const point_t &pt)
   { env.moveto (pt); }
 
-  static inline void line (ENV &env, PARAM& param, const point_t &pt1)
+  static void line (ENV &env, PARAM& param, const point_t &pt1)
   { PATH::moveto (env, param, pt1); }
 
-  static inline void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
+  static void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   { PATH::moveto (env, param, pt3); }
 
-  static inline void hflex (ENV &env, PARAM& param)
+  static void hflex (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 7))
     {
@@ -782,7 +782,7 @@ struct path_procs_t
       env.set_error ();
   }
 
-  static inline void flex (ENV &env, PARAM& param)
+  static void flex (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 13))
     {
@@ -805,7 +805,7 @@ struct path_procs_t
       env.set_error ();
   }
 
-  static inline void hflex1 (ENV &env, PARAM& param)
+  static void hflex1 (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 9))
     {
@@ -829,7 +829,7 @@ struct path_procs_t
       env.set_error ();
   }
 
-  static inline void flex1 (ENV &env, PARAM& param)
+  static void flex1 (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 11))
     {
@@ -868,7 +868,7 @@ struct path_procs_t
   }
 
   protected:
-  static inline void curve2 (ENV &env, PARAM& param,
+  static void curve2 (ENV &env, PARAM& param,
 		      const point_t &pt1, const point_t &pt2, const point_t &pt3,
 		      const point_t &pt4, const point_t &pt5, const point_t &pt6)
   {
@@ -880,7 +880,7 @@ struct path_procs_t
 template <typename ENV, typename OPSET, typename PARAM>
 struct cs_interpreter_t : interpreter_t<ENV>
 {
-  inline bool interpret (PARAM& param)
+  bool interpret (PARAM& param)
   {
     SUPER::env.set_endchar (false);
 
@@ -902,4 +902,3 @@ struct cs_interpreter_t : interpreter_t<ENV>
 } /* namespace CFF */
 
 #endif /* HB_CFF_INTERP_CS_COMMON_HH */
-

--- a/src/hb-cff-interp-cs-common.hh
+++ b/src/hb-cff-interp-cs-common.hh
@@ -33,7 +33,7 @@ namespace CFF {
 
 using namespace OT;
 
-enum CSType {
+enum cs_type_t {
   CSType_CharString,
   CSType_GlobalSubr,
   CSType_LocalSubr
@@ -41,7 +41,7 @@ enum CSType {
 
 struct call_context_t
 {
-  void init (const byte_str_ref_t substr_=byte_str_ref_t (), CSType type_=CSType_CharString, unsigned int subr_num_=0)
+  void init (const byte_str_ref_t substr_=byte_str_ref_t (), cs_type_t type_=CSType_CharString, unsigned int subr_num_=0)
   {
     str_ref = substr_;
     type = type_;
@@ -51,7 +51,7 @@ struct call_context_t
   void fini () {}
 
   byte_str_ref_t      str_ref;
-  CSType	  type;
+  cs_type_t	  type;
   unsigned int    subr_num;
 };
 
@@ -157,7 +157,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     return true;
   }
 
-  void callSubr (const biased_subrs_t<SUBRS>& biasedSubrs, CSType type)
+  void callSubr (const biased_subrs_t<SUBRS>& biasedSubrs, cs_type_t type)
   {
     unsigned int subr_num;
 
@@ -248,7 +248,7 @@ struct path_procs_null_t
 template <typename ARG, typename OPSET, typename ENV, typename PARAM, typename PATH=path_procs_null_t<ENV, PARAM> >
 struct cs_opset_t : opset_t<ARG>
 {
-  static void process_op (OpCode op, ENV &env, PARAM& param)
+  static void process_op (op_code_t op, ENV &env, PARAM& param)
   {
     switch (op) {
 
@@ -370,19 +370,19 @@ struct cs_opset_t : opset_t<ARG>
     }
   }
 
-  static void process_hstem (OpCode op, ENV &env, PARAM& param)
+  static void process_hstem (op_code_t op, ENV &env, PARAM& param)
   {
     env.hstem_count += env.argStack.get_count () / 2;
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void process_vstem (OpCode op, ENV &env, PARAM& param)
+  static void process_vstem (op_code_t op, ENV &env, PARAM& param)
   {
     env.vstem_count += env.argStack.get_count () / 2;
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void process_hintmask (OpCode op, ENV &env, PARAM& param)
+  static void process_hintmask (op_code_t op, ENV &env, PARAM& param)
   {
     env.determine_hintmask_size ();
     if (likely (env.str_ref.avail (env.hintmask_size)))
@@ -392,15 +392,15 @@ struct cs_opset_t : opset_t<ARG>
     }
   }
 
-  static void process_post_flex (OpCode op, ENV &env, PARAM& param)
+  static void process_post_flex (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void check_width (OpCode op, ENV &env, PARAM& param)
+  static void check_width (op_code_t op, ENV &env, PARAM& param)
   {}
 
-  static void process_post_move (OpCode op, ENV &env, PARAM& param)
+  static void process_post_move (op_code_t op, ENV &env, PARAM& param)
   {
     if (!env.seen_moveto)
     {
@@ -410,12 +410,12 @@ struct cs_opset_t : opset_t<ARG>
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void process_post_path (OpCode op, ENV &env, PARAM& param)
+  static void process_post_path (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void flush_args_and_op (OpCode op, ENV &env, PARAM& param)
+  static void flush_args_and_op (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args (env, param);
     OPSET::flush_op (op, env, param);
@@ -426,16 +426,16 @@ struct cs_opset_t : opset_t<ARG>
     env.pop_n_args (env.argStack.get_count ());
   }
 
-  static void flush_op (OpCode op, ENV &env, PARAM& param)
+  static void flush_op (op_code_t op, ENV &env, PARAM& param)
   {
   }
 
-  static void flush_hintmask (OpCode op, ENV &env, PARAM& param)
+  static void flush_hintmask (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static bool is_number_op (OpCode op)
+  static bool is_number_op (op_code_t op)
   {
     switch (op)
     {

--- a/src/hb-cff-interp-cs-common.hh
+++ b/src/hb-cff-interp-cs-common.hh
@@ -43,14 +43,14 @@ struct CallContext
 {
   void init (const byte_str_ref_t substr_=byte_str_ref_t (), CSType type_=CSType_CharString, unsigned int subr_num_=0)
   {
-    substr = substr_;
+    str_ref = substr_;
     type = type_;
     subr_num = subr_num_;
   }
 
   void fini () {}
 
-  byte_str_ref_t      substr;
+  byte_str_ref_t      str_ref;
   CSType	  type;
   unsigned int    subr_num;
 };
@@ -167,19 +167,19 @@ struct CSInterpEnv : InterpEnv<ARG>
       SUPER::set_error ();
       return;
     }
-    context.substr = SUPER::substr;
+    context.str_ref = SUPER::str_ref;
     callStack.push (context);
 
     context.init ( biasedSubrs[subr_num], type, subr_num);
-    SUPER::substr = context.substr;
+    SUPER::str_ref = context.str_ref;
   }
 
   void returnFromSubr ()
   {
-    if (unlikely (SUPER::substr.in_error ()))
+    if (unlikely (SUPER::str_ref.in_error ()))
       SUPER::set_error ();
     context = callStack.pop ();
-    SUPER::substr = context.substr;
+    SUPER::str_ref = context.str_ref;
   }
 
   void determine_hintmask_size ()
@@ -262,7 +262,7 @@ struct CSOpSet : OpSet<ARG>
 	break;
 
       case OpCode_fixedcs:
-	env.argStack.push_fixed_from_substr (env.substr);
+	env.argStack.push_fixed_from_substr (env.str_ref);
 	break;
 
       case OpCode_callsubr:
@@ -385,10 +385,10 @@ struct CSOpSet : OpSet<ARG>
   static void process_hintmask (OpCode op, ENV &env, PARAM& param)
   {
     env.determine_hintmask_size ();
-    if (likely (env.substr.avail (env.hintmask_size)))
+    if (likely (env.str_ref.avail (env.hintmask_size)))
     {
       OPSET::flush_hintmask (op, env, param);
-      env.substr.inc (env.hintmask_size);
+      env.str_ref.inc (env.hintmask_size);
     }
   }
 

--- a/src/hb-cff-interp-cs-common.hh
+++ b/src/hb-cff-interp-cs-common.hh
@@ -41,7 +41,7 @@ enum cs_type_t {
 
 struct call_context_t
 {
-  void init (const byte_str_ref_t substr_=byte_str_ref_t (), cs_type_t type_=CSType_CharString, unsigned int subr_num_=0)
+  inline void init (const byte_str_ref_t substr_=byte_str_ref_t (), cs_type_t type_=CSType_CharString, unsigned int subr_num_=0)
   {
     str_ref = substr_;
     type = type_;
@@ -62,7 +62,7 @@ struct call_stack_t : stack_t<call_context_t, kMaxCallLimit> {};
 template <typename SUBRS>
 struct biased_subrs_t
 {
-  void init (const SUBRS &subrs_)
+  inline void init (const SUBRS &subrs_)
   {
     subrs = &subrs_;
     unsigned int  nSubrs = get_count ();
@@ -74,12 +74,12 @@ struct biased_subrs_t
       bias = 32768;
   }
 
-  void fini () {}
+  inline void fini () {}
 
-  unsigned int get_count () const { return (subrs == nullptr)? 0: subrs->count; }
-  unsigned int get_bias () const { return bias; }
+  inline unsigned int get_count () const { return (subrs == nullptr)? 0: subrs->count; }
+  inline unsigned int get_bias () const { return bias; }
 
-  byte_str_t operator [] (unsigned int index) const
+  inline byte_str_t operator [] (unsigned int index) const
   {
     if (unlikely ((subrs == nullptr) || index >= subrs->count))
       return Null(byte_str_t);
@@ -94,22 +94,22 @@ struct biased_subrs_t
 
 struct point_t
 {
-  void init ()
+  inline void init ()
   {
     x.init ();
     y.init ();
   }
 
-  void set_int (int _x, int _y)
+  inline void set_int (int _x, int _y)
   {
     x.set_int (_x);
     y.set_int (_y);
   }
 
-  void move_x (const number_t &dx) { x += dx; }
-  void move_y (const number_t &dy) { y += dy; }
-  void move (const number_t &dx, const number_t &dy) { move_x (dx); move_y (dy); }
-  void move (const point_t &d) { move_x (d.x); move_y (d.y); }
+  inline void move_x (const number_t &dx) { x += dx; }
+  inline void move_y (const number_t &dy) { y += dy; }
+  inline void move (const number_t &dx, const number_t &dy) { move_x (dx); move_y (dy); }
+  inline void move (const point_t &d) { move_x (d.x); move_y (d.y); }
 
   number_t  x;
   number_t  y;
@@ -118,7 +118,7 @@ struct point_t
 template <typename ARG, typename SUBRS>
 struct cs_interp_env_t : interp_env_t<ARG>
 {
-  void init (const byte_str_t &str, const SUBRS &globalSubrs_, const SUBRS &localSubrs_)
+  inline void init (const byte_str_t &str, const SUBRS &globalSubrs_, const SUBRS &localSubrs_)
   {
     interp_env_t<ARG>::init (str);
 
@@ -132,7 +132,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     globalSubrs.init (globalSubrs_);
     localSubrs.init (localSubrs_);
   }
-  void fini ()
+  inline void fini ()
   {
     interp_env_t<ARG>::fini ();
 
@@ -141,12 +141,12 @@ struct cs_interp_env_t : interp_env_t<ARG>
     localSubrs.fini ();
   }
 
-  bool in_error () const
+  inline bool in_error () const
   {
     return callStack.in_error () || SUPER::in_error ();
   }
 
-  bool popSubrNum (const biased_subrs_t<SUBRS>& biasedSubrs, unsigned int &subr_num)
+  inline bool popSubrNum (const biased_subrs_t<SUBRS>& biasedSubrs, unsigned int &subr_num)
   {
     int n = SUPER::argStack.pop_int ();
     n += biasedSubrs.get_bias ();
@@ -157,7 +157,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     return true;
   }
 
-  void callSubr (const biased_subrs_t<SUBRS>& biasedSubrs, cs_type_t type)
+  inline void callSubr (const biased_subrs_t<SUBRS>& biasedSubrs, cs_type_t type)
   {
     unsigned int subr_num;
 
@@ -174,7 +174,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     SUPER::str_ref = context.str_ref;
   }
 
-  void returnFromSubr ()
+  inline void returnFromSubr ()
   {
     if (unlikely (SUPER::str_ref.in_error ()))
       SUPER::set_error ();
@@ -182,7 +182,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
     SUPER::str_ref = context.str_ref;
   }
 
-  void determine_hintmask_size ()
+  inline void determine_hintmask_size ()
   {
     if (!seen_hintmask)
     {
@@ -192,14 +192,14 @@ struct cs_interp_env_t : interp_env_t<ARG>
     }
   }
 
-  void set_endchar (bool endchar_flag_) { endchar_flag = endchar_flag_; }
-  bool is_endchar () const { return endchar_flag; }
+  inline void set_endchar (bool endchar_flag_) { endchar_flag = endchar_flag_; }
+  inline bool is_endchar () const { return endchar_flag; }
 
-  const number_t &get_x () const { return pt.x; }
-  const number_t &get_y () const { return pt.y; }
-  const point_t &get_pt () const { return pt; }
+  inline const number_t &get_x () const { return pt.x; }
+  inline const number_t &get_y () const { return pt.y; }
+  inline const point_t &get_pt () const { return pt; }
 
-  void moveto (const point_t &pt_ ) { pt = pt_; }
+  inline void moveto (const point_t &pt_ ) { pt = pt_; }
 
   public:
   call_context_t   context;
@@ -210,7 +210,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
   unsigned int  hstem_count;
   unsigned int  vstem_count;
   unsigned int  hintmask_size;
-  call_stack_t	    callStack;
+  call_stack_t	callStack;
   biased_subrs_t<SUBRS>   globalSubrs;
   biased_subrs_t<SUBRS>   localSubrs;
 
@@ -223,32 +223,32 @@ struct cs_interp_env_t : interp_env_t<ARG>
 template <typename ENV, typename PARAM>
 struct path_procs_null_t
 {
-  static void rmoveto (ENV &env, PARAM& param) {}
-  static void hmoveto (ENV &env, PARAM& param) {}
-  static void vmoveto (ENV &env, PARAM& param) {}
-  static void rlineto (ENV &env, PARAM& param) {}
-  static void hlineto (ENV &env, PARAM& param) {}
-  static void vlineto (ENV &env, PARAM& param) {}
-  static void rrcurveto (ENV &env, PARAM& param) {}
-  static void rcurveline (ENV &env, PARAM& param) {}
-  static void rlinecurve (ENV &env, PARAM& param) {}
-  static void vvcurveto (ENV &env, PARAM& param) {}
-  static void hhcurveto (ENV &env, PARAM& param) {}
-  static void vhcurveto (ENV &env, PARAM& param) {}
-  static void hvcurveto (ENV &env, PARAM& param) {}
-  static void moveto (ENV &env, PARAM& param, const point_t &pt) {}
-  static void line (ENV &env, PARAM& param, const point_t &pt1) {}
-  static void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3) {}
-  static void hflex (ENV &env, PARAM& param) {}
-  static void flex (ENV &env, PARAM& param) {}
-  static void hflex1 (ENV &env, PARAM& param) {}
-  static void flex1 (ENV &env, PARAM& param) {}
+  static inline void rmoveto (ENV &env, PARAM& param) {}
+  static inline void hmoveto (ENV &env, PARAM& param) {}
+  static inline void vmoveto (ENV &env, PARAM& param) {}
+  static inline void rlineto (ENV &env, PARAM& param) {}
+  static inline void hlineto (ENV &env, PARAM& param) {}
+  static inline void vlineto (ENV &env, PARAM& param) {}
+  static inline void rrcurveto (ENV &env, PARAM& param) {}
+  static inline void rcurveline (ENV &env, PARAM& param) {}
+  static inline void rlinecurve (ENV &env, PARAM& param) {}
+  static inline void vvcurveto (ENV &env, PARAM& param) {}
+  static inline void hhcurveto (ENV &env, PARAM& param) {}
+  static inline void vhcurveto (ENV &env, PARAM& param) {}
+  static inline void hvcurveto (ENV &env, PARAM& param) {}
+  static inline void moveto (ENV &env, PARAM& param, const point_t &pt) {}
+  static inline void line (ENV &env, PARAM& param, const point_t &pt1) {}
+  static inline void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3) {}
+  static inline void hflex (ENV &env, PARAM& param) {}
+  static inline void flex (ENV &env, PARAM& param) {}
+  static inline void hflex1 (ENV &env, PARAM& param) {}
+  static inline void flex1 (ENV &env, PARAM& param) {}
 };
 
 template <typename ARG, typename OPSET, typename ENV, typename PARAM, typename PATH=path_procs_null_t<ENV, PARAM> >
 struct cs_opset_t : opset_t<ARG>
 {
-  static void process_op (op_code_t op, ENV &env, PARAM& param)
+  static inline void process_op (op_code_t op, ENV &env, PARAM& param)
   {
     switch (op) {
 
@@ -370,19 +370,19 @@ struct cs_opset_t : opset_t<ARG>
     }
   }
 
-  static void process_hstem (op_code_t op, ENV &env, PARAM& param)
+  static inline void process_hstem (op_code_t op, ENV &env, PARAM& param)
   {
     env.hstem_count += env.argStack.get_count () / 2;
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void process_vstem (op_code_t op, ENV &env, PARAM& param)
+  static inline void process_vstem (op_code_t op, ENV &env, PARAM& param)
   {
     env.vstem_count += env.argStack.get_count () / 2;
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void process_hintmask (op_code_t op, ENV &env, PARAM& param)
+  static inline void process_hintmask (op_code_t op, ENV &env, PARAM& param)
   {
     env.determine_hintmask_size ();
     if (likely (env.str_ref.avail (env.hintmask_size)))
@@ -392,15 +392,15 @@ struct cs_opset_t : opset_t<ARG>
     }
   }
 
-  static void process_post_flex (op_code_t op, ENV &env, PARAM& param)
+  static inline void process_post_flex (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void check_width (op_code_t op, ENV &env, PARAM& param)
+  static inline void check_width (op_code_t op, ENV &env, PARAM& param)
   {}
 
-  static void process_post_move (op_code_t op, ENV &env, PARAM& param)
+  static inline void process_post_move (op_code_t op, ENV &env, PARAM& param)
   {
     if (!env.seen_moveto)
     {
@@ -410,27 +410,27 @@ struct cs_opset_t : opset_t<ARG>
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void process_post_path (op_code_t op, ENV &env, PARAM& param)
+  static inline void process_post_path (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
 
-  static void flush_args_and_op (op_code_t op, ENV &env, PARAM& param)
+  static inline void flush_args_and_op (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args (env, param);
     OPSET::flush_op (op, env, param);
   }
 
-  static void flush_args (ENV &env, PARAM& param)
+  static inline void flush_args (ENV &env, PARAM& param)
   {
     env.pop_n_args (env.argStack.get_count ());
   }
 
-  static void flush_op (op_code_t op, ENV &env, PARAM& param)
+  static inline void flush_op (op_code_t op, ENV &env, PARAM& param)
   {
   }
 
-  static void flush_hintmask (op_code_t op, ENV &env, PARAM& param)
+  static inline void flush_hintmask (op_code_t op, ENV &env, PARAM& param)
   {
     OPSET::flush_args_and_op (op, env, param);
   }
@@ -460,7 +460,7 @@ struct cs_opset_t : opset_t<ARG>
 template <typename PATH, typename ENV, typename PARAM>
 struct path_procs_t
 {
-  static void rmoveto (ENV &env, PARAM& param)
+  static inline void rmoveto (ENV &env, PARAM& param)
   {
     point_t pt1 = env.get_pt ();
     const number_t &dy = env.pop_arg ();
@@ -469,21 +469,21 @@ struct path_procs_t
     PATH::moveto (env, param, pt1);
   }
 
-  static void hmoveto (ENV &env, PARAM& param)
+  static inline void hmoveto (ENV &env, PARAM& param)
   {
     point_t pt1 = env.get_pt ();
     pt1.move_x (env.pop_arg ());
     PATH::moveto (env, param, pt1);
   }
 
-  static void vmoveto (ENV &env, PARAM& param)
+  static inline void vmoveto (ENV &env, PARAM& param)
   {
     point_t pt1 = env.get_pt ();
     pt1.move_y (env.pop_arg ());
     PATH::moveto (env, param, pt1);
   }
 
-  static void rlineto (ENV &env, PARAM& param)
+  static inline void rlineto (ENV &env, PARAM& param)
   {
     for (unsigned int i = 0; i + 2 <= env.argStack.get_count (); i += 2)
     {
@@ -493,7 +493,7 @@ struct path_procs_t
     }
   }
 
-  static void hlineto (ENV &env, PARAM& param)
+  static inline void hlineto (ENV &env, PARAM& param)
   {
     point_t pt1;
     unsigned int i = 0;
@@ -513,7 +513,7 @@ struct path_procs_t
     }
   }
 
-  static void vlineto (ENV &env, PARAM& param)
+  static inline void vlineto (ENV &env, PARAM& param)
   {
     point_t pt1;
     unsigned int i = 0;
@@ -533,7 +533,7 @@ struct path_procs_t
     }
   }
 
-  static void rrcurveto (ENV &env, PARAM& param)
+  static inline void rrcurveto (ENV &env, PARAM& param)
   {
     for (unsigned int i = 0; i + 6 <= env.argStack.get_count (); i += 6)
     {
@@ -547,7 +547,7 @@ struct path_procs_t
     }
   }
 
-  static void rcurveline (ENV &env, PARAM& param)
+  static inline void rcurveline (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
     for (; i + 6 <= env.argStack.get_count (); i += 6)
@@ -568,7 +568,7 @@ struct path_procs_t
     }
   }
 
-  static void rlinecurve (ENV &env, PARAM& param)
+  static inline void rlinecurve (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
     unsigned int line_limit = (env.argStack.get_count () % 6);
@@ -590,7 +590,7 @@ struct path_procs_t
     }
   }
 
-  static void vvcurveto (ENV &env, PARAM& param)
+  static inline void vvcurveto (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
     point_t pt1 = env.get_pt ();
@@ -608,7 +608,7 @@ struct path_procs_t
     }
   }
 
-  static void hhcurveto (ENV &env, PARAM& param)
+  static inline void hhcurveto (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
     point_t pt1 = env.get_pt ();
@@ -626,7 +626,7 @@ struct path_procs_t
     }
   }
 
-  static void vhcurveto (ENV &env, PARAM& param)
+  static inline void vhcurveto (ENV &env, PARAM& param)
   {
     point_t pt1, pt2, pt3;
     unsigned int i = 0;
@@ -687,7 +687,7 @@ struct path_procs_t
     }
   }
 
-  static void hvcurveto (ENV &env, PARAM& param)
+  static inline void hvcurveto (ENV &env, PARAM& param)
   {
     point_t pt1, pt2, pt3;
     unsigned int i = 0;
@@ -749,16 +749,16 @@ struct path_procs_t
   }
 
   /* default actions to be overridden */
-  static void moveto (ENV &env, PARAM& param, const point_t &pt)
+  static inline void moveto (ENV &env, PARAM& param, const point_t &pt)
   { env.moveto (pt); }
 
-  static void line (ENV &env, PARAM& param, const point_t &pt1)
+  static inline void line (ENV &env, PARAM& param, const point_t &pt1)
   { PATH::moveto (env, param, pt1); }
 
-  static void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
+  static inline void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   { PATH::moveto (env, param, pt3); }
 
-  static void hflex (ENV &env, PARAM& param)
+  static inline void hflex (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 7))
     {
@@ -782,7 +782,7 @@ struct path_procs_t
       env.set_error ();
   }
 
-  static void flex (ENV &env, PARAM& param)
+  static inline void flex (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 13))
     {
@@ -805,7 +805,7 @@ struct path_procs_t
       env.set_error ();
   }
 
-  static void hflex1 (ENV &env, PARAM& param)
+  static inline void hflex1 (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 9))
     {
@@ -829,7 +829,7 @@ struct path_procs_t
       env.set_error ();
   }
 
-  static void flex1 (ENV &env, PARAM& param)
+  static inline void flex1 (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 11))
     {
@@ -868,7 +868,7 @@ struct path_procs_t
   }
 
   protected:
-  static void curve2 (ENV &env, PARAM& param,
+  static inline void curve2 (ENV &env, PARAM& param,
 		      const point_t &pt1, const point_t &pt2, const point_t &pt3,
 		      const point_t &pt4, const point_t &pt5, const point_t &pt6)
   {
@@ -880,7 +880,7 @@ struct path_procs_t
 template <typename ENV, typename OPSET, typename PARAM>
 struct cs_interpreter_t : interpreter_t<ENV>
 {
-  bool interpret (PARAM& param)
+  inline bool interpret (PARAM& param)
   {
     SUPER::env.set_endchar (false);
 
@@ -902,3 +902,4 @@ struct cs_interpreter_t : interpreter_t<ENV>
 } /* namespace CFF */
 
 #endif /* HB_CFF_INTERP_CS_COMMON_HH */
+

--- a/src/hb-cff-interp-cs-common.hh
+++ b/src/hb-cff-interp-cs-common.hh
@@ -39,7 +39,7 @@ enum CSType {
   CSType_LocalSubr
 };
 
-struct CallContext
+struct call_context_t
 {
   void init (const byte_str_ref_t substr_=byte_str_ref_t (), CSType type_=CSType_CharString, unsigned int subr_num_=0)
   {
@@ -57,10 +57,10 @@ struct CallContext
 
 /* call stack */
 const unsigned int kMaxCallLimit = 10;
-struct CallStack : Stack<CallContext, kMaxCallLimit> {};
+struct call_stack_t : stack_t<call_context_t, kMaxCallLimit> {};
 
 template <typename SUBRS>
-struct BiasedSubrs
+struct biased_subrs_t
 {
   void init (const SUBRS &subrs_)
   {
@@ -92,7 +92,7 @@ struct BiasedSubrs
   const SUBRS   *subrs;
 };
 
-struct Point
+struct point_t
 {
   void init ()
   {
@@ -106,21 +106,21 @@ struct Point
     y.set_int (_y);
   }
 
-  void move_x (const Number &dx) { x += dx; }
-  void move_y (const Number &dy) { y += dy; }
-  void move (const Number &dx, const Number &dy) { move_x (dx); move_y (dy); }
-  void move (const Point &d) { move_x (d.x); move_y (d.y); }
+  void move_x (const number_t &dx) { x += dx; }
+  void move_y (const number_t &dy) { y += dy; }
+  void move (const number_t &dx, const number_t &dy) { move_x (dx); move_y (dy); }
+  void move (const point_t &d) { move_x (d.x); move_y (d.y); }
 
-  Number  x;
-  Number  y;
+  number_t  x;
+  number_t  y;
 };
 
 template <typename ARG, typename SUBRS>
-struct CSInterpEnv : InterpEnv<ARG>
+struct cs_interp_env_t : interp_env_t<ARG>
 {
   void init (const byte_str_t &str, const SUBRS &globalSubrs_, const SUBRS &localSubrs_)
   {
-    InterpEnv<ARG>::init (str);
+    interp_env_t<ARG>::init (str);
 
     context.init (str, CSType_CharString);
     seen_moveto = true;
@@ -134,7 +134,7 @@ struct CSInterpEnv : InterpEnv<ARG>
   }
   void fini ()
   {
-    InterpEnv<ARG>::fini ();
+    interp_env_t<ARG>::fini ();
 
     callStack.fini ();
     globalSubrs.fini ();
@@ -146,7 +146,7 @@ struct CSInterpEnv : InterpEnv<ARG>
     return callStack.in_error () || SUPER::in_error ();
   }
 
-  bool popSubrNum (const BiasedSubrs<SUBRS>& biasedSubrs, unsigned int &subr_num)
+  bool popSubrNum (const biased_subrs_t<SUBRS>& biasedSubrs, unsigned int &subr_num)
   {
     int n = SUPER::argStack.pop_int ();
     n += biasedSubrs.get_bias ();
@@ -157,7 +157,7 @@ struct CSInterpEnv : InterpEnv<ARG>
     return true;
   }
 
-  void callSubr (const BiasedSubrs<SUBRS>& biasedSubrs, CSType type)
+  void callSubr (const biased_subrs_t<SUBRS>& biasedSubrs, CSType type)
   {
     unsigned int subr_num;
 
@@ -195,14 +195,14 @@ struct CSInterpEnv : InterpEnv<ARG>
   void set_endchar (bool endchar_flag_) { endchar_flag = endchar_flag_; }
   bool is_endchar () const { return endchar_flag; }
 
-  const Number &get_x () const { return pt.x; }
-  const Number &get_y () const { return pt.y; }
-  const Point &get_pt () const { return pt; }
+  const number_t &get_x () const { return pt.x; }
+  const number_t &get_y () const { return pt.y; }
+  const point_t &get_pt () const { return pt; }
 
-  void moveto (const Point &pt_ ) { pt = pt_; }
+  void moveto (const point_t &pt_ ) { pt = pt_; }
 
   public:
-  CallContext   context;
+  call_context_t   context;
   bool	  endchar_flag;
   bool	  seen_moveto;
   bool	  seen_hintmask;
@@ -210,18 +210,18 @@ struct CSInterpEnv : InterpEnv<ARG>
   unsigned int  hstem_count;
   unsigned int  vstem_count;
   unsigned int  hintmask_size;
-  CallStack	    callStack;
-  BiasedSubrs<SUBRS>   globalSubrs;
-  BiasedSubrs<SUBRS>   localSubrs;
+  call_stack_t	    callStack;
+  biased_subrs_t<SUBRS>   globalSubrs;
+  biased_subrs_t<SUBRS>   localSubrs;
 
   private:
-  Point	 pt;
+  point_t	 pt;
 
-  typedef InterpEnv<ARG> SUPER;
+  typedef interp_env_t<ARG> SUPER;
 };
 
 template <typename ENV, typename PARAM>
-struct PathProcsNull
+struct path_procs_null_t
 {
   static void rmoveto (ENV &env, PARAM& param) {}
   static void hmoveto (ENV &env, PARAM& param) {}
@@ -236,17 +236,17 @@ struct PathProcsNull
   static void hhcurveto (ENV &env, PARAM& param) {}
   static void vhcurveto (ENV &env, PARAM& param) {}
   static void hvcurveto (ENV &env, PARAM& param) {}
-  static void moveto (ENV &env, PARAM& param, const Point &pt) {}
-  static void line (ENV &env, PARAM& param, const Point &pt1) {}
-  static void curve (ENV &env, PARAM& param, const Point &pt1, const Point &pt2, const Point &pt3) {}
+  static void moveto (ENV &env, PARAM& param, const point_t &pt) {}
+  static void line (ENV &env, PARAM& param, const point_t &pt1) {}
+  static void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3) {}
   static void hflex (ENV &env, PARAM& param) {}
   static void flex (ENV &env, PARAM& param) {}
   static void hflex1 (ENV &env, PARAM& param) {}
   static void flex1 (ENV &env, PARAM& param) {}
 };
 
-template <typename ARG, typename OPSET, typename ENV, typename PARAM, typename PATH=PathProcsNull<ENV, PARAM> >
-struct CSOpSet : OpSet<ARG>
+template <typename ARG, typename OPSET, typename ENV, typename PARAM, typename PATH=path_procs_null_t<ENV, PARAM> >
+struct cs_opset_t : opset_t<ARG>
 {
   static void process_op (OpCode op, ENV &env, PARAM& param)
   {
@@ -454,31 +454,31 @@ struct CSOpSet : OpSet<ARG>
   }
 
   protected:
-  typedef OpSet<ARG>  SUPER;
+  typedef opset_t<ARG>  SUPER;
 };
 
 template <typename PATH, typename ENV, typename PARAM>
-struct PathProcs
+struct path_procs_t
 {
   static void rmoveto (ENV &env, PARAM& param)
   {
-    Point pt1 = env.get_pt ();
-    const Number &dy = env.pop_arg ();
-    const Number &dx = env.pop_arg ();
+    point_t pt1 = env.get_pt ();
+    const number_t &dy = env.pop_arg ();
+    const number_t &dx = env.pop_arg ();
     pt1.move (dx, dy);
     PATH::moveto (env, param, pt1);
   }
 
   static void hmoveto (ENV &env, PARAM& param)
   {
-    Point pt1 = env.get_pt ();
+    point_t pt1 = env.get_pt ();
     pt1.move_x (env.pop_arg ());
     PATH::moveto (env, param, pt1);
   }
 
   static void vmoveto (ENV &env, PARAM& param)
   {
-    Point pt1 = env.get_pt ();
+    point_t pt1 = env.get_pt ();
     pt1.move_y (env.pop_arg ());
     PATH::moveto (env, param, pt1);
   }
@@ -487,7 +487,7 @@ struct PathProcs
   {
     for (unsigned int i = 0; i + 2 <= env.argStack.get_count (); i += 2)
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (i), env.eval_arg (i+1));
       PATH::line (env, param, pt1);
     }
@@ -495,7 +495,7 @@ struct PathProcs
 
   static void hlineto (ENV &env, PARAM& param)
   {
-    Point pt1;
+    point_t pt1;
     unsigned int i = 0;
     for (; i + 2 <= env.argStack.get_count (); i += 2)
     {
@@ -515,7 +515,7 @@ struct PathProcs
 
   static void vlineto (ENV &env, PARAM& param)
   {
-    Point pt1;
+    point_t pt1;
     unsigned int i = 0;
     for (; i + 2 <= env.argStack.get_count (); i += 2)
     {
@@ -537,11 +537,11 @@ struct PathProcs
   {
     for (unsigned int i = 0; i + 6 <= env.argStack.get_count (); i += 6)
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (i), env.eval_arg (i+1));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (i+2), env.eval_arg (i+3));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move (env.eval_arg (i+4), env.eval_arg (i+5));
       PATH::curve (env, param, pt1, pt2, pt3);
     }
@@ -552,17 +552,17 @@ struct PathProcs
     unsigned int i = 0;
     for (; i + 6 <= env.argStack.get_count (); i += 6)
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (i), env.eval_arg (i+1));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (i+2), env.eval_arg (i+3));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move (env.eval_arg (i+4), env.eval_arg (i+5));
       PATH::curve (env, param, pt1, pt2, pt3);
     }
     for (; i + 2 <= env.argStack.get_count (); i += 2)
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (i), env.eval_arg (i+1));
       PATH::line (env, param, pt1);
     }
@@ -574,17 +574,17 @@ struct PathProcs
     unsigned int line_limit = (env.argStack.get_count () % 6);
     for (; i + 2 <= line_limit; i += 2)
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (i), env.eval_arg (i+1));
       PATH::line (env, param, pt1);
     }
     for (; i + 6 <= env.argStack.get_count (); i += 6)
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (i), env.eval_arg (i+1));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (i+2), env.eval_arg (i+3));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move (env.eval_arg (i+4), env.eval_arg (i+5));
       PATH::curve (env, param, pt1, pt2, pt3);
     }
@@ -593,15 +593,15 @@ struct PathProcs
   static void vvcurveto (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
-    Point pt1 = env.get_pt ();
+    point_t pt1 = env.get_pt ();
     if ((env.argStack.get_count () & 1) != 0)
       pt1.move_x (env.eval_arg (i++));
     for (; i + 4 <= env.argStack.get_count (); i += 4)
     {
       pt1.move_y (env.eval_arg (i));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (i+1), env.eval_arg (i+2));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move_y (env.eval_arg (i+3));
       PATH::curve (env, param, pt1, pt2, pt3);
       pt1 = env.get_pt ();
@@ -611,15 +611,15 @@ struct PathProcs
   static void hhcurveto (ENV &env, PARAM& param)
   {
     unsigned int i = 0;
-    Point pt1 = env.get_pt ();
+    point_t pt1 = env.get_pt ();
     if ((env.argStack.get_count () & 1) != 0)
       pt1.move_y (env.eval_arg (i++));
     for (; i + 4 <= env.argStack.get_count (); i += 4)
     {
       pt1.move_x (env.eval_arg (i));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (i+1), env.eval_arg (i+2));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move_x (env.eval_arg (i+3));
       PATH::curve (env, param, pt1, pt2, pt3);
       pt1 = env.get_pt ();
@@ -628,15 +628,15 @@ struct PathProcs
 
   static void vhcurveto (ENV &env, PARAM& param)
   {
-    Point pt1, pt2, pt3;
+    point_t pt1, pt2, pt3;
     unsigned int i = 0;
     if ((env.argStack.get_count () % 8) >= 4)
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move_y (env.eval_arg (i));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (i+1), env.eval_arg (i+2));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move_x (env.eval_arg (i+3));
       i += 4;
 
@@ -689,15 +689,15 @@ struct PathProcs
 
   static void hvcurveto (ENV &env, PARAM& param)
   {
-    Point pt1, pt2, pt3;
+    point_t pt1, pt2, pt3;
     unsigned int i = 0;
     if ((env.argStack.get_count () % 8) >= 4)
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move_x (env.eval_arg (i));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (i+1), env.eval_arg (i+2));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move_y (env.eval_arg (i+3));
       i += 4;
 
@@ -749,31 +749,31 @@ struct PathProcs
   }
 
   /* default actions to be overridden */
-  static void moveto (ENV &env, PARAM& param, const Point &pt)
+  static void moveto (ENV &env, PARAM& param, const point_t &pt)
   { env.moveto (pt); }
 
-  static void line (ENV &env, PARAM& param, const Point &pt1)
+  static void line (ENV &env, PARAM& param, const point_t &pt1)
   { PATH::moveto (env, param, pt1); }
 
-  static void curve (ENV &env, PARAM& param, const Point &pt1, const Point &pt2, const Point &pt3)
+  static void curve (ENV &env, PARAM& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   { PATH::moveto (env, param, pt3); }
 
   static void hflex (ENV &env, PARAM& param)
   {
     if (likely (env.argStack.get_count () == 7))
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move_x (env.eval_arg (0));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (1), env.eval_arg (2));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move_x (env.eval_arg (3));
-      Point pt4 = pt3;
+      point_t pt4 = pt3;
       pt4.move_x (env.eval_arg (4));
-      Point pt5 = pt4;
+      point_t pt5 = pt4;
       pt5.move_x (env.eval_arg (5));
       pt5.y = pt1.y;
-      Point pt6 = pt5;
+      point_t pt6 = pt5;
       pt6.move_x (env.eval_arg (6));
 
       curve2 (env, param, pt1, pt2, pt3, pt4, pt5, pt6);
@@ -786,17 +786,17 @@ struct PathProcs
   {
     if (likely (env.argStack.get_count () == 13))
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (0), env.eval_arg (1));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (2), env.eval_arg (3));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move (env.eval_arg (4), env.eval_arg (5));
-      Point pt4 = pt3;
+      point_t pt4 = pt3;
       pt4.move (env.eval_arg (6), env.eval_arg (7));
-      Point pt5 = pt4;
+      point_t pt5 = pt4;
       pt5.move (env.eval_arg (8), env.eval_arg (9));
-      Point pt6 = pt5;
+      point_t pt6 = pt5;
       pt6.move (env.eval_arg (10), env.eval_arg (11));
 
       curve2 (env, param, pt1, pt2, pt3, pt4, pt5, pt6);
@@ -809,17 +809,17 @@ struct PathProcs
   {
     if (likely (env.argStack.get_count () == 9))
     {
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (0), env.eval_arg (1));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (2), env.eval_arg (3));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move_x (env.eval_arg (4));
-      Point pt4 = pt3;
+      point_t pt4 = pt3;
       pt4.move_x (env.eval_arg (5));
-      Point pt5 = pt4;
+      point_t pt5 = pt4;
       pt5.move (env.eval_arg (6), env.eval_arg (7));
-      Point pt6 = pt5;
+      point_t pt6 = pt5;
       pt6.move_x (env.eval_arg (8));
       pt6.y = env.get_pt ().y;
 
@@ -833,22 +833,22 @@ struct PathProcs
   {
     if (likely (env.argStack.get_count () == 11))
     {
-      Point d;
+      point_t d;
       d.init ();
       for (unsigned int i = 0; i < 10; i += 2)
 	d.move (env.eval_arg (i), env.eval_arg (i+1));
 
-      Point pt1 = env.get_pt ();
+      point_t pt1 = env.get_pt ();
       pt1.move (env.eval_arg (0), env.eval_arg (1));
-      Point pt2 = pt1;
+      point_t pt2 = pt1;
       pt2.move (env.eval_arg (2), env.eval_arg (3));
-      Point pt3 = pt2;
+      point_t pt3 = pt2;
       pt3.move (env.eval_arg (4), env.eval_arg (5));
-      Point pt4 = pt3;
+      point_t pt4 = pt3;
       pt4.move (env.eval_arg (6), env.eval_arg (7));
-      Point pt5 = pt4;
+      point_t pt5 = pt4;
       pt5.move (env.eval_arg (8), env.eval_arg (9));
-      Point pt6 = pt5;
+      point_t pt6 = pt5;
 
       if (fabs (d.x.to_real ()) > fabs (d.y.to_real ()))
       {
@@ -869,8 +869,8 @@ struct PathProcs
 
   protected:
   static void curve2 (ENV &env, PARAM& param,
-		      const Point &pt1, const Point &pt2, const Point &pt3,
-		      const Point &pt4, const Point &pt5, const Point &pt6)
+		      const point_t &pt1, const point_t &pt2, const point_t &pt3,
+		      const point_t &pt4, const point_t &pt5, const point_t &pt6)
   {
     PATH::curve (env, param, pt1, pt2, pt3);
     PATH::curve (env, param, pt4, pt5, pt6);
@@ -878,7 +878,7 @@ struct PathProcs
 };
 
 template <typename ENV, typename OPSET, typename PARAM>
-struct CSInterpreter : Interpreter<ENV>
+struct cs_interpreter_t : interpreter_t<ENV>
 {
   bool interpret (PARAM& param)
   {
@@ -896,7 +896,7 @@ struct CSInterpreter : Interpreter<ENV>
   }
 
   private:
-  typedef Interpreter<ENV> SUPER;
+  typedef interpreter_t<ENV> SUPER;
 };
 
 } /* namespace CFF */

--- a/src/hb-cff-interp-cs-common.hh
+++ b/src/hb-cff-interp-cs-common.hh
@@ -41,7 +41,7 @@ enum CSType {
 
 struct CallContext
 {
-  void init (const SubByteStr substr_=SubByteStr (), CSType type_=CSType_CharString, unsigned int subr_num_=0)
+  void init (const byte_str_ref_t substr_=byte_str_ref_t (), CSType type_=CSType_CharString, unsigned int subr_num_=0)
   {
     substr = substr_;
     type = type_;
@@ -50,7 +50,7 @@ struct CallContext
 
   void fini () {}
 
-  SubByteStr      substr;
+  byte_str_ref_t      substr;
   CSType	  type;
   unsigned int    subr_num;
 };
@@ -79,10 +79,10 @@ struct BiasedSubrs
   unsigned int get_count () const { return (subrs == nullptr)? 0: subrs->count; }
   unsigned int get_bias () const { return bias; }
 
-  ByteStr operator [] (unsigned int index) const
+  byte_str_t operator [] (unsigned int index) const
   {
     if (unlikely ((subrs == nullptr) || index >= subrs->count))
-      return Null(ByteStr);
+      return Null(byte_str_t);
     else
       return (*subrs)[index];
   }
@@ -118,7 +118,7 @@ struct Point
 template <typename ARG, typename SUBRS>
 struct CSInterpEnv : InterpEnv<ARG>
 {
-  void init (const ByteStr &str, const SUBRS &globalSubrs_, const SUBRS &localSubrs_)
+  void init (const byte_str_t &str, const SUBRS &globalSubrs_, const SUBRS &localSubrs_)
   {
     InterpEnv<ARG>::init (str);
 

--- a/src/hb-cff-interp-cs-common.hh
+++ b/src/hb-cff-interp-cs-common.hh
@@ -50,7 +50,7 @@ struct call_context_t
 
   void fini () {}
 
-  byte_str_ref_t      str_ref;
+  byte_str_ref_t  str_ref;
   cs_type_t	  type;
   unsigned int    subr_num;
 };
@@ -210,7 +210,7 @@ struct cs_interp_env_t : interp_env_t<ARG>
   unsigned int  hstem_count;
   unsigned int  vstem_count;
   unsigned int  hintmask_size;
-  call_stack_t	    callStack;
+  call_stack_t	callStack;
   biased_subrs_t<SUBRS>   globalSubrs;
   biased_subrs_t<SUBRS>   localSubrs;
 

--- a/src/hb-cff-interp-dict-common.hh
+++ b/src/hb-cff-interp-dict-common.hh
@@ -35,28 +35,28 @@ namespace CFF {
 using namespace OT;
 
 /* an opstr and the parsed out dict value(s) */
-struct DictVal : OpStr
+struct dict_val_t : op_str_t
 {
   void init () { single_val.set_int (0); }
   void fini () {}
 
-  Number	      single_val;
+  number_t	      single_val;
 };
 
-typedef DictVal NumDictVal;
+typedef dict_val_t num_dict_val_t;
 
-template <typename VAL> struct DictValues : ParsedValues<VAL> {};
+template <typename VAL> struct dict_values_t : parsed_values_t<VAL> {};
 
-template <typename OPSTR=OpStr>
-struct TopDictValues : DictValues<OPSTR>
+template <typename OPSTR=op_str_t>
+struct top_dict_values_t : dict_values_t<OPSTR>
 {
   void init ()
   {
-    DictValues<OPSTR>::init ();
+    dict_values_t<OPSTR>::init ();
     charStringsOffset = 0;
     FDArrayOffset = 0;
   }
-  void fini () { DictValues<OPSTR>::fini (); }
+  void fini () { dict_values_t<OPSTR>::fini (); }
 
   unsigned int calculate_serialized_op_size (const OPSTR& opstr) const
   {
@@ -75,9 +75,9 @@ struct TopDictValues : DictValues<OPSTR>
   unsigned int  FDArrayOffset;
 };
 
-struct DictOpSet : OpSet<Number>
+struct dict_opset_t : opset_t<number_t>
 {
-  static void process_op (OpCode op, InterpEnv<Number>& env)
+  static void process_op (OpCode op, interp_env_t<number_t>& env)
   {
     switch (op) {
       case OpCode_longintdict:  /* 5-byte integer */
@@ -89,7 +89,7 @@ struct DictOpSet : OpSet<Number>
 	break;
 
       default:
-	OpSet<Number>::process_op (op, env);
+	opset_t<number_t>::process_op (op, env);
 	break;
     }
   }
@@ -245,10 +245,10 @@ struct DictOpSet : OpSet<Number>
   }
 };
 
-template <typename VAL=OpStr>
-struct TopDictOpSet : DictOpSet
+template <typename VAL=op_str_t>
+struct top_dict_opset_t : dict_opset_t
 {
-  static void process_op (OpCode op, InterpEnv<Number>& env, TopDictValues<VAL> & dictval)
+  static void process_op (OpCode op, interp_env_t<number_t>& env, top_dict_values_t<VAL> & dictval)
   {
     switch (op) {
       case OpCode_CharStrings:
@@ -263,14 +263,14 @@ struct TopDictOpSet : DictOpSet
 	env.clear_args ();
 	break;
       default:
-	DictOpSet::process_op (op, env);
+	dict_opset_t::process_op (op, env);
 	break;
     }
   }
 };
 
-template <typename OPSET, typename PARAM, typename ENV=NumInterpEnv>
-struct DictInterpreter : Interpreter<ENV>
+template <typename OPSET, typename PARAM, typename ENV=num_interp_env_t>
+struct dict_interpreter_t : interpreter_t<ENV>
 {
   bool interpret (PARAM& param)
   {
@@ -286,7 +286,7 @@ struct DictInterpreter : Interpreter<ENV>
   }
 
   private:
-  typedef Interpreter<ENV> SUPER;
+  typedef interpreter_t<ENV> SUPER;
 };
 
 } /* namespace CFF */

--- a/src/hb-cff-interp-dict-common.hh
+++ b/src/hb-cff-interp-dict-common.hh
@@ -37,8 +37,8 @@ using namespace OT;
 /* an opstr and the parsed out dict value(s) */
 struct dict_val_t : op_str_t
 {
-  inline void init () { single_val.set_int (0); }
-  inline void fini () {}
+  void init () { single_val.set_int (0); }
+  void fini () {}
 
   number_t	      single_val;
 };
@@ -50,15 +50,15 @@ template <typename VAL> struct dict_values_t : parsed_values_t<VAL> {};
 template <typename OPSTR=op_str_t>
 struct top_dict_values_t : dict_values_t<OPSTR>
 {
-  inline void init ()
+  void init ()
   {
     dict_values_t<OPSTR>::init ();
     charStringsOffset = 0;
     FDArrayOffset = 0;
   }
-  inline void fini () { dict_values_t<OPSTR>::fini (); }
+  void fini () { dict_values_t<OPSTR>::fini (); }
 
-  inline unsigned int calculate_serialized_op_size (const OPSTR& opstr) const
+  unsigned int calculate_serialized_op_size (const OPSTR& opstr) const
   {
     switch (opstr.op)
     {
@@ -77,7 +77,7 @@ struct top_dict_values_t : dict_values_t<OPSTR>
 
 struct dict_opset_t : opset_t<number_t>
 {
-  static inline void process_op (op_code_t op, interp_env_t<number_t>& env)
+  static void process_op (op_code_t op, interp_env_t<number_t>& env)
   {
     switch (op) {
       case OpCode_longintdict:  /* 5-byte integer */
@@ -96,19 +96,19 @@ struct dict_opset_t : opset_t<number_t>
 
   static double parse_bcd (byte_str_ref_t& str_ref)
   {
-    bool	neg = false;
-    double	int_part = 0;
-    uint64_t	frac_part = 0;
-    uint32_t	frac_count = 0;
-    bool	exp_neg = false;
-    uint32_t	exp_part = 0;
-    bool	exp_overflow = false;
+    bool    neg = false;
+    double  int_part = 0;
+    uint64_t frac_part = 0;
+    uint32_t  frac_count = 0;
+    bool    exp_neg = false;
+    uint32_t  exp_part = 0;
+    bool    exp_overflow = false;
     enum Part { INT_PART=0, FRAC_PART, EXP_PART } part = INT_PART;
     enum Nibble { DECIMAL=10, EXP_POS, EXP_NEG, RESERVED, NEG, END };
     const uint64_t MAX_FRACT = 0xFFFFFFFFFFFFFull; /* 1^52-1 */
     const uint32_t MAX_EXP = 0x7FFu; /* 1^11-1 */
 
-    double	value = 0.0;
+    double  value = 0.0;
     unsigned char byte = 0;
     for (uint32_t i = 0;; i++)
     {
@@ -220,7 +220,7 @@ struct dict_opset_t : opset_t<number_t>
     return value;
   }
 
-  static inline bool is_hint_op (op_code_t op)
+  static bool is_hint_op (op_code_t op)
   {
     switch (op)
     {
@@ -248,7 +248,7 @@ struct dict_opset_t : opset_t<number_t>
 template <typename VAL=op_str_t>
 struct top_dict_opset_t : dict_opset_t
 {
-  static inline void process_op (op_code_t op, interp_env_t<number_t>& env, top_dict_values_t<VAL> & dictval)
+  static void process_op (op_code_t op, interp_env_t<number_t>& env, top_dict_values_t<VAL> & dictval)
   {
     switch (op) {
       case OpCode_CharStrings:
@@ -272,7 +272,7 @@ struct top_dict_opset_t : dict_opset_t
 template <typename OPSET, typename PARAM, typename ENV=num_interp_env_t>
 struct dict_interpreter_t : interpreter_t<ENV>
 {
-  inline bool interpret (PARAM& param)
+  bool interpret (PARAM& param)
   {
     param.init ();
     while (SUPER::env.str_ref.avail ())

--- a/src/hb-cff-interp-dict-common.hh
+++ b/src/hb-cff-interp-dict-common.hh
@@ -37,8 +37,8 @@ using namespace OT;
 /* an opstr and the parsed out dict value(s) */
 struct dict_val_t : op_str_t
 {
-  void init () { single_val.set_int (0); }
-  void fini () {}
+  inline void init () { single_val.set_int (0); }
+  inline void fini () {}
 
   number_t	      single_val;
 };
@@ -50,15 +50,15 @@ template <typename VAL> struct dict_values_t : parsed_values_t<VAL> {};
 template <typename OPSTR=op_str_t>
 struct top_dict_values_t : dict_values_t<OPSTR>
 {
-  void init ()
+  inline void init ()
   {
     dict_values_t<OPSTR>::init ();
     charStringsOffset = 0;
     FDArrayOffset = 0;
   }
-  void fini () { dict_values_t<OPSTR>::fini (); }
+  inline void fini () { dict_values_t<OPSTR>::fini (); }
 
-  unsigned int calculate_serialized_op_size (const OPSTR& opstr) const
+  inline unsigned int calculate_serialized_op_size (const OPSTR& opstr) const
   {
     switch (opstr.op)
     {
@@ -77,7 +77,7 @@ struct top_dict_values_t : dict_values_t<OPSTR>
 
 struct dict_opset_t : opset_t<number_t>
 {
-  static void process_op (op_code_t op, interp_env_t<number_t>& env)
+  static inline void process_op (op_code_t op, interp_env_t<number_t>& env)
   {
     switch (op) {
       case OpCode_longintdict:  /* 5-byte integer */
@@ -96,19 +96,19 @@ struct dict_opset_t : opset_t<number_t>
 
   static double parse_bcd (byte_str_ref_t& str_ref)
   {
-    bool    neg = false;
-    double  int_part = 0;
-    uint64_t frac_part = 0;
-    uint32_t  frac_count = 0;
-    bool    exp_neg = false;
-    uint32_t  exp_part = 0;
-    bool    exp_overflow = false;
+    bool	neg = false;
+    double	int_part = 0;
+    uint64_t	frac_part = 0;
+    uint32_t	frac_count = 0;
+    bool	exp_neg = false;
+    uint32_t	exp_part = 0;
+    bool	exp_overflow = false;
     enum Part { INT_PART=0, FRAC_PART, EXP_PART } part = INT_PART;
     enum Nibble { DECIMAL=10, EXP_POS, EXP_NEG, RESERVED, NEG, END };
     const uint64_t MAX_FRACT = 0xFFFFFFFFFFFFFull; /* 1^52-1 */
     const uint32_t MAX_EXP = 0x7FFu; /* 1^11-1 */
 
-    double  value = 0.0;
+    double	value = 0.0;
     unsigned char byte = 0;
     for (uint32_t i = 0;; i++)
     {
@@ -220,7 +220,7 @@ struct dict_opset_t : opset_t<number_t>
     return value;
   }
 
-  static bool is_hint_op (op_code_t op)
+  static inline bool is_hint_op (op_code_t op)
   {
     switch (op)
     {
@@ -248,7 +248,7 @@ struct dict_opset_t : opset_t<number_t>
 template <typename VAL=op_str_t>
 struct top_dict_opset_t : dict_opset_t
 {
-  static void process_op (op_code_t op, interp_env_t<number_t>& env, top_dict_values_t<VAL> & dictval)
+  static inline void process_op (op_code_t op, interp_env_t<number_t>& env, top_dict_values_t<VAL> & dictval)
   {
     switch (op) {
       case OpCode_CharStrings:
@@ -272,7 +272,7 @@ struct top_dict_opset_t : dict_opset_t
 template <typename OPSET, typename PARAM, typename ENV=num_interp_env_t>
 struct dict_interpreter_t : interpreter_t<ENV>
 {
-  bool interpret (PARAM& param)
+  inline bool interpret (PARAM& param)
   {
     param.init ();
     while (SUPER::env.str_ref.avail ())

--- a/src/hb-cff-interp-dict-common.hh
+++ b/src/hb-cff-interp-dict-common.hh
@@ -81,11 +81,11 @@ struct DictOpSet : OpSet<Number>
   {
     switch (op) {
       case OpCode_longintdict:  /* 5-byte integer */
-	env.argStack.push_longint_from_substr (env.substr);
+	env.argStack.push_longint_from_substr (env.str_ref);
 	break;
 
       case OpCode_BCD:  /* real number */
-	env.argStack.push_real (parse_bcd (env.substr));
+	env.argStack.push_real (parse_bcd (env.str_ref));
 	break;
 
       default:
@@ -94,7 +94,7 @@ struct DictOpSet : OpSet<Number>
     }
   }
 
-  static double parse_bcd (byte_str_ref_t& substr)
+  static double parse_bcd (byte_str_ref_t& str_ref)
   {
     bool    neg = false;
     double  int_part = 0;
@@ -115,13 +115,13 @@ struct DictOpSet : OpSet<Number>
       char d;
       if ((i & 1) == 0)
       {
-	if (!substr.avail ())
+	if (!str_ref.avail ())
 	{
-	  substr.set_error ();
+	  str_ref.set_error ();
 	  return 0.0;
 	}
-	byte = substr[0];
-	substr.inc ();
+	byte = str_ref[0];
+	str_ref.inc ();
 	d = byte >> 4;
       }
       else
@@ -130,7 +130,7 @@ struct DictOpSet : OpSet<Number>
       switch (d)
       {
 	case RESERVED:
-	  substr.set_error ();
+	  str_ref.set_error ();
 	  return value;
 
 	case END:
@@ -162,7 +162,7 @@ struct DictOpSet : OpSet<Number>
 	case NEG:
 	  if (i != 0)
 	  {
-	    substr.set_error ();
+	    str_ref.set_error ();
 	    return 0.0;
 	  }
 	  neg = true;
@@ -171,7 +171,7 @@ struct DictOpSet : OpSet<Number>
 	case DECIMAL:
 	  if (part != INT_PART)
 	  {
-	    substr.set_error ();
+	    str_ref.set_error ();
 	    return value;
 	  }
 	  part = FRAC_PART;
@@ -184,7 +184,7 @@ struct DictOpSet : OpSet<Number>
 	case EXP_POS:
 	  if (part == EXP_PART)
 	  {
-	    substr.set_error ();
+	    str_ref.set_error ();
 	    return value;
 	  }
 	  part = EXP_PART;
@@ -275,7 +275,7 @@ struct DictInterpreter : Interpreter<ENV>
   bool interpret (PARAM& param)
   {
     param.init ();
-    while (SUPER::env.substr.avail ())
+    while (SUPER::env.str_ref.avail ())
     {
       OPSET::process_op (SUPER::env.fetch_op (), SUPER::env, param);
       if (unlikely (SUPER::env.in_error ()))

--- a/src/hb-cff-interp-dict-common.hh
+++ b/src/hb-cff-interp-dict-common.hh
@@ -94,7 +94,7 @@ struct DictOpSet : OpSet<Number>
     }
   }
 
-  static double parse_bcd (SubByteStr& substr)
+  static double parse_bcd (byte_str_ref_t& substr)
   {
     bool    neg = false;
     double  int_part = 0;

--- a/src/hb-cff-interp-dict-common.hh
+++ b/src/hb-cff-interp-dict-common.hh
@@ -77,7 +77,7 @@ struct top_dict_values_t : dict_values_t<OPSTR>
 
 struct dict_opset_t : opset_t<number_t>
 {
-  static void process_op (OpCode op, interp_env_t<number_t>& env)
+  static void process_op (op_code_t op, interp_env_t<number_t>& env)
   {
     switch (op) {
       case OpCode_longintdict:  /* 5-byte integer */
@@ -220,7 +220,7 @@ struct dict_opset_t : opset_t<number_t>
     return value;
   }
 
-  static bool is_hint_op (OpCode op)
+  static bool is_hint_op (op_code_t op)
   {
     switch (op)
     {
@@ -248,7 +248,7 @@ struct dict_opset_t : opset_t<number_t>
 template <typename VAL=op_str_t>
 struct top_dict_opset_t : dict_opset_t
 {
-  static void process_op (OpCode op, interp_env_t<number_t>& env, top_dict_values_t<VAL> & dictval)
+  static void process_op (op_code_t op, interp_env_t<number_t>& env, top_dict_values_t<VAL> & dictval)
   {
     switch (op) {
       case OpCode_CharStrings:

--- a/src/hb-cff1-interp-cs.hh
+++ b/src/hb-cff1-interp-cs.hh
@@ -33,9 +33,9 @@ namespace CFF {
 
 using namespace OT;
 
-typedef BiasedSubrs<CFF1Subrs>   CFF1BiasedSubrs;
+typedef biased_subrs_t<CFF1Subrs>   cff1_biased_subrs_t;
 
-struct CFF1CSInterpEnv : CSInterpEnv<Number, CFF1Subrs>
+struct cff1_cs_interp_env_t : cs_interp_env_t<number_t, CFF1Subrs>
 {
   template <typename ACC>
   void init (const byte_str_t &str, ACC &acc, unsigned int fd)
@@ -74,20 +74,20 @@ struct CFF1CSInterpEnv : CSInterpEnv<Number, CFF1Subrs>
   bool	  processed_width;
   bool	  has_width;
   unsigned int  arg_start;
-  Number	width;
+  number_t	width;
   bool	  in_seac;
 
   private:
-  typedef CSInterpEnv<Number, CFF1Subrs> SUPER;
+  typedef cs_interp_env_t<number_t, CFF1Subrs> SUPER;
 };
 
-template <typename OPSET, typename PARAM, typename PATH=PathProcsNull<CFF1CSInterpEnv, PARAM> >
-struct CFF1CSOpSet : CSOpSet<Number, OPSET, CFF1CSInterpEnv, PARAM, PATH>
+template <typename OPSET, typename PARAM, typename PATH=path_procs_null_t<cff1_cs_interp_env_t, PARAM> >
+struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM, PATH>
 {
   /* PostScript-originated legacy opcodes (OpCode_add etc) are unsupported */
   /* Type 1-originated deprecated opcodes, seac behavior of endchar and dotsection are supported */
 
-  static void process_op (OpCode op, CFF1CSInterpEnv &env, PARAM& param)
+  static void process_op (OpCode op, cff1_cs_interp_env_t &env, PARAM& param)
   {
     switch (op) {
       case OpCode_dotsection:
@@ -109,7 +109,7 @@ struct CFF1CSOpSet : CSOpSet<Number, OPSET, CFF1CSInterpEnv, PARAM, PATH>
     }
   }
 
-  static void check_width (OpCode op, CFF1CSInterpEnv &env, PARAM& param)
+  static void check_width (OpCode op, cff1_cs_interp_env_t &env, PARAM& param)
   {
     if (!env.processed_width)
     {
@@ -139,22 +139,22 @@ struct CFF1CSOpSet : CSOpSet<Number, OPSET, CFF1CSInterpEnv, PARAM, PATH>
     }
   }
 
-  static void process_seac (CFF1CSInterpEnv &env, PARAM& param)
+  static void process_seac (cff1_cs_interp_env_t &env, PARAM& param)
   {
   }
 
-  static void flush_args (CFF1CSInterpEnv &env, PARAM& param)
+  static void flush_args (cff1_cs_interp_env_t &env, PARAM& param)
   {
     SUPER::flush_args (env, param);
     env.clear_args ();  /* pop off width */
   }
 
   private:
-  typedef CSOpSet<Number, OPSET, CFF1CSInterpEnv, PARAM, PATH>  SUPER;
+  typedef cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM, PATH>  SUPER;
 };
 
 template <typename OPSET, typename PARAM>
-struct CFF1CSInterpreter : CSInterpreter<CFF1CSInterpEnv, OPSET, PARAM> {};
+struct cff1_cs_interpreter_t : cs_interpreter_t<cff1_cs_interp_env_t, OPSET, PARAM> {};
 
 } /* namespace CFF */
 

--- a/src/hb-cff1-interp-cs.hh
+++ b/src/hb-cff1-interp-cs.hh
@@ -38,7 +38,7 @@ typedef biased_subrs_t<CFF1Subrs>   cff1_biased_subrs_t;
 struct cff1_cs_interp_env_t : cs_interp_env_t<number_t, CFF1Subrs>
 {
   template <typename ACC>
-  void init (const byte_str_t &str, ACC &acc, unsigned int fd)
+  inline void init (const byte_str_t &str, ACC &acc, unsigned int fd)
   {
     SUPER::init (str, *acc.globalSubrs, *acc.privateDicts[fd].localSubrs);
     processed_width = false;
@@ -47,9 +47,9 @@ struct cff1_cs_interp_env_t : cs_interp_env_t<number_t, CFF1Subrs>
     in_seac = false;
   }
 
-  void fini () { SUPER::fini (); }
+  inline void fini () { SUPER::fini (); }
 
-  void set_width (bool has_width_)
+  inline void set_width (bool has_width_)
   {
     if (likely (!processed_width && (SUPER::argStack.get_count () > 0)))
     {
@@ -63,13 +63,13 @@ struct cff1_cs_interp_env_t : cs_interp_env_t<number_t, CFF1Subrs>
     processed_width = true;
   }
 
-  void clear_args ()
+  inline void clear_args ()
   {
     arg_start = 0;
     SUPER::clear_args ();
   }
 
-  void set_in_seac (bool _in_seac) { in_seac = _in_seac; }
+  inline void set_in_seac (bool _in_seac) { in_seac = _in_seac; }
 
   bool	  processed_width;
   bool	  has_width;
@@ -87,7 +87,7 @@ struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM
   /* PostScript-originated legacy opcodes (OpCode_add etc) are unsupported */
   /* Type 1-originated deprecated opcodes, seac behavior of endchar and dotsection are supported */
 
-  static void process_op (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
+  static inline void process_op (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
   {
     switch (op) {
       case OpCode_dotsection:
@@ -109,7 +109,7 @@ struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM
     }
   }
 
-  static void check_width (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
+  static inline void check_width (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
   {
     if (!env.processed_width)
     {
@@ -139,11 +139,11 @@ struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM
     }
   }
 
-  static void process_seac (cff1_cs_interp_env_t &env, PARAM& param)
+  static inline void process_seac (cff1_cs_interp_env_t &env, PARAM& param)
   {
   }
 
-  static void flush_args (cff1_cs_interp_env_t &env, PARAM& param)
+  static inline void flush_args (cff1_cs_interp_env_t &env, PARAM& param)
   {
     SUPER::flush_args (env, param);
     env.clear_args ();  /* pop off width */

--- a/src/hb-cff1-interp-cs.hh
+++ b/src/hb-cff1-interp-cs.hh
@@ -87,7 +87,7 @@ struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM
   /* PostScript-originated legacy opcodes (OpCode_add etc) are unsupported */
   /* Type 1-originated deprecated opcodes, seac behavior of endchar and dotsection are supported */
 
-  static void process_op (OpCode op, cff1_cs_interp_env_t &env, PARAM& param)
+  static void process_op (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
   {
     switch (op) {
       case OpCode_dotsection:
@@ -109,7 +109,7 @@ struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM
     }
   }
 
-  static void check_width (OpCode op, cff1_cs_interp_env_t &env, PARAM& param)
+  static void check_width (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
   {
     if (!env.processed_width)
     {

--- a/src/hb-cff1-interp-cs.hh
+++ b/src/hb-cff1-interp-cs.hh
@@ -38,7 +38,7 @@ typedef biased_subrs_t<CFF1Subrs>   cff1_biased_subrs_t;
 struct cff1_cs_interp_env_t : cs_interp_env_t<number_t, CFF1Subrs>
 {
   template <typename ACC>
-  inline void init (const byte_str_t &str, ACC &acc, unsigned int fd)
+  void init (const byte_str_t &str, ACC &acc, unsigned int fd)
   {
     SUPER::init (str, *acc.globalSubrs, *acc.privateDicts[fd].localSubrs);
     processed_width = false;
@@ -47,9 +47,9 @@ struct cff1_cs_interp_env_t : cs_interp_env_t<number_t, CFF1Subrs>
     in_seac = false;
   }
 
-  inline void fini () { SUPER::fini (); }
+  void fini () { SUPER::fini (); }
 
-  inline void set_width (bool has_width_)
+  void set_width (bool has_width_)
   {
     if (likely (!processed_width && (SUPER::argStack.get_count () > 0)))
     {
@@ -63,13 +63,13 @@ struct cff1_cs_interp_env_t : cs_interp_env_t<number_t, CFF1Subrs>
     processed_width = true;
   }
 
-  inline void clear_args ()
+  void clear_args ()
   {
     arg_start = 0;
     SUPER::clear_args ();
   }
 
-  inline void set_in_seac (bool _in_seac) { in_seac = _in_seac; }
+  void set_in_seac (bool _in_seac) { in_seac = _in_seac; }
 
   bool	  processed_width;
   bool	  has_width;
@@ -87,7 +87,7 @@ struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM
   /* PostScript-originated legacy opcodes (OpCode_add etc) are unsupported */
   /* Type 1-originated deprecated opcodes, seac behavior of endchar and dotsection are supported */
 
-  static inline void process_op (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
+  static void process_op (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
   {
     switch (op) {
       case OpCode_dotsection:
@@ -109,7 +109,7 @@ struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM
     }
   }
 
-  static inline void check_width (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
+  static void check_width (op_code_t op, cff1_cs_interp_env_t &env, PARAM& param)
   {
     if (!env.processed_width)
     {
@@ -139,11 +139,11 @@ struct cff1_cs_opset_t : cs_opset_t<number_t, OPSET, cff1_cs_interp_env_t, PARAM
     }
   }
 
-  static inline void process_seac (cff1_cs_interp_env_t &env, PARAM& param)
+  static void process_seac (cff1_cs_interp_env_t &env, PARAM& param)
   {
   }
 
-  static inline void flush_args (cff1_cs_interp_env_t &env, PARAM& param)
+  static void flush_args (cff1_cs_interp_env_t &env, PARAM& param)
   {
     SUPER::flush_args (env, param);
     env.clear_args ();  /* pop off width */

--- a/src/hb-cff1-interp-cs.hh
+++ b/src/hb-cff1-interp-cs.hh
@@ -38,7 +38,7 @@ typedef BiasedSubrs<CFF1Subrs>   CFF1BiasedSubrs;
 struct CFF1CSInterpEnv : CSInterpEnv<Number, CFF1Subrs>
 {
   template <typename ACC>
-  void init (const ByteStr &str, ACC &acc, unsigned int fd)
+  void init (const byte_str_t &str, ACC &acc, unsigned int fd)
   {
     SUPER::init (str, *acc.globalSubrs, *acc.privateDicts[fd].localSubrs);
     processed_width = false;

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -35,23 +35,23 @@ using namespace OT;
 
 struct blend_arg_t : number_t
 {
-  inline void init ()
+  void init ()
   {
     number_t::init ();
     deltas.init ();
   }
 
-  inline void fini ()
+  void fini ()
   {
     number_t::fini ();
     deltas.fini_deep ();
   }
 
-  inline void set_int (int v) { reset_blends (); number_t::set_int (v); }
-  inline void set_fixed (int32_t v) { reset_blends (); number_t::set_fixed (v); }
-  inline void set_real (double v) { reset_blends (); number_t::set_real (v); }
+  void set_int (int v) { reset_blends (); number_t::set_int (v); }
+  void set_fixed (int32_t v) { reset_blends (); number_t::set_fixed (v); }
+  void set_real (double v) { reset_blends (); number_t::set_real (v); }
 
-  inline void set_blends (unsigned int numValues_, unsigned int valueIndex_,
+  void set_blends (unsigned int numValues_, unsigned int valueIndex_,
 			  unsigned int numBlends, hb_array_t<const blend_arg_t> blends_)
   {
     numValues = numValues_;
@@ -61,8 +61,8 @@ struct blend_arg_t : number_t
       deltas[i] = blends_[i];
   }
 
-  inline bool blending () const { return deltas.len > 0; }
-  inline void reset_blends ()
+  bool blending () const { return deltas.len > 0; }
+  void reset_blends ()
   {
     numValues = valueIndex = 0;
     deltas.resize (0);
@@ -79,7 +79,7 @@ typedef biased_subrs_t<CFF2Subrs>   cff2_biased_subrs_t;
 struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
 {
   template <typename ACC>
-  inline void init (const byte_str_t &str, ACC &acc, unsigned int fd,
+  void init (const byte_str_t &str, ACC &acc, unsigned int fd,
 		    const int *coords_=nullptr, unsigned int num_coords_=0)
   {
     SUPER::init (str, *acc.globalSubrs, *acc.privateDicts[fd].localSubrs);
@@ -90,17 +90,17 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
     seen_blend = false;
     seen_vsindex_ = false;
     scalars.init ();
-    do_blend = (coords != nullptr) && num_coords && (varStore != &Null(cff2_variation_store_t));
+    do_blend = (coords != nullptr) && num_coords && (varStore != &Null(CFF2VariationStore));
     set_ivs (acc.privateDicts[fd].ivs);
   }
 
-  inline void fini ()
+  void fini ()
   {
     scalars.fini ();
     SUPER::fini ();
   }
 
-  inline op_code_t fetch_op ()
+  op_code_t fetch_op ()
   {
     if (this->str_ref.avail ())
       return SUPER::fetch_op ();
@@ -112,21 +112,21 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
       return OpCode_return;
   }
 
-  inline const blend_arg_t& eval_arg (unsigned int i)
+  const blend_arg_t& eval_arg (unsigned int i)
   {
     blend_arg_t  &arg = argStack[i];
     blend_arg (arg);
     return arg;
   }
 
-  inline const blend_arg_t& pop_arg ()
+  const blend_arg_t& pop_arg ()
   {
     blend_arg_t  &arg = argStack.pop ();
     blend_arg (arg);
     return arg;
   }
 
-  inline void process_blend ()
+  void process_blend ()
   {
     if (!seen_blend)
     {
@@ -142,7 +142,7 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
     }
   }
 
-  inline void process_vsindex ()
+  void process_vsindex ()
   {
     unsigned int  index = argStack.pop_uint ();
     if (unlikely (seen_vsindex () || seen_blend))
@@ -156,14 +156,14 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
     seen_vsindex_ = true;
   }
 
-  inline unsigned int get_region_count () const { return region_count; }
-  inline void	 set_region_count (unsigned int region_count_) { region_count = region_count_; }
-  inline unsigned int get_ivs () const { return ivs; }
-  inline void	 set_ivs (unsigned int ivs_) { ivs = ivs_; }
-  inline bool	 seen_vsindex () const { return seen_vsindex_; }
+  unsigned int get_region_count () const { return region_count; }
+  void	 set_region_count (unsigned int region_count_) { region_count = region_count_; }
+  unsigned int get_ivs () const { return ivs; }
+  void	 set_ivs (unsigned int ivs_) { ivs = ivs_; }
+  bool	 seen_vsindex () const { return seen_vsindex_; }
 
   protected:
-  inline void blend_arg (blend_arg_t &arg)
+  void blend_arg (blend_arg_t &arg)
   {
     if (do_blend && arg.blending ())
     {
@@ -183,7 +183,7 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
   protected:
   const int     *coords;
   unsigned int  num_coords;
-  const cff2_variation_store_t *varStore;
+  const	 CFF2VariationStore *varStore;
   unsigned int  region_count;
   unsigned int  ivs;
   hb_vector_t<float>  scalars;
@@ -196,7 +196,7 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
 template <typename OPSET, typename PARAM, typename PATH=path_procs_null_t<cff2_cs_interp_env_t, PARAM> >
 struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PARAM, PATH>
 {
-  static inline void process_op (op_code_t op, cff2_cs_interp_env_t &env, PARAM& param)
+  static void process_op (op_code_t op, cff2_cs_interp_env_t &env, PARAM& param)
   {
     switch (op) {
       case OpCode_callsubr:
@@ -228,7 +228,7 @@ struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PA
     }
   }
 
-  static inline void process_blend (cff2_cs_interp_env_t &env, PARAM& param)
+  static void process_blend (cff2_cs_interp_env_t &env, PARAM& param)
   {
     unsigned int n, k;
 
@@ -253,7 +253,7 @@ struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PA
     env.argStack.pop (k * n);
   }
 
-  static inline void process_vsindex (cff2_cs_interp_env_t &env, PARAM& param)
+  static void process_vsindex (cff2_cs_interp_env_t &env, PARAM& param)
   {
     env.process_vsindex ();
     env.clear_args ();

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -33,26 +33,26 @@ namespace CFF {
 
 using namespace OT;
 
-struct BlendArg : Number
+struct blend_arg_t : number_t
 {
   void init ()
   {
-    Number::init ();
+    number_t::init ();
     deltas.init ();
   }
 
   void fini ()
   {
-    Number::fini ();
+    number_t::fini ();
     deltas.fini_deep ();
   }
 
-  void set_int (int v) { reset_blends (); Number::set_int (v); }
-  void set_fixed (int32_t v) { reset_blends (); Number::set_fixed (v); }
-  void set_real (double v) { reset_blends (); Number::set_real (v); }
+  void set_int (int v) { reset_blends (); number_t::set_int (v); }
+  void set_fixed (int32_t v) { reset_blends (); number_t::set_fixed (v); }
+  void set_real (double v) { reset_blends (); number_t::set_real (v); }
 
   void set_blends (unsigned int numValues_, unsigned int valueIndex_,
-			  unsigned int numBlends, hb_array_t<const BlendArg> blends_)
+			  unsigned int numBlends, hb_array_t<const blend_arg_t> blends_)
   {
     numValues = numValues_;
     valueIndex = valueIndex_;
@@ -70,13 +70,13 @@ struct BlendArg : Number
 
   unsigned int numValues;
   unsigned int valueIndex;
-  hb_vector_t<Number> deltas;
+  hb_vector_t<number_t> deltas;
 };
 
-typedef InterpEnv<BlendArg> BlendInterpEnv;
-typedef BiasedSubrs<CFF2Subrs>   CFF2BiasedSubrs;
+typedef interp_env_t<blend_arg_t> BlendInterpEnv;
+typedef biased_subrs_t<CFF2Subrs>   cff2_biased_subrs_t;
 
-struct CFF2CSInterpEnv : CSInterpEnv<BlendArg, CFF2Subrs>
+struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
 {
   template <typename ACC>
   void init (const byte_str_t &str, ACC &acc, unsigned int fd,
@@ -112,16 +112,16 @@ struct CFF2CSInterpEnv : CSInterpEnv<BlendArg, CFF2Subrs>
       return OpCode_return;
   }
 
-  const BlendArg& eval_arg (unsigned int i)
+  const blend_arg_t& eval_arg (unsigned int i)
   {
-    BlendArg  &arg = argStack[i];
+    blend_arg_t  &arg = argStack[i];
     blend_arg (arg);
     return arg;
   }
 
-  const BlendArg& pop_arg ()
+  const blend_arg_t& pop_arg ()
   {
-    BlendArg  &arg = argStack.pop ();
+    blend_arg_t  &arg = argStack.pop ();
     blend_arg (arg);
     return arg;
   }
@@ -163,7 +163,7 @@ struct CFF2CSInterpEnv : CSInterpEnv<BlendArg, CFF2Subrs>
   bool	 seen_vsindex () const { return seen_vsindex_; }
 
   protected:
-  void blend_arg (BlendArg &arg)
+  void blend_arg (blend_arg_t &arg)
   {
     if (do_blend && arg.blending ())
     {
@@ -191,12 +191,12 @@ struct CFF2CSInterpEnv : CSInterpEnv<BlendArg, CFF2Subrs>
   bool	  seen_vsindex_;
   bool	  seen_blend;
 
-  typedef CSInterpEnv<BlendArg, CFF2Subrs> SUPER;
+  typedef cs_interp_env_t<blend_arg_t, CFF2Subrs> SUPER;
 };
-template <typename OPSET, typename PARAM, typename PATH=PathProcsNull<CFF2CSInterpEnv, PARAM> >
-struct CFF2CSOpSet : CSOpSet<BlendArg, OPSET, CFF2CSInterpEnv, PARAM, PATH>
+template <typename OPSET, typename PARAM, typename PATH=path_procs_null_t<cff2_cs_interp_env_t, PARAM> >
+struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PARAM, PATH>
 {
-  static void process_op (OpCode op, CFF2CSInterpEnv &env, PARAM& param)
+  static void process_op (OpCode op, cff2_cs_interp_env_t &env, PARAM& param)
   {
     switch (op) {
       case OpCode_callsubr:
@@ -228,7 +228,7 @@ struct CFF2CSOpSet : CSOpSet<BlendArg, OPSET, CFF2CSInterpEnv, PARAM, PATH>
     }
   }
 
-  static void process_blend (CFF2CSInterpEnv &env, PARAM& param)
+  static void process_blend (cff2_cs_interp_env_t &env, PARAM& param)
   {
     unsigned int n, k;
 
@@ -245,7 +245,7 @@ struct CFF2CSOpSet : CSOpSet<BlendArg, OPSET, CFF2CSInterpEnv, PARAM, PATH>
     }
     for (unsigned int i = 0; i < n; i++)
     {
-      const hb_array_t<const BlendArg>	blends = env.argStack.get_subarray (start + n + (i * k));
+      const hb_array_t<const blend_arg_t>	blends = env.argStack.get_subarray (start + n + (i * k));
       env.argStack[start + i].set_blends (n, i, k, blends);
     }
 
@@ -253,18 +253,18 @@ struct CFF2CSOpSet : CSOpSet<BlendArg, OPSET, CFF2CSInterpEnv, PARAM, PATH>
     env.argStack.pop (k * n);
   }
 
-  static void process_vsindex (CFF2CSInterpEnv &env, PARAM& param)
+  static void process_vsindex (cff2_cs_interp_env_t &env, PARAM& param)
   {
     env.process_vsindex ();
     env.clear_args ();
   }
 
   private:
-  typedef CSOpSet<BlendArg, OPSET, CFF2CSInterpEnv, PARAM, PATH>  SUPER;
+  typedef cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PARAM, PATH>  SUPER;
 };
 
 template <typename OPSET, typename PARAM>
-struct CFF2CSInterpreter : CSInterpreter<CFF2CSInterpEnv, OPSET, PARAM> {};
+struct cff2_cs_interpreter_t : cs_interpreter_t<cff2_cs_interp_env_t, OPSET, PARAM> {};
 
 } /* namespace CFF */
 

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -79,7 +79,7 @@ typedef BiasedSubrs<CFF2Subrs>   CFF2BiasedSubrs;
 struct CFF2CSInterpEnv : CSInterpEnv<BlendArg, CFF2Subrs>
 {
   template <typename ACC>
-  void init (const ByteStr &str, ACC &acc, unsigned int fd,
+  void init (const byte_str_t &str, ACC &acc, unsigned int fd,
 		    const int *coords_=nullptr, unsigned int num_coords_=0)
   {
     SUPER::init (str, *acc.globalSubrs, *acc.privateDicts[fd].localSubrs);

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -100,7 +100,7 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
     SUPER::fini ();
   }
 
-  OpCode fetch_op ()
+  op_code_t fetch_op ()
   {
     if (this->str_ref.avail ())
       return SUPER::fetch_op ();
@@ -196,7 +196,7 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
 template <typename OPSET, typename PARAM, typename PATH=path_procs_null_t<cff2_cs_interp_env_t, PARAM> >
 struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PARAM, PATH>
 {
-  static void process_op (OpCode op, cff2_cs_interp_env_t &env, PARAM& param)
+  static void process_op (op_code_t op, cff2_cs_interp_env_t &env, PARAM& param)
   {
     switch (op) {
       case OpCode_callsubr:

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -102,7 +102,7 @@ struct CFF2CSInterpEnv : CSInterpEnv<BlendArg, CFF2Subrs>
 
   OpCode fetch_op ()
   {
-    if (this->substr.avail ())
+    if (this->str_ref.avail ())
       return SUPER::fetch_op ();
 
     /* make up return or endchar op */

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -35,23 +35,23 @@ using namespace OT;
 
 struct blend_arg_t : number_t
 {
-  void init ()
+  inline void init ()
   {
     number_t::init ();
     deltas.init ();
   }
 
-  void fini ()
+  inline void fini ()
   {
     number_t::fini ();
     deltas.fini_deep ();
   }
 
-  void set_int (int v) { reset_blends (); number_t::set_int (v); }
-  void set_fixed (int32_t v) { reset_blends (); number_t::set_fixed (v); }
-  void set_real (double v) { reset_blends (); number_t::set_real (v); }
+  inline void set_int (int v) { reset_blends (); number_t::set_int (v); }
+  inline void set_fixed (int32_t v) { reset_blends (); number_t::set_fixed (v); }
+  inline void set_real (double v) { reset_blends (); number_t::set_real (v); }
 
-  void set_blends (unsigned int numValues_, unsigned int valueIndex_,
+  inline void set_blends (unsigned int numValues_, unsigned int valueIndex_,
 			  unsigned int numBlends, hb_array_t<const blend_arg_t> blends_)
   {
     numValues = numValues_;
@@ -61,8 +61,8 @@ struct blend_arg_t : number_t
       deltas[i] = blends_[i];
   }
 
-  bool blending () const { return deltas.len > 0; }
-  void reset_blends ()
+  inline bool blending () const { return deltas.len > 0; }
+  inline void reset_blends ()
   {
     numValues = valueIndex = 0;
     deltas.resize (0);
@@ -79,7 +79,7 @@ typedef biased_subrs_t<CFF2Subrs>   cff2_biased_subrs_t;
 struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
 {
   template <typename ACC>
-  void init (const byte_str_t &str, ACC &acc, unsigned int fd,
+  inline void init (const byte_str_t &str, ACC &acc, unsigned int fd,
 		    const int *coords_=nullptr, unsigned int num_coords_=0)
   {
     SUPER::init (str, *acc.globalSubrs, *acc.privateDicts[fd].localSubrs);
@@ -90,17 +90,17 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
     seen_blend = false;
     seen_vsindex_ = false;
     scalars.init ();
-    do_blend = (coords != nullptr) && num_coords && (varStore != &Null(CFF2VariationStore));
+    do_blend = (coords != nullptr) && num_coords && (varStore != &Null(cff2_variation_store_t));
     set_ivs (acc.privateDicts[fd].ivs);
   }
 
-  void fini ()
+  inline void fini ()
   {
     scalars.fini ();
     SUPER::fini ();
   }
 
-  op_code_t fetch_op ()
+  inline op_code_t fetch_op ()
   {
     if (this->str_ref.avail ())
       return SUPER::fetch_op ();
@@ -112,21 +112,21 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
       return OpCode_return;
   }
 
-  const blend_arg_t& eval_arg (unsigned int i)
+  inline const blend_arg_t& eval_arg (unsigned int i)
   {
     blend_arg_t  &arg = argStack[i];
     blend_arg (arg);
     return arg;
   }
 
-  const blend_arg_t& pop_arg ()
+  inline const blend_arg_t& pop_arg ()
   {
     blend_arg_t  &arg = argStack.pop ();
     blend_arg (arg);
     return arg;
   }
 
-  void process_blend ()
+  inline void process_blend ()
   {
     if (!seen_blend)
     {
@@ -142,7 +142,7 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
     }
   }
 
-  void process_vsindex ()
+  inline void process_vsindex ()
   {
     unsigned int  index = argStack.pop_uint ();
     if (unlikely (seen_vsindex () || seen_blend))
@@ -156,14 +156,14 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
     seen_vsindex_ = true;
   }
 
-  unsigned int get_region_count () const { return region_count; }
-  void	 set_region_count (unsigned int region_count_) { region_count = region_count_; }
-  unsigned int get_ivs () const { return ivs; }
-  void	 set_ivs (unsigned int ivs_) { ivs = ivs_; }
-  bool	 seen_vsindex () const { return seen_vsindex_; }
+  inline unsigned int get_region_count () const { return region_count; }
+  inline void	 set_region_count (unsigned int region_count_) { region_count = region_count_; }
+  inline unsigned int get_ivs () const { return ivs; }
+  inline void	 set_ivs (unsigned int ivs_) { ivs = ivs_; }
+  inline bool	 seen_vsindex () const { return seen_vsindex_; }
 
   protected:
-  void blend_arg (blend_arg_t &arg)
+  inline void blend_arg (blend_arg_t &arg)
   {
     if (do_blend && arg.blending ())
     {
@@ -183,7 +183,7 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
   protected:
   const int     *coords;
   unsigned int  num_coords;
-  const	 CFF2VariationStore *varStore;
+  const cff2_variation_store_t *varStore;
   unsigned int  region_count;
   unsigned int  ivs;
   hb_vector_t<float>  scalars;
@@ -196,7 +196,7 @@ struct cff2_cs_interp_env_t : cs_interp_env_t<blend_arg_t, CFF2Subrs>
 template <typename OPSET, typename PARAM, typename PATH=path_procs_null_t<cff2_cs_interp_env_t, PARAM> >
 struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PARAM, PATH>
 {
-  static void process_op (op_code_t op, cff2_cs_interp_env_t &env, PARAM& param)
+  static inline void process_op (op_code_t op, cff2_cs_interp_env_t &env, PARAM& param)
   {
     switch (op) {
       case OpCode_callsubr:
@@ -228,7 +228,7 @@ struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PA
     }
   }
 
-  static void process_blend (cff2_cs_interp_env_t &env, PARAM& param)
+  static inline void process_blend (cff2_cs_interp_env_t &env, PARAM& param)
   {
     unsigned int n, k;
 
@@ -253,7 +253,7 @@ struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PA
     env.argStack.pop (k * n);
   }
 
-  static void process_vsindex (cff2_cs_interp_env_t &env, PARAM& param)
+  static inline void process_vsindex (cff2_cs_interp_env_t &env, PARAM& param)
   {
     env.process_vsindex ();
     env.clear_args ();

--- a/src/hb-ot-cff-common.hh
+++ b/src/hb-ot-cff-common.hh
@@ -64,9 +64,9 @@ struct code_pair_t
 typedef hb_vector_t<unsigned char, 1> str_buff_t;
 struct str_buff_vec_t : hb_vector_t<str_buff_t>
 {
-  inline void fini () { SUPER::fini_deep (); }
+  void fini () { SUPER::fini_deep (); }
 
-  inline unsigned int total_size () const
+  unsigned int total_size () const
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < len; i++)
@@ -82,7 +82,7 @@ struct str_buff_vec_t : hb_vector_t<str_buff_t>
 template <typename COUNT>
 struct CFFIndex
 {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (likely ((count.sanitize (c) && count == 0) || /* empty INDEX */
@@ -91,13 +91,13 @@ struct CFFIndex
 			   c->check_array ((const HBUINT8*)data_base (), 1, max_offset () - 1))));
   }
 
-  static inline unsigned int calculate_offset_array_size (unsigned int offSize, unsigned int count)
+  static unsigned int calculate_offset_array_size (unsigned int offSize, unsigned int count)
   { return offSize * (count + 1); }
 
-  inline unsigned int offset_array_size () const
+  unsigned int offset_array_size () const
   { return calculate_offset_array_size (offSize, count); }
 
-  static inline unsigned int calculate_serialized_size (unsigned int offSize, unsigned int count, unsigned int dataSize)
+  static unsigned int calculate_serialized_size (unsigned int offSize, unsigned int count, unsigned int dataSize)
   {
     if (count == 0)
       return COUNT::static_size;
@@ -105,7 +105,7 @@ struct CFFIndex
       return min_size + calculate_offset_array_size (offSize, count) + dataSize;
   }
 
-  inline bool serialize (hb_serialize_context_t *c, const CFFIndex &src)
+  bool serialize (hb_serialize_context_t *c, const CFFIndex &src)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size ();
@@ -115,9 +115,9 @@ struct CFFIndex
     return_trace (true);
   }
 
-  inline bool serialize (hb_serialize_context_t *c,
-			unsigned int offSize_,
-			const byte_str_array_t &byteArray)
+  bool serialize (hb_serialize_context_t *c,
+		  unsigned int offSize_,
+		  const byte_str_array_t &byteArray)
   {
     TRACE_SERIALIZE (this);
     if (byteArray.len == 0)
@@ -158,9 +158,9 @@ struct CFFIndex
     return_trace (true);
   }
 
-  inline bool serialize (hb_serialize_context_t *c,
-			unsigned int offSize_,
-			const str_buff_vec_t &buffArray)
+  bool serialize (hb_serialize_context_t *c,
+		  unsigned int offSize_,
+		  const str_buff_vec_t &buffArray)
   {
     byte_str_array_t  byteArray;
     byteArray.init ();
@@ -174,7 +174,7 @@ struct CFFIndex
     return result;
   }
 
-  inline void set_offset_at (unsigned int index, unsigned int offset)
+  void set_offset_at (unsigned int index, unsigned int offset)
   {
     HBUINT8 *p = offsets + offSize * index + offSize;
     unsigned int size = offSize;
@@ -186,7 +186,7 @@ struct CFFIndex
     }
   }
 
-  inline unsigned int offset_at (unsigned int index) const
+  unsigned int offset_at (unsigned int index) const
   {
     assert (index <= count);
     const HBUINT8 *p = offsets + offSize * index;
@@ -197,7 +197,7 @@ struct CFFIndex
     return offset;
   }
 
-  inline unsigned int length_at (unsigned int index) const
+  unsigned int length_at (unsigned int index) const
   {
 	if (likely ((offset_at (index + 1) >= offset_at (index)) &&
 		    (offset_at (index + 1) <= offset_at (count))))
@@ -206,12 +206,12 @@ struct CFFIndex
 	  return 0;
   }
 
-  inline const unsigned char *data_base () const
+  const unsigned char *data_base () const
   { return (const unsigned char *)this + min_size + offset_array_size (); }
 
   unsigned int data_size () const { return HBINT8::static_size; }
 
-  inline byte_str_t operator [] (unsigned int index) const
+  byte_str_t operator [] (unsigned int index) const
   {
     if (likely (index < count))
       return byte_str_t (data_base () + offset_at (index) - 1, length_at (index));
@@ -219,7 +219,7 @@ struct CFFIndex
       return Null(byte_str_t);
   }
 
-  inline unsigned int get_size () const
+  unsigned int get_size () const
   {
     if (this != &Null(CFFIndex))
     {
@@ -233,7 +233,7 @@ struct CFFIndex
   }
 
   protected:
-  inline unsigned int max_offset () const
+  unsigned int max_offset () const
   {
     unsigned int max = 0;
     for (unsigned int i = 0; i < count + 1u; i++)
@@ -256,7 +256,7 @@ struct CFFIndex
 template <typename COUNT, typename TYPE>
 struct CFFIndexOf : CFFIndex<COUNT>
 {
-  inline const byte_str_t operator [] (unsigned int index) const
+  const byte_str_t operator [] (unsigned int index) const
   {
     if (likely (index < CFFIndex<COUNT>::count))
       return byte_str_t (CFFIndex<COUNT>::data_base () + CFFIndex<COUNT>::offset_at (index) - 1, CFFIndex<COUNT>::length_at (index));
@@ -264,13 +264,13 @@ struct CFFIndexOf : CFFIndex<COUNT>
   }
 
   template <typename DATA, typename PARAM1, typename PARAM2>
-  inline bool serialize (hb_serialize_context_t *c,
-			unsigned int offSize_,
-			const DATA *dataArray,
-			unsigned int dataArrayLen,
-			const hb_vector_t<unsigned int> &dataSizeArray,
-			const PARAM1 &param1,
-			const PARAM2 &param2)
+  bool serialize (hb_serialize_context_t *c,
+		  unsigned int offSize_,
+		  const DATA *dataArray,
+		  unsigned int dataArrayLen,
+		  const hb_vector_t<unsigned int> &dataSizeArray,
+		  const PARAM1 &param1,
+		  const PARAM2 &param2)
   {
     TRACE_SERIALIZE (this);
     /* serialize CFFIndex header */
@@ -303,11 +303,11 @@ struct CFFIndexOf : CFFIndex<COUNT>
 
   /* in parallel to above */
   template <typename DATA, typename PARAM>
-  static inline unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
-							const DATA *dataArray,
-							unsigned int dataArrayLen,
-							hb_vector_t<unsigned int> &dataSizeArray, /* OUT */
-							const PARAM &param)
+  static unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
+						 const DATA *dataArray,
+						 unsigned int dataArrayLen,
+						 hb_vector_t<unsigned int> &dataSizeArray, /* OUT */
+						 const PARAM &param)
   {
     /* determine offset size */
     unsigned int  totalDataSize = 0;
@@ -327,10 +327,10 @@ struct CFFIndexOf : CFFIndex<COUNT>
 struct Dict : UnsizedByteStr
 {
   template <typename DICTVAL, typename OP_SERIALIZER, typename PARAM>
-  inline bool serialize (hb_serialize_context_t *c,
-			const DICTVAL &dictval,
-			OP_SERIALIZER& opszr,
-			PARAM& param)
+  bool serialize (hb_serialize_context_t *c,
+		  const DICTVAL &dictval,
+		  OP_SERIALIZER& opszr,
+		  PARAM& param)
   {
     TRACE_SERIALIZE (this);
     for (unsigned int i = 0; i < dictval.get_count (); i++)
@@ -343,9 +343,9 @@ struct Dict : UnsizedByteStr
 
   /* in parallel to above */
   template <typename DICTVAL, typename OP_SERIALIZER, typename PARAM>
-  static inline unsigned int calculate_serialized_size (const DICTVAL &dictval,
-							OP_SERIALIZER& opszr,
-							PARAM& param)
+  static unsigned int calculate_serialized_size (const DICTVAL &dictval,
+						 OP_SERIALIZER& opszr,
+						 PARAM& param)
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < dictval.get_count (); i++)
@@ -354,8 +354,8 @@ struct Dict : UnsizedByteStr
   }
 
   template <typename DICTVAL, typename OP_SERIALIZER>
-  static inline unsigned int calculate_serialized_size (const DICTVAL &dictval,
-						      	OP_SERIALIZER& opszr)
+  static unsigned int calculate_serialized_size (const DICTVAL &dictval,
+						 OP_SERIALIZER& opszr)
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < dictval.get_count (); i++)
@@ -364,7 +364,7 @@ struct Dict : UnsizedByteStr
   }
 
   template <typename INTTYPE, int minVal, int maxVal>
-  static inline bool serialize_int_op (hb_serialize_context_t *c, op_code_t op, int value, op_code_t intOp)
+  static bool serialize_int_op (hb_serialize_context_t *c, op_code_t op, int value, op_code_t intOp)
   {
     // XXX: not sure why but LLVM fails to compile the following 'unlikely' macro invocation
     if (/*unlikely*/ (!serialize_int<INTTYPE, minVal, maxVal> (c, intOp, value)))
@@ -384,18 +384,18 @@ struct Dict : UnsizedByteStr
     return_trace (true);
   }
 
-  static inline bool serialize_uint4_op (hb_serialize_context_t *c, op_code_t op, int value)
+  static bool serialize_uint4_op (hb_serialize_context_t *c, op_code_t op, int value)
   { return serialize_int_op<HBUINT32, 0, 0x7FFFFFFF> (c, op, value, OpCode_longintdict); }
 
-  static inline bool serialize_uint2_op (hb_serialize_context_t *c, op_code_t op, int value)
+  static bool serialize_uint2_op (hb_serialize_context_t *c, op_code_t op, int value)
   { return serialize_int_op<HBUINT16, 0, 0x7FFF> (c, op, value, OpCode_shortint); }
 
-  static inline bool serialize_offset4_op (hb_serialize_context_t *c, op_code_t op, int value)
+  static bool serialize_offset4_op (hb_serialize_context_t *c, op_code_t op, int value)
   {
     return serialize_uint4_op (c, op, value);
   }
 
-  static inline bool serialize_offset2_op (hb_serialize_context_t *c, op_code_t op, int value)
+  static bool serialize_offset2_op (hb_serialize_context_t *c, op_code_t op, int value)
   {
     return serialize_uint2_op (c, op, value);
   }
@@ -407,7 +407,7 @@ struct PrivateDict : Dict {};
 
 struct table_info_t
 {
-  inline void init () { offSize = offset = size = 0; }
+  void init () { offSize = offset = size = 0; }
 
   unsigned int    offset;
   unsigned int    size;
@@ -418,11 +418,11 @@ struct table_info_t
  * set to CFF_UNDEF_CODE if excluded from subset */
 struct remap_t : hb_vector_t<hb_codepoint_t>
 {
-  inline void init () { SUPER::init (); }
+  void init () { SUPER::init (); }
 
-  inline void fini () { SUPER::fini (); }
+  void fini () { SUPER::fini (); }
 
-  inline bool reset (unsigned int size)
+  bool reset (unsigned int size)
   {
     if (unlikely (!SUPER::resize (size)))
       return false;
@@ -432,7 +432,7 @@ struct remap_t : hb_vector_t<hb_codepoint_t>
     return true;
   }
 
-  inline bool identity (unsigned int size)
+  bool identity (unsigned int size)
   {
     if (unlikely (!SUPER::resize (size)))
       return false;
@@ -443,20 +443,20 @@ struct remap_t : hb_vector_t<hb_codepoint_t>
     return true;
   }
 
-  inline bool excludes (hb_codepoint_t id) const
+  bool excludes (hb_codepoint_t id) const
   { return (id < len) && ((*this)[id] == CFF_UNDEF_CODE); }
 
-  inline bool includes (hb_codepoint_t id) const
+  bool includes (hb_codepoint_t id) const
   { return !excludes (id); }
 
-  inline unsigned int add (unsigned int i)
+  unsigned int add (unsigned int i)
   {
     if ((*this)[i] == CFF_UNDEF_CODE)
       (*this)[i] = count++;
     return (*this)[i];
   }
 
-  inline hb_codepoint_t get_count () const { return count; }
+  hb_codepoint_t get_count () const { return count; }
 
   protected:
   hb_codepoint_t  count;
@@ -470,10 +470,10 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 {
   /* used by CFF1 */
   template <typename DICTVAL, typename OP_SERIALIZER>
-  inline bool serialize (hb_serialize_context_t *c,
-			unsigned int offSize_,
-			const hb_vector_t<DICTVAL> &fontDicts,
-			OP_SERIALIZER& opszr)
+  bool serialize (hb_serialize_context_t *c,
+		  unsigned int offSize_,
+		  const hb_vector_t<DICTVAL> &fontDicts,
+		  OP_SERIALIZER& opszr)
   {
     TRACE_SERIALIZE (this);
     if (unlikely (!c->extend_min (*this))) return_trace (false);
@@ -504,13 +504,13 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 
   /* used by CFF2 */
   template <typename DICTVAL, typename OP_SERIALIZER>
-  inline bool serialize (hb_serialize_context_t *c,
-			unsigned int offSize_,
-			const hb_vector_t<DICTVAL> &fontDicts,
-			unsigned int fdCount,
-			const remap_t &fdmap,
-			OP_SERIALIZER& opszr,
-			const hb_vector_t<table_info_t> &privateInfos)
+  bool serialize (hb_serialize_context_t *c,
+		  unsigned int offSize_,
+		  const hb_vector_t<DICTVAL> &fontDicts,
+		  unsigned int fdCount,
+		  const remap_t &fdmap,
+		  OP_SERIALIZER& opszr,
+		  const hb_vector_t<table_info_t> &privateInfos)
   {
     TRACE_SERIALIZE (this);
     if (unlikely (!c->extend_min (*this))) return_trace (false);
@@ -543,11 +543,11 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 
   /* in parallel to above */
   template <typename OP_SERIALIZER, typename DICTVAL>
-  static inline unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
-							const hb_vector_t<DICTVAL> &fontDicts,
-							unsigned int fdCount,
-							const remap_t &fdmap,
-							OP_SERIALIZER& opszr)
+  static unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
+						 const hb_vector_t<DICTVAL> &fontDicts,
+						 unsigned int fdCount,
+						 const remap_t &fdmap,
+						 OP_SERIALIZER& opszr)
   {
     unsigned int dictsSize = 0;
     for (unsigned int i = 0; i < fontDicts.len; i++)
@@ -561,7 +561,7 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 
 /* FDSelect */
 struct FDSelect0 {
-  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
     if (unlikely (!(c->check_struct (this))))
@@ -573,12 +573,12 @@ struct FDSelect0 {
     return_trace (true);
   }
 
-  inline hb_codepoint_t get_fd (hb_codepoint_t glyph) const
+  hb_codepoint_t get_fd (hb_codepoint_t glyph) const
   {
     return (hb_codepoint_t)fds[glyph];
   }
 
-  inline unsigned int get_size (unsigned int num_glyphs) const
+  unsigned int get_size (unsigned int num_glyphs) const
   { return HBUINT8::static_size * num_glyphs; }
 
   HBUINT8     fds[VAR];
@@ -588,7 +588,7 @@ struct FDSelect0 {
 
 template <typename GID_TYPE, typename FD_TYPE>
 struct FDSelect3_4_Range {
-  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
     return_trace (likely (c->check_struct (this) && (first < c->get_num_glyphs ()) && (fd < fdcount)));
@@ -602,10 +602,10 @@ struct FDSelect3_4_Range {
 
 template <typename GID_TYPE, typename FD_TYPE>
 struct FDSelect3_4 {
-  inline unsigned int get_size () const
+  unsigned int get_size () const
   { return GID_TYPE::static_size * 2 + FDSelect3_4_Range<GID_TYPE, FD_TYPE>::static_size * nRanges; }
 
-  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
     if (unlikely (!(c->check_struct (this) && (nRanges > 0) && (ranges[0].first == 0))))
@@ -624,7 +624,7 @@ struct FDSelect3_4 {
     return_trace (true);
   }
 
-  inline hb_codepoint_t get_fd (hb_codepoint_t glyph) const
+  hb_codepoint_t get_fd (hb_codepoint_t glyph) const
   {
     unsigned int i;
     for (i = 1; i < nRanges; i++)
@@ -634,8 +634,8 @@ struct FDSelect3_4 {
     return (hb_codepoint_t)ranges[i - 1].fd;
   }
 
-  inline GID_TYPE &sentinel ()  { return StructAfter<GID_TYPE> (ranges[nRanges - 1]); }
-  inline const GID_TYPE &sentinel () const  { return StructAfter<GID_TYPE> (ranges[nRanges - 1]); }
+  GID_TYPE &sentinel ()  { return StructAfter<GID_TYPE> (ranges[nRanges - 1]); }
+  const GID_TYPE &sentinel () const  { return StructAfter<GID_TYPE> (ranges[nRanges - 1]); }
 
   GID_TYPE	 nRanges;
   FDSelect3_4_Range<GID_TYPE, FD_TYPE>  ranges[VAR];
@@ -648,7 +648,7 @@ typedef FDSelect3_4<HBUINT16, HBUINT8> FDSelect3;
 typedef FDSelect3_4_Range<HBUINT16, HBUINT8> FDSelect3_Range;
 
 struct FDSelect {
-  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
 
@@ -658,7 +658,7 @@ struct FDSelect {
 			  u.format3.sanitize (c, fdcount)));
   }
 
-  inline bool serialize (hb_serialize_context_t *c, const FDSelect &src, unsigned int num_glyphs)
+  bool serialize (hb_serialize_context_t *c, const FDSelect &src, unsigned int num_glyphs)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size (num_glyphs);
@@ -668,10 +668,10 @@ struct FDSelect {
     return_trace (true);
   }
 
-  inline unsigned int calculate_serialized_size (unsigned int num_glyphs) const
+  unsigned int calculate_serialized_size (unsigned int num_glyphs) const
   { return get_size (num_glyphs); }
 
-  inline unsigned int get_size (unsigned int num_glyphs) const
+  unsigned int get_size (unsigned int num_glyphs) const
   {
     unsigned int size = format.static_size;
     if (format == 0)
@@ -681,7 +681,7 @@ struct FDSelect {
     return size;
   }
 
-  inline hb_codepoint_t get_fd (hb_codepoint_t glyph) const
+  hb_codepoint_t get_fd (hb_codepoint_t glyph) const
   {
     if (this == &Null(FDSelect))
       return 0;

--- a/src/hb-ot-cff-common.hh
+++ b/src/hb-ot-cff-common.hh
@@ -64,9 +64,9 @@ struct code_pair_t
 typedef hb_vector_t<unsigned char, 1> str_buff_t;
 struct str_buff_vec_t : hb_vector_t<str_buff_t>
 {
-  void fini () { SUPER::fini_deep (); }
+  inline void fini () { SUPER::fini_deep (); }
 
-  unsigned int total_size () const
+  inline unsigned int total_size () const
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < len; i++)
@@ -82,7 +82,7 @@ struct str_buff_vec_t : hb_vector_t<str_buff_t>
 template <typename COUNT>
 struct CFFIndex
 {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (likely ((count.sanitize (c) && count == 0) || /* empty INDEX */
@@ -91,13 +91,13 @@ struct CFFIndex
 			   c->check_array ((const HBUINT8*)data_base (), 1, max_offset () - 1))));
   }
 
-  static unsigned int calculate_offset_array_size (unsigned int offSize, unsigned int count)
+  static inline unsigned int calculate_offset_array_size (unsigned int offSize, unsigned int count)
   { return offSize * (count + 1); }
 
-  unsigned int offset_array_size () const
+  inline unsigned int offset_array_size () const
   { return calculate_offset_array_size (offSize, count); }
 
-  static unsigned int calculate_serialized_size (unsigned int offSize, unsigned int count, unsigned int dataSize)
+  static inline unsigned int calculate_serialized_size (unsigned int offSize, unsigned int count, unsigned int dataSize)
   {
     if (count == 0)
       return COUNT::static_size;
@@ -105,7 +105,7 @@ struct CFFIndex
       return min_size + calculate_offset_array_size (offSize, count) + dataSize;
   }
 
-  bool serialize (hb_serialize_context_t *c, const CFFIndex &src)
+  inline bool serialize (hb_serialize_context_t *c, const CFFIndex &src)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size ();
@@ -115,9 +115,9 @@ struct CFFIndex
     return_trace (true);
   }
 
-  bool serialize (hb_serialize_context_t *c,
-		  unsigned int offSize_,
-		  const byte_str_array_t &byteArray)
+  inline bool serialize (hb_serialize_context_t *c,
+			unsigned int offSize_,
+			const byte_str_array_t &byteArray)
   {
     TRACE_SERIALIZE (this);
     if (byteArray.len == 0)
@@ -158,9 +158,9 @@ struct CFFIndex
     return_trace (true);
   }
 
-  bool serialize (hb_serialize_context_t *c,
-		  unsigned int offSize_,
-		  const str_buff_vec_t &buffArray)
+  inline bool serialize (hb_serialize_context_t *c,
+			unsigned int offSize_,
+			const str_buff_vec_t &buffArray)
   {
     byte_str_array_t  byteArray;
     byteArray.init ();
@@ -174,7 +174,7 @@ struct CFFIndex
     return result;
   }
 
-  void set_offset_at (unsigned int index, unsigned int offset)
+  inline void set_offset_at (unsigned int index, unsigned int offset)
   {
     HBUINT8 *p = offsets + offSize * index + offSize;
     unsigned int size = offSize;
@@ -186,7 +186,7 @@ struct CFFIndex
     }
   }
 
-  unsigned int offset_at (unsigned int index) const
+  inline unsigned int offset_at (unsigned int index) const
   {
     assert (index <= count);
     const HBUINT8 *p = offsets + offSize * index;
@@ -197,7 +197,7 @@ struct CFFIndex
     return offset;
   }
 
-  unsigned int length_at (unsigned int index) const
+  inline unsigned int length_at (unsigned int index) const
   {
 	if (likely ((offset_at (index + 1) >= offset_at (index)) &&
 		    (offset_at (index + 1) <= offset_at (count))))
@@ -206,12 +206,12 @@ struct CFFIndex
 	  return 0;
   }
 
-  const unsigned char *data_base () const
+  inline const unsigned char *data_base () const
   { return (const unsigned char *)this + min_size + offset_array_size (); }
 
   unsigned int data_size () const { return HBINT8::static_size; }
 
-  byte_str_t operator [] (unsigned int index) const
+  inline byte_str_t operator [] (unsigned int index) const
   {
     if (likely (index < count))
       return byte_str_t (data_base () + offset_at (index) - 1, length_at (index));
@@ -219,7 +219,7 @@ struct CFFIndex
       return Null(byte_str_t);
   }
 
-  unsigned int get_size () const
+  inline unsigned int get_size () const
   {
     if (this != &Null(CFFIndex))
     {
@@ -233,7 +233,7 @@ struct CFFIndex
   }
 
   protected:
-  unsigned int max_offset () const
+  inline unsigned int max_offset () const
   {
     unsigned int max = 0;
     for (unsigned int i = 0; i < count + 1u; i++)
@@ -256,7 +256,7 @@ struct CFFIndex
 template <typename COUNT, typename TYPE>
 struct CFFIndexOf : CFFIndex<COUNT>
 {
-  const byte_str_t operator [] (unsigned int index) const
+  inline const byte_str_t operator [] (unsigned int index) const
   {
     if (likely (index < CFFIndex<COUNT>::count))
       return byte_str_t (CFFIndex<COUNT>::data_base () + CFFIndex<COUNT>::offset_at (index) - 1, CFFIndex<COUNT>::length_at (index));
@@ -264,13 +264,13 @@ struct CFFIndexOf : CFFIndex<COUNT>
   }
 
   template <typename DATA, typename PARAM1, typename PARAM2>
-  bool serialize (hb_serialize_context_t *c,
-		  unsigned int offSize_,
-		  const DATA *dataArray,
-		  unsigned int dataArrayLen,
-		  const hb_vector_t<unsigned int> &dataSizeArray,
-		  const PARAM1 &param1,
-		  const PARAM2 &param2)
+  inline bool serialize (hb_serialize_context_t *c,
+			unsigned int offSize_,
+			const DATA *dataArray,
+			unsigned int dataArrayLen,
+			const hb_vector_t<unsigned int> &dataSizeArray,
+			const PARAM1 &param1,
+			const PARAM2 &param2)
   {
     TRACE_SERIALIZE (this);
     /* serialize CFFIndex header */
@@ -303,11 +303,11 @@ struct CFFIndexOf : CFFIndex<COUNT>
 
   /* in parallel to above */
   template <typename DATA, typename PARAM>
-  static unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
-						 const DATA *dataArray,
-						 unsigned int dataArrayLen,
-						 hb_vector_t<unsigned int> &dataSizeArray, /* OUT */
-						 const PARAM &param)
+  static inline unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
+							const DATA *dataArray,
+							unsigned int dataArrayLen,
+							hb_vector_t<unsigned int> &dataSizeArray, /* OUT */
+							const PARAM &param)
   {
     /* determine offset size */
     unsigned int  totalDataSize = 0;
@@ -327,10 +327,10 @@ struct CFFIndexOf : CFFIndex<COUNT>
 struct Dict : UnsizedByteStr
 {
   template <typename DICTVAL, typename OP_SERIALIZER, typename PARAM>
-  bool serialize (hb_serialize_context_t *c,
-		  const DICTVAL &dictval,
-		  OP_SERIALIZER& opszr,
-		  PARAM& param)
+  inline bool serialize (hb_serialize_context_t *c,
+			const DICTVAL &dictval,
+			OP_SERIALIZER& opszr,
+			PARAM& param)
   {
     TRACE_SERIALIZE (this);
     for (unsigned int i = 0; i < dictval.get_count (); i++)
@@ -343,9 +343,9 @@ struct Dict : UnsizedByteStr
 
   /* in parallel to above */
   template <typename DICTVAL, typename OP_SERIALIZER, typename PARAM>
-  static unsigned int calculate_serialized_size (const DICTVAL &dictval,
-						 OP_SERIALIZER& opszr,
-						 PARAM& param)
+  static inline unsigned int calculate_serialized_size (const DICTVAL &dictval,
+							OP_SERIALIZER& opszr,
+							PARAM& param)
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < dictval.get_count (); i++)
@@ -354,8 +354,8 @@ struct Dict : UnsizedByteStr
   }
 
   template <typename DICTVAL, typename OP_SERIALIZER>
-  static unsigned int calculate_serialized_size (const DICTVAL &dictval,
-						 OP_SERIALIZER& opszr)
+  static inline unsigned int calculate_serialized_size (const DICTVAL &dictval,
+						      	OP_SERIALIZER& opszr)
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < dictval.get_count (); i++)
@@ -364,7 +364,7 @@ struct Dict : UnsizedByteStr
   }
 
   template <typename INTTYPE, int minVal, int maxVal>
-  static bool serialize_int_op (hb_serialize_context_t *c, op_code_t op, int value, op_code_t intOp)
+  static inline bool serialize_int_op (hb_serialize_context_t *c, op_code_t op, int value, op_code_t intOp)
   {
     // XXX: not sure why but LLVM fails to compile the following 'unlikely' macro invocation
     if (/*unlikely*/ (!serialize_int<INTTYPE, minVal, maxVal> (c, intOp, value)))
@@ -384,18 +384,18 @@ struct Dict : UnsizedByteStr
     return_trace (true);
   }
 
-  static bool serialize_uint4_op (hb_serialize_context_t *c, op_code_t op, int value)
+  static inline bool serialize_uint4_op (hb_serialize_context_t *c, op_code_t op, int value)
   { return serialize_int_op<HBUINT32, 0, 0x7FFFFFFF> (c, op, value, OpCode_longintdict); }
 
-  static bool serialize_uint2_op (hb_serialize_context_t *c, op_code_t op, int value)
+  static inline bool serialize_uint2_op (hb_serialize_context_t *c, op_code_t op, int value)
   { return serialize_int_op<HBUINT16, 0, 0x7FFF> (c, op, value, OpCode_shortint); }
 
-  static bool serialize_offset4_op (hb_serialize_context_t *c, op_code_t op, int value)
+  static inline bool serialize_offset4_op (hb_serialize_context_t *c, op_code_t op, int value)
   {
     return serialize_uint4_op (c, op, value);
   }
 
-  static bool serialize_offset2_op (hb_serialize_context_t *c, op_code_t op, int value)
+  static inline bool serialize_offset2_op (hb_serialize_context_t *c, op_code_t op, int value)
   {
     return serialize_uint2_op (c, op, value);
   }
@@ -407,7 +407,7 @@ struct PrivateDict : Dict {};
 
 struct table_info_t
 {
-  void init () { offSize = offset = size = 0; }
+  inline void init () { offSize = offset = size = 0; }
 
   unsigned int    offset;
   unsigned int    size;
@@ -418,11 +418,11 @@ struct table_info_t
  * set to CFF_UNDEF_CODE if excluded from subset */
 struct remap_t : hb_vector_t<hb_codepoint_t>
 {
-  void init () { SUPER::init (); }
+  inline void init () { SUPER::init (); }
 
-  void fini () { SUPER::fini (); }
+  inline void fini () { SUPER::fini (); }
 
-  bool reset (unsigned int size)
+  inline bool reset (unsigned int size)
   {
     if (unlikely (!SUPER::resize (size)))
       return false;
@@ -432,7 +432,7 @@ struct remap_t : hb_vector_t<hb_codepoint_t>
     return true;
   }
 
-  bool identity (unsigned int size)
+  inline bool identity (unsigned int size)
   {
     if (unlikely (!SUPER::resize (size)))
       return false;
@@ -443,20 +443,20 @@ struct remap_t : hb_vector_t<hb_codepoint_t>
     return true;
   }
 
-  bool excludes (hb_codepoint_t id) const
+  inline bool excludes (hb_codepoint_t id) const
   { return (id < len) && ((*this)[id] == CFF_UNDEF_CODE); }
 
-  bool includes (hb_codepoint_t id) const
+  inline bool includes (hb_codepoint_t id) const
   { return !excludes (id); }
 
-  unsigned int add (unsigned int i)
+  inline unsigned int add (unsigned int i)
   {
     if ((*this)[i] == CFF_UNDEF_CODE)
       (*this)[i] = count++;
     return (*this)[i];
   }
 
-  hb_codepoint_t get_count () const { return count; }
+  inline hb_codepoint_t get_count () const { return count; }
 
   protected:
   hb_codepoint_t  count;
@@ -470,10 +470,10 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 {
   /* used by CFF1 */
   template <typename DICTVAL, typename OP_SERIALIZER>
-  bool serialize (hb_serialize_context_t *c,
-		  unsigned int offSize_,
-		  const hb_vector_t<DICTVAL> &fontDicts,
-		  OP_SERIALIZER& opszr)
+  inline bool serialize (hb_serialize_context_t *c,
+			unsigned int offSize_,
+			const hb_vector_t<DICTVAL> &fontDicts,
+			OP_SERIALIZER& opszr)
   {
     TRACE_SERIALIZE (this);
     if (unlikely (!c->extend_min (*this))) return_trace (false);
@@ -504,13 +504,13 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 
   /* used by CFF2 */
   template <typename DICTVAL, typename OP_SERIALIZER>
-  bool serialize (hb_serialize_context_t *c,
-		  unsigned int offSize_,
-		  const hb_vector_t<DICTVAL> &fontDicts,
-		  unsigned int fdCount,
-		  const remap_t &fdmap,
-		  OP_SERIALIZER& opszr,
-		  const hb_vector_t<table_info_t> &privateInfos)
+  inline bool serialize (hb_serialize_context_t *c,
+			unsigned int offSize_,
+			const hb_vector_t<DICTVAL> &fontDicts,
+			unsigned int fdCount,
+			const remap_t &fdmap,
+			OP_SERIALIZER& opszr,
+			const hb_vector_t<table_info_t> &privateInfos)
   {
     TRACE_SERIALIZE (this);
     if (unlikely (!c->extend_min (*this))) return_trace (false);
@@ -543,11 +543,11 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 
   /* in parallel to above */
   template <typename OP_SERIALIZER, typename DICTVAL>
-  static unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
-						 const hb_vector_t<DICTVAL> &fontDicts,
-						 unsigned int fdCount,
-						 const remap_t &fdmap,
-						 OP_SERIALIZER& opszr)
+  static inline unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
+							const hb_vector_t<DICTVAL> &fontDicts,
+							unsigned int fdCount,
+							const remap_t &fdmap,
+							OP_SERIALIZER& opszr)
   {
     unsigned int dictsSize = 0;
     for (unsigned int i = 0; i < fontDicts.len; i++)
@@ -561,7 +561,7 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 
 /* FDSelect */
 struct FDSelect0 {
-  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
     if (unlikely (!(c->check_struct (this))))
@@ -573,12 +573,12 @@ struct FDSelect0 {
     return_trace (true);
   }
 
-  hb_codepoint_t get_fd (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_fd (hb_codepoint_t glyph) const
   {
     return (hb_codepoint_t)fds[glyph];
   }
 
-  unsigned int get_size (unsigned int num_glyphs) const
+  inline unsigned int get_size (unsigned int num_glyphs) const
   { return HBUINT8::static_size * num_glyphs; }
 
   HBUINT8     fds[VAR];
@@ -588,7 +588,7 @@ struct FDSelect0 {
 
 template <typename GID_TYPE, typename FD_TYPE>
 struct FDSelect3_4_Range {
-  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
     return_trace (likely (c->check_struct (this) && (first < c->get_num_glyphs ()) && (fd < fdcount)));
@@ -602,10 +602,10 @@ struct FDSelect3_4_Range {
 
 template <typename GID_TYPE, typename FD_TYPE>
 struct FDSelect3_4 {
-  unsigned int get_size () const
+  inline unsigned int get_size () const
   { return GID_TYPE::static_size * 2 + FDSelect3_4_Range<GID_TYPE, FD_TYPE>::static_size * nRanges; }
 
-  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
     if (unlikely (!(c->check_struct (this) && (nRanges > 0) && (ranges[0].first == 0))))
@@ -624,7 +624,7 @@ struct FDSelect3_4 {
     return_trace (true);
   }
 
-  hb_codepoint_t get_fd (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_fd (hb_codepoint_t glyph) const
   {
     unsigned int i;
     for (i = 1; i < nRanges; i++)
@@ -634,8 +634,8 @@ struct FDSelect3_4 {
     return (hb_codepoint_t)ranges[i - 1].fd;
   }
 
-  GID_TYPE &sentinel ()  { return StructAfter<GID_TYPE> (ranges[nRanges - 1]); }
-  const GID_TYPE &sentinel () const  { return StructAfter<GID_TYPE> (ranges[nRanges - 1]); }
+  inline GID_TYPE &sentinel ()  { return StructAfter<GID_TYPE> (ranges[nRanges - 1]); }
+  inline const GID_TYPE &sentinel () const  { return StructAfter<GID_TYPE> (ranges[nRanges - 1]); }
 
   GID_TYPE	 nRanges;
   FDSelect3_4_Range<GID_TYPE, FD_TYPE>  ranges[VAR];
@@ -648,7 +648,7 @@ typedef FDSelect3_4<HBUINT16, HBUINT8> FDSelect3;
 typedef FDSelect3_4_Range<HBUINT16, HBUINT8> FDSelect3_Range;
 
 struct FDSelect {
-  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
 
@@ -658,7 +658,7 @@ struct FDSelect {
 			  u.format3.sanitize (c, fdcount)));
   }
 
-  bool serialize (hb_serialize_context_t *c, const FDSelect &src, unsigned int num_glyphs)
+  inline bool serialize (hb_serialize_context_t *c, const FDSelect &src, unsigned int num_glyphs)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size (num_glyphs);
@@ -668,10 +668,10 @@ struct FDSelect {
     return_trace (true);
   }
 
-  unsigned int calculate_serialized_size (unsigned int num_glyphs) const
+  inline unsigned int calculate_serialized_size (unsigned int num_glyphs) const
   { return get_size (num_glyphs); }
 
-  unsigned int get_size (unsigned int num_glyphs) const
+  inline unsigned int get_size (unsigned int num_glyphs) const
   {
     unsigned int size = format.static_size;
     if (format == 0)
@@ -681,7 +681,7 @@ struct FDSelect {
     return size;
   }
 
-  hb_codepoint_t get_fd (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_fd (hb_codepoint_t glyph) const
   {
     if (this == &Null(FDSelect))
       return 0;

--- a/src/hb-ot-cff-common.hh
+++ b/src/hb-ot-cff-common.hh
@@ -364,7 +364,7 @@ struct Dict : UnsizedByteStr
   }
 
   template <typename INTTYPE, int minVal, int maxVal>
-  static bool serialize_int_op (hb_serialize_context_t *c, OpCode op, int value, OpCode intOp)
+  static bool serialize_int_op (hb_serialize_context_t *c, op_code_t op, int value, op_code_t intOp)
   {
     // XXX: not sure why but LLVM fails to compile the following 'unlikely' macro invocation
     if (/*unlikely*/ (!serialize_int<INTTYPE, minVal, maxVal> (c, intOp, value)))
@@ -384,18 +384,18 @@ struct Dict : UnsizedByteStr
     return_trace (true);
   }
 
-  static bool serialize_uint4_op (hb_serialize_context_t *c, OpCode op, int value)
+  static bool serialize_uint4_op (hb_serialize_context_t *c, op_code_t op, int value)
   { return serialize_int_op<HBUINT32, 0, 0x7FFFFFFF> (c, op, value, OpCode_longintdict); }
 
-  static bool serialize_uint2_op (hb_serialize_context_t *c, OpCode op, int value)
+  static bool serialize_uint2_op (hb_serialize_context_t *c, op_code_t op, int value)
   { return serialize_int_op<HBUINT16, 0, 0x7FFF> (c, op, value, OpCode_shortint); }
 
-  static bool serialize_offset4_op (hb_serialize_context_t *c, OpCode op, int value)
+  static bool serialize_offset4_op (hb_serialize_context_t *c, op_code_t op, int value)
   {
     return serialize_uint4_op (c, op, value);
   }
 
-  static bool serialize_offset2_op (hb_serialize_context_t *c, OpCode op, int value)
+  static bool serialize_offset2_op (hb_serialize_context_t *c, op_code_t op, int value)
   {
     return serialize_uint2_op (c, op, value);
   }

--- a/src/hb-ot-cff-common.hh
+++ b/src/hb-ot-cff-common.hh
@@ -55,14 +55,14 @@ inline unsigned int calcOffSize(unsigned int dataSize)
   return size;
 }
 
-struct code_pair
+struct code_pair_t
 {
   hb_codepoint_t  code;
   hb_codepoint_t  glyph;
 };
 
-typedef hb_vector_t<unsigned char, 1> StrBuff;
-struct StrBuffArray : hb_vector_t<StrBuff>
+typedef hb_vector_t<unsigned char, 1> str_buff_t;
+struct str_buff_vec_t : hb_vector_t<str_buff_t>
 {
   void fini () { SUPER::fini_deep (); }
 
@@ -75,7 +75,7 @@ struct StrBuffArray : hb_vector_t<StrBuff>
   }
 
   private:
-  typedef hb_vector_t<StrBuff> SUPER;
+  typedef hb_vector_t<str_buff_t> SUPER;
 };
 
 /* CFF INDEX */
@@ -160,7 +160,7 @@ struct CFFIndex
 
   bool serialize (hb_serialize_context_t *c,
 		  unsigned int offSize_,
-		  const StrBuffArray &buffArray)
+		  const str_buff_vec_t &buffArray)
   {
     byte_str_array_t  byteArray;
     byteArray.init ();
@@ -405,7 +405,7 @@ struct TopDict : Dict {};
 struct FontDict : Dict {};
 struct PrivateDict : Dict {};
 
-struct TableInfo
+struct table_info_t
 {
   void init () { offSize = offset = size = 0; }
 
@@ -416,7 +416,7 @@ struct TableInfo
 
 /* used to remap font index or SID from fullset to subset.
  * set to CFF_UNDEF_CODE if excluded from subset */
-struct Remap : hb_vector_t<hb_codepoint_t>
+struct remap_t : hb_vector_t<hb_codepoint_t>
 {
   void init () { SUPER::init (); }
 
@@ -508,9 +508,9 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
 		  unsigned int offSize_,
 		  const hb_vector_t<DICTVAL> &fontDicts,
 		  unsigned int fdCount,
-		  const Remap &fdmap,
+		  const remap_t &fdmap,
 		  OP_SERIALIZER& opszr,
-		  const hb_vector_t<TableInfo> &privateInfos)
+		  const hb_vector_t<table_info_t> &privateInfos)
   {
     TRACE_SERIALIZE (this);
     if (unlikely (!c->extend_min (*this))) return_trace (false);
@@ -546,7 +546,7 @@ struct FDArray : CFFIndexOf<COUNT, FontDict>
   static unsigned int calculate_serialized_size (unsigned int &offSize_ /* OUT */,
 						 const hb_vector_t<DICTVAL> &fontDicts,
 						 unsigned int fdCount,
-						 const Remap &fdmap,
+						 const remap_t &fdmap,
 						 OP_SERIALIZER& opszr)
   {
     unsigned int dictsSize = 0;

--- a/src/hb-ot-cff1-table.cc
+++ b/src/hb-ot-cff1-table.cc
@@ -163,13 +163,13 @@ hb_codepoint_t OT::cff1::lookup_standard_encoding_for_sid (hb_codepoint_t code)
 
 struct bounds_t
 {
-  inline void init ()
+  void init ()
   {
     min.set_int (0x7FFFFFFF, 0x7FFFFFFF);
     max.set_int (-0x80000000, -0x80000000);
   }
 
-  inline void update (const point_t &pt)
+  void update (const point_t &pt)
   {
     if (pt.x < min.x) min.x = pt.x;
     if (pt.x > max.x) max.x = pt.x;
@@ -177,7 +177,7 @@ struct bounds_t
     if (pt.y > max.y) max.y = pt.y;
   }
 
-  inline void merge (const bounds_t &b)
+  void merge (const bounds_t &b)
   {
     if (empty ())
       *this = b;
@@ -190,7 +190,7 @@ struct bounds_t
     }
   }
 
-  inline void offset (const point_t &delta)
+  void offset (const point_t &delta)
   {
     if (!empty ())
     {
@@ -199,7 +199,7 @@ struct bounds_t
     }
   }
 
-  inline bool empty () const
+  bool empty () const
   { return (min.x >= max.x) || (min.y >= max.y); }
 
   point_t min;
@@ -208,32 +208,32 @@ struct bounds_t
 
 struct extents_param_t
 {
-  inline void init (const OT::cff1::accelerator_t *_cff)
+  void init (const OT::cff1::accelerator_t *_cff)
   {
     path_open = false;
     cff = _cff;
     bounds.init ();
   }
 
-  inline void start_path ()         { path_open = true; }
-  inline void end_path ()           { path_open = false; }
-  inline bool is_path_open () const { return path_open; }
+  void start_path ()         { path_open = true; }
+  void end_path ()           { path_open = false; }
+  bool is_path_open () const { return path_open; }
 
-  bool		path_open;
-  bounds_t	bounds;
+  bool    path_open;
+  bounds_t  bounds;
 
   const OT::cff1::accelerator_t *cff;
 };
 
 struct cff1_path_procs_extents_t : path_procs_t<cff1_path_procs_extents_t, cff1_cs_interp_env_t, extents_param_t>
 {
-  static inline void moveto (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
+  static void moveto (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
   {
     param.end_path ();
     env.moveto (pt);
   }
 
-  static inline void line (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
+  static void line (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
   {
     if (!param.is_path_open ())
     {
@@ -244,7 +244,7 @@ struct cff1_path_procs_extents_t : path_procs_t<cff1_path_procs_extents_t, cff1_
     param.bounds.update (env.get_pt ());
   }
 
-  static inline void curve (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
+  static void curve (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   {
     if (!param.is_path_open ())
     {
@@ -259,11 +259,11 @@ struct cff1_path_procs_extents_t : path_procs_t<cff1_path_procs_extents_t, cff1_
   }
 };
 
-static inline bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac=false);
+static bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac=false);
 
 struct cff1_cs_opset_extents_t : cff1_cs_opset_t<cff1_cs_opset_extents_t, extents_param_t, cff1_path_procs_extents_t>
 {
-  static inline void process_seac (cff1_cs_interp_env_t &env, extents_param_t& param)
+  static void process_seac (cff1_cs_interp_env_t &env, extents_param_t& param)
   {
     unsigned int  n = env.argStack.get_count ();
     point_t delta;
@@ -286,7 +286,7 @@ struct cff1_cs_opset_extents_t : cff1_cs_opset_t<cff1_cs_opset_extents_t, extent
   }
 };
 
-static inline bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac)
+bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac)
 {
   bounds.init ();
   if (unlikely (!cff->is_valid () || (glyph >= cff->num_glyphs))) return false;
@@ -336,14 +336,14 @@ bool OT::cff1::accelerator_t::get_extents (hb_codepoint_t glyph, hb_glyph_extent
 
 struct get_seac_param_t
 {
-  inline void init (const OT::cff1::accelerator_t *_cff)
+  void init (const OT::cff1::accelerator_t *_cff)
   {
     cff = _cff;
     base = 0;
     accent = 0;
   }
 
-  inline bool has_seac () const { return base && accent; }
+  bool has_seac () const { return base && accent; }
 
   const OT::cff1::accelerator_t *cff;
   hb_codepoint_t  base;
@@ -352,7 +352,7 @@ struct get_seac_param_t
 
 struct cff1_cs_opset_seac_t : cff1_cs_opset_t<cff1_cs_opset_seac_t, get_seac_param_t>
 {
-  static inline void process_seac (cff1_cs_interp_env_t &env, get_seac_param_t& param)
+  static void process_seac (cff1_cs_interp_env_t &env, get_seac_param_t& param)
   {
     unsigned int  n = env.argStack.get_count ();
     hb_codepoint_t  base_char = (hb_codepoint_t)env.argStack[n-2].to_int ();

--- a/src/hb-ot-cff1-table.cc
+++ b/src/hb-ot-cff1-table.cc
@@ -161,7 +161,7 @@ hb_codepoint_t OT::cff1::lookup_standard_encoding_for_sid (hb_codepoint_t code)
     return CFF_UNDEF_SID;
 }
 
-struct Bounds
+struct bounds_t
 {
   void init ()
   {
@@ -169,7 +169,7 @@ struct Bounds
     max.set_int (-0x80000000, -0x80000000);
   }
 
-  void update (const Point &pt)
+  void update (const point_t &pt)
   {
     if (pt.x < min.x) min.x = pt.x;
     if (pt.x > max.x) max.x = pt.x;
@@ -177,7 +177,7 @@ struct Bounds
     if (pt.y > max.y) max.y = pt.y;
   }
 
-  void merge (const Bounds &b)
+  void merge (const bounds_t &b)
   {
     if (empty ())
       *this = b;
@@ -190,7 +190,7 @@ struct Bounds
     }
   }
 
-  void offset (const Point &delta)
+  void offset (const point_t &delta)
   {
     if (!empty ())
     {
@@ -202,11 +202,11 @@ struct Bounds
   bool empty () const
   { return (min.x >= max.x) || (min.y >= max.y); }
 
-  Point min;
-  Point max;
+  point_t min;
+  point_t max;
 };
 
-struct ExtentsParam
+struct extents_param_t
 {
   void init (const OT::cff1::accelerator_t *_cff)
   {
@@ -220,20 +220,20 @@ struct ExtentsParam
   bool is_path_open () const { return path_open; }
 
   bool    path_open;
-  Bounds  bounds;
+  bounds_t  bounds;
 
   const OT::cff1::accelerator_t *cff;
 };
 
-struct CFF1PathProcs_Extents : PathProcs<CFF1PathProcs_Extents, CFF1CSInterpEnv, ExtentsParam>
+struct cff1_path_procs_extents_t : path_procs_t<cff1_path_procs_extents_t, cff1_cs_interp_env_t, extents_param_t>
 {
-  static void moveto (CFF1CSInterpEnv &env, ExtentsParam& param, const Point &pt)
+  static void moveto (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
   {
     param.end_path ();
     env.moveto (pt);
   }
 
-  static void line (CFF1CSInterpEnv &env, ExtentsParam& param, const Point &pt1)
+  static void line (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
   {
     if (!param.is_path_open ())
     {
@@ -244,7 +244,7 @@ struct CFF1PathProcs_Extents : PathProcs<CFF1PathProcs_Extents, CFF1CSInterpEnv,
     param.bounds.update (env.get_pt ());
   }
 
-  static void curve (CFF1CSInterpEnv &env, ExtentsParam& param, const Point &pt1, const Point &pt2, const Point &pt3)
+  static void curve (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   {
     if (!param.is_path_open ())
     {
@@ -259,20 +259,20 @@ struct CFF1PathProcs_Extents : PathProcs<CFF1PathProcs_Extents, CFF1CSInterpEnv,
   }
 };
 
-static bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, Bounds &bounds, bool in_seac=false);
+static bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac=false);
 
-struct CFF1CSOpSet_Extents : CFF1CSOpSet<CFF1CSOpSet_Extents, ExtentsParam, CFF1PathProcs_Extents>
+struct cff1_cs_opset_extents_t : cff1_cs_opset_t<cff1_cs_opset_extents_t, extents_param_t, cff1_path_procs_extents_t>
 {
-  static void process_seac (CFF1CSInterpEnv &env, ExtentsParam& param)
+  static void process_seac (cff1_cs_interp_env_t &env, extents_param_t& param)
   {
     unsigned int  n = env.argStack.get_count ();
-    Point delta;
+    point_t delta;
     delta.x = env.argStack[n-4];
     delta.y = env.argStack[n-3];
     hb_codepoint_t base = param.cff->std_code_to_glyph (env.argStack[n-2].to_int ());
     hb_codepoint_t accent = param.cff->std_code_to_glyph (env.argStack[n-1].to_int ());
 
-    Bounds  base_bounds, accent_bounds;
+    bounds_t  base_bounds, accent_bounds;
     if (likely (!env.in_seac && base && accent
 	       && _get_bounds (param.cff, base, base_bounds, true)
 	       && _get_bounds (param.cff, accent, accent_bounds, true)))
@@ -286,17 +286,17 @@ struct CFF1CSOpSet_Extents : CFF1CSOpSet<CFF1CSOpSet_Extents, ExtentsParam, CFF1
   }
 };
 
-bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, Bounds &bounds, bool in_seac)
+bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac)
 {
   bounds.init ();
   if (unlikely (!cff->is_valid () || (glyph >= cff->num_glyphs))) return false;
 
   unsigned int fd = cff->fdSelect->get_fd (glyph);
-  CFF1CSInterpreter<CFF1CSOpSet_Extents, ExtentsParam> interp;
+  cff1_cs_interpreter_t<cff1_cs_opset_extents_t, extents_param_t> interp;
   const byte_str_t str = (*cff->charStrings)[glyph];
   interp.env.init (str, *cff, fd);
   interp.env.set_in_seac (in_seac);
-  ExtentsParam  param;
+  extents_param_t  param;
   param.init (cff);
   if (unlikely (!interp.interpret (param))) return false;
   bounds = param.bounds;
@@ -305,7 +305,7 @@ bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, Boun
 
 bool OT::cff1::accelerator_t::get_extents (hb_codepoint_t glyph, hb_glyph_extents_t *extents) const
 {
-  Bounds  bounds;
+  bounds_t  bounds;
 
   if (!_get_bounds (this, glyph, bounds))
     return false;
@@ -334,7 +334,7 @@ bool OT::cff1::accelerator_t::get_extents (hb_codepoint_t glyph, hb_glyph_extent
   return true;
 }
 
-struct GetSeacParam
+struct get_seac_param_t
 {
   void init (const OT::cff1::accelerator_t *_cff)
   {
@@ -350,9 +350,9 @@ struct GetSeacParam
   hb_codepoint_t  accent;
 };
 
-struct CFF1CSOpSet_Seac : CFF1CSOpSet<CFF1CSOpSet_Seac, GetSeacParam>
+struct cff1_cs_opset_seac_t : cff1_cs_opset_t<cff1_cs_opset_seac_t, get_seac_param_t>
 {
-  static void process_seac (CFF1CSInterpEnv &env, GetSeacParam& param)
+  static void process_seac (cff1_cs_interp_env_t &env, get_seac_param_t& param)
   {
     unsigned int  n = env.argStack.get_count ();
     hb_codepoint_t  base_char = (hb_codepoint_t)env.argStack[n-2].to_int ();
@@ -368,10 +368,10 @@ bool OT::cff1::accelerator_t::get_seac_components (hb_codepoint_t glyph, hb_code
   if (unlikely (!is_valid () || (glyph >= num_glyphs))) return false;
 
   unsigned int fd = fdSelect->get_fd (glyph);
-  CFF1CSInterpreter<CFF1CSOpSet_Seac, GetSeacParam> interp;
+  cff1_cs_interpreter_t<cff1_cs_opset_seac_t, get_seac_param_t> interp;
   const byte_str_t str = (*charStrings)[glyph];
   interp.env.init (str, *this, fd);
-  GetSeacParam  param;
+  get_seac_param_t  param;
   param.init (this);
   if (unlikely (!interp.interpret (param))) return false;
 

--- a/src/hb-ot-cff1-table.cc
+++ b/src/hb-ot-cff1-table.cc
@@ -163,13 +163,13 @@ hb_codepoint_t OT::cff1::lookup_standard_encoding_for_sid (hb_codepoint_t code)
 
 struct bounds_t
 {
-  void init ()
+  inline void init ()
   {
     min.set_int (0x7FFFFFFF, 0x7FFFFFFF);
     max.set_int (-0x80000000, -0x80000000);
   }
 
-  void update (const point_t &pt)
+  inline void update (const point_t &pt)
   {
     if (pt.x < min.x) min.x = pt.x;
     if (pt.x > max.x) max.x = pt.x;
@@ -177,7 +177,7 @@ struct bounds_t
     if (pt.y > max.y) max.y = pt.y;
   }
 
-  void merge (const bounds_t &b)
+  inline void merge (const bounds_t &b)
   {
     if (empty ())
       *this = b;
@@ -190,7 +190,7 @@ struct bounds_t
     }
   }
 
-  void offset (const point_t &delta)
+  inline void offset (const point_t &delta)
   {
     if (!empty ())
     {
@@ -199,7 +199,7 @@ struct bounds_t
     }
   }
 
-  bool empty () const
+  inline bool empty () const
   { return (min.x >= max.x) || (min.y >= max.y); }
 
   point_t min;
@@ -208,32 +208,32 @@ struct bounds_t
 
 struct extents_param_t
 {
-  void init (const OT::cff1::accelerator_t *_cff)
+  inline void init (const OT::cff1::accelerator_t *_cff)
   {
     path_open = false;
     cff = _cff;
     bounds.init ();
   }
 
-  void start_path ()         { path_open = true; }
-  void end_path ()           { path_open = false; }
-  bool is_path_open () const { return path_open; }
+  inline void start_path ()         { path_open = true; }
+  inline void end_path ()           { path_open = false; }
+  inline bool is_path_open () const { return path_open; }
 
-  bool    path_open;
-  bounds_t  bounds;
+  bool		path_open;
+  bounds_t	bounds;
 
   const OT::cff1::accelerator_t *cff;
 };
 
 struct cff1_path_procs_extents_t : path_procs_t<cff1_path_procs_extents_t, cff1_cs_interp_env_t, extents_param_t>
 {
-  static void moveto (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
+  static inline void moveto (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
   {
     param.end_path ();
     env.moveto (pt);
   }
 
-  static void line (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
+  static inline void line (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
   {
     if (!param.is_path_open ())
     {
@@ -244,7 +244,7 @@ struct cff1_path_procs_extents_t : path_procs_t<cff1_path_procs_extents_t, cff1_
     param.bounds.update (env.get_pt ());
   }
 
-  static void curve (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
+  static inline void curve (cff1_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   {
     if (!param.is_path_open ())
     {
@@ -259,11 +259,11 @@ struct cff1_path_procs_extents_t : path_procs_t<cff1_path_procs_extents_t, cff1_
   }
 };
 
-static bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac=false);
+static inline bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac=false);
 
 struct cff1_cs_opset_extents_t : cff1_cs_opset_t<cff1_cs_opset_extents_t, extents_param_t, cff1_path_procs_extents_t>
 {
-  static void process_seac (cff1_cs_interp_env_t &env, extents_param_t& param)
+  static inline void process_seac (cff1_cs_interp_env_t &env, extents_param_t& param)
   {
     unsigned int  n = env.argStack.get_count ();
     point_t delta;
@@ -286,7 +286,7 @@ struct cff1_cs_opset_extents_t : cff1_cs_opset_t<cff1_cs_opset_extents_t, extent
   }
 };
 
-bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac)
+static inline bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, bounds_t &bounds, bool in_seac)
 {
   bounds.init ();
   if (unlikely (!cff->is_valid () || (glyph >= cff->num_glyphs))) return false;
@@ -336,14 +336,14 @@ bool OT::cff1::accelerator_t::get_extents (hb_codepoint_t glyph, hb_glyph_extent
 
 struct get_seac_param_t
 {
-  void init (const OT::cff1::accelerator_t *_cff)
+  inline void init (const OT::cff1::accelerator_t *_cff)
   {
     cff = _cff;
     base = 0;
     accent = 0;
   }
 
-  bool has_seac () const { return base && accent; }
+  inline bool has_seac () const { return base && accent; }
 
   const OT::cff1::accelerator_t *cff;
   hb_codepoint_t  base;
@@ -352,7 +352,7 @@ struct get_seac_param_t
 
 struct cff1_cs_opset_seac_t : cff1_cs_opset_t<cff1_cs_opset_seac_t, get_seac_param_t>
 {
-  static void process_seac (cff1_cs_interp_env_t &env, get_seac_param_t& param)
+  static inline void process_seac (cff1_cs_interp_env_t &env, get_seac_param_t& param)
   {
     unsigned int  n = env.argStack.get_count ();
     hb_codepoint_t  base_char = (hb_codepoint_t)env.argStack[n-2].to_int ();

--- a/src/hb-ot-cff1-table.cc
+++ b/src/hb-ot-cff1-table.cc
@@ -293,7 +293,7 @@ bool _get_bounds (const OT::cff1::accelerator_t *cff, hb_codepoint_t glyph, Boun
 
   unsigned int fd = cff->fdSelect->get_fd (glyph);
   CFF1CSInterpreter<CFF1CSOpSet_Extents, ExtentsParam> interp;
-  const ByteStr str = (*cff->charStrings)[glyph];
+  const byte_str_t str = (*cff->charStrings)[glyph];
   interp.env.init (str, *cff, fd);
   interp.env.set_in_seac (in_seac);
   ExtentsParam  param;
@@ -369,7 +369,7 @@ bool OT::cff1::accelerator_t::get_seac_components (hb_codepoint_t glyph, hb_code
 
   unsigned int fd = fdSelect->get_fd (glyph);
   CFF1CSInterpreter<CFF1CSOpSet_Seac, GetSeacParam> interp;
-  const ByteStr str = (*charStrings)[glyph];
+  const byte_str_t str = (*charStrings)[glyph];
   interp.env.init (str, *this, fd);
   GetSeacParam  param;
   param.init (this);

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -56,13 +56,13 @@ struct CFF1FDSelect : FDSelect {};
 
 /* Encoding */
 struct Encoding0 {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && codes[nCodes - 1].sanitize (c));
   }
 
-  hb_codepoint_t get_code (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_code (hb_codepoint_t glyph) const
   {
     assert (glyph > 0);
     glyph--;
@@ -74,7 +74,7 @@ struct Encoding0 {
       return CFF_UNDEF_CODE;
   }
 
-  unsigned int get_size () const
+  inline unsigned int get_size () const
   { return HBUINT8::static_size * (nCodes + 1); }
 
   HBUINT8     nCodes;
@@ -84,7 +84,7 @@ struct Encoding0 {
 };
 
 struct Encoding1_Range {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this));
@@ -97,16 +97,16 @@ struct Encoding1_Range {
 };
 
 struct Encoding1 {
-  unsigned int get_size () const
+  inline unsigned int get_size () const
   { return HBUINT8::static_size + Encoding1_Range::static_size * nRanges; }
 
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && ((nRanges == 0) || (ranges[nRanges - 1]).sanitize (c)));
   }
 
-  hb_codepoint_t get_code (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_code (hb_codepoint_t glyph) const
   {
     assert (glyph > 0);
     glyph--;
@@ -128,7 +128,7 @@ struct Encoding1 {
 };
 
 struct SuppEncoding {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this));
@@ -141,20 +141,20 @@ struct SuppEncoding {
 };
 
 struct CFF1SuppEncData {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && ((nSups == 0) || (supps[nSups - 1]).sanitize (c)));
   }
 
-  void get_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
+  inline void get_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
   {
     for (unsigned int i = 0; i < nSups; i++)
       if (sid == supps[i].glyph)
 	codes.push (supps[i].code);
   }
 
-  unsigned int get_size () const
+  inline unsigned int get_size () const
   { return HBUINT8::static_size + SuppEncoding::static_size * nSups; }
 
   HBUINT8	 nSups;
@@ -164,7 +164,7 @@ struct CFF1SuppEncData {
 };
 
 struct Encoding {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
 
@@ -179,7 +179,7 @@ struct Encoding {
   }
 
   /* serialize a fullset Encoding */
-  bool serialize (hb_serialize_context_t *c, const Encoding &src)
+  inline bool serialize (hb_serialize_context_t *c, const Encoding &src)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size ();
@@ -190,11 +190,11 @@ struct Encoding {
   }
 
   /* serialize a subset Encoding */
-  bool serialize (hb_serialize_context_t *c,
-		  uint8_t format,
-		  unsigned int enc_count,
-		  const hb_vector_t<code_pair_t>& code_ranges,
-		  const hb_vector_t<code_pair_t>& supp_codes)
+  inline bool serialize (hb_serialize_context_t *c,
+			uint8_t format,
+			unsigned int enc_count,
+			const hb_vector_t<code_pair_t>& code_ranges,
+			const hb_vector_t<code_pair_t>& supp_codes)
   {
     TRACE_SERIALIZE (this);
     Encoding *dest = c->extend_min (*this);
@@ -243,9 +243,9 @@ struct Encoding {
   }
 
   /* parallel to above: calculate the size of a subset Encoding */
-  static unsigned int calculate_serialized_size (uint8_t format,
-						 unsigned int enc_count,
-						 unsigned int supp_count)
+  static inline unsigned int calculate_serialized_size (uint8_t format,
+							unsigned int enc_count,
+							unsigned int supp_count)
   {
     unsigned int  size = min_size;
     if (format == 0)
@@ -257,7 +257,7 @@ struct Encoding {
     return size;
   }
 
-  unsigned int get_size () const
+  inline unsigned int get_size () const
   {
     unsigned int size = min_size;
     if (table_format () == 0)
@@ -269,7 +269,7 @@ struct Encoding {
     return size;
   }
 
-  hb_codepoint_t get_code (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_code (hb_codepoint_t glyph) const
   {
     if (table_format () == 0)
       return u.format0.get_code (glyph);
@@ -277,10 +277,10 @@ struct Encoding {
       return u.format1.get_code (glyph);
   }
 
-  uint8_t table_format () const { return (format & 0x7F); }
-  bool  has_supplement () const { return (format & 0x80) != 0; }
+  inline uint8_t table_format () const { return (format & 0x7F); }
+  inline bool  has_supplement () const { return (format & 0x80) != 0; }
 
-  void get_supplement_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
+  inline void get_supplement_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
   {
     codes.resize (0);
     if (has_supplement ())
@@ -288,7 +288,7 @@ struct Encoding {
   }
 
   protected:
-  const CFF1SuppEncData &suppEncData () const
+  inline const CFF1SuppEncData &suppEncData () const
   {
     if ((format & 0x7F) == 0)
       return StructAfter<CFF1SuppEncData> (u.format0.codes[u.format0.nCodes-1]);
@@ -310,13 +310,13 @@ struct Encoding {
 
 /* Charset */
 struct Charset0 {
-  bool sanitize (hb_sanitize_context_t *c, unsigned int num_glyphs) const
+  inline bool sanitize (hb_sanitize_context_t *c, unsigned int num_glyphs) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && sids[num_glyphs - 1].sanitize (c));
   }
 
-  hb_codepoint_t get_sid (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_sid (hb_codepoint_t glyph) const
   {
     if (glyph == 0)
       return 0;
@@ -324,7 +324,7 @@ struct Charset0 {
       return sids[glyph - 1];
   }
 
-  hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
+  inline hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
   {
     if (sid == 0)
       return 0;
@@ -337,7 +337,7 @@ struct Charset0 {
     return 0;
   }
 
-  unsigned int get_size (unsigned int num_glyphs) const
+  inline unsigned int get_size (unsigned int num_glyphs) const
   {
     assert (num_glyphs > 0);
     return HBUINT16::static_size * (num_glyphs - 1);
@@ -350,7 +350,7 @@ struct Charset0 {
 
 template <typename TYPE>
 struct Charset_Range {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this));
@@ -364,7 +364,7 @@ struct Charset_Range {
 
 template <typename TYPE>
 struct Charset1_2 {
-  bool sanitize (hb_sanitize_context_t *c, unsigned int num_glyphs) const
+  inline bool sanitize (hb_sanitize_context_t *c, unsigned int num_glyphs) const
   {
     TRACE_SANITIZE (this);
     if (unlikely (!c->check_struct (this)))
@@ -379,7 +379,7 @@ struct Charset1_2 {
     return_trace (true);
   }
 
-  hb_codepoint_t get_sid (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_sid (hb_codepoint_t glyph) const
   {
     if (glyph == 0) return 0;
     glyph--;
@@ -393,7 +393,7 @@ struct Charset1_2 {
     return 0;
   }
 
-  hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
+  inline hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
   {
     if (sid == 0) return 0;
     hb_codepoint_t  glyph = 1;
@@ -409,7 +409,7 @@ struct Charset1_2 {
     return 0;
   }
 
-  unsigned int get_size (unsigned int num_glyphs) const
+  inline unsigned int get_size (unsigned int num_glyphs) const
   {
     unsigned int size = HBUINT8::static_size;
     int glyph = (int)num_glyphs;
@@ -436,7 +436,7 @@ typedef Charset_Range<HBUINT8>  Charset1_Range;
 typedef Charset_Range<HBUINT16> Charset2_Range;
 
 struct Charset {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
 
@@ -453,7 +453,7 @@ struct Charset {
   }
 
   /* serialize a fullset Charset */
-  bool serialize (hb_serialize_context_t *c, const Charset &src, unsigned int num_glyphs)
+  inline bool serialize (hb_serialize_context_t *c, const Charset &src, unsigned int num_glyphs)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size (num_glyphs);
@@ -464,7 +464,7 @@ struct Charset {
   }
 
   /* serialize a subset Charset */
-  bool serialize (hb_serialize_context_t *c,
+  inline bool serialize (hb_serialize_context_t *c,
 		  uint8_t format,
 		  unsigned int num_glyphs,
 		  const hb_vector_t<code_pair_t>& sid_ranges)
@@ -513,9 +513,8 @@ struct Charset {
   }
 
   /* parallel to above: calculate the size of a subset Charset */
-  static unsigned int calculate_serialized_size (
-			uint8_t format,
-			unsigned int count)
+  static inline unsigned int calculate_serialized_size (uint8_t format,
+							unsigned int count)
   {
     unsigned int  size = min_size;
     if (format == 0)
@@ -528,7 +527,7 @@ struct Charset {
     return size;
   }
 
-  unsigned int get_size (unsigned int num_glyphs) const
+  inline unsigned int get_size (unsigned int num_glyphs) const
   {
     unsigned int size = min_size;
     if (format == 0)
@@ -540,7 +539,7 @@ struct Charset {
     return size;
   }
 
-  hb_codepoint_t get_sid (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_sid (hb_codepoint_t glyph) const
   {
     if (format == 0)
       return u.format0.get_sid (glyph);
@@ -550,7 +549,7 @@ struct Charset {
       return u.format2.get_sid (glyph);
   }
 
-  hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
+  inline hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
   {
     if (format == 0)
       return u.format0.get_glyph (sid, num_glyphs);
@@ -572,8 +571,8 @@ struct Charset {
 
 struct CFF1StringIndex : CFF1Index
 {
-  bool serialize (hb_serialize_context_t *c, const CFF1StringIndex &strings,
-		  unsigned int offSize_, const remap_t &sidmap)
+  inline bool serialize (hb_serialize_context_t *c, const CFF1StringIndex &strings,
+			unsigned int offSize_, const remap_t &sidmap)
   {
     TRACE_SERIALIZE (this);
     if (unlikely ((strings.count == 0) || (sidmap.get_count () == 0)))
@@ -601,7 +600,7 @@ struct CFF1StringIndex : CFF1Index
   }
 
   /* in parallel to above */
-  unsigned int calculate_serialized_size (unsigned int &offSize /*OUT*/, const remap_t &sidmap) const
+  inline unsigned int calculate_serialized_size (unsigned int &offSize /*OUT*/, const remap_t &sidmap) const
   {
     offSize = 0;
     if ((count == 0) || (sidmap.get_count () == 0))
@@ -619,7 +618,7 @@ struct CFF1StringIndex : CFF1Index
 
 struct cff1_top_dict_interp_env_t : num_interp_env_t
 {
-  cff1_top_dict_interp_env_t ()
+  inline cff1_top_dict_interp_env_t ()
     : num_interp_env_t(), prev_offset(0), last_offset(0) {}
 
   unsigned int prev_offset;
@@ -645,19 +644,19 @@ struct name_dict_values_t
       ValCount
   };
 
-  void init ()
+  inline void init ()
   {
     for (unsigned int i = 0; i < ValCount; i++)
       values[i] = CFF_UNDEF_SID;
   }
 
-  unsigned int& operator[] (unsigned int i)
+  inline unsigned int& operator[] (unsigned int i)
   { assert (i < ValCount); return values[i]; }
 
-  unsigned int operator[] (unsigned int i) const
+  inline unsigned int operator[] (unsigned int i) const
   { assert (i < ValCount); return values[i]; }
 
-  static enum name_dict_val_index_t name_op_to_index (op_code_t op)
+  static inline enum name_dict_val_index_t name_op_to_index (op_code_t op)
   {
     switch (op) {
       default: // can't happen - just make some compiler happy
@@ -692,7 +691,7 @@ struct cff1_top_dict_val_t : op_str_t
 
 struct cff1_top_dict_values_t : top_dict_values_t<cff1_top_dict_val_t>
 {
-  void init ()
+  inline void init ()
   {
     top_dict_values_t<cff1_top_dict_val_t>::init ();
 
@@ -704,25 +703,25 @@ struct cff1_top_dict_values_t : top_dict_values_t<cff1_top_dict_val_t>
     FDSelectOffset = 0;
     privateDictInfo.init ();
   }
-  void fini () { top_dict_values_t<cff1_top_dict_val_t>::fini (); }
+  inline void fini () { top_dict_values_t<cff1_top_dict_val_t>::fini (); }
 
-  bool is_CID () const
+  inline bool is_CID () const
   { return nameSIDs[name_dict_values_t::registry] != CFF_UNDEF_SID; }
 
-  name_dict_values_t  nameSIDs;
-  unsigned int    ros_supplement_offset;
-  unsigned int    ros_supplement;
-  unsigned int    cidCount;
+  name_dict_values_t	nameSIDs;
+  unsigned int		ros_supplement_offset;
+  unsigned int		ros_supplement;
+  unsigned int		cidCount;
 
-  unsigned int    EncodingOffset;
-  unsigned int    CharsetOffset;
-  unsigned int    FDSelectOffset;
-  table_info_t       privateDictInfo;
+  unsigned int		EncodingOffset;
+  unsigned int		CharsetOffset;
+  unsigned int		FDSelectOffset;
+  table_info_t		privateDictInfo;
 };
 
 struct cff1_top_dict_opset_t : top_dict_opset_t<cff1_top_dict_val_t>
 {
-  static void process_op (op_code_t op, cff1_top_dict_interp_env_t& env, cff1_top_dict_values_t& dictval)
+  static inline void process_op (op_code_t op, cff1_top_dict_interp_env_t& env, cff1_top_dict_values_t& dictval)
   {
     cff1_top_dict_val_t  val;
     val.last_arg_offset = (env.last_offset-1) - dictval.opStart;  /* offset to the last argument */
@@ -809,21 +808,21 @@ struct cff1_top_dict_opset_t : top_dict_opset_t<cff1_top_dict_val_t>
 
 struct cff1_font_dict_values_t : dict_values_t<op_str_t>
 {
-  void init ()
+  inline void init ()
   {
     dict_values_t<op_str_t>::init ();
     privateDictInfo.init ();
     fontName = CFF_UNDEF_SID;
   }
-  void fini () { dict_values_t<op_str_t>::fini (); }
+  inline void fini () { dict_values_t<op_str_t>::fini (); }
 
-  table_info_t       privateDictInfo;
-  unsigned int    fontName;
+  table_info_t	privateDictInfo;
+  unsigned int	fontName;
 };
 
 struct cff1_font_dict_opset_t : dict_opset_t
 {
-  static void process_op (op_code_t op, num_interp_env_t& env, cff1_font_dict_values_t& dictval)
+  static inline void process_op (op_code_t op, num_interp_env_t& env, cff1_font_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_FontName:
@@ -855,15 +854,15 @@ struct cff1_font_dict_opset_t : dict_opset_t
 template <typename VAL>
 struct cff1_private_dict_values_base_t : dict_values_t<VAL>
 {
-  void init ()
+  inline void init ()
   {
     dict_values_t<VAL>::init ();
     subrsOffset = 0;
     localSubrs = &Null(CFF1Subrs);
   }
-  void fini () { dict_values_t<VAL>::fini (); }
+  inline void fini () { dict_values_t<VAL>::fini (); }
 
-  unsigned int calculate_serialized_size () const
+  inline unsigned int calculate_serialized_size () const
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < dict_values_t<VAL>::get_count; i++)
@@ -874,8 +873,8 @@ struct cff1_private_dict_values_base_t : dict_values_t<VAL>
     return size;
   }
 
-  unsigned int      subrsOffset;
-  const CFF1Subrs    *localSubrs;
+  unsigned int		subrsOffset;
+  const CFF1Subrs	*localSubrs;
 };
 
 typedef cff1_private_dict_values_base_t<op_str_t> cff1_private_dict_values_subset_t;
@@ -883,7 +882,7 @@ typedef cff1_private_dict_values_base_t<num_dict_val_t> cff1_private_dict_values
 
 struct cff1_private_dict_opset_t : dict_opset_t
 {
-  static void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_t& dictval)
+  static inline void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_t& dictval)
   {
     num_dict_val_t val;
     val.init ();
@@ -930,7 +929,7 @@ struct cff1_private_dict_opset_t : dict_opset_t
 
 struct cff1_private_dict_opset_subset : dict_opset_t
 {
-  static void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_subset_t& dictval)
+  static inline void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_subset_t& dictval)
   {
     switch (op) {
       case OpCode_BlueValues:
@@ -986,7 +985,7 @@ struct cff1
 {
   static const hb_tag_t tableTag	= HB_OT_TAG_cff1;
 
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) &&
@@ -996,7 +995,7 @@ struct cff1
   template <typename PRIVOPSET, typename PRIVDICTVAL>
   struct accelerator_templ_t
   {
-    void init (hb_face_t *face)
+    inline void init (hb_face_t *face)
     {
       topDict.init ();
       fontDicts.init ();
@@ -1123,7 +1122,7 @@ struct cff1
       }
     }
 
-    void fini ()
+    inline void fini ()
     {
       sc.end_processing ();
       topDict.fini ();
@@ -1133,12 +1132,12 @@ struct cff1
       blob = nullptr;
     }
 
-    bool is_valid () const { return blob != nullptr; }
-    bool is_CID () const { return topDict.is_CID (); }
+    inline bool is_valid () const { return blob != nullptr; }
+    inline bool is_CID () const { return topDict.is_CID (); }
 
-    bool is_predef_charset () const { return topDict.CharsetOffset <= ExpertSubsetCharset; }
+    inline bool is_predef_charset () const { return topDict.CharsetOffset <= ExpertSubsetCharset; }
 
-    unsigned int std_code_to_glyph (hb_codepoint_t code) const
+    inline unsigned int std_code_to_glyph (hb_codepoint_t code) const
     {
       hb_codepoint_t sid = lookup_standard_encoding_for_sid (code);
       if (unlikely (sid == CFF_UNDEF_SID))
@@ -1152,23 +1151,23 @@ struct cff1
     }
 
     protected:
-    hb_blob_t	       *blob;
-    hb_sanitize_context_t   sc;
+    hb_blob_t			*blob;
+    hb_sanitize_context_t	sc;
 
     public:
-    const Charset	   *charset;
-    const CFF1NameIndex     *nameIndex;
-    const CFF1TopDictIndex  *topDictIndex;
-    const CFF1StringIndex   *stringIndex;
-    const CFF1Subrs	 *globalSubrs;
-    const CFF1CharStrings   *charStrings;
-    const CFF1FDArray       *fdArray;
-    const CFF1FDSelect      *fdSelect;
-    unsigned int	    fdCount;
+    const Charset		*charset;
+    const CFF1NameIndex		*nameIndex;
+    const CFF1TopDictIndex	*topDictIndex;
+    const CFF1StringIndex	*stringIndex;
+    const CFF1Subrs		*globalSubrs;
+    const CFF1CharStrings	*charStrings;
+    const CFF1FDArray		*fdArray;
+    const CFF1FDSelect		*fdSelect;
+    unsigned int		fdCount;
 
-    cff1_top_dict_values_t       topDict;
-    hb_vector_t<cff1_font_dict_values_t>   fontDicts;
-    hb_vector_t<PRIVDICTVAL>	  privateDicts;
+    cff1_top_dict_values_t	topDict;
+    hb_vector_t<cff1_font_dict_values_t>	fontDicts;
+    hb_vector_t<PRIVDICTVAL>	privateDicts;
 
     unsigned int	    num_glyphs;
   };
@@ -1181,7 +1180,7 @@ struct cff1
 
   struct accelerator_subset_t : accelerator_templ_t<cff1_private_dict_opset_subset, cff1_private_dict_values_subset_t>
   {
-    void init (hb_face_t *face)
+    inline void init (hb_face_t *face)
     {
       SUPER::init (face);
       if (blob == nullptr) return;
@@ -1202,9 +1201,9 @@ struct cff1
       }
     }
 
-    bool is_predef_encoding () const { return topDict.EncodingOffset <= ExpertEncoding; }
+    inline bool is_predef_encoding () const { return topDict.EncodingOffset <= ExpertEncoding; }
 
-    hb_codepoint_t  glyph_to_code (hb_codepoint_t glyph) const
+    inline hb_codepoint_t  glyph_to_code (hb_codepoint_t glyph) const
     {
       if (encoding != &Null(Encoding))
 	return encoding->get_code (glyph);
@@ -1228,7 +1227,7 @@ struct cff1
       }
     }
 
-    hb_codepoint_t glyph_to_sid (hb_codepoint_t glyph) const
+    inline hb_codepoint_t glyph_to_sid (hb_codepoint_t glyph) const
     {
       if (charset != &Null(Charset))
 	return charset->get_sid (glyph);
@@ -1259,7 +1258,7 @@ struct cff1
     typedef accelerator_templ_t<cff1_private_dict_opset_subset, cff1_private_dict_values_subset_t> SUPER;
   };
 
-  bool subset (hb_subset_plan_t *plan) const
+  inline bool subset (hb_subset_plan_t *plan) const
   {
     hb_blob_t *cff_prime = nullptr;
 

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -584,7 +584,7 @@ struct CFF1StringIndex : CFF1Index
       return_trace (true);
     }
 
-    ByteStrArray bytesArray;
+    byte_str_array_t bytesArray;
     bytesArray.init ();
     if (!bytesArray.resize (sidmap.get_count ()))
       return_trace (false);
@@ -1023,7 +1023,7 @@ struct cff1
       { fini (); return; }
 
       { /* parse top dict */
-	const ByteStr topDictStr = (*topDictIndex)[0];
+	const byte_str_t topDictStr = (*topDictIndex)[0];
 	if (unlikely (!topDictStr.sanitize (&sc))) { fini (); return; }
 	CFF1TopDict_Interpreter top_interp;
 	top_interp.env.init (topDictStr);
@@ -1082,7 +1082,7 @@ struct cff1
       {
 	for (unsigned int i = 0; i < fdCount; i++)
 	{
-	  ByteStr fontDictStr = (*fdArray)[i];
+	  byte_str_t fontDictStr = (*fdArray)[i];
 	  if (unlikely (!fontDictStr.sanitize (&sc))) { fini (); return; }
 	  CFF1FontDictValues  *font;
 	  CFF1FontDict_Interpreter font_interp;
@@ -1092,14 +1092,14 @@ struct cff1
 	  font->init ();
 	  if (unlikely (!font_interp.interpret (*font))) { fini (); return; }
 	  PRIVDICTVAL  *priv = &privateDicts[i];
-	  const ByteStr privDictStr (StructAtOffset<UnsizedByteStr> (cff, font->privateDictInfo.offset), font->privateDictInfo.size);
+	  const byte_str_t privDictStr (StructAtOffset<UnsizedByteStr> (cff, font->privateDictInfo.offset), font->privateDictInfo.size);
 	  if (unlikely (!privDictStr.sanitize (&sc))) { fini (); return; }
 	  DictInterpreter<PRIVOPSET, PRIVDICTVAL> priv_interp;
 	  priv_interp.env.init (privDictStr);
 	  priv->init ();
 	  if (unlikely (!priv_interp.interpret (*priv))) { fini (); return; }
 
-	  priv->localSubrs = &StructAtOffsetOrNull<CFF1Subrs> (privDictStr.str, priv->subrsOffset);
+	  priv->localSubrs = &StructAtOffsetOrNull<CFF1Subrs> (&privDictStr, priv->subrsOffset);
 	  if (priv->localSubrs != &Null(CFF1Subrs) &&
 	      unlikely (!priv->localSubrs->sanitize (&sc)))
 	  { fini (); return; }
@@ -1110,14 +1110,14 @@ struct cff1
 	CFF1TopDictValues  *font = &topDict;
 	PRIVDICTVAL  *priv = &privateDicts[0];
 
-	const ByteStr privDictStr (StructAtOffset<UnsizedByteStr> (cff, font->privateDictInfo.offset), font->privateDictInfo.size);
+	const byte_str_t privDictStr (StructAtOffset<UnsizedByteStr> (cff, font->privateDictInfo.offset), font->privateDictInfo.size);
 	if (unlikely (!privDictStr.sanitize (&sc))) { fini (); return; }
 	DictInterpreter<PRIVOPSET, PRIVDICTVAL> priv_interp;
 	priv_interp.env.init (privDictStr);
 	priv->init ();
 	if (unlikely (!priv_interp.interpret (*priv))) { fini (); return; }
 
-	priv->localSubrs = &StructAtOffsetOrNull<CFF1Subrs> (privDictStr.str, priv->subrsOffset);
+	priv->localSubrs = &StructAtOffsetOrNull<CFF1Subrs> (&privDictStr, priv->subrsOffset);
 	if (priv->localSubrs != &Null(CFF1Subrs) &&
 	    unlikely (!priv->localSubrs->sanitize (&sc)))
 	{ fini (); return; }

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -628,7 +628,7 @@ struct cff1_top_dict_interp_env_t : num_interp_env_t
 
 struct name_dict_values_t
 {
-  enum NameDictValIndex
+  enum name_dict_val_index_t
   {
       version,
       notice,
@@ -657,7 +657,7 @@ struct name_dict_values_t
   unsigned int operator[] (unsigned int i) const
   { assert (i < ValCount); return values[i]; }
 
-  static enum NameDictValIndex name_op_to_index (OpCode op)
+  static enum name_dict_val_index_t name_op_to_index (op_code_t op)
   {
     switch (op) {
       default: // can't happen - just make some compiler happy
@@ -722,7 +722,7 @@ struct cff1_top_dict_values_t : top_dict_values_t<cff1_top_dict_val_t>
 
 struct cff1_top_dict_opset_t : top_dict_opset_t<cff1_top_dict_val_t>
 {
-  static void process_op (OpCode op, cff1_top_dict_interp_env_t& env, cff1_top_dict_values_t& dictval)
+  static void process_op (op_code_t op, cff1_top_dict_interp_env_t& env, cff1_top_dict_values_t& dictval)
   {
     cff1_top_dict_val_t  val;
     val.last_arg_offset = (env.last_offset-1) - dictval.opStart;  /* offset to the last argument */
@@ -823,7 +823,7 @@ struct cff1_font_dict_values_t : dict_values_t<op_str_t>
 
 struct cff1_font_dict_opset_t : dict_opset_t
 {
-  static void process_op (OpCode op, num_interp_env_t& env, cff1_font_dict_values_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff1_font_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_FontName:
@@ -883,7 +883,7 @@ typedef cff1_private_dict_values_base_t<num_dict_val_t> cff1_private_dict_values
 
 struct cff1_private_dict_opset_t : dict_opset_t
 {
-  static void process_op (OpCode op, num_interp_env_t& env, cff1_private_dict_values_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_t& dictval)
   {
     num_dict_val_t val;
     val.init ();
@@ -930,7 +930,7 @@ struct cff1_private_dict_opset_t : dict_opset_t
 
 struct cff1_private_dict_opset_subset : dict_opset_t
 {
-  static void process_op (OpCode op, num_interp_env_t& env, cff1_private_dict_values_subset_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_subset_t& dictval)
   {
     switch (op) {
       case OpCode_BlueValues:

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -794,7 +794,7 @@ struct CFF1TopDictOpSet : TopDictOpSet<CFF1TopDictVal>
 	break;
 
       default:
-	env.last_offset = env.substr.offset;
+	env.last_offset = env.str_ref.offset;
 	TopDictOpSet<CFF1TopDictVal>::process_op (op, env, dictval);
 	/* Record this operand below if stack is empty, otherwise done */
 	if (!env.argStack.is_empty ()) return;
@@ -803,7 +803,7 @@ struct CFF1TopDictOpSet : TopDictOpSet<CFF1TopDictVal>
 
     if (unlikely (env.in_error ())) return;
 
-    dictval.add_op (op, env.substr, val);
+    dictval.add_op (op, env.str_ref, val);
   }
 };
 
@@ -848,7 +848,7 @@ struct CFF1FontDictOpSet : DictOpSet
 
     if (unlikely (env.in_error ())) return;
 
-    dictval.add_op (op, env.substr);
+    dictval.add_op (op, env.str_ref);
   }
 };
 
@@ -924,7 +924,7 @@ struct CFF1PrivateDictOpSet : DictOpSet
 
     if (unlikely (env.in_error ())) return;
 
-    dictval.add_op (op, env.substr, val);
+    dictval.add_op (op, env.str_ref, val);
   }
 };
 
@@ -966,7 +966,7 @@ struct CFF1PrivateDictOpSet_Subset : DictOpSet
 
     if (unlikely (env.in_error ())) return;
 
-    dictval.add_op (op, env.substr);
+    dictval.add_op (op, env.str_ref);
   }
 };
 

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -56,13 +56,13 @@ struct CFF1FDSelect : FDSelect {};
 
 /* Encoding */
 struct Encoding0 {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && codes[nCodes - 1].sanitize (c));
   }
 
-  inline hb_codepoint_t get_code (hb_codepoint_t glyph) const
+  hb_codepoint_t get_code (hb_codepoint_t glyph) const
   {
     assert (glyph > 0);
     glyph--;
@@ -74,7 +74,7 @@ struct Encoding0 {
       return CFF_UNDEF_CODE;
   }
 
-  inline unsigned int get_size () const
+  unsigned int get_size () const
   { return HBUINT8::static_size * (nCodes + 1); }
 
   HBUINT8     nCodes;
@@ -84,7 +84,7 @@ struct Encoding0 {
 };
 
 struct Encoding1_Range {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this));
@@ -97,16 +97,16 @@ struct Encoding1_Range {
 };
 
 struct Encoding1 {
-  inline unsigned int get_size () const
+  unsigned int get_size () const
   { return HBUINT8::static_size + Encoding1_Range::static_size * nRanges; }
 
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && ((nRanges == 0) || (ranges[nRanges - 1]).sanitize (c)));
   }
 
-  inline hb_codepoint_t get_code (hb_codepoint_t glyph) const
+  hb_codepoint_t get_code (hb_codepoint_t glyph) const
   {
     assert (glyph > 0);
     glyph--;
@@ -128,7 +128,7 @@ struct Encoding1 {
 };
 
 struct SuppEncoding {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this));
@@ -141,20 +141,20 @@ struct SuppEncoding {
 };
 
 struct CFF1SuppEncData {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && ((nSups == 0) || (supps[nSups - 1]).sanitize (c)));
   }
 
-  inline void get_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
+  void get_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
   {
     for (unsigned int i = 0; i < nSups; i++)
       if (sid == supps[i].glyph)
 	codes.push (supps[i].code);
   }
 
-  inline unsigned int get_size () const
+  unsigned int get_size () const
   { return HBUINT8::static_size + SuppEncoding::static_size * nSups; }
 
   HBUINT8	 nSups;
@@ -164,7 +164,7 @@ struct CFF1SuppEncData {
 };
 
 struct Encoding {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
 
@@ -179,7 +179,7 @@ struct Encoding {
   }
 
   /* serialize a fullset Encoding */
-  inline bool serialize (hb_serialize_context_t *c, const Encoding &src)
+  bool serialize (hb_serialize_context_t *c, const Encoding &src)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size ();
@@ -190,11 +190,11 @@ struct Encoding {
   }
 
   /* serialize a subset Encoding */
-  inline bool serialize (hb_serialize_context_t *c,
-			uint8_t format,
-			unsigned int enc_count,
-			const hb_vector_t<code_pair_t>& code_ranges,
-			const hb_vector_t<code_pair_t>& supp_codes)
+  bool serialize (hb_serialize_context_t *c,
+		  uint8_t format,
+		  unsigned int enc_count,
+		  const hb_vector_t<code_pair_t>& code_ranges,
+		  const hb_vector_t<code_pair_t>& supp_codes)
   {
     TRACE_SERIALIZE (this);
     Encoding *dest = c->extend_min (*this);
@@ -243,9 +243,9 @@ struct Encoding {
   }
 
   /* parallel to above: calculate the size of a subset Encoding */
-  static inline unsigned int calculate_serialized_size (uint8_t format,
-							unsigned int enc_count,
-							unsigned int supp_count)
+  static unsigned int calculate_serialized_size (uint8_t format,
+						 unsigned int enc_count,
+						 unsigned int supp_count)
   {
     unsigned int  size = min_size;
     if (format == 0)
@@ -257,7 +257,7 @@ struct Encoding {
     return size;
   }
 
-  inline unsigned int get_size () const
+  unsigned int get_size () const
   {
     unsigned int size = min_size;
     if (table_format () == 0)
@@ -269,7 +269,7 @@ struct Encoding {
     return size;
   }
 
-  inline hb_codepoint_t get_code (hb_codepoint_t glyph) const
+  hb_codepoint_t get_code (hb_codepoint_t glyph) const
   {
     if (table_format () == 0)
       return u.format0.get_code (glyph);
@@ -277,10 +277,10 @@ struct Encoding {
       return u.format1.get_code (glyph);
   }
 
-  inline uint8_t table_format () const { return (format & 0x7F); }
-  inline bool  has_supplement () const { return (format & 0x80) != 0; }
+  uint8_t table_format () const { return (format & 0x7F); }
+  bool  has_supplement () const { return (format & 0x80) != 0; }
 
-  inline void get_supplement_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
+  void get_supplement_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
   {
     codes.resize (0);
     if (has_supplement ())
@@ -288,7 +288,7 @@ struct Encoding {
   }
 
   protected:
-  inline const CFF1SuppEncData &suppEncData () const
+  const CFF1SuppEncData &suppEncData () const
   {
     if ((format & 0x7F) == 0)
       return StructAfter<CFF1SuppEncData> (u.format0.codes[u.format0.nCodes-1]);
@@ -310,13 +310,13 @@ struct Encoding {
 
 /* Charset */
 struct Charset0 {
-  inline bool sanitize (hb_sanitize_context_t *c, unsigned int num_glyphs) const
+  bool sanitize (hb_sanitize_context_t *c, unsigned int num_glyphs) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) && sids[num_glyphs - 1].sanitize (c));
   }
 
-  inline hb_codepoint_t get_sid (hb_codepoint_t glyph) const
+  hb_codepoint_t get_sid (hb_codepoint_t glyph) const
   {
     if (glyph == 0)
       return 0;
@@ -324,7 +324,7 @@ struct Charset0 {
       return sids[glyph - 1];
   }
 
-  inline hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
+  hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
   {
     if (sid == 0)
       return 0;
@@ -337,7 +337,7 @@ struct Charset0 {
     return 0;
   }
 
-  inline unsigned int get_size (unsigned int num_glyphs) const
+  unsigned int get_size (unsigned int num_glyphs) const
   {
     assert (num_glyphs > 0);
     return HBUINT16::static_size * (num_glyphs - 1);
@@ -350,7 +350,7 @@ struct Charset0 {
 
 template <typename TYPE>
 struct Charset_Range {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this));
@@ -364,7 +364,7 @@ struct Charset_Range {
 
 template <typename TYPE>
 struct Charset1_2 {
-  inline bool sanitize (hb_sanitize_context_t *c, unsigned int num_glyphs) const
+  bool sanitize (hb_sanitize_context_t *c, unsigned int num_glyphs) const
   {
     TRACE_SANITIZE (this);
     if (unlikely (!c->check_struct (this)))
@@ -379,7 +379,7 @@ struct Charset1_2 {
     return_trace (true);
   }
 
-  inline hb_codepoint_t get_sid (hb_codepoint_t glyph) const
+  hb_codepoint_t get_sid (hb_codepoint_t glyph) const
   {
     if (glyph == 0) return 0;
     glyph--;
@@ -393,7 +393,7 @@ struct Charset1_2 {
     return 0;
   }
 
-  inline hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
+  hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
   {
     if (sid == 0) return 0;
     hb_codepoint_t  glyph = 1;
@@ -409,7 +409,7 @@ struct Charset1_2 {
     return 0;
   }
 
-  inline unsigned int get_size (unsigned int num_glyphs) const
+  unsigned int get_size (unsigned int num_glyphs) const
   {
     unsigned int size = HBUINT8::static_size;
     int glyph = (int)num_glyphs;
@@ -436,7 +436,7 @@ typedef Charset_Range<HBUINT8>  Charset1_Range;
 typedef Charset_Range<HBUINT16> Charset2_Range;
 
 struct Charset {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
 
@@ -453,7 +453,7 @@ struct Charset {
   }
 
   /* serialize a fullset Charset */
-  inline bool serialize (hb_serialize_context_t *c, const Charset &src, unsigned int num_glyphs)
+  bool serialize (hb_serialize_context_t *c, const Charset &src, unsigned int num_glyphs)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size (num_glyphs);
@@ -464,7 +464,7 @@ struct Charset {
   }
 
   /* serialize a subset Charset */
-  inline bool serialize (hb_serialize_context_t *c,
+  bool serialize (hb_serialize_context_t *c,
 		  uint8_t format,
 		  unsigned int num_glyphs,
 		  const hb_vector_t<code_pair_t>& sid_ranges)
@@ -513,8 +513,9 @@ struct Charset {
   }
 
   /* parallel to above: calculate the size of a subset Charset */
-  static inline unsigned int calculate_serialized_size (uint8_t format,
-							unsigned int count)
+  static unsigned int calculate_serialized_size (
+			uint8_t format,
+			unsigned int count)
   {
     unsigned int  size = min_size;
     if (format == 0)
@@ -527,7 +528,7 @@ struct Charset {
     return size;
   }
 
-  inline unsigned int get_size (unsigned int num_glyphs) const
+  unsigned int get_size (unsigned int num_glyphs) const
   {
     unsigned int size = min_size;
     if (format == 0)
@@ -539,7 +540,7 @@ struct Charset {
     return size;
   }
 
-  inline hb_codepoint_t get_sid (hb_codepoint_t glyph) const
+  hb_codepoint_t get_sid (hb_codepoint_t glyph) const
   {
     if (format == 0)
       return u.format0.get_sid (glyph);
@@ -549,7 +550,7 @@ struct Charset {
       return u.format2.get_sid (glyph);
   }
 
-  inline hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
+  hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
   {
     if (format == 0)
       return u.format0.get_glyph (sid, num_glyphs);
@@ -571,8 +572,8 @@ struct Charset {
 
 struct CFF1StringIndex : CFF1Index
 {
-  inline bool serialize (hb_serialize_context_t *c, const CFF1StringIndex &strings,
-			unsigned int offSize_, const remap_t &sidmap)
+  bool serialize (hb_serialize_context_t *c, const CFF1StringIndex &strings,
+		  unsigned int offSize_, const remap_t &sidmap)
   {
     TRACE_SERIALIZE (this);
     if (unlikely ((strings.count == 0) || (sidmap.get_count () == 0)))
@@ -600,7 +601,7 @@ struct CFF1StringIndex : CFF1Index
   }
 
   /* in parallel to above */
-  inline unsigned int calculate_serialized_size (unsigned int &offSize /*OUT*/, const remap_t &sidmap) const
+  unsigned int calculate_serialized_size (unsigned int &offSize /*OUT*/, const remap_t &sidmap) const
   {
     offSize = 0;
     if ((count == 0) || (sidmap.get_count () == 0))
@@ -618,7 +619,7 @@ struct CFF1StringIndex : CFF1Index
 
 struct cff1_top_dict_interp_env_t : num_interp_env_t
 {
-  inline cff1_top_dict_interp_env_t ()
+  cff1_top_dict_interp_env_t ()
     : num_interp_env_t(), prev_offset(0), last_offset(0) {}
 
   unsigned int prev_offset;
@@ -644,19 +645,19 @@ struct name_dict_values_t
       ValCount
   };
 
-  inline void init ()
+  void init ()
   {
     for (unsigned int i = 0; i < ValCount; i++)
       values[i] = CFF_UNDEF_SID;
   }
 
-  inline unsigned int& operator[] (unsigned int i)
+  unsigned int& operator[] (unsigned int i)
   { assert (i < ValCount); return values[i]; }
 
-  inline unsigned int operator[] (unsigned int i) const
+  unsigned int operator[] (unsigned int i) const
   { assert (i < ValCount); return values[i]; }
 
-  static inline enum name_dict_val_index_t name_op_to_index (op_code_t op)
+  static enum name_dict_val_index_t name_op_to_index (op_code_t op)
   {
     switch (op) {
       default: // can't happen - just make some compiler happy
@@ -691,7 +692,7 @@ struct cff1_top_dict_val_t : op_str_t
 
 struct cff1_top_dict_values_t : top_dict_values_t<cff1_top_dict_val_t>
 {
-  inline void init ()
+  void init ()
   {
     top_dict_values_t<cff1_top_dict_val_t>::init ();
 
@@ -703,25 +704,25 @@ struct cff1_top_dict_values_t : top_dict_values_t<cff1_top_dict_val_t>
     FDSelectOffset = 0;
     privateDictInfo.init ();
   }
-  inline void fini () { top_dict_values_t<cff1_top_dict_val_t>::fini (); }
+  void fini () { top_dict_values_t<cff1_top_dict_val_t>::fini (); }
 
-  inline bool is_CID () const
+  bool is_CID () const
   { return nameSIDs[name_dict_values_t::registry] != CFF_UNDEF_SID; }
 
-  name_dict_values_t	nameSIDs;
-  unsigned int		ros_supplement_offset;
-  unsigned int		ros_supplement;
-  unsigned int		cidCount;
+  name_dict_values_t  nameSIDs;
+  unsigned int    ros_supplement_offset;
+  unsigned int    ros_supplement;
+  unsigned int    cidCount;
 
-  unsigned int		EncodingOffset;
-  unsigned int		CharsetOffset;
-  unsigned int		FDSelectOffset;
-  table_info_t		privateDictInfo;
+  unsigned int    EncodingOffset;
+  unsigned int    CharsetOffset;
+  unsigned int    FDSelectOffset;
+  table_info_t       privateDictInfo;
 };
 
 struct cff1_top_dict_opset_t : top_dict_opset_t<cff1_top_dict_val_t>
 {
-  static inline void process_op (op_code_t op, cff1_top_dict_interp_env_t& env, cff1_top_dict_values_t& dictval)
+  static void process_op (op_code_t op, cff1_top_dict_interp_env_t& env, cff1_top_dict_values_t& dictval)
   {
     cff1_top_dict_val_t  val;
     val.last_arg_offset = (env.last_offset-1) - dictval.opStart;  /* offset to the last argument */
@@ -808,21 +809,21 @@ struct cff1_top_dict_opset_t : top_dict_opset_t<cff1_top_dict_val_t>
 
 struct cff1_font_dict_values_t : dict_values_t<op_str_t>
 {
-  inline void init ()
+  void init ()
   {
     dict_values_t<op_str_t>::init ();
     privateDictInfo.init ();
     fontName = CFF_UNDEF_SID;
   }
-  inline void fini () { dict_values_t<op_str_t>::fini (); }
+  void fini () { dict_values_t<op_str_t>::fini (); }
 
-  table_info_t	privateDictInfo;
-  unsigned int	fontName;
+  table_info_t       privateDictInfo;
+  unsigned int    fontName;
 };
 
 struct cff1_font_dict_opset_t : dict_opset_t
 {
-  static inline void process_op (op_code_t op, num_interp_env_t& env, cff1_font_dict_values_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff1_font_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_FontName:
@@ -854,15 +855,15 @@ struct cff1_font_dict_opset_t : dict_opset_t
 template <typename VAL>
 struct cff1_private_dict_values_base_t : dict_values_t<VAL>
 {
-  inline void init ()
+  void init ()
   {
     dict_values_t<VAL>::init ();
     subrsOffset = 0;
     localSubrs = &Null(CFF1Subrs);
   }
-  inline void fini () { dict_values_t<VAL>::fini (); }
+  void fini () { dict_values_t<VAL>::fini (); }
 
-  inline unsigned int calculate_serialized_size () const
+  unsigned int calculate_serialized_size () const
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < dict_values_t<VAL>::get_count; i++)
@@ -873,8 +874,8 @@ struct cff1_private_dict_values_base_t : dict_values_t<VAL>
     return size;
   }
 
-  unsigned int		subrsOffset;
-  const CFF1Subrs	*localSubrs;
+  unsigned int      subrsOffset;
+  const CFF1Subrs    *localSubrs;
 };
 
 typedef cff1_private_dict_values_base_t<op_str_t> cff1_private_dict_values_subset_t;
@@ -882,7 +883,7 @@ typedef cff1_private_dict_values_base_t<num_dict_val_t> cff1_private_dict_values
 
 struct cff1_private_dict_opset_t : dict_opset_t
 {
-  static inline void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_t& dictval)
   {
     num_dict_val_t val;
     val.init ();
@@ -929,7 +930,7 @@ struct cff1_private_dict_opset_t : dict_opset_t
 
 struct cff1_private_dict_opset_subset : dict_opset_t
 {
-  static inline void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_subset_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff1_private_dict_values_subset_t& dictval)
   {
     switch (op) {
       case OpCode_BlueValues:
@@ -985,7 +986,7 @@ struct cff1
 {
   static const hb_tag_t tableTag	= HB_OT_TAG_cff1;
 
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) &&
@@ -995,7 +996,7 @@ struct cff1
   template <typename PRIVOPSET, typename PRIVDICTVAL>
   struct accelerator_templ_t
   {
-    inline void init (hb_face_t *face)
+    void init (hb_face_t *face)
     {
       topDict.init ();
       fontDicts.init ();
@@ -1122,7 +1123,7 @@ struct cff1
       }
     }
 
-    inline void fini ()
+    void fini ()
     {
       sc.end_processing ();
       topDict.fini ();
@@ -1132,12 +1133,12 @@ struct cff1
       blob = nullptr;
     }
 
-    inline bool is_valid () const { return blob != nullptr; }
-    inline bool is_CID () const { return topDict.is_CID (); }
+    bool is_valid () const { return blob != nullptr; }
+    bool is_CID () const { return topDict.is_CID (); }
 
-    inline bool is_predef_charset () const { return topDict.CharsetOffset <= ExpertSubsetCharset; }
+    bool is_predef_charset () const { return topDict.CharsetOffset <= ExpertSubsetCharset; }
 
-    inline unsigned int std_code_to_glyph (hb_codepoint_t code) const
+    unsigned int std_code_to_glyph (hb_codepoint_t code) const
     {
       hb_codepoint_t sid = lookup_standard_encoding_for_sid (code);
       if (unlikely (sid == CFF_UNDEF_SID))
@@ -1151,23 +1152,23 @@ struct cff1
     }
 
     protected:
-    hb_blob_t			*blob;
-    hb_sanitize_context_t	sc;
+    hb_blob_t	       *blob;
+    hb_sanitize_context_t   sc;
 
     public:
-    const Charset		*charset;
-    const CFF1NameIndex		*nameIndex;
-    const CFF1TopDictIndex	*topDictIndex;
-    const CFF1StringIndex	*stringIndex;
-    const CFF1Subrs		*globalSubrs;
-    const CFF1CharStrings	*charStrings;
-    const CFF1FDArray		*fdArray;
-    const CFF1FDSelect		*fdSelect;
-    unsigned int		fdCount;
+    const Charset	   *charset;
+    const CFF1NameIndex     *nameIndex;
+    const CFF1TopDictIndex  *topDictIndex;
+    const CFF1StringIndex   *stringIndex;
+    const CFF1Subrs	 *globalSubrs;
+    const CFF1CharStrings   *charStrings;
+    const CFF1FDArray       *fdArray;
+    const CFF1FDSelect      *fdSelect;
+    unsigned int	    fdCount;
 
-    cff1_top_dict_values_t	topDict;
-    hb_vector_t<cff1_font_dict_values_t>	fontDicts;
-    hb_vector_t<PRIVDICTVAL>	privateDicts;
+    cff1_top_dict_values_t       topDict;
+    hb_vector_t<cff1_font_dict_values_t>   fontDicts;
+    hb_vector_t<PRIVDICTVAL>	  privateDicts;
 
     unsigned int	    num_glyphs;
   };
@@ -1180,7 +1181,7 @@ struct cff1
 
   struct accelerator_subset_t : accelerator_templ_t<cff1_private_dict_opset_subset, cff1_private_dict_values_subset_t>
   {
-    inline void init (hb_face_t *face)
+    void init (hb_face_t *face)
     {
       SUPER::init (face);
       if (blob == nullptr) return;
@@ -1201,9 +1202,9 @@ struct cff1
       }
     }
 
-    inline bool is_predef_encoding () const { return topDict.EncodingOffset <= ExpertEncoding; }
+    bool is_predef_encoding () const { return topDict.EncodingOffset <= ExpertEncoding; }
 
-    inline hb_codepoint_t  glyph_to_code (hb_codepoint_t glyph) const
+    hb_codepoint_t  glyph_to_code (hb_codepoint_t glyph) const
     {
       if (encoding != &Null(Encoding))
 	return encoding->get_code (glyph);
@@ -1227,7 +1228,7 @@ struct cff1
       }
     }
 
-    inline hb_codepoint_t glyph_to_sid (hb_codepoint_t glyph) const
+    hb_codepoint_t glyph_to_sid (hb_codepoint_t glyph) const
     {
       if (charset != &Null(Charset))
 	return charset->get_sid (glyph);
@@ -1258,7 +1259,7 @@ struct cff1
     typedef accelerator_templ_t<cff1_private_dict_opset_subset, cff1_private_dict_values_subset_t> SUPER;
   };
 
-  inline bool subset (hb_subset_plan_t *plan) const
+  bool subset (hb_subset_plan_t *plan) const
   {
     hb_blob_t *cff_prime = nullptr;
 

--- a/src/hb-ot-cff2-table.cc
+++ b/src/hb-ot-cff2-table.cc
@@ -31,7 +31,7 @@ using namespace CFF;
 
 struct extents_param_t
 {
-  inline void init ()
+  void init ()
   {
     path_open = false;
     min_x.set_int (0x7FFFFFFF);
@@ -40,11 +40,11 @@ struct extents_param_t
     max_y.set_int (-0x80000000);
   }
 
-  inline void start_path ()         { path_open = true; }
-  inline void end_path ()           { path_open = false; }
-  inline bool is_path_open () const { return path_open; }
+  void start_path ()         { path_open = true; }
+  void end_path ()           { path_open = false; }
+  bool is_path_open () const { return path_open; }
 
-  inline void update_bounds (const point_t &pt)
+  void update_bounds (const point_t &pt)
   {
     if (pt.x < min_x) min_x = pt.x;
     if (pt.x > max_x) max_x = pt.x;
@@ -61,13 +61,13 @@ struct extents_param_t
 
 struct cff2_path_procs_extents_t : path_procs_t<cff2_path_procs_extents_t, cff2_cs_interp_env_t, extents_param_t>
 {
-  static inline void moveto (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
+  static void moveto (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
   {
     param.end_path ();
     env.moveto (pt);
   }
 
-  static inline void line (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
+  static void line (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
   {
     if (!param.is_path_open ())
     {
@@ -78,7 +78,7 @@ struct cff2_path_procs_extents_t : path_procs_t<cff2_path_procs_extents_t, cff2_
     param.update_bounds (env.get_pt ());
   }
 
-  static inline void curve (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
+  static void curve (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   {
     if (!param.is_path_open ())
     {

--- a/src/hb-ot-cff2-table.cc
+++ b/src/hb-ot-cff2-table.cc
@@ -31,7 +31,7 @@ using namespace CFF;
 
 struct extents_param_t
 {
-  void init ()
+  inline void init ()
   {
     path_open = false;
     min_x.set_int (0x7FFFFFFF);
@@ -40,11 +40,11 @@ struct extents_param_t
     max_y.set_int (-0x80000000);
   }
 
-  void start_path ()         { path_open = true; }
-  void end_path ()           { path_open = false; }
-  bool is_path_open () const { return path_open; }
+  inline void start_path ()         { path_open = true; }
+  inline void end_path ()           { path_open = false; }
+  inline bool is_path_open () const { return path_open; }
 
-  void update_bounds (const point_t &pt)
+  inline void update_bounds (const point_t &pt)
   {
     if (pt.x < min_x) min_x = pt.x;
     if (pt.x > max_x) max_x = pt.x;
@@ -61,13 +61,13 @@ struct extents_param_t
 
 struct cff2_path_procs_extents_t : path_procs_t<cff2_path_procs_extents_t, cff2_cs_interp_env_t, extents_param_t>
 {
-  static void moveto (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
+  static inline void moveto (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
   {
     param.end_path ();
     env.moveto (pt);
   }
 
-  static void line (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
+  static inline void line (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
   {
     if (!param.is_path_open ())
     {
@@ -78,7 +78,7 @@ struct cff2_path_procs_extents_t : path_procs_t<cff2_path_procs_extents_t, cff2_
     param.update_bounds (env.get_pt ());
   }
 
-  static void curve (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
+  static inline void curve (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   {
     if (!param.is_path_open ())
     {

--- a/src/hb-ot-cff2-table.cc
+++ b/src/hb-ot-cff2-table.cc
@@ -105,7 +105,7 @@ bool OT::cff2::accelerator_t::get_extents (hb_font_t *font,
   const int *coords = hb_font_get_var_coords_normalized (font, &num_coords);
   unsigned int fd = fdSelect->get_fd (glyph);
   CFF2CSInterpreter<CFF2CSOpSet_Extents, ExtentsParam> interp;
-  const ByteStr str = (*charStrings)[glyph];
+  const byte_str_t str = (*charStrings)[glyph];
   interp.env.init (str, *this, fd, coords, num_coords);
   ExtentsParam  param;
   param.init ();

--- a/src/hb-ot-cff2-table.cc
+++ b/src/hb-ot-cff2-table.cc
@@ -29,7 +29,7 @@
 
 using namespace CFF;
 
-struct ExtentsParam
+struct extents_param_t
 {
   void init ()
   {
@@ -44,7 +44,7 @@ struct ExtentsParam
   void end_path ()           { path_open = false; }
   bool is_path_open () const { return path_open; }
 
-  void update_bounds (const Point &pt)
+  void update_bounds (const point_t &pt)
   {
     if (pt.x < min_x) min_x = pt.x;
     if (pt.x > max_x) max_x = pt.x;
@@ -53,21 +53,21 @@ struct ExtentsParam
   }
 
   bool  path_open;
-  Number min_x;
-  Number min_y;
-  Number max_x;
-  Number max_y;
+  number_t min_x;
+  number_t min_y;
+  number_t max_x;
+  number_t max_y;
 };
 
-struct CFF2PathProcs_Extents : PathProcs<CFF2PathProcs_Extents, CFF2CSInterpEnv, ExtentsParam>
+struct cff2_path_procs_extents_t : path_procs_t<cff2_path_procs_extents_t, cff2_cs_interp_env_t, extents_param_t>
 {
-  static void moveto (CFF2CSInterpEnv &env, ExtentsParam& param, const Point &pt)
+  static void moveto (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt)
   {
     param.end_path ();
     env.moveto (pt);
   }
 
-  static void line (CFF2CSInterpEnv &env, ExtentsParam& param, const Point &pt1)
+  static void line (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1)
   {
     if (!param.is_path_open ())
     {
@@ -78,7 +78,7 @@ struct CFF2PathProcs_Extents : PathProcs<CFF2PathProcs_Extents, CFF2CSInterpEnv,
     param.update_bounds (env.get_pt ());
   }
 
-  static void curve (CFF2CSInterpEnv &env, ExtentsParam& param, const Point &pt1, const Point &pt2, const Point &pt3)
+  static void curve (cff2_cs_interp_env_t &env, extents_param_t& param, const point_t &pt1, const point_t &pt2, const point_t &pt3)
   {
     if (!param.is_path_open ())
     {
@@ -93,7 +93,7 @@ struct CFF2PathProcs_Extents : PathProcs<CFF2PathProcs_Extents, CFF2CSInterpEnv,
   }
 };
 
-struct CFF2CSOpSet_Extents : CFF2CSOpSet<CFF2CSOpSet_Extents, ExtentsParam, CFF2PathProcs_Extents> {};
+struct cff2_cs_opset_extents_t : cff2_cs_opset_t<cff2_cs_opset_extents_t, extents_param_t, cff2_path_procs_extents_t> {};
 
 bool OT::cff2::accelerator_t::get_extents (hb_font_t *font,
 					   hb_codepoint_t glyph,
@@ -104,10 +104,10 @@ bool OT::cff2::accelerator_t::get_extents (hb_font_t *font,
   unsigned int num_coords;
   const int *coords = hb_font_get_var_coords_normalized (font, &num_coords);
   unsigned int fd = fdSelect->get_fd (glyph);
-  CFF2CSInterpreter<CFF2CSOpSet_Extents, ExtentsParam> interp;
+  cff2_cs_interpreter_t<cff2_cs_opset_extents_t, extents_param_t> interp;
   const byte_str_t str = (*charStrings)[glyph];
   interp.env.init (str, *this, fd, coords, num_coords);
-  ExtentsParam  param;
+  extents_param_t  param;
   param.init ();
   if (unlikely (!interp.interpret (param))) return false;
 

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -278,7 +278,7 @@ typedef CFF2PrivateDictValues_Base<NumDictVal> CFF2PrivateDictValues;
 
 struct CFF2PrivDictInterpEnv : NumInterpEnv
 {
-  void init (const ByteStr &str)
+  void init (const byte_str_t &str)
   {
     NumInterpEnv::init (str);
     ivs = 0;
@@ -438,7 +438,7 @@ struct cff2
       { fini (); return; }
 
       { /* parse top dict */
-	ByteStr topDictStr (cff2 + cff2->topDict, cff2->topDictSize);
+	byte_str_t topDictStr (cff2 + cff2->topDict, cff2->topDictSize);
 	if (unlikely (!topDictStr.sanitize (&sc))) { fini (); return; }
 	CFF2TopDict_Interpreter top_interp;
 	top_interp.env.init (topDictStr);
@@ -469,7 +469,7 @@ struct cff2
       /* parse font dicts and gather private dicts */
       for (unsigned int i = 0; i < fdCount; i++)
       {
-	const ByteStr fontDictStr = (*fdArray)[i];
+	const byte_str_t fontDictStr = (*fdArray)[i];
 	if (unlikely (!fontDictStr.sanitize (&sc))) { fini (); return; }
 	CFF2FontDictValues  *font;
 	CFF2FontDict_Interpreter font_interp;
@@ -479,14 +479,14 @@ struct cff2
 	font->init ();
 	if (unlikely (!font_interp.interpret (*font))) { fini (); return; }
 
-	const ByteStr privDictStr (StructAtOffsetOrNull<UnsizedByteStr> (cff2, font->privateDictInfo.offset), font->privateDictInfo.size);
+	const byte_str_t privDictStr (StructAtOffsetOrNull<UnsizedByteStr> (cff2, font->privateDictInfo.offset), font->privateDictInfo.size);
 	if (unlikely (!privDictStr.sanitize (&sc))) { fini (); return; }
 	DictInterpreter<PRIVOPSET, PRIVDICTVAL, CFF2PrivDictInterpEnv>  priv_interp;
 	priv_interp.env.init(privDictStr);
 	privateDicts[i].init ();
 	if (unlikely (!priv_interp.interpret (privateDicts[i]))) { fini (); return; }
 
-	privateDicts[i].localSubrs = &StructAtOffsetOrNull<CFF2Subrs> (privDictStr.str, privateDicts[i].subrsOffset);
+	privateDicts[i].localSubrs = &StructAtOffsetOrNull<CFF2Subrs> (&privDictStr[0], privateDicts[i].subrsOffset);
 	if (privateDicts[i].localSubrs != &Null(CFF2Subrs) &&
 	  unlikely (!privateDicts[i].localSubrs->sanitize (&sc)))
 	{ fini (); return; }

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -179,7 +179,7 @@ struct CFF2TopDictOpSet : TopDictOpSet<>
 	{
 	  DictVal val;
 	  val.init ();
-	  dictval.add_op (op, env.substr);
+	  dictval.add_op (op, env.str_ref);
 	  env.clear_args ();
 	}
 	break;
@@ -201,7 +201,7 @@ struct CFF2TopDictOpSet : TopDictOpSet<>
 
     if (unlikely (env.in_error ())) return;
 
-    dictval.add_op (op, env.substr);
+    dictval.add_op (op, env.str_ref);
   }
 
   typedef TopDictOpSet<> SUPER;
@@ -238,7 +238,7 @@ struct CFF2FontDictOpSet : DictOpSet
 
     if (unlikely (env.in_error ())) return;
 
-    dictval.add_op (op, env.substr);
+    dictval.add_op (op, env.str_ref);
   }
 
   private:
@@ -348,7 +348,7 @@ struct CFF2PrivateDictOpSet : DictOpSet
 
     if (unlikely (env.in_error ())) return;
 
-    dictval.add_op (op, env.substr, val);
+    dictval.add_op (op, env.str_ref, val);
   }
 };
 
@@ -390,7 +390,7 @@ struct CFF2PrivateDictOpSet_Subset : DictOpSet
 
     if (unlikely (env.in_error ())) return;
 
-    dictval.add_op (op, env.substr);
+    dictval.add_op (op, env.str_ref);
   }
 
   private:

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -51,7 +51,7 @@ typedef FDSelect3_4_Range<HBUINT32, HBUINT16> FDSelect4_Range;
 
 struct CFF2FDSelect
 {
-  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
 
@@ -63,7 +63,7 @@ struct CFF2FDSelect
 			    u.format4.sanitize (c, fdcount))));
   }
 
-  inline bool serialize (hb_serialize_context_t *c, const CFF2FDSelect &src, unsigned int num_glyphs)
+  bool serialize (hb_serialize_context_t *c, const CFF2FDSelect &src, unsigned int num_glyphs)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size (num_glyphs);
@@ -73,10 +73,10 @@ struct CFF2FDSelect
     return_trace (true);
   }
 
-  inline unsigned int calculate_serialized_size (unsigned int num_glyphs) const
+  unsigned int calculate_serialized_size (unsigned int num_glyphs) const
   { return get_size (num_glyphs); }
 
-  inline unsigned int get_size (unsigned int num_glyphs) const
+  unsigned int get_size (unsigned int num_glyphs) const
   {
     unsigned int size = format.static_size;
     if (format == 0)
@@ -88,7 +88,7 @@ struct CFF2FDSelect
     return size;
   }
 
-  inline hb_codepoint_t get_fd (hb_codepoint_t glyph) const
+  hb_codepoint_t get_fd (hb_codepoint_t glyph) const
   {
     if (this == &Null(CFF2FDSelect))
       return 0;
@@ -110,43 +110,43 @@ struct CFF2FDSelect
   DEFINE_SIZE_MIN (2);
 };
 
-struct cff2_variation_store_t
+struct CFF2VariationStore
 {
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (likely (c->check_struct (this)) && c->check_range (&varStore, size) && varStore.sanitize (c));
   }
 
-  inline bool serialize (hb_serialize_context_t *c, const cff2_variation_store_t *varStore)
+  bool serialize (hb_serialize_context_t *c, const CFF2VariationStore *varStore)
   {
     TRACE_SERIALIZE (this);
     unsigned int size_ = varStore->get_size ();
-    cff2_variation_store_t *dest = c->allocate_size<cff2_variation_store_t> (size_);
+    CFF2VariationStore *dest = c->allocate_size<CFF2VariationStore> (size_);
     if (unlikely (dest == nullptr)) return_trace (false);
     memcpy (dest, varStore, size_);
     return_trace (true);
   }
 
-  inline unsigned int get_size () const { return HBUINT16::static_size + size; }
+  unsigned int get_size () const { return HBUINT16::static_size + size; }
 
-  HBUINT16		size;
-  VariationStore	varStore;
+  HBUINT16	size;
+  VariationStore  varStore;
 
   DEFINE_SIZE_MIN (2 + VariationStore::min_size);
 };
 
 struct cff2_top_dict_values_t : top_dict_values_t<>
 {
-  inline void init ()
+  void init ()
   {
     top_dict_values_t<>::init ();
     vstoreOffset = 0;
     FDSelectOffset = 0;
   }
-  inline void fini () { top_dict_values_t<>::fini (); }
+  void fini () { top_dict_values_t<>::fini (); }
 
-  inline unsigned int calculate_serialized_size () const
+  unsigned int calculate_serialized_size () const
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < get_count (); i++)
@@ -172,7 +172,7 @@ struct cff2_top_dict_values_t : top_dict_values_t<>
 
 struct cff2_top_dict_opset_t : top_dict_opset_t<>
 {
-  static inline void process_op (op_code_t op, num_interp_env_t& env, cff2_top_dict_values_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff2_top_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_FontMatrix:
@@ -221,7 +221,7 @@ struct cff2_font_dict_values_t : dict_values_t<op_str_t>
 
 struct cff2_font_dict_opset_t : dict_opset_t
 {
-  static inline void process_op (op_code_t op, num_interp_env_t& env, cff2_font_dict_values_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff2_font_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_Private:
@@ -304,7 +304,7 @@ struct cff2_priv_dict_interp_env_t : num_interp_env_t
 
 struct cff2_private_dict_opset_t : dict_opset_t
 {
-  static inline void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_t& dictval)
+  static void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_t& dictval)
   {
     num_dict_val_t val;
     val.init ();
@@ -354,7 +354,7 @@ struct cff2_private_dict_opset_t : dict_opset_t
 
 struct cff2_private_dict_opset_subset_t : dict_opset_t
 {
-  static inline void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_subset_t& dictval)
+  static void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_subset_t& dictval)
   {
     switch (op) {
       case OpCode_BlueValues:
@@ -410,7 +410,7 @@ struct cff2
 {
   static const hb_tag_t tableTag	= HB_OT_TAG_cff2;
 
-  inline bool sanitize (hb_sanitize_context_t *c) const
+  bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) &&
@@ -420,7 +420,7 @@ struct cff2
   template <typename PRIVOPSET, typename PRIVDICTVAL>
   struct accelerator_templ_t
   {
-    inline void init (hb_face_t *face)
+    void init (hb_face_t *face)
     {
       topDict.init ();
       fontDicts.init ();
@@ -447,12 +447,12 @@ struct cff2
       }
 
       globalSubrs = &StructAtOffset<CFF2Subrs> (cff2, cff2->topDict + cff2->topDictSize);
-      varStore = &StructAtOffsetOrNull<cff2_variation_store_t> (cff2, topDict.vstoreOffset);
+      varStore = &StructAtOffsetOrNull<CFF2VariationStore> (cff2, topDict.vstoreOffset);
       charStrings = &StructAtOffsetOrNull<CFF2CharStrings> (cff2, topDict.charStringsOffset);
       fdArray = &StructAtOffsetOrNull<CFF2FDArray> (cff2, topDict.FDArrayOffset);
       fdSelect = &StructAtOffsetOrNull<CFF2FDSelect> (cff2, topDict.FDSelectOffset);
 
-      if (((varStore != &Null(cff2_variation_store_t)) && unlikely (!varStore->sanitize (&sc))) ||
+      if (((varStore != &Null(CFF2VariationStore)) && unlikely (!varStore->sanitize (&sc))) ||
 	  (charStrings == &Null(CFF2CharStrings)) || unlikely (!charStrings->sanitize (&sc)) ||
 	  (globalSubrs == &Null(CFF2Subrs)) || unlikely (!globalSubrs->sanitize (&sc)) ||
 	  (fdArray == &Null(CFF2FDArray)) || unlikely (!fdArray->sanitize (&sc)) ||
@@ -493,7 +493,7 @@ struct cff2
       }
     }
 
-    inline void fini ()
+    void fini ()
     {
       sc.end_processing ();
       fontDicts.fini_deep ();
@@ -502,25 +502,25 @@ struct cff2
       blob = nullptr;
     }
 
-    inline bool is_valid () const { return blob != nullptr; }
+    bool is_valid () const { return blob != nullptr; }
 
     protected:
-    hb_blob_t			*blob;
-    hb_sanitize_context_t	sc;
+    hb_blob_t	       *blob;
+    hb_sanitize_context_t   sc;
 
     public:
-    cff2_top_dict_values_t	topDict;
-    const CFF2Subrs		*globalSubrs;
-    const cff2_variation_store_t  *varStore;
-    const CFF2CharStrings	*charStrings;
-    const CFF2FDArray		*fdArray;
-    const CFF2FDSelect		*fdSelect;
-    unsigned int		fdCount;
+    cff2_top_dict_values_t	 topDict;
+    const CFF2Subrs	   *globalSubrs;
+    const CFF2VariationStore  *varStore;
+    const CFF2CharStrings     *charStrings;
+    const CFF2FDArray	 *fdArray;
+    const CFF2FDSelect	*fdSelect;
+    unsigned int	      fdCount;
 
-    hb_vector_t<cff2_font_dict_values_t>	fontDicts;
-    hb_vector_t<PRIVDICTVAL>	privateDicts;
+    hb_vector_t<cff2_font_dict_values_t>     fontDicts;
+    hb_vector_t<PRIVDICTVAL>  privateDicts;
 
-    unsigned int		num_glyphs;
+    unsigned int	    num_glyphs;
   };
 
   struct accelerator_t : accelerator_templ_t<cff2_private_dict_opset_t, cff2_private_dict_values_t>
@@ -532,7 +532,7 @@ struct cff2
 
   typedef accelerator_templ_t<cff2_private_dict_opset_subset_t, cff2_private_dict_values_subset_t> accelerator_subset_t;
 
-  inline bool subset (hb_subset_plan_t *plan) const
+  bool subset (hb_subset_plan_t *plan) const
   {
     hb_blob_t *cff2_prime = nullptr;
 

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -51,7 +51,7 @@ typedef FDSelect3_4_Range<HBUINT32, HBUINT16> FDSelect4_Range;
 
 struct CFF2FDSelect
 {
-  bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
+  inline bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
     TRACE_SANITIZE (this);
 
@@ -63,7 +63,7 @@ struct CFF2FDSelect
 			    u.format4.sanitize (c, fdcount))));
   }
 
-  bool serialize (hb_serialize_context_t *c, const CFF2FDSelect &src, unsigned int num_glyphs)
+  inline bool serialize (hb_serialize_context_t *c, const CFF2FDSelect &src, unsigned int num_glyphs)
   {
     TRACE_SERIALIZE (this);
     unsigned int size = src.get_size (num_glyphs);
@@ -73,10 +73,10 @@ struct CFF2FDSelect
     return_trace (true);
   }
 
-  unsigned int calculate_serialized_size (unsigned int num_glyphs) const
+  inline unsigned int calculate_serialized_size (unsigned int num_glyphs) const
   { return get_size (num_glyphs); }
 
-  unsigned int get_size (unsigned int num_glyphs) const
+  inline unsigned int get_size (unsigned int num_glyphs) const
   {
     unsigned int size = format.static_size;
     if (format == 0)
@@ -88,7 +88,7 @@ struct CFF2FDSelect
     return size;
   }
 
-  hb_codepoint_t get_fd (hb_codepoint_t glyph) const
+  inline hb_codepoint_t get_fd (hb_codepoint_t glyph) const
   {
     if (this == &Null(CFF2FDSelect))
       return 0;
@@ -110,43 +110,43 @@ struct CFF2FDSelect
   DEFINE_SIZE_MIN (2);
 };
 
-struct CFF2VariationStore
+struct cff2_variation_store_t
 {
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (likely (c->check_struct (this)) && c->check_range (&varStore, size) && varStore.sanitize (c));
   }
 
-  bool serialize (hb_serialize_context_t *c, const CFF2VariationStore *varStore)
+  inline bool serialize (hb_serialize_context_t *c, const cff2_variation_store_t *varStore)
   {
     TRACE_SERIALIZE (this);
     unsigned int size_ = varStore->get_size ();
-    CFF2VariationStore *dest = c->allocate_size<CFF2VariationStore> (size_);
+    cff2_variation_store_t *dest = c->allocate_size<cff2_variation_store_t> (size_);
     if (unlikely (dest == nullptr)) return_trace (false);
     memcpy (dest, varStore, size_);
     return_trace (true);
   }
 
-  unsigned int get_size () const { return HBUINT16::static_size + size; }
+  inline unsigned int get_size () const { return HBUINT16::static_size + size; }
 
-  HBUINT16	size;
-  VariationStore  varStore;
+  HBUINT16		size;
+  VariationStore	varStore;
 
   DEFINE_SIZE_MIN (2 + VariationStore::min_size);
 };
 
 struct cff2_top_dict_values_t : top_dict_values_t<>
 {
-  void init ()
+  inline void init ()
   {
     top_dict_values_t<>::init ();
     vstoreOffset = 0;
     FDSelectOffset = 0;
   }
-  void fini () { top_dict_values_t<>::fini (); }
+  inline void fini () { top_dict_values_t<>::fini (); }
 
-  unsigned int calculate_serialized_size () const
+  inline unsigned int calculate_serialized_size () const
   {
     unsigned int size = 0;
     for (unsigned int i = 0; i < get_count (); i++)
@@ -172,7 +172,7 @@ struct cff2_top_dict_values_t : top_dict_values_t<>
 
 struct cff2_top_dict_opset_t : top_dict_opset_t<>
 {
-  static void process_op (op_code_t op, num_interp_env_t& env, cff2_top_dict_values_t& dictval)
+  static inline void process_op (op_code_t op, num_interp_env_t& env, cff2_top_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_FontMatrix:
@@ -221,7 +221,7 @@ struct cff2_font_dict_values_t : dict_values_t<op_str_t>
 
 struct cff2_font_dict_opset_t : dict_opset_t
 {
-  static void process_op (op_code_t op, num_interp_env_t& env, cff2_font_dict_values_t& dictval)
+  static inline void process_op (op_code_t op, num_interp_env_t& env, cff2_font_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_Private:
@@ -304,7 +304,7 @@ struct cff2_priv_dict_interp_env_t : num_interp_env_t
 
 struct cff2_private_dict_opset_t : dict_opset_t
 {
-  static void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_t& dictval)
+  static inline void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_t& dictval)
   {
     num_dict_val_t val;
     val.init ();
@@ -354,7 +354,7 @@ struct cff2_private_dict_opset_t : dict_opset_t
 
 struct cff2_private_dict_opset_subset_t : dict_opset_t
 {
-  static void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_subset_t& dictval)
+  static inline void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_subset_t& dictval)
   {
     switch (op) {
       case OpCode_BlueValues:
@@ -410,7 +410,7 @@ struct cff2
 {
   static const hb_tag_t tableTag	= HB_OT_TAG_cff2;
 
-  bool sanitize (hb_sanitize_context_t *c) const
+  inline bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
     return_trace (c->check_struct (this) &&
@@ -420,7 +420,7 @@ struct cff2
   template <typename PRIVOPSET, typename PRIVDICTVAL>
   struct accelerator_templ_t
   {
-    void init (hb_face_t *face)
+    inline void init (hb_face_t *face)
     {
       topDict.init ();
       fontDicts.init ();
@@ -447,12 +447,12 @@ struct cff2
       }
 
       globalSubrs = &StructAtOffset<CFF2Subrs> (cff2, cff2->topDict + cff2->topDictSize);
-      varStore = &StructAtOffsetOrNull<CFF2VariationStore> (cff2, topDict.vstoreOffset);
+      varStore = &StructAtOffsetOrNull<cff2_variation_store_t> (cff2, topDict.vstoreOffset);
       charStrings = &StructAtOffsetOrNull<CFF2CharStrings> (cff2, topDict.charStringsOffset);
       fdArray = &StructAtOffsetOrNull<CFF2FDArray> (cff2, topDict.FDArrayOffset);
       fdSelect = &StructAtOffsetOrNull<CFF2FDSelect> (cff2, topDict.FDSelectOffset);
 
-      if (((varStore != &Null(CFF2VariationStore)) && unlikely (!varStore->sanitize (&sc))) ||
+      if (((varStore != &Null(cff2_variation_store_t)) && unlikely (!varStore->sanitize (&sc))) ||
 	  (charStrings == &Null(CFF2CharStrings)) || unlikely (!charStrings->sanitize (&sc)) ||
 	  (globalSubrs == &Null(CFF2Subrs)) || unlikely (!globalSubrs->sanitize (&sc)) ||
 	  (fdArray == &Null(CFF2FDArray)) || unlikely (!fdArray->sanitize (&sc)) ||
@@ -493,7 +493,7 @@ struct cff2
       }
     }
 
-    void fini ()
+    inline void fini ()
     {
       sc.end_processing ();
       fontDicts.fini_deep ();
@@ -502,25 +502,25 @@ struct cff2
       blob = nullptr;
     }
 
-    bool is_valid () const { return blob != nullptr; }
+    inline bool is_valid () const { return blob != nullptr; }
 
     protected:
-    hb_blob_t	       *blob;
-    hb_sanitize_context_t   sc;
+    hb_blob_t			*blob;
+    hb_sanitize_context_t	sc;
 
     public:
-    cff2_top_dict_values_t	 topDict;
-    const CFF2Subrs	   *globalSubrs;
-    const CFF2VariationStore  *varStore;
-    const CFF2CharStrings     *charStrings;
-    const CFF2FDArray	 *fdArray;
-    const CFF2FDSelect	*fdSelect;
-    unsigned int	      fdCount;
+    cff2_top_dict_values_t	topDict;
+    const CFF2Subrs		*globalSubrs;
+    const cff2_variation_store_t  *varStore;
+    const CFF2CharStrings	*charStrings;
+    const CFF2FDArray		*fdArray;
+    const CFF2FDSelect		*fdSelect;
+    unsigned int		fdCount;
 
-    hb_vector_t<cff2_font_dict_values_t>     fontDicts;
-    hb_vector_t<PRIVDICTVAL>  privateDicts;
+    hb_vector_t<cff2_font_dict_values_t>	fontDicts;
+    hb_vector_t<PRIVDICTVAL>	privateDicts;
 
-    unsigned int	    num_glyphs;
+    unsigned int		num_glyphs;
   };
 
   struct accelerator_t : accelerator_templ_t<cff2_private_dict_opset_t, cff2_private_dict_values_t>
@@ -532,7 +532,7 @@ struct cff2
 
   typedef accelerator_templ_t<cff2_private_dict_opset_subset_t, cff2_private_dict_values_subset_t> accelerator_subset_t;
 
-  bool subset (hb_subset_plan_t *plan) const
+  inline bool subset (hb_subset_plan_t *plan) const
   {
     hb_blob_t *cff2_prime = nullptr;
 

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -136,15 +136,15 @@ struct CFF2VariationStore
   DEFINE_SIZE_MIN (2 + VariationStore::min_size);
 };
 
-struct CFF2TopDictValues : TopDictValues<>
+struct cff2_top_dict_values_t : top_dict_values_t<>
 {
   void init ()
   {
-    TopDictValues<>::init ();
+    top_dict_values_t<>::init ();
     vstoreOffset = 0;
     FDSelectOffset = 0;
   }
-  void fini () { TopDictValues<>::fini (); }
+  void fini () { top_dict_values_t<>::fini (); }
 
   unsigned int calculate_serialized_size () const
   {
@@ -159,7 +159,7 @@ struct CFF2TopDictValues : TopDictValues<>
 	  size += OpCode_Size (OpCode_longintdict) + 4 + OpCode_Size (op);
 	  break;
 	default:
-	  size += TopDictValues<>::calculate_serialized_op_size (get_value (i));
+	  size += top_dict_values_t<>::calculate_serialized_op_size (get_value (i));
 	  break;
       }
     }
@@ -170,14 +170,14 @@ struct CFF2TopDictValues : TopDictValues<>
   unsigned int  FDSelectOffset;
 };
 
-struct CFF2TopDictOpSet : TopDictOpSet<>
+struct cff2_top_dict_opset_t : top_dict_opset_t<>
 {
-  static void process_op (OpCode op, NumInterpEnv& env, CFF2TopDictValues& dictval)
+  static void process_op (OpCode op, num_interp_env_t& env, cff2_top_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_FontMatrix:
 	{
-	  DictVal val;
+	  dict_val_t val;
 	  val.init ();
 	  dictval.add_op (op, env.str_ref);
 	  env.clear_args ();
@@ -204,24 +204,24 @@ struct CFF2TopDictOpSet : TopDictOpSet<>
     dictval.add_op (op, env.str_ref);
   }
 
-  typedef TopDictOpSet<> SUPER;
+  typedef top_dict_opset_t<> SUPER;
 };
 
-struct CFF2FontDictValues : DictValues<OpStr>
+struct cff2_font_dict_values_t : dict_values_t<op_str_t>
 {
   void init ()
   {
-    DictValues<OpStr>::init ();
+    dict_values_t<op_str_t>::init ();
     privateDictInfo.init ();
   }
-  void fini () { DictValues<OpStr>::fini (); }
+  void fini () { dict_values_t<op_str_t>::fini (); }
 
-  TableInfo    privateDictInfo;
+  table_info_t    privateDictInfo;
 };
 
-struct CFF2FontDictOpSet : DictOpSet
+struct cff2_font_dict_opset_t : dict_opset_t
 {
-  static void process_op (OpCode op, NumInterpEnv& env, CFF2FontDictValues& dictval)
+  static void process_op (OpCode op, num_interp_env_t& env, cff2_font_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_Private:
@@ -242,29 +242,29 @@ struct CFF2FontDictOpSet : DictOpSet
   }
 
   private:
-  typedef DictOpSet SUPER;
+  typedef dict_opset_t SUPER;
 };
 
 template <typename VAL>
-struct CFF2PrivateDictValues_Base : DictValues<VAL>
+struct cff2_private_dict_values_base_t : dict_values_t<VAL>
 {
   void init ()
   {
-    DictValues<VAL>::init ();
+    dict_values_t<VAL>::init ();
     subrsOffset = 0;
     localSubrs = &Null(CFF2Subrs);
     ivs = 0;
   }
-  void fini () { DictValues<VAL>::fini (); }
+  void fini () { dict_values_t<VAL>::fini (); }
 
   unsigned int calculate_serialized_size () const
   {
     unsigned int size = 0;
-    for (unsigned int i = 0; i < DictValues<VAL>::get_count; i++)
-      if (DictValues<VAL>::get_value (i).op == OpCode_Subrs)
+    for (unsigned int i = 0; i < dict_values_t<VAL>::get_count; i++)
+      if (dict_values_t<VAL>::get_value (i).op == OpCode_Subrs)
 	size += OpCode_Size (OpCode_shortint) + 2 + OpCode_Size (OpCode_Subrs);
       else
-	size += DictValues<VAL>::get_value (i).str.len;
+	size += dict_values_t<VAL>::get_value (i).str.len;
     return size;
   }
 
@@ -273,14 +273,14 @@ struct CFF2PrivateDictValues_Base : DictValues<VAL>
   unsigned int      ivs;
 };
 
-typedef CFF2PrivateDictValues_Base<OpStr> CFF2PrivateDictValues_Subset;
-typedef CFF2PrivateDictValues_Base<NumDictVal> CFF2PrivateDictValues;
+typedef cff2_private_dict_values_base_t<op_str_t> cff2_private_dict_values_subset_t;
+typedef cff2_private_dict_values_base_t<num_dict_val_t> cff2_private_dict_values_t;
 
-struct CFF2PrivDictInterpEnv : NumInterpEnv
+struct cff2_priv_dict_interp_env_t : num_interp_env_t
 {
   void init (const byte_str_t &str)
   {
-    NumInterpEnv::init (str);
+    num_interp_env_t::init (str);
     ivs = 0;
     seen_vsindex = false;
   }
@@ -302,11 +302,11 @@ struct CFF2PrivDictInterpEnv : NumInterpEnv
   bool	  seen_vsindex;
 };
 
-struct CFF2PrivateDictOpSet : DictOpSet
+struct cff2_private_dict_opset_t : dict_opset_t
 {
-  static void process_op (OpCode op, CFF2PrivDictInterpEnv& env, CFF2PrivateDictValues& dictval)
+  static void process_op (OpCode op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_t& dictval)
   {
-    NumDictVal val;
+    num_dict_val_t val;
     val.init ();
 
     switch (op) {
@@ -341,7 +341,7 @@ struct CFF2PrivateDictOpSet : DictOpSet
 	break;
 
       default:
-	DictOpSet::process_op (op, env);
+	dict_opset_t::process_op (op, env);
 	if (!env.argStack.is_empty ()) return;
 	break;
     }
@@ -352,9 +352,9 @@ struct CFF2PrivateDictOpSet : DictOpSet
   }
 };
 
-struct CFF2PrivateDictOpSet_Subset : DictOpSet
+struct cff2_private_dict_opset_subset_t : dict_opset_t
 {
-  static void process_op (OpCode op, CFF2PrivDictInterpEnv& env, CFF2PrivateDictValues_Subset& dictval)
+  static void process_op (OpCode op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_subset_t& dictval)
   {
     switch (op) {
       case OpCode_BlueValues:
@@ -394,11 +394,11 @@ struct CFF2PrivateDictOpSet_Subset : DictOpSet
   }
 
   private:
-  typedef DictOpSet SUPER;
+  typedef dict_opset_t SUPER;
 };
 
-typedef DictInterpreter<CFF2TopDictOpSet, CFF2TopDictValues> CFF2TopDict_Interpreter;
-typedef DictInterpreter<CFF2FontDictOpSet, CFF2FontDictValues> CFF2FontDict_Interpreter;
+typedef dict_interpreter_t<cff2_top_dict_opset_t, cff2_top_dict_values_t> cff2_top_dict_interpreter_t;
+typedef dict_interpreter_t<cff2_font_dict_opset_t, cff2_font_dict_values_t> cff2_font_dict_interpreter_t;
 
 }; /* namespace CFF */
 
@@ -440,7 +440,7 @@ struct cff2
       { /* parse top dict */
 	byte_str_t topDictStr (cff2 + cff2->topDict, cff2->topDictSize);
 	if (unlikely (!topDictStr.sanitize (&sc))) { fini (); return; }
-	CFF2TopDict_Interpreter top_interp;
+	cff2_top_dict_interpreter_t top_interp;
 	top_interp.env.init (topDictStr);
 	topDict.init ();
 	if (unlikely (!top_interp.interpret (topDict))) { fini (); return; }
@@ -471,17 +471,17 @@ struct cff2
       {
 	const byte_str_t fontDictStr = (*fdArray)[i];
 	if (unlikely (!fontDictStr.sanitize (&sc))) { fini (); return; }
-	CFF2FontDictValues  *font;
-	CFF2FontDict_Interpreter font_interp;
+	cff2_font_dict_values_t  *font;
+	cff2_font_dict_interpreter_t font_interp;
 	font_interp.env.init (fontDictStr);
 	font = fontDicts.push ();
-	if (unlikely (font == &Crap(CFF2FontDictValues))) { fini (); return; }
+	if (unlikely (font == &Crap(cff2_font_dict_values_t))) { fini (); return; }
 	font->init ();
 	if (unlikely (!font_interp.interpret (*font))) { fini (); return; }
 
 	const byte_str_t privDictStr (StructAtOffsetOrNull<UnsizedByteStr> (cff2, font->privateDictInfo.offset), font->privateDictInfo.size);
 	if (unlikely (!privDictStr.sanitize (&sc))) { fini (); return; }
-	DictInterpreter<PRIVOPSET, PRIVDICTVAL, CFF2PrivDictInterpEnv>  priv_interp;
+	dict_interpreter_t<PRIVOPSET, PRIVDICTVAL, cff2_priv_dict_interp_env_t>  priv_interp;
 	priv_interp.env.init(privDictStr);
 	privateDicts[i].init ();
 	if (unlikely (!priv_interp.interpret (privateDicts[i]))) { fini (); return; }
@@ -509,7 +509,7 @@ struct cff2
     hb_sanitize_context_t   sc;
 
     public:
-    CFF2TopDictValues	 topDict;
+    cff2_top_dict_values_t	 topDict;
     const CFF2Subrs	   *globalSubrs;
     const CFF2VariationStore  *varStore;
     const CFF2CharStrings     *charStrings;
@@ -517,20 +517,20 @@ struct cff2
     const CFF2FDSelect	*fdSelect;
     unsigned int	      fdCount;
 
-    hb_vector_t<CFF2FontDictValues>     fontDicts;
+    hb_vector_t<cff2_font_dict_values_t>     fontDicts;
     hb_vector_t<PRIVDICTVAL>  privateDicts;
 
     unsigned int	    num_glyphs;
   };
 
-  struct accelerator_t : accelerator_templ_t<CFF2PrivateDictOpSet, CFF2PrivateDictValues>
+  struct accelerator_t : accelerator_templ_t<cff2_private_dict_opset_t, cff2_private_dict_values_t>
   {
     HB_INTERNAL bool get_extents (hb_font_t *font,
 				  hb_codepoint_t glyph,
 				  hb_glyph_extents_t *extents) const;
   };
 
-  typedef accelerator_templ_t<CFF2PrivateDictOpSet_Subset, CFF2PrivateDictValues_Subset> accelerator_subset_t;
+  typedef accelerator_templ_t<cff2_private_dict_opset_subset_t, cff2_private_dict_values_subset_t> accelerator_subset_t;
 
   bool subset (hb_subset_plan_t *plan) const
   {

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -505,22 +505,22 @@ struct cff2
     bool is_valid () const { return blob != nullptr; }
 
     protected:
-    hb_blob_t	       *blob;
-    hb_sanitize_context_t   sc;
+    hb_blob_t			*blob;
+    hb_sanitize_context_t	sc;
 
     public:
-    cff2_top_dict_values_t	 topDict;
-    const CFF2Subrs	   *globalSubrs;
-    const CFF2VariationStore  *varStore;
-    const CFF2CharStrings     *charStrings;
-    const CFF2FDArray	 *fdArray;
-    const CFF2FDSelect	*fdSelect;
-    unsigned int	      fdCount;
+    cff2_top_dict_values_t	topDict;
+    const CFF2Subrs		*globalSubrs;
+    const CFF2VariationStore	*varStore;
+    const CFF2CharStrings	*charStrings;
+    const CFF2FDArray		*fdArray;
+    const CFF2FDSelect		*fdSelect;
+    unsigned int		fdCount;
 
     hb_vector_t<cff2_font_dict_values_t>     fontDicts;
     hb_vector_t<PRIVDICTVAL>  privateDicts;
 
-    unsigned int	    num_glyphs;
+    unsigned int	      num_glyphs;
   };
 
   struct accelerator_t : accelerator_templ_t<cff2_private_dict_opset_t, cff2_private_dict_values_t>

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -151,7 +151,7 @@ struct cff2_top_dict_values_t : top_dict_values_t<>
     unsigned int size = 0;
     for (unsigned int i = 0; i < get_count (); i++)
     {
-      OpCode op = get_value (i).op;
+      op_code_t op = get_value (i).op;
       switch (op)
       {
 	case OpCode_vstore:
@@ -172,7 +172,7 @@ struct cff2_top_dict_values_t : top_dict_values_t<>
 
 struct cff2_top_dict_opset_t : top_dict_opset_t<>
 {
-  static void process_op (OpCode op, num_interp_env_t& env, cff2_top_dict_values_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff2_top_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_FontMatrix:
@@ -221,7 +221,7 @@ struct cff2_font_dict_values_t : dict_values_t<op_str_t>
 
 struct cff2_font_dict_opset_t : dict_opset_t
 {
-  static void process_op (OpCode op, num_interp_env_t& env, cff2_font_dict_values_t& dictval)
+  static void process_op (op_code_t op, num_interp_env_t& env, cff2_font_dict_values_t& dictval)
   {
     switch (op) {
       case OpCode_Private:
@@ -304,7 +304,7 @@ struct cff2_priv_dict_interp_env_t : num_interp_env_t
 
 struct cff2_private_dict_opset_t : dict_opset_t
 {
-  static void process_op (OpCode op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_t& dictval)
+  static void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_t& dictval)
   {
     num_dict_val_t val;
     val.init ();
@@ -354,7 +354,7 @@ struct cff2_private_dict_opset_t : dict_opset_t
 
 struct cff2_private_dict_opset_subset_t : dict_opset_t
 {
-  static void process_op (OpCode op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_subset_t& dictval)
+  static void process_op (op_code_t op, cff2_priv_dict_interp_env_t& env, cff2_private_dict_values_subset_t& dictval)
   {
     switch (op) {
       case OpCode_BlueValues:

--- a/src/hb-subset-cff-common.cc
+++ b/src/hb-subset-cff-common.cc
@@ -49,8 +49,8 @@ hb_plan_subset_cff_fdselect (const hb_vector_t<hb_codepoint_t> &glyphs,
 			    unsigned int &subset_fd_count /* OUT */,
 			    unsigned int &subset_fdselect_size /* OUT */,
 			    unsigned int &subset_fdselect_format /* OUT */,
-			    hb_vector_t<code_pair> &fdselect_ranges /* OUT */,
-			    Remap &fdmap /* OUT */)
+			    hb_vector_t<code_pair_t> &fdselect_ranges /* OUT */,
+			    remap_t &fdmap /* OUT */)
 {
   subset_fd_count = 0;
   subset_fdselect_size = 0;
@@ -76,7 +76,7 @@ hb_plan_subset_cff_fdselect (const hb_vector_t<hb_codepoint_t> &glyphs,
       {
 	num_ranges++;
 	prev_fd = fd;
-	code_pair pair = { fd, i };
+	code_pair_t pair = { fd, i };
 	fdselect_ranges.push (pair);
       }
     }
@@ -148,7 +148,7 @@ serialize_fdselect_3_4 (hb_serialize_context_t *c,
 			  const unsigned int num_glyphs,
 			  const FDSelect &src,
 			  unsigned int size,
-			  const hb_vector_t<code_pair> &fdselect_ranges)
+			  const hb_vector_t<code_pair_t> &fdselect_ranges)
 {
   TRACE_SERIALIZE (this);
   FDSELECT3_4 *p = c->allocate_size<FDSELECT3_4> (size);
@@ -174,7 +174,7 @@ hb_serialize_cff_fdselect (hb_serialize_context_t *c,
 			  unsigned int fd_count,
 			  unsigned int fdselect_format,
 			  unsigned int size,
-			  const hb_vector_t<code_pair> &fdselect_ranges)
+			  const hb_vector_t<code_pair_t> &fdselect_ranges)
 {
   TRACE_SERIALIZE (this);
   FDSelect  *p = c->allocate_min<FDSelect> ();

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -403,13 +403,13 @@ struct ParsedCStr : ParsedValues<ParsedCSOp>
     has_prefix_ = false;
   }
 
-  void add_op (OpCode op, const byte_str_ref_t& substr)
+  void add_op (OpCode op, const byte_str_ref_t& str_ref)
   {
     if (!is_parsed ())
-      SUPER::add_op (op, substr);
+      SUPER::add_op (op, str_ref);
   }
 
-  void add_call_op (OpCode op, const byte_str_ref_t& substr, unsigned int subr_num)
+  void add_call_op (OpCode op, const byte_str_ref_t& str_ref, unsigned int subr_num)
   {
     if (!is_parsed ())
     {
@@ -419,7 +419,7 @@ struct ParsedCStr : ParsedValues<ParsedCSOp>
 
       ParsedCSOp val;
       val.init (subr_num);
-      SUPER::add_op (op, substr, val);
+      SUPER::add_op (op, str_ref, val);
     }
   }
 

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -454,8 +454,8 @@ struct parsed_cs_str_t : parsed_values_t<parsed_cs_op_t>
   bool    hint_dropped;
   bool    vsindex_dropped;
   bool    has_prefix_;
-  op_code_t  prefix_op_;
-  number_t  prefix_num_;
+  op_code_t	prefix_op_;
+  number_t 	prefix_num_;
 
   private:
   typedef parsed_values_t<parsed_cs_op_t> SUPER;
@@ -530,11 +530,11 @@ struct subr_subset_param_t
       env.set_error ();
   }
 
-  parsed_cs_str_t    *current_parsed_str;
+  parsed_cs_str_t	*current_parsed_str;
 
-  parsed_cs_str_t    *parsed_charstring;
-  parsed_cs_str_vec_t   *parsed_global_subrs;
-  parsed_cs_str_vec_t   *parsed_local_subrs;
+  parsed_cs_str_t	*parsed_charstring;
+  parsed_cs_str_vec_t	*parsed_global_subrs;
+  parsed_cs_str_vec_t	*parsed_local_subrs;
   hb_set_t      *global_closure;
   hb_set_t      *local_closure;
   bool	  drop_hints;

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -37,18 +37,18 @@ namespace CFF {
 /* Used for writing a temporary charstring */
 struct str_encoder_t
 {
-  inline str_encoder_t (str_buff_t &buff_)
+  str_encoder_t (str_buff_t &buff_)
     : buff (buff_), error (false) {}
 
-  inline void reset () { buff.resize (0); }
+  void reset () { buff.resize (0); }
 
-  inline void encode_byte (unsigned char b)
+  void encode_byte (unsigned char b)
   {
     if (unlikely (buff.push (b) == &Crap(unsigned char)))
       set_error ();
   }
 
-  inline void encode_int (int v)
+  void encode_int (int v)
   {
     if ((-1131 <= v) && (v <= 1131))
     {
@@ -79,7 +79,7 @@ struct str_encoder_t
     }
   }
 
-  inline void encode_num (const number_t& n)
+  void encode_num (const number_t& n)
   {
     if (n.in_int_range ())
     {
@@ -96,7 +96,7 @@ struct str_encoder_t
     }
   }
 
-  inline void encode_op (op_code_t op)
+  void encode_op (op_code_t op)
   {
     if (Is_OpCode_ESC (op))
     {
@@ -107,7 +107,7 @@ struct str_encoder_t
       encode_byte (op);
   }
 
-  inline void copy_str (const byte_str_t &str)
+  void copy_str (const byte_str_t &str)
   {
     unsigned int  offset = buff.len;
     buff.resize (offset + str.len);
@@ -119,17 +119,17 @@ struct str_encoder_t
     memcpy (&buff[offset], &str[0], str.len);
   }
 
-  inline bool is_error () const { return error; }
+  bool is_error () const { return error; }
 
   protected:
-  inline void set_error () { error = true; }
+  void set_error () { error = true; }
 
   str_buff_t &buff;
   bool    error;
 };
 
 struct cff_sub_table_offsets_t {
-  inline cff_sub_table_offsets_t () : privateDictsOffset (0)
+  cff_sub_table_offsets_t () : privateDictsOffset (0)
   {
     topDictInfo.init ();
     FDSelectInfo.init ();
@@ -139,23 +139,23 @@ struct cff_sub_table_offsets_t {
     localSubrsInfos.init ();
   }
 
-  inline ~cff_sub_table_offsets_t () { localSubrsInfos.fini (); }
+  ~cff_sub_table_offsets_t () { localSubrsInfos.fini (); }
 
-  table_info_t	topDictInfo;
-  table_info_t	FDSelectInfo;
-  table_info_t	FDArrayInfo;
-  table_info_t	charStringsInfo;
-  unsigned int	privateDictsOffset;
-  table_info_t	globalSubrsInfo;
+  table_info_t     topDictInfo;
+  table_info_t     FDSelectInfo;
+  table_info_t     FDArrayInfo;
+  table_info_t     charStringsInfo;
+  unsigned int  privateDictsOffset;
+  table_info_t     globalSubrsInfo;
   hb_vector_t<table_info_t>  localSubrsInfos;
 };
 
 template <typename OPSTR=op_str_t>
 struct cff_top_dict_op_serializer_t : op_serializer_t
 {
-  inline bool serialize (hb_serialize_context_t *c,
-			const OPSTR &opstr,
-			const cff_sub_table_offsets_t &offsets) const
+  bool serialize (hb_serialize_context_t *c,
+		  const OPSTR &opstr,
+		  const cff_sub_table_offsets_t &offsets) const
   {
     TRACE_SERIALIZE (this);
 
@@ -176,7 +176,7 @@ struct cff_top_dict_op_serializer_t : op_serializer_t
     return_trace (true);
   }
 
-  inline unsigned int calculate_serialized_size (const OPSTR &opstr) const
+  unsigned int calculate_serialized_size (const OPSTR &opstr) const
   {
     switch (opstr.op)
     {
@@ -193,9 +193,9 @@ struct cff_top_dict_op_serializer_t : op_serializer_t
 
 struct cff_font_dict_op_serializer_t : op_serializer_t
 {
-  inline bool serialize (hb_serialize_context_t *c,
-			const op_str_t &opstr,
-			const table_info_t &privateDictInfo) const
+  bool serialize (hb_serialize_context_t *c,
+		  const op_str_t &opstr,
+		  const table_info_t &privateDictInfo) const
   {
     TRACE_SERIALIZE (this);
 
@@ -222,7 +222,7 @@ struct cff_font_dict_op_serializer_t : op_serializer_t
     return_trace (true);
   }
 
-  inline unsigned int calculate_serialized_size (const op_str_t &opstr) const
+  unsigned int calculate_serialized_size (const op_str_t &opstr) const
   {
     if (opstr.op == OpCode_Private)
       return OpCode_Size (OpCode_longintdict) + 4 + OpCode_Size (OpCode_shortint) + 2 + OpCode_Size (OpCode_Private);
@@ -233,12 +233,12 @@ struct cff_font_dict_op_serializer_t : op_serializer_t
 
 struct cff_private_dict_op_serializer_t : op_serializer_t
 {
-  inline cff_private_dict_op_serializer_t (bool desubroutinize_, bool drop_hints_)
+  cff_private_dict_op_serializer_t (bool desubroutinize_, bool drop_hints_)
     : desubroutinize (desubroutinize_), drop_hints (drop_hints_) {}
 
-  inline bool serialize (hb_serialize_context_t *c,
-			const op_str_t &opstr,
-			const unsigned int subrsOffset) const
+  bool serialize (hb_serialize_context_t *c,
+		  const op_str_t &opstr,
+		  const unsigned int subrsOffset) const
   {
     TRACE_SERIALIZE (this);
 
@@ -255,8 +255,8 @@ struct cff_private_dict_op_serializer_t : op_serializer_t
       return_trace (copy_opstr (c, opstr));
   }
 
-  inline unsigned int calculate_serialized_size (const op_str_t &opstr,
-						bool has_localsubr=true) const
+  unsigned int calculate_serialized_size (const op_str_t &opstr,
+					  bool has_localsubr=true) const
   {
     if (drop_hints && dict_opset_t::is_hint_op (opstr.op))
       return 0;
@@ -278,22 +278,22 @@ struct cff_private_dict_op_serializer_t : op_serializer_t
 
 struct flatten_param_t
 {
-  str_buff_t	&flatStr;
-  bool		drop_hints;
+  str_buff_t     &flatStr;
+  bool	drop_hints;
 };
 
 template <typename ACC, typename ENV, typename OPSET>
 struct subr_flattener_t
 {
-  inline subr_flattener_t (const ACC &acc_,
-			  const hb_vector_t<hb_codepoint_t> &glyphs_,
-			  bool drop_hints_)
+  subr_flattener_t (const ACC &acc_,
+			const hb_vector_t<hb_codepoint_t> &glyphs_,
+			bool drop_hints_)
     : acc (acc_),
       glyphs (glyphs_),
       drop_hints (drop_hints_)
   {}
 
-  inline bool flatten (str_buff_vec_t &flat_charstrings)
+  bool flatten (str_buff_vec_t &flat_charstrings)
   {
     if (!flat_charstrings.resize (glyphs.len))
       return false;
@@ -322,10 +322,10 @@ struct subr_flattener_t
 
 struct subr_closures_t
 {
-  inline subr_closures_t () : valid (false), global_closure (nullptr)
+  subr_closures_t () : valid (false), global_closure (nullptr)
   { local_closures.init (); }
 
-  inline void init (unsigned int fd_count)
+  void init (unsigned int fd_count)
   {
     valid = true;
     global_closure = hb_set_create ();
@@ -342,7 +342,7 @@ struct subr_closures_t
     }
   }
 
-  inline void fini ()
+  void fini ()
   {
     hb_set_destroy (global_closure);
     for (unsigned int i = 0; i < local_closures.len; i++)
@@ -365,7 +365,7 @@ struct subr_closures_t
 
 struct parsed_cs_op_t : op_str_t
 {
-  inline void init (unsigned int subr_num_ = 0)
+  void init (unsigned int subr_num_ = 0)
   {
     op_str_t::init ();
     subr_num = subr_num_;
@@ -374,16 +374,16 @@ struct parsed_cs_op_t : op_str_t
     skip_flag = false;
   }
 
-  inline void fini () { op_str_t::fini (); }
+  void fini () { op_str_t::fini (); }
 
-  inline bool for_drop () const { return drop_flag; }
-  inline void set_drop ()       { if (!for_keep ()) drop_flag = true; }
+  bool for_drop () const { return drop_flag; }
+  void set_drop ()       { if (!for_keep ()) drop_flag = true; }
 
-  inline bool for_keep () const { return keep_flag; }
-  inline void set_keep ()       { keep_flag = true; }
+  bool for_keep () const { return keep_flag; }
+  void set_keep ()       { keep_flag = true; }
 
-  inline bool for_skip () const { return skip_flag; }
-  inline void set_skip ()       { skip_flag = true; }
+  bool for_skip () const { return skip_flag; }
+  void set_skip ()       { skip_flag = true; }
 
   unsigned int  subr_num;
 

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -44,7 +44,7 @@ struct StrEncoder
 
   void encode_byte (unsigned char b)
   {
-    if (unlikely (buff.push ((const char)b) == &Crap(char)))
+    if (unlikely (buff.push (b) == &Crap(unsigned char)))
       set_error ();
   }
 
@@ -107,7 +107,7 @@ struct StrEncoder
       encode_byte (op);
   }
 
-  void copy_str (const ByteStr &str)
+  void copy_str (const byte_str_t &str)
   {
     unsigned int  offset = buff.len;
     buff.resize (offset + str.len);
@@ -116,7 +116,7 @@ struct StrEncoder
       set_error ();
       return;
     }
-    memcpy (&buff[offset], &str.str[0], str.len);
+    memcpy (&buff[offset], &str[0], str.len);
   }
 
   bool is_error () const { return error; }
@@ -217,7 +217,7 @@ struct CFFFontDict_OpSerializer : OpSerializer
     {
       HBUINT8 *d = c->allocate_size<HBUINT8> (opstr.str.len);
       if (unlikely (d == nullptr)) return_trace (false);
-      memcpy (d, &opstr.str.str[0], opstr.str.len);
+      memcpy (d, &opstr.str[0], opstr.str.len);
     }
     return_trace (true);
   }
@@ -302,7 +302,7 @@ struct SubrFlattener
     for (unsigned int i = 0; i < glyphs.len; i++)
     {
       hb_codepoint_t  glyph = glyphs[i];
-      const ByteStr str = (*acc.charStrings)[glyph];
+      const byte_str_t str = (*acc.charStrings)[glyph];
       unsigned int fd = acc.fdSelect->get_fd (glyph);
       if (unlikely (fd >= acc.fdCount))
       	return false;
@@ -403,13 +403,13 @@ struct ParsedCStr : ParsedValues<ParsedCSOp>
     has_prefix_ = false;
   }
 
-  void add_op (OpCode op, const SubByteStr& substr)
+  void add_op (OpCode op, const byte_str_ref_t& substr)
   {
     if (!is_parsed ())
       SUPER::add_op (op, substr);
   }
 
-  void add_call_op (OpCode op, const SubByteStr& substr, unsigned int subr_num)
+  void add_call_op (OpCode op, const byte_str_ref_t& substr, unsigned int subr_num)
   {
     if (!is_parsed ())
     {
@@ -666,7 +666,7 @@ struct SubrSubsetter
     for (unsigned int i = 0; i < glyphs.len; i++)
     {
       hb_codepoint_t  glyph = glyphs[i];
-      const ByteStr str = (*acc.charStrings)[glyph];
+      const byte_str_t str = (*acc.charStrings)[glyph];
       unsigned int fd = acc.fdSelect->get_fd (glyph);
       if (unlikely (fd >= acc.fdCount))
       	return false;

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -37,18 +37,18 @@ namespace CFF {
 /* Used for writing a temporary charstring */
 struct str_encoder_t
 {
-  str_encoder_t (str_buff_t &buff_)
+  inline str_encoder_t (str_buff_t &buff_)
     : buff (buff_), error (false) {}
 
-  void reset () { buff.resize (0); }
+  inline void reset () { buff.resize (0); }
 
-  void encode_byte (unsigned char b)
+  inline void encode_byte (unsigned char b)
   {
     if (unlikely (buff.push (b) == &Crap(unsigned char)))
       set_error ();
   }
 
-  void encode_int (int v)
+  inline void encode_int (int v)
   {
     if ((-1131 <= v) && (v <= 1131))
     {
@@ -79,7 +79,7 @@ struct str_encoder_t
     }
   }
 
-  void encode_num (const number_t& n)
+  inline void encode_num (const number_t& n)
   {
     if (n.in_int_range ())
     {
@@ -96,7 +96,7 @@ struct str_encoder_t
     }
   }
 
-  void encode_op (op_code_t op)
+  inline void encode_op (op_code_t op)
   {
     if (Is_OpCode_ESC (op))
     {
@@ -107,7 +107,7 @@ struct str_encoder_t
       encode_byte (op);
   }
 
-  void copy_str (const byte_str_t &str)
+  inline void copy_str (const byte_str_t &str)
   {
     unsigned int  offset = buff.len;
     buff.resize (offset + str.len);
@@ -119,17 +119,17 @@ struct str_encoder_t
     memcpy (&buff[offset], &str[0], str.len);
   }
 
-  bool is_error () const { return error; }
+  inline bool is_error () const { return error; }
 
   protected:
-  void set_error () { error = true; }
+  inline void set_error () { error = true; }
 
   str_buff_t &buff;
   bool    error;
 };
 
 struct cff_sub_table_offsets_t {
-  cff_sub_table_offsets_t () : privateDictsOffset (0)
+  inline cff_sub_table_offsets_t () : privateDictsOffset (0)
   {
     topDictInfo.init ();
     FDSelectInfo.init ();
@@ -139,23 +139,23 @@ struct cff_sub_table_offsets_t {
     localSubrsInfos.init ();
   }
 
-  ~cff_sub_table_offsets_t () { localSubrsInfos.fini (); }
+  inline ~cff_sub_table_offsets_t () { localSubrsInfos.fini (); }
 
-  table_info_t     topDictInfo;
-  table_info_t     FDSelectInfo;
-  table_info_t     FDArrayInfo;
-  table_info_t     charStringsInfo;
-  unsigned int  privateDictsOffset;
-  table_info_t     globalSubrsInfo;
+  table_info_t	topDictInfo;
+  table_info_t	FDSelectInfo;
+  table_info_t	FDArrayInfo;
+  table_info_t	charStringsInfo;
+  unsigned int	privateDictsOffset;
+  table_info_t	globalSubrsInfo;
   hb_vector_t<table_info_t>  localSubrsInfos;
 };
 
 template <typename OPSTR=op_str_t>
 struct cff_top_dict_op_serializer_t : op_serializer_t
 {
-  bool serialize (hb_serialize_context_t *c,
-		  const OPSTR &opstr,
-		  const cff_sub_table_offsets_t &offsets) const
+  inline bool serialize (hb_serialize_context_t *c,
+			const OPSTR &opstr,
+			const cff_sub_table_offsets_t &offsets) const
   {
     TRACE_SERIALIZE (this);
 
@@ -176,7 +176,7 @@ struct cff_top_dict_op_serializer_t : op_serializer_t
     return_trace (true);
   }
 
-  unsigned int calculate_serialized_size (const OPSTR &opstr) const
+  inline unsigned int calculate_serialized_size (const OPSTR &opstr) const
   {
     switch (opstr.op)
     {
@@ -193,9 +193,9 @@ struct cff_top_dict_op_serializer_t : op_serializer_t
 
 struct cff_font_dict_op_serializer_t : op_serializer_t
 {
-  bool serialize (hb_serialize_context_t *c,
-		  const op_str_t &opstr,
-		  const table_info_t &privateDictInfo) const
+  inline bool serialize (hb_serialize_context_t *c,
+			const op_str_t &opstr,
+			const table_info_t &privateDictInfo) const
   {
     TRACE_SERIALIZE (this);
 
@@ -222,7 +222,7 @@ struct cff_font_dict_op_serializer_t : op_serializer_t
     return_trace (true);
   }
 
-  unsigned int calculate_serialized_size (const op_str_t &opstr) const
+  inline unsigned int calculate_serialized_size (const op_str_t &opstr) const
   {
     if (opstr.op == OpCode_Private)
       return OpCode_Size (OpCode_longintdict) + 4 + OpCode_Size (OpCode_shortint) + 2 + OpCode_Size (OpCode_Private);
@@ -233,12 +233,12 @@ struct cff_font_dict_op_serializer_t : op_serializer_t
 
 struct cff_private_dict_op_serializer_t : op_serializer_t
 {
-  cff_private_dict_op_serializer_t (bool desubroutinize_, bool drop_hints_)
+  inline cff_private_dict_op_serializer_t (bool desubroutinize_, bool drop_hints_)
     : desubroutinize (desubroutinize_), drop_hints (drop_hints_) {}
 
-  bool serialize (hb_serialize_context_t *c,
-		  const op_str_t &opstr,
-		  const unsigned int subrsOffset) const
+  inline bool serialize (hb_serialize_context_t *c,
+			const op_str_t &opstr,
+			const unsigned int subrsOffset) const
   {
     TRACE_SERIALIZE (this);
 
@@ -255,8 +255,8 @@ struct cff_private_dict_op_serializer_t : op_serializer_t
       return_trace (copy_opstr (c, opstr));
   }
 
-  unsigned int calculate_serialized_size (const op_str_t &opstr,
-					  bool has_localsubr=true) const
+  inline unsigned int calculate_serialized_size (const op_str_t &opstr,
+						bool has_localsubr=true) const
   {
     if (drop_hints && dict_opset_t::is_hint_op (opstr.op))
       return 0;
@@ -278,22 +278,22 @@ struct cff_private_dict_op_serializer_t : op_serializer_t
 
 struct flatten_param_t
 {
-  str_buff_t     &flatStr;
-  bool	drop_hints;
+  str_buff_t	&flatStr;
+  bool		drop_hints;
 };
 
 template <typename ACC, typename ENV, typename OPSET>
 struct subr_flattener_t
 {
-  subr_flattener_t (const ACC &acc_,
-			const hb_vector_t<hb_codepoint_t> &glyphs_,
-			bool drop_hints_)
+  inline subr_flattener_t (const ACC &acc_,
+			  const hb_vector_t<hb_codepoint_t> &glyphs_,
+			  bool drop_hints_)
     : acc (acc_),
       glyphs (glyphs_),
       drop_hints (drop_hints_)
   {}
 
-  bool flatten (str_buff_vec_t &flat_charstrings)
+  inline bool flatten (str_buff_vec_t &flat_charstrings)
   {
     if (!flat_charstrings.resize (glyphs.len))
       return false;
@@ -322,10 +322,10 @@ struct subr_flattener_t
 
 struct subr_closures_t
 {
-  subr_closures_t () : valid (false), global_closure (nullptr)
+  inline subr_closures_t () : valid (false), global_closure (nullptr)
   { local_closures.init (); }
 
-  void init (unsigned int fd_count)
+  inline void init (unsigned int fd_count)
   {
     valid = true;
     global_closure = hb_set_create ();
@@ -342,7 +342,7 @@ struct subr_closures_t
     }
   }
 
-  void fini ()
+  inline void fini ()
   {
     hb_set_destroy (global_closure);
     for (unsigned int i = 0; i < local_closures.len; i++)
@@ -365,7 +365,7 @@ struct subr_closures_t
 
 struct parsed_cs_op_t : op_str_t
 {
-  void init (unsigned int subr_num_ = 0)
+  inline void init (unsigned int subr_num_ = 0)
   {
     op_str_t::init ();
     subr_num = subr_num_;
@@ -374,16 +374,16 @@ struct parsed_cs_op_t : op_str_t
     skip_flag = false;
   }
 
-  void fini () { op_str_t::fini (); }
+  inline void fini () { op_str_t::fini (); }
 
-  bool for_drop () const { return drop_flag; }
-  void set_drop ()       { if (!for_keep ()) drop_flag = true; }
+  inline bool for_drop () const { return drop_flag; }
+  inline void set_drop ()       { if (!for_keep ()) drop_flag = true; }
 
-  bool for_keep () const { return keep_flag; }
-  void set_keep ()       { keep_flag = true; }
+  inline bool for_keep () const { return keep_flag; }
+  inline void set_keep ()       { keep_flag = true; }
 
-  bool for_skip () const { return skip_flag; }
-  void set_skip ()       { skip_flag = true; }
+  inline bool for_skip () const { return skip_flag; }
+  inline void set_skip ()       { skip_flag = true; }
 
   unsigned int  subr_num;
 

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -96,7 +96,7 @@ struct str_encoder_t
     }
   }
 
-  void encode_op (OpCode op)
+  void encode_op (op_code_t op)
   {
     if (Is_OpCode_ESC (op))
     {
@@ -403,13 +403,13 @@ struct parsed_cs_str_t : parsed_values_t<parsed_cs_op_t>
     has_prefix_ = false;
   }
 
-  void add_op (OpCode op, const byte_str_ref_t& str_ref)
+  void add_op (op_code_t op, const byte_str_ref_t& str_ref)
   {
     if (!is_parsed ())
       SUPER::add_op (op, str_ref);
   }
 
-  void add_call_op (OpCode op, const byte_str_ref_t& str_ref, unsigned int subr_num)
+  void add_call_op (op_code_t op, const byte_str_ref_t& str_ref, unsigned int subr_num)
   {
     if (!is_parsed ())
     {
@@ -423,7 +423,7 @@ struct parsed_cs_str_t : parsed_values_t<parsed_cs_op_t>
     }
   }
 
-  void set_prefix (const number_t &num, OpCode op = OpCode_Invalid)
+  void set_prefix (const number_t &num, op_code_t op = OpCode_Invalid)
   {
     has_prefix_ = true;
     prefix_op_ = op;
@@ -446,7 +446,7 @@ struct parsed_cs_str_t : parsed_values_t<parsed_cs_op_t>
   void set_vsindex_dropped ()      { vsindex_dropped = true; }
 
   bool has_prefix () const          { return has_prefix_; }
-  OpCode prefix_op () const         { return prefix_op_; }
+  op_code_t prefix_op () const         { return prefix_op_; }
   const number_t &prefix_num () const { return prefix_num_; }
 
   protected:
@@ -454,7 +454,7 @@ struct parsed_cs_str_t : parsed_values_t<parsed_cs_op_t>
   bool    hint_dropped;
   bool    vsindex_dropped;
   bool    has_prefix_;
-  OpCode  prefix_op_;
+  op_code_t  prefix_op_;
   number_t  prefix_num_;
 
   private:

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -130,7 +130,7 @@ struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dic
   {
     TRACE_SERIALIZE (this);
 
-    OpCode op = opstr.op;
+    op_code_t op = opstr.op;
     switch (op)
     {
       case OpCode_charset:
@@ -183,7 +183,7 @@ struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dic
 
   unsigned int calculate_serialized_size (const cff1_top_dict_val_t &opstr) const
   {
-    OpCode op = opstr.op;
+    op_code_t op = opstr.op;
     switch (op)
     {
       case OpCode_charset:
@@ -261,7 +261,7 @@ struct cff1_font_dict_op_serializer_t : cff_font_dict_op_serializer_t
 
 struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatten_param_t>
 {
-  static void flush_args_and_op (OpCode op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_args_and_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     if (env.arg_start > 0)
       flush_width (env, param);
@@ -295,7 +295,7 @@ struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatte
     SUPER::flush_args (env, param);
   }
 
-  static void flush_op (OpCode op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     str_encoder_t  encoder (param.flatStr);
     encoder.encode_op (op);
@@ -308,7 +308,7 @@ struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatte
     encoder.encode_num (env.width);
   }
 
-  static void flush_hintmask (OpCode op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_hintmask (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     SUPER::flush_hintmask (op, env, param);
     if (!param.drop_hints)
@@ -344,7 +344,7 @@ struct range_list_t : hb_vector_t<code_pair_t>
 
 struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t, subr_subset_param_t>
 {
-  static void process_op (OpCode op, cff1_cs_interp_env_t &env, subr_subset_param_t& param)
+  static void process_op (op_code_t op, cff1_cs_interp_env_t &env, subr_subset_param_t& param)
   {
     switch (op) {
 
@@ -377,7 +377,7 @@ struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t
   }
 
   protected:
-  static void process_call_subr (OpCode op, CSType type,
+  static void process_call_subr (op_code_t op, cs_type_t type,
 				 cff1_cs_interp_env_t &env, subr_subset_param_t& param,
 				 cff1_biased_subrs_t& subrs, hb_set_t *closure)
   {

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -36,7 +36,7 @@ using namespace CFF;
 
 struct remap_sid_t : remap_t
 {
-  unsigned int add (unsigned int sid)
+  inline unsigned int add (unsigned int sid)
   {
     if ((sid != CFF_UNDEF_SID) && !is_std_std (sid))
       return offset_sid (remap_t::add (unoffset_sid (sid)));
@@ -44,7 +44,7 @@ struct remap_sid_t : remap_t
       return sid;
   }
 
-  unsigned int operator[] (unsigned int sid) const
+  inline unsigned int operator[] (unsigned int sid) const
   {
     if (is_std_std (sid) || (sid == CFF_UNDEF_SID))
       return sid;
@@ -54,14 +54,14 @@ struct remap_sid_t : remap_t
 
   static const unsigned int num_std_strings = 391;
 
-  static bool is_std_std (unsigned int sid) { return sid < num_std_strings; }
-  static unsigned int offset_sid (unsigned int sid) { return sid + num_std_strings; }
-  static unsigned int unoffset_sid (unsigned int sid) { return sid - num_std_strings; }
+  static inline bool is_std_std (unsigned int sid) { return sid < num_std_strings; }
+  static inline unsigned int offset_sid (unsigned int sid) { return sid + num_std_strings; }
+  static inline unsigned int unoffset_sid (unsigned int sid) { return sid - num_std_strings; }
 };
 
 struct cff1_sub_table_offsets_t : cff_sub_table_offsets_t
 {
-  cff1_sub_table_offsets_t ()
+  inline cff1_sub_table_offsets_t ()
     : cff_sub_table_offsets_t (),
       nameIndexOffset (0),
       encodingOffset (0)
@@ -71,35 +71,35 @@ struct cff1_sub_table_offsets_t : cff_sub_table_offsets_t
     privateDictInfo.init ();
   }
 
-  unsigned int  nameIndexOffset;
-  table_info_t     stringIndexInfo;
-  unsigned int  encodingOffset;
-  table_info_t     charsetInfo;
-  table_info_t     privateDictInfo;
+  unsigned int	nameIndexOffset;
+  table_info_t	stringIndexInfo;
+  unsigned int	encodingOffset;
+  table_info_t	charsetInfo;
+  table_info_t	privateDictInfo;
 };
 
 /* a copy of a parsed out cff1_top_dict_values_t augmented with additional operators */
 struct cff1_top_dict_values_mod_t : cff1_top_dict_values_t
 {
-  void init (const cff1_top_dict_values_t *base_= &Null(cff1_top_dict_values_t))
+  inline void init (const cff1_top_dict_values_t *base_= &Null(cff1_top_dict_values_t))
   {
     SUPER::init ();
     base = base_;
   }
 
-  void fini () { SUPER::fini (); }
+  inline void fini () { SUPER::fini (); }
 
-  unsigned get_count () const { return base->get_count () + SUPER::get_count (); }
-  const cff1_top_dict_val_t &get_value (unsigned int i) const
+  inline unsigned get_count () const { return base->get_count () + SUPER::get_count (); }
+  inline const cff1_top_dict_val_t &get_value (unsigned int i) const
   {
     if (i < base->get_count ())
       return (*base)[i];
     else
       return SUPER::values[i - base->get_count ()];
   }
-  const cff1_top_dict_val_t &operator [] (unsigned int i) const { return get_value (i); }
+  inline const cff1_top_dict_val_t &operator [] (unsigned int i) const { return get_value (i); }
 
-  void reassignSIDs (const remap_sid_t& sidmap)
+  inline void reassignSIDs (const remap_sid_t& sidmap)
   {
     for (unsigned int i = 0; i < name_dict_values_t::ValCount; i++)
       nameSIDs[i] = sidmap[base->nameSIDs[i]];
@@ -113,7 +113,7 @@ struct cff1_top_dict_values_mod_t : cff1_top_dict_values_t
 struct top_dict_modifiers_t
 {
   top_dict_modifiers_t (const cff1_sub_table_offsets_t &offsets_,
-			   const unsigned int (&nameSIDs_)[name_dict_values_t::ValCount])
+			const unsigned int (&nameSIDs_)[name_dict_values_t::ValCount])
     : offsets (offsets_),
       nameSIDs (nameSIDs_)
   {}
@@ -124,9 +124,9 @@ struct top_dict_modifiers_t
 
 struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dict_val_t>
 {
-  bool serialize (hb_serialize_context_t *c,
-		  const cff1_top_dict_val_t &opstr,
-		  const top_dict_modifiers_t &mod) const
+  inline bool serialize (hb_serialize_context_t *c,
+			const cff1_top_dict_val_t &opstr,
+			const top_dict_modifiers_t &mod) const
   {
     TRACE_SERIALIZE (this);
 
@@ -181,7 +181,7 @@ struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dic
     return_trace (true);
   }
 
-  unsigned int calculate_serialized_size (const cff1_top_dict_val_t &opstr) const
+  inline unsigned int calculate_serialized_size (const cff1_top_dict_val_t &opstr) const
   {
     op_code_t op = opstr.op;
     switch (op)
@@ -215,29 +215,29 @@ struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dic
 
 struct font_dict_values_mod_t
 {
-  void init (const cff1_font_dict_values_t *base_,
-	     unsigned int fontName_,
-	     const table_info_t &privateDictInfo_)
+  inline void init (const cff1_font_dict_values_t *base_,
+		   unsigned int fontName_,
+		   const table_info_t &privateDictInfo_)
   {
     base = base_;
     fontName = fontName_;
     privateDictInfo = privateDictInfo_;
   }
 
-  unsigned get_count () const { return base->get_count (); }
+  inline unsigned get_count () const { return base->get_count (); }
 
-  const op_str_t &operator [] (unsigned int i) const { return (*base)[i]; }
+  inline const op_str_t &operator [] (unsigned int i) const { return (*base)[i]; }
 
-  const cff1_font_dict_values_t    *base;
-  table_info_t		   privateDictInfo;
-  unsigned int		fontName;
+  const cff1_font_dict_values_t	*base;
+  table_info_t			privateDictInfo;
+  unsigned int			fontName;
 };
 
 struct cff1_font_dict_op_serializer_t : cff_font_dict_op_serializer_t
 {
-  bool serialize (hb_serialize_context_t *c,
-		  const op_str_t &opstr,
-		  const font_dict_values_mod_t &mod) const
+  inline bool serialize (hb_serialize_context_t *c,
+			const op_str_t &opstr,
+			const font_dict_values_mod_t &mod) const
   {
     TRACE_SERIALIZE (this);
 
@@ -247,7 +247,7 @@ struct cff1_font_dict_op_serializer_t : cff_font_dict_op_serializer_t
       return_trace (SUPER::serialize (c, opstr, mod.privateDictInfo));
   }
 
-  unsigned int calculate_serialized_size (const op_str_t &opstr) const
+  inline unsigned int calculate_serialized_size (const op_str_t &opstr) const
   {
     if (opstr.op == OpCode_FontName)
       return OpCode_Size (OpCode_shortint) + 2 + OpCode_Size (OpCode_FontName);
@@ -261,7 +261,7 @@ struct cff1_font_dict_op_serializer_t : cff_font_dict_op_serializer_t
 
 struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatten_param_t>
 {
-  static void flush_args_and_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static inline void flush_args_and_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     if (env.arg_start > 0)
       flush_width (env, param);
@@ -287,7 +287,8 @@ struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatte
 	break;
     }
   }
-  static void flush_args (cff1_cs_interp_env_t &env, flatten_param_t& param)
+
+  static inline void flush_args (cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     str_encoder_t  encoder (param.flatStr);
     for (unsigned int i = env.arg_start; i < env.argStack.get_count (); i++)
@@ -295,20 +296,20 @@ struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatte
     SUPER::flush_args (env, param);
   }
 
-  static void flush_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static inline void flush_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     str_encoder_t  encoder (param.flatStr);
     encoder.encode_op (op);
   }
 
-  static void flush_width (cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static inline void flush_width (cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     assert (env.has_width);
     str_encoder_t  encoder (param.flatStr);
     encoder.encode_num (env.width);
   }
 
-  static void flush_hintmask (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static inline void flush_hintmask (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     SUPER::flush_hintmask (op, env, param);
     if (!param.drop_hints)
@@ -326,7 +327,7 @@ struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatte
 struct range_list_t : hb_vector_t<code_pair_t>
 {
   /* replace the first glyph ID in the "glyph" field each range with a nLeft value */
-  bool finalize (unsigned int last_glyph)
+  inline bool finalize (unsigned int last_glyph)
   {
     bool  two_byte = false;
     for (unsigned int i = (*this).len; i > 0; i--)
@@ -344,7 +345,7 @@ struct range_list_t : hb_vector_t<code_pair_t>
 
 struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t, subr_subset_param_t>
 {
-  static void process_op (op_code_t op, cff1_cs_interp_env_t &env, subr_subset_param_t& param)
+  static inline void process_op (op_code_t op, cff1_cs_interp_env_t &env, subr_subset_param_t& param)
   {
     switch (op) {
 
@@ -377,7 +378,7 @@ struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t
   }
 
   protected:
-  static void process_call_subr (op_code_t op, cs_type_t type,
+  static inline void process_call_subr (op_code_t op, cs_type_t type,
 				 cff1_cs_interp_env_t &env, subr_subset_param_t& param,
 				 cff1_biased_subrs_t& subrs, hb_set_t *closure)
   {
@@ -394,7 +395,7 @@ struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t
 
 struct cff1_subr_subsetter_t : subr_subsetter_t<cff1_subr_subsetter_t, CFF1Subrs, const OT::cff1::accelerator_subset_t, cff1_cs_interp_env_t, cff1_cs_opset_subr_subset_t>
 {
-  static void finalize_parsed_str (cff1_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
+  static inline void finalize_parsed_str (cff1_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
   {
     /* insert width at the beginning of the charstring as necessary */
     if (env.has_width)
@@ -416,7 +417,7 @@ struct cff1_subr_subsetter_t : subr_subsetter_t<cff1_subr_subsetter_t, CFF1Subrs
 };
 
 struct cff_subset_plan {
-  cff_subset_plan ()
+  inline cff_subset_plan ()
     : final_size (0),
       offsets (),
       orig_fdcount (0),
@@ -442,7 +443,7 @@ struct cff_subset_plan {
       topDictModSIDs[i] = CFF_UNDEF_SID;
   }
 
-  ~cff_subset_plan ()
+  inline ~cff_subset_plan ()
   {
     topdict_sizes.fini ();
     topdict_mod.fini ();
@@ -459,7 +460,7 @@ struct cff_subset_plan {
     fontdicts_mod.fini ();
   }
 
-  unsigned int plan_subset_encoding (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
+  inline unsigned int plan_subset_encoding (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
   {
     const Encoding *encoding = acc.encoding;
     unsigned int  size0, size1, supp_size;
@@ -520,10 +521,10 @@ struct cff_subset_plan {
 			subset_enc_supp_codes.len);
   }
 
-  unsigned int plan_subset_charset (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
+  inline unsigned int plan_subset_charset (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
   {
-    unsigned int  size0, size_ranges;
-    hb_codepoint_t  sid, last_sid = CFF_UNDEF_CODE;
+    unsigned int	size0, size_ranges;
+    hb_codepoint_t	sid, last_sid = CFF_UNDEF_CODE;
 
     subset_charset_ranges.resize (0);
     unsigned int glyph;
@@ -563,7 +564,7 @@ struct cff_subset_plan {
 			subset_charset_format? subset_charset_ranges.len: plan->glyphs.len);
   }
 
-  bool collect_sids_in_dicts (const OT::cff1::accelerator_subset_t &acc)
+  inline bool collect_sids_in_dicts (const OT::cff1::accelerator_subset_t &acc)
   {
     if (unlikely (!sidmap.reset (acc.stringIndex->count)))
       return false;
@@ -586,7 +587,7 @@ struct cff_subset_plan {
     return true;
   }
 
-  bool create (const OT::cff1::accelerator_subset_t &acc,
+  inline bool create (const OT::cff1::accelerator_subset_t &acc,
 		      hb_subset_plan_t *plan)
   {
      /* make sure notdef is first */
@@ -821,46 +822,46 @@ struct cff_subset_plan {
 	   && (fontdicts_mod.len == subset_fdcount));
   }
 
-  unsigned int get_final_size () const  { return final_size; }
+  inline unsigned int get_final_size () const  { return final_size; }
 
-  unsigned int	      final_size;
-  hb_vector_t<unsigned int> topdict_sizes;
-  cff1_top_dict_values_mod_t      topdict_mod;
-  cff1_sub_table_offsets_t       offsets;
+  unsigned int			final_size;
+  hb_vector_t<unsigned int>	topdict_sizes;
+  cff1_top_dict_values_mod_t	topdict_mod;
+  cff1_sub_table_offsets_t	offsets;
 
   unsigned int    num_glyphs;
   unsigned int    orig_fdcount;
   unsigned int    subset_fdcount;
   unsigned int    subset_fdselect_format;
-  hb_vector_t<code_pair_t>   subset_fdselect_ranges;
+  hb_vector_t<code_pair_t>	subset_fdselect_ranges;
 
   /* font dict index remap table from fullset FDArray to subset FDArray.
    * set to CFF_UNDEF_CODE if excluded from subset */
   remap_t   fdmap;
 
-  str_buff_vec_t	    subset_charstrings;
-  str_buff_vec_t	    subset_globalsubrs;
-  hb_vector_t<str_buff_vec_t> subset_localsubrs;
+  str_buff_vec_t		subset_charstrings;
+  str_buff_vec_t		subset_globalsubrs;
+  hb_vector_t<str_buff_vec_t>	subset_localsubrs;
   hb_vector_t<font_dict_values_mod_t>  fontdicts_mod;
 
-  bool		    drop_hints;
+  bool				drop_hints;
 
-  bool		    gid_renum;
-  bool		    subset_encoding;
-  uint8_t		 subset_enc_format;
-  unsigned int	    subset_enc_num_codes;
-  range_list_t	       subset_enc_code_ranges;
-  hb_vector_t<code_pair_t>  subset_enc_supp_codes;
+  bool				gid_renum;
+  bool				subset_encoding;
+  uint8_t			subset_enc_format;
+  unsigned int			subset_enc_num_codes;
+  range_list_t			subset_enc_code_ranges;
+  hb_vector_t<code_pair_t>	subset_enc_supp_codes;
 
-  uint8_t		 subset_charset_format;
-  range_list_t	       subset_charset_ranges;
-  bool		    subset_charset;
+  uint8_t			subset_charset_format;
+  range_list_t			subset_charset_ranges;
+  bool				subset_charset;
 
-  remap_sid_t		sidmap;
-  unsigned int	    topDictModSIDs[name_dict_values_t::ValCount];
+  remap_sid_t			sidmap;
+  unsigned int			topDictModSIDs[name_dict_values_t::ValCount];
 
-  bool		    desubroutinize;
-  cff1_subr_subsetter_t       subr_subsetter;
+  bool				desubroutinize;
+  cff1_subr_subsetter_t		subr_subsetter;
 };
 
 static inline bool _write_cff1 (const cff_subset_plan &plan,

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -315,7 +315,7 @@ struct CFF1CSOpSet_Flatten : CFF1CSOpSet<CFF1CSOpSet_Flatten, FlattenParam>
     {
       StrEncoder  encoder (param.flatStr);
       for (unsigned int i = 0; i < env.hintmask_size; i++)
-	encoder.encode_byte (env.substr[i]);
+	encoder.encode_byte (env.str_ref[i]);
     }
   }
 
@@ -349,14 +349,14 @@ struct CFF1CSOpSet_SubrSubset : CFF1CSOpSet<CFF1CSOpSet_SubrSubset, SubrSubsetPa
     switch (op) {
 
       case OpCode_return:
-	param.current_parsed_str->add_op (op, env.substr);
+	param.current_parsed_str->add_op (op, env.str_ref);
 	param.current_parsed_str->set_parsed ();
 	env.returnFromSubr ();
 	param.set_current_str (env, false);
 	break;
 
       case OpCode_endchar:
-	param.current_parsed_str->add_op (op, env.substr);
+	param.current_parsed_str->add_op (op, env.str_ref);
 	param.current_parsed_str->set_parsed ();
 	SUPER::process_op (op, env, param);
 	break;
@@ -371,7 +371,7 @@ struct CFF1CSOpSet_SubrSubset : CFF1CSOpSet<CFF1CSOpSet_SubrSubset, SubrSubsetPa
 
       default:
 	SUPER::process_op (op, env, param);
-	param.current_parsed_str->add_op (op, env.substr);
+	param.current_parsed_str->add_op (op, env.str_ref);
 	break;
     }
   }
@@ -381,9 +381,9 @@ struct CFF1CSOpSet_SubrSubset : CFF1CSOpSet<CFF1CSOpSet_SubrSubset, SubrSubsetPa
 				 CFF1CSInterpEnv &env, SubrSubsetParam& param,
 				 CFF1BiasedSubrs& subrs, hb_set_t *closure)
   {
-    byte_str_ref_t    substr = env.substr;
+    byte_str_ref_t    str_ref = env.str_ref;
     env.callSubr (subrs, type);
-    param.current_parsed_str->add_call_op (op, substr, env.context.subr_num);
+    param.current_parsed_str->add_call_op (op, str_ref, env.context.subr_num);
     hb_set_add (closure, env.context.subr_num);
     param.set_current_str (env, true);
   }

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -36,7 +36,7 @@ using namespace CFF;
 
 struct remap_sid_t : remap_t
 {
-  inline unsigned int add (unsigned int sid)
+  unsigned int add (unsigned int sid)
   {
     if ((sid != CFF_UNDEF_SID) && !is_std_std (sid))
       return offset_sid (remap_t::add (unoffset_sid (sid)));
@@ -44,7 +44,7 @@ struct remap_sid_t : remap_t
       return sid;
   }
 
-  inline unsigned int operator[] (unsigned int sid) const
+  unsigned int operator[] (unsigned int sid) const
   {
     if (is_std_std (sid) || (sid == CFF_UNDEF_SID))
       return sid;
@@ -54,14 +54,14 @@ struct remap_sid_t : remap_t
 
   static const unsigned int num_std_strings = 391;
 
-  static inline bool is_std_std (unsigned int sid) { return sid < num_std_strings; }
-  static inline unsigned int offset_sid (unsigned int sid) { return sid + num_std_strings; }
-  static inline unsigned int unoffset_sid (unsigned int sid) { return sid - num_std_strings; }
+  static bool is_std_std (unsigned int sid) { return sid < num_std_strings; }
+  static unsigned int offset_sid (unsigned int sid) { return sid + num_std_strings; }
+  static unsigned int unoffset_sid (unsigned int sid) { return sid - num_std_strings; }
 };
 
 struct cff1_sub_table_offsets_t : cff_sub_table_offsets_t
 {
-  inline cff1_sub_table_offsets_t ()
+  cff1_sub_table_offsets_t ()
     : cff_sub_table_offsets_t (),
       nameIndexOffset (0),
       encodingOffset (0)
@@ -71,35 +71,35 @@ struct cff1_sub_table_offsets_t : cff_sub_table_offsets_t
     privateDictInfo.init ();
   }
 
-  unsigned int	nameIndexOffset;
-  table_info_t	stringIndexInfo;
-  unsigned int	encodingOffset;
-  table_info_t	charsetInfo;
-  table_info_t	privateDictInfo;
+  unsigned int  nameIndexOffset;
+  table_info_t     stringIndexInfo;
+  unsigned int  encodingOffset;
+  table_info_t     charsetInfo;
+  table_info_t     privateDictInfo;
 };
 
 /* a copy of a parsed out cff1_top_dict_values_t augmented with additional operators */
 struct cff1_top_dict_values_mod_t : cff1_top_dict_values_t
 {
-  inline void init (const cff1_top_dict_values_t *base_= &Null(cff1_top_dict_values_t))
+  void init (const cff1_top_dict_values_t *base_= &Null(cff1_top_dict_values_t))
   {
     SUPER::init ();
     base = base_;
   }
 
-  inline void fini () { SUPER::fini (); }
+  void fini () { SUPER::fini (); }
 
-  inline unsigned get_count () const { return base->get_count () + SUPER::get_count (); }
-  inline const cff1_top_dict_val_t &get_value (unsigned int i) const
+  unsigned get_count () const { return base->get_count () + SUPER::get_count (); }
+  const cff1_top_dict_val_t &get_value (unsigned int i) const
   {
     if (i < base->get_count ())
       return (*base)[i];
     else
       return SUPER::values[i - base->get_count ()];
   }
-  inline const cff1_top_dict_val_t &operator [] (unsigned int i) const { return get_value (i); }
+  const cff1_top_dict_val_t &operator [] (unsigned int i) const { return get_value (i); }
 
-  inline void reassignSIDs (const remap_sid_t& sidmap)
+  void reassignSIDs (const remap_sid_t& sidmap)
   {
     for (unsigned int i = 0; i < name_dict_values_t::ValCount; i++)
       nameSIDs[i] = sidmap[base->nameSIDs[i]];
@@ -113,7 +113,7 @@ struct cff1_top_dict_values_mod_t : cff1_top_dict_values_t
 struct top_dict_modifiers_t
 {
   top_dict_modifiers_t (const cff1_sub_table_offsets_t &offsets_,
-			const unsigned int (&nameSIDs_)[name_dict_values_t::ValCount])
+			   const unsigned int (&nameSIDs_)[name_dict_values_t::ValCount])
     : offsets (offsets_),
       nameSIDs (nameSIDs_)
   {}
@@ -124,9 +124,9 @@ struct top_dict_modifiers_t
 
 struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dict_val_t>
 {
-  inline bool serialize (hb_serialize_context_t *c,
-			const cff1_top_dict_val_t &opstr,
-			const top_dict_modifiers_t &mod) const
+  bool serialize (hb_serialize_context_t *c,
+		  const cff1_top_dict_val_t &opstr,
+		  const top_dict_modifiers_t &mod) const
   {
     TRACE_SERIALIZE (this);
 
@@ -181,7 +181,7 @@ struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dic
     return_trace (true);
   }
 
-  inline unsigned int calculate_serialized_size (const cff1_top_dict_val_t &opstr) const
+  unsigned int calculate_serialized_size (const cff1_top_dict_val_t &opstr) const
   {
     op_code_t op = opstr.op;
     switch (op)
@@ -215,29 +215,29 @@ struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dic
 
 struct font_dict_values_mod_t
 {
-  inline void init (const cff1_font_dict_values_t *base_,
-		   unsigned int fontName_,
-		   const table_info_t &privateDictInfo_)
+  void init (const cff1_font_dict_values_t *base_,
+	     unsigned int fontName_,
+	     const table_info_t &privateDictInfo_)
   {
     base = base_;
     fontName = fontName_;
     privateDictInfo = privateDictInfo_;
   }
 
-  inline unsigned get_count () const { return base->get_count (); }
+  unsigned get_count () const { return base->get_count (); }
 
-  inline const op_str_t &operator [] (unsigned int i) const { return (*base)[i]; }
+  const op_str_t &operator [] (unsigned int i) const { return (*base)[i]; }
 
-  const cff1_font_dict_values_t	*base;
-  table_info_t			privateDictInfo;
-  unsigned int			fontName;
+  const cff1_font_dict_values_t    *base;
+  table_info_t		   privateDictInfo;
+  unsigned int		fontName;
 };
 
 struct cff1_font_dict_op_serializer_t : cff_font_dict_op_serializer_t
 {
-  inline bool serialize (hb_serialize_context_t *c,
-			const op_str_t &opstr,
-			const font_dict_values_mod_t &mod) const
+  bool serialize (hb_serialize_context_t *c,
+		  const op_str_t &opstr,
+		  const font_dict_values_mod_t &mod) const
   {
     TRACE_SERIALIZE (this);
 
@@ -247,7 +247,7 @@ struct cff1_font_dict_op_serializer_t : cff_font_dict_op_serializer_t
       return_trace (SUPER::serialize (c, opstr, mod.privateDictInfo));
   }
 
-  inline unsigned int calculate_serialized_size (const op_str_t &opstr) const
+  unsigned int calculate_serialized_size (const op_str_t &opstr) const
   {
     if (opstr.op == OpCode_FontName)
       return OpCode_Size (OpCode_shortint) + 2 + OpCode_Size (OpCode_FontName);
@@ -261,7 +261,7 @@ struct cff1_font_dict_op_serializer_t : cff_font_dict_op_serializer_t
 
 struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatten_param_t>
 {
-  static inline void flush_args_and_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_args_and_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     if (env.arg_start > 0)
       flush_width (env, param);
@@ -287,8 +287,7 @@ struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatte
 	break;
     }
   }
-
-  static inline void flush_args (cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_args (cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     str_encoder_t  encoder (param.flatStr);
     for (unsigned int i = env.arg_start; i < env.argStack.get_count (); i++)
@@ -296,20 +295,20 @@ struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatte
     SUPER::flush_args (env, param);
   }
 
-  static inline void flush_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_op (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     str_encoder_t  encoder (param.flatStr);
     encoder.encode_op (op);
   }
 
-  static inline void flush_width (cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_width (cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     assert (env.has_width);
     str_encoder_t  encoder (param.flatStr);
     encoder.encode_num (env.width);
   }
 
-  static inline void flush_hintmask (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_hintmask (op_code_t op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     SUPER::flush_hintmask (op, env, param);
     if (!param.drop_hints)
@@ -327,7 +326,7 @@ struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatte
 struct range_list_t : hb_vector_t<code_pair_t>
 {
   /* replace the first glyph ID in the "glyph" field each range with a nLeft value */
-  inline bool finalize (unsigned int last_glyph)
+  bool finalize (unsigned int last_glyph)
   {
     bool  two_byte = false;
     for (unsigned int i = (*this).len; i > 0; i--)
@@ -345,7 +344,7 @@ struct range_list_t : hb_vector_t<code_pair_t>
 
 struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t, subr_subset_param_t>
 {
-  static inline void process_op (op_code_t op, cff1_cs_interp_env_t &env, subr_subset_param_t& param)
+  static void process_op (op_code_t op, cff1_cs_interp_env_t &env, subr_subset_param_t& param)
   {
     switch (op) {
 
@@ -378,7 +377,7 @@ struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t
   }
 
   protected:
-  static inline void process_call_subr (op_code_t op, cs_type_t type,
+  static void process_call_subr (op_code_t op, cs_type_t type,
 				 cff1_cs_interp_env_t &env, subr_subset_param_t& param,
 				 cff1_biased_subrs_t& subrs, hb_set_t *closure)
   {
@@ -395,7 +394,7 @@ struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t
 
 struct cff1_subr_subsetter_t : subr_subsetter_t<cff1_subr_subsetter_t, CFF1Subrs, const OT::cff1::accelerator_subset_t, cff1_cs_interp_env_t, cff1_cs_opset_subr_subset_t>
 {
-  static inline void finalize_parsed_str (cff1_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
+  static void finalize_parsed_str (cff1_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
   {
     /* insert width at the beginning of the charstring as necessary */
     if (env.has_width)
@@ -417,7 +416,7 @@ struct cff1_subr_subsetter_t : subr_subsetter_t<cff1_subr_subsetter_t, CFF1Subrs
 };
 
 struct cff_subset_plan {
-  inline cff_subset_plan ()
+  cff_subset_plan ()
     : final_size (0),
       offsets (),
       orig_fdcount (0),
@@ -443,7 +442,7 @@ struct cff_subset_plan {
       topDictModSIDs[i] = CFF_UNDEF_SID;
   }
 
-  inline ~cff_subset_plan ()
+  ~cff_subset_plan ()
   {
     topdict_sizes.fini ();
     topdict_mod.fini ();
@@ -460,7 +459,7 @@ struct cff_subset_plan {
     fontdicts_mod.fini ();
   }
 
-  inline unsigned int plan_subset_encoding (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
+  unsigned int plan_subset_encoding (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
   {
     const Encoding *encoding = acc.encoding;
     unsigned int  size0, size1, supp_size;
@@ -521,10 +520,10 @@ struct cff_subset_plan {
 			subset_enc_supp_codes.len);
   }
 
-  inline unsigned int plan_subset_charset (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
+  unsigned int plan_subset_charset (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
   {
-    unsigned int	size0, size_ranges;
-    hb_codepoint_t	sid, last_sid = CFF_UNDEF_CODE;
+    unsigned int  size0, size_ranges;
+    hb_codepoint_t  sid, last_sid = CFF_UNDEF_CODE;
 
     subset_charset_ranges.resize (0);
     unsigned int glyph;
@@ -564,7 +563,7 @@ struct cff_subset_plan {
 			subset_charset_format? subset_charset_ranges.len: plan->glyphs.len);
   }
 
-  inline bool collect_sids_in_dicts (const OT::cff1::accelerator_subset_t &acc)
+  bool collect_sids_in_dicts (const OT::cff1::accelerator_subset_t &acc)
   {
     if (unlikely (!sidmap.reset (acc.stringIndex->count)))
       return false;
@@ -587,7 +586,7 @@ struct cff_subset_plan {
     return true;
   }
 
-  inline bool create (const OT::cff1::accelerator_subset_t &acc,
+  bool create (const OT::cff1::accelerator_subset_t &acc,
 		      hb_subset_plan_t *plan)
   {
      /* make sure notdef is first */
@@ -822,46 +821,46 @@ struct cff_subset_plan {
 	   && (fontdicts_mod.len == subset_fdcount));
   }
 
-  inline unsigned int get_final_size () const  { return final_size; }
+  unsigned int get_final_size () const  { return final_size; }
 
-  unsigned int			final_size;
-  hb_vector_t<unsigned int>	topdict_sizes;
-  cff1_top_dict_values_mod_t	topdict_mod;
-  cff1_sub_table_offsets_t	offsets;
+  unsigned int	      final_size;
+  hb_vector_t<unsigned int> topdict_sizes;
+  cff1_top_dict_values_mod_t      topdict_mod;
+  cff1_sub_table_offsets_t       offsets;
 
   unsigned int    num_glyphs;
   unsigned int    orig_fdcount;
   unsigned int    subset_fdcount;
   unsigned int    subset_fdselect_format;
-  hb_vector_t<code_pair_t>	subset_fdselect_ranges;
+  hb_vector_t<code_pair_t>   subset_fdselect_ranges;
 
   /* font dict index remap table from fullset FDArray to subset FDArray.
    * set to CFF_UNDEF_CODE if excluded from subset */
   remap_t   fdmap;
 
-  str_buff_vec_t		subset_charstrings;
-  str_buff_vec_t		subset_globalsubrs;
-  hb_vector_t<str_buff_vec_t>	subset_localsubrs;
+  str_buff_vec_t	    subset_charstrings;
+  str_buff_vec_t	    subset_globalsubrs;
+  hb_vector_t<str_buff_vec_t> subset_localsubrs;
   hb_vector_t<font_dict_values_mod_t>  fontdicts_mod;
 
-  bool				drop_hints;
+  bool		    drop_hints;
 
-  bool				gid_renum;
-  bool				subset_encoding;
-  uint8_t			subset_enc_format;
-  unsigned int			subset_enc_num_codes;
-  range_list_t			subset_enc_code_ranges;
-  hb_vector_t<code_pair_t>	subset_enc_supp_codes;
+  bool		    gid_renum;
+  bool		    subset_encoding;
+  uint8_t		 subset_enc_format;
+  unsigned int	    subset_enc_num_codes;
+  range_list_t	       subset_enc_code_ranges;
+  hb_vector_t<code_pair_t>  subset_enc_supp_codes;
 
-  uint8_t			subset_charset_format;
-  range_list_t			subset_charset_ranges;
-  bool				subset_charset;
+  uint8_t		 subset_charset_format;
+  range_list_t	       subset_charset_ranges;
+  bool		    subset_charset;
 
-  remap_sid_t			sidmap;
-  unsigned int			topDictModSIDs[name_dict_values_t::ValCount];
+  remap_sid_t		sidmap;
+  unsigned int	    topDictModSIDs[name_dict_values_t::ValCount];
 
-  bool				desubroutinize;
-  cff1_subr_subsetter_t		subr_subsetter;
+  bool		    desubroutinize;
+  cff1_subr_subsetter_t       subr_subsetter;
 };
 
 static inline bool _write_cff1 (const cff_subset_plan &plan,

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -168,10 +168,9 @@ struct CFF1TopDict_OpSerializer : CFFTopDict_OpSerializer<CFF1TopDictVal>
 	   * for supplement, the original byte string is copied along with the op code */
 	  OpStr supp_op;
 	  supp_op.op = op;
-	  supp_op.str.str = opstr.str.str + opstr.last_arg_offset;
 	  if ( unlikely (!(opstr.str.len >= opstr.last_arg_offset + 3)))
 	    return_trace (false);
-	  supp_op.str.len = opstr.str.len - opstr.last_arg_offset;
+	  supp_op.str = byte_str_t (&opstr.str + opstr.last_arg_offset, opstr.str.len - opstr.last_arg_offset);
 	  return_trace (UnsizedByteStr::serialize_int2 (c, mod.nameSIDs[NameDictValues::registry]) &&
 			UnsizedByteStr::serialize_int2 (c, mod.nameSIDs[NameDictValues::ordering]) &&
 			copy_opstr (c, supp_op));
@@ -382,7 +381,7 @@ struct CFF1CSOpSet_SubrSubset : CFF1CSOpSet<CFF1CSOpSet_SubrSubset, SubrSubsetPa
 				 CFF1CSInterpEnv &env, SubrSubsetParam& param,
 				 CFF1BiasedSubrs& subrs, hb_set_t *closure)
   {
-    SubByteStr    substr = env.substr;
+    byte_str_ref_t    substr = env.substr;
     env.callSubr (subrs, type);
     param.current_parsed_str->add_call_op (op, substr, env.context.subr_num);
     hb_set_add (closure, env.context.subr_num);
@@ -871,9 +870,6 @@ static inline bool _write_cff1 (const cff_subset_plan &plan,
 				void *dest)
 {
   hb_serialize_context_t c (dest, dest_sz);
-
-  char RETURN_OP[1] = { OpCode_return };
-  const ByteStr NULL_SUBR (RETURN_OP, 1);
 
   OT::cff1 *cff = c.start_serialize<OT::cff1> ();
   if (unlikely (!c.extend_min (*cff)))

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -34,12 +34,12 @@
 
 using namespace CFF;
 
-struct RemapSID : Remap
+struct remap_sid_t : remap_t
 {
   unsigned int add (unsigned int sid)
   {
     if ((sid != CFF_UNDEF_SID) && !is_std_std (sid))
-      return offset_sid (Remap::add (unoffset_sid (sid)));
+      return offset_sid (remap_t::add (unoffset_sid (sid)));
     else
       return sid;
   }
@@ -49,7 +49,7 @@ struct RemapSID : Remap
     if (is_std_std (sid) || (sid == CFF_UNDEF_SID))
       return sid;
     else
-      return offset_sid (Remap::operator [] (unoffset_sid (sid)));
+      return offset_sid (remap_t::operator [] (unoffset_sid (sid)));
   }
 
   static const unsigned int num_std_strings = 391;
@@ -59,10 +59,10 @@ struct RemapSID : Remap
   static unsigned int unoffset_sid (unsigned int sid) { return sid - num_std_strings; }
 };
 
-struct CFF1SubTableOffsets : CFFSubTableOffsets
+struct cff1_sub_table_offsets_t : cff_sub_table_offsets_t
 {
-  CFF1SubTableOffsets ()
-    : CFFSubTableOffsets (),
+  cff1_sub_table_offsets_t ()
+    : cff_sub_table_offsets_t (),
       nameIndexOffset (0),
       encodingOffset (0)
   {
@@ -72,16 +72,16 @@ struct CFF1SubTableOffsets : CFFSubTableOffsets
   }
 
   unsigned int  nameIndexOffset;
-  TableInfo     stringIndexInfo;
+  table_info_t     stringIndexInfo;
   unsigned int  encodingOffset;
-  TableInfo     charsetInfo;
-  TableInfo     privateDictInfo;
+  table_info_t     charsetInfo;
+  table_info_t     privateDictInfo;
 };
 
-/* a copy of a parsed out CFF1TopDictValues augmented with additional operators */
-struct CFF1TopDictValuesMod : CFF1TopDictValues
+/* a copy of a parsed out cff1_top_dict_values_t augmented with additional operators */
+struct cff1_top_dict_values_mod_t : cff1_top_dict_values_t
 {
-  void init (const CFF1TopDictValues *base_= &Null(CFF1TopDictValues))
+  void init (const cff1_top_dict_values_t *base_= &Null(cff1_top_dict_values_t))
   {
     SUPER::init ();
     base = base_;
@@ -90,43 +90,43 @@ struct CFF1TopDictValuesMod : CFF1TopDictValues
   void fini () { SUPER::fini (); }
 
   unsigned get_count () const { return base->get_count () + SUPER::get_count (); }
-  const CFF1TopDictVal &get_value (unsigned int i) const
+  const cff1_top_dict_val_t &get_value (unsigned int i) const
   {
     if (i < base->get_count ())
       return (*base)[i];
     else
       return SUPER::values[i - base->get_count ()];
   }
-  const CFF1TopDictVal &operator [] (unsigned int i) const { return get_value (i); }
+  const cff1_top_dict_val_t &operator [] (unsigned int i) const { return get_value (i); }
 
-  void reassignSIDs (const RemapSID& sidmap)
+  void reassignSIDs (const remap_sid_t& sidmap)
   {
-    for (unsigned int i = 0; i < NameDictValues::ValCount; i++)
+    for (unsigned int i = 0; i < name_dict_values_t::ValCount; i++)
       nameSIDs[i] = sidmap[base->nameSIDs[i]];
   }
 
   protected:
-  typedef CFF1TopDictValues SUPER;
-  const CFF1TopDictValues *base;
+  typedef cff1_top_dict_values_t SUPER;
+  const cff1_top_dict_values_t *base;
 };
 
-struct TopDictModifiers
+struct top_dict_modifiers_t
 {
-  TopDictModifiers (const CFF1SubTableOffsets &offsets_,
-			   const unsigned int (&nameSIDs_)[NameDictValues::ValCount])
+  top_dict_modifiers_t (const cff1_sub_table_offsets_t &offsets_,
+			   const unsigned int (&nameSIDs_)[name_dict_values_t::ValCount])
     : offsets (offsets_),
       nameSIDs (nameSIDs_)
   {}
 
-  const CFF1SubTableOffsets &offsets;
-  const unsigned int	(&nameSIDs)[NameDictValues::ValCount];
+  const cff1_sub_table_offsets_t &offsets;
+  const unsigned int	(&nameSIDs)[name_dict_values_t::ValCount];
 };
 
-struct CFF1TopDict_OpSerializer : CFFTopDict_OpSerializer<CFF1TopDictVal>
+struct cff1_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<cff1_top_dict_val_t>
 {
   bool serialize (hb_serialize_context_t *c,
-		  const CFF1TopDictVal &opstr,
-		  const TopDictModifiers &mod) const
+		  const cff1_top_dict_val_t &opstr,
+		  const top_dict_modifiers_t &mod) const
   {
     TRACE_SERIALIZE (this);
 
@@ -160,28 +160,28 @@ struct CFF1TopDict_OpSerializer : CFFTopDict_OpSerializer<CFF1TopDictVal>
       case OpCode_PostScript:
       case OpCode_BaseFontName:
       case OpCode_FontName:
-	return_trace (FontDict::serialize_offset2_op(c, op, mod.nameSIDs[NameDictValues::name_op_to_index (op)]));
+	return_trace (FontDict::serialize_offset2_op(c, op, mod.nameSIDs[name_dict_values_t::name_op_to_index (op)]));
 
       case OpCode_ROS:
 	{
 	  /* for registry & ordering, reassigned SIDs are serialized
 	   * for supplement, the original byte string is copied along with the op code */
-	  OpStr supp_op;
+	  op_str_t supp_op;
 	  supp_op.op = op;
 	  if ( unlikely (!(opstr.str.len >= opstr.last_arg_offset + 3)))
 	    return_trace (false);
 	  supp_op.str = byte_str_t (&opstr.str + opstr.last_arg_offset, opstr.str.len - opstr.last_arg_offset);
-	  return_trace (UnsizedByteStr::serialize_int2 (c, mod.nameSIDs[NameDictValues::registry]) &&
-			UnsizedByteStr::serialize_int2 (c, mod.nameSIDs[NameDictValues::ordering]) &&
+	  return_trace (UnsizedByteStr::serialize_int2 (c, mod.nameSIDs[name_dict_values_t::registry]) &&
+			UnsizedByteStr::serialize_int2 (c, mod.nameSIDs[name_dict_values_t::ordering]) &&
 			copy_opstr (c, supp_op));
 	}
       default:
-	return_trace (CFFTopDict_OpSerializer<CFF1TopDictVal>::serialize (c, opstr, mod.offsets));
+	return_trace (cff_top_dict_op_serializer_t<cff1_top_dict_val_t>::serialize (c, opstr, mod.offsets));
     }
     return_trace (true);
   }
 
-  unsigned int calculate_serialized_size (const CFF1TopDictVal &opstr) const
+  unsigned int calculate_serialized_size (const cff1_top_dict_val_t &opstr) const
   {
     OpCode op = opstr.op;
     switch (op)
@@ -208,16 +208,16 @@ struct CFF1TopDict_OpSerializer : CFFTopDict_OpSerializer<CFF1TopDictVal>
 	return ((OpCode_Size (OpCode_shortint) + 2) * 2) + (opstr.str.len - opstr.last_arg_offset)/* supplement + op */;
 
       default:
-	return CFFTopDict_OpSerializer<CFF1TopDictVal>::calculate_serialized_size (opstr);
+	return cff_top_dict_op_serializer_t<cff1_top_dict_val_t>::calculate_serialized_size (opstr);
     }
   }
 };
 
-struct FontDictValuesMod
+struct font_dict_values_mod_t
 {
-  void init (const CFF1FontDictValues *base_,
+  void init (const cff1_font_dict_values_t *base_,
 	     unsigned int fontName_,
-	     const TableInfo &privateDictInfo_)
+	     const table_info_t &privateDictInfo_)
   {
     base = base_;
     fontName = fontName_;
@@ -226,18 +226,18 @@ struct FontDictValuesMod
 
   unsigned get_count () const { return base->get_count (); }
 
-  const OpStr &operator [] (unsigned int i) const { return (*base)[i]; }
+  const op_str_t &operator [] (unsigned int i) const { return (*base)[i]; }
 
-  const CFF1FontDictValues    *base;
-  TableInfo		   privateDictInfo;
+  const cff1_font_dict_values_t    *base;
+  table_info_t		   privateDictInfo;
   unsigned int		fontName;
 };
 
-struct CFF1FontDict_OpSerializer : CFFFontDict_OpSerializer
+struct cff1_font_dict_op_serializer_t : cff_font_dict_op_serializer_t
 {
   bool serialize (hb_serialize_context_t *c,
-		  const OpStr &opstr,
-		  const FontDictValuesMod &mod) const
+		  const op_str_t &opstr,
+		  const font_dict_values_mod_t &mod) const
   {
     TRACE_SERIALIZE (this);
 
@@ -247,7 +247,7 @@ struct CFF1FontDict_OpSerializer : CFFFontDict_OpSerializer
       return_trace (SUPER::serialize (c, opstr, mod.privateDictInfo));
   }
 
-  unsigned int calculate_serialized_size (const OpStr &opstr) const
+  unsigned int calculate_serialized_size (const op_str_t &opstr) const
   {
     if (opstr.op == OpCode_FontName)
       return OpCode_Size (OpCode_shortint) + 2 + OpCode_Size (OpCode_FontName);
@@ -256,12 +256,12 @@ struct CFF1FontDict_OpSerializer : CFFFontDict_OpSerializer
   }
 
   private:
-  typedef CFFFontDict_OpSerializer SUPER;
+  typedef cff_font_dict_op_serializer_t SUPER;
 };
 
-struct CFF1CSOpSet_Flatten : CFF1CSOpSet<CFF1CSOpSet_Flatten, FlattenParam>
+struct cff1_cs_opset_flatten_t : cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatten_param_t>
 {
-  static void flush_args_and_op (OpCode op, CFF1CSInterpEnv &env, FlattenParam& param)
+  static void flush_args_and_op (OpCode op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     if (env.arg_start > 0)
       flush_width (env, param);
@@ -287,43 +287,43 @@ struct CFF1CSOpSet_Flatten : CFF1CSOpSet<CFF1CSOpSet_Flatten, FlattenParam>
 	break;
     }
   }
-  static void flush_args (CFF1CSInterpEnv &env, FlattenParam& param)
+  static void flush_args (cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
-    StrEncoder  encoder (param.flatStr);
+    str_encoder_t  encoder (param.flatStr);
     for (unsigned int i = env.arg_start; i < env.argStack.get_count (); i++)
       encoder.encode_num (env.eval_arg (i));
     SUPER::flush_args (env, param);
   }
 
-  static void flush_op (OpCode op, CFF1CSInterpEnv &env, FlattenParam& param)
+  static void flush_op (OpCode op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
-    StrEncoder  encoder (param.flatStr);
+    str_encoder_t  encoder (param.flatStr);
     encoder.encode_op (op);
   }
 
-  static void flush_width (CFF1CSInterpEnv &env, FlattenParam& param)
+  static void flush_width (cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     assert (env.has_width);
-    StrEncoder  encoder (param.flatStr);
+    str_encoder_t  encoder (param.flatStr);
     encoder.encode_num (env.width);
   }
 
-  static void flush_hintmask (OpCode op, CFF1CSInterpEnv &env, FlattenParam& param)
+  static void flush_hintmask (OpCode op, cff1_cs_interp_env_t &env, flatten_param_t& param)
   {
     SUPER::flush_hintmask (op, env, param);
     if (!param.drop_hints)
     {
-      StrEncoder  encoder (param.flatStr);
+      str_encoder_t  encoder (param.flatStr);
       for (unsigned int i = 0; i < env.hintmask_size; i++)
 	encoder.encode_byte (env.str_ref[i]);
     }
   }
 
   private:
-  typedef CFF1CSOpSet<CFF1CSOpSet_Flatten, FlattenParam> SUPER;
+  typedef cff1_cs_opset_t<cff1_cs_opset_flatten_t, flatten_param_t> SUPER;
 };
 
-struct RangeList : hb_vector_t<code_pair>
+struct range_list_t : hb_vector_t<code_pair_t>
 {
   /* replace the first glyph ID in the "glyph" field each range with a nLeft value */
   bool finalize (unsigned int last_glyph)
@@ -331,7 +331,7 @@ struct RangeList : hb_vector_t<code_pair>
     bool  two_byte = false;
     for (unsigned int i = (*this).len; i > 0; i--)
     {
-      code_pair &pair = (*this)[i - 1];
+      code_pair_t &pair = (*this)[i - 1];
       unsigned int  nLeft = last_glyph - pair.glyph - 1;
       if (nLeft >= 0x100)
 	two_byte = true;
@@ -342,9 +342,9 @@ struct RangeList : hb_vector_t<code_pair>
   }
 };
 
-struct CFF1CSOpSet_SubrSubset : CFF1CSOpSet<CFF1CSOpSet_SubrSubset, SubrSubsetParam>
+struct cff1_cs_opset_subr_subset_t : cff1_cs_opset_t<cff1_cs_opset_subr_subset_t, subr_subset_param_t>
 {
-  static void process_op (OpCode op, CFF1CSInterpEnv &env, SubrSubsetParam& param)
+  static void process_op (OpCode op, cff1_cs_interp_env_t &env, subr_subset_param_t& param)
   {
     switch (op) {
 
@@ -378,8 +378,8 @@ struct CFF1CSOpSet_SubrSubset : CFF1CSOpSet<CFF1CSOpSet_SubrSubset, SubrSubsetPa
 
   protected:
   static void process_call_subr (OpCode op, CSType type,
-				 CFF1CSInterpEnv &env, SubrSubsetParam& param,
-				 CFF1BiasedSubrs& subrs, hb_set_t *closure)
+				 cff1_cs_interp_env_t &env, subr_subset_param_t& param,
+				 cff1_biased_subrs_t& subrs, hb_set_t *closure)
   {
     byte_str_ref_t    str_ref = env.str_ref;
     env.callSubr (subrs, type);
@@ -389,12 +389,12 @@ struct CFF1CSOpSet_SubrSubset : CFF1CSOpSet<CFF1CSOpSet_SubrSubset, SubrSubsetPa
   }
 
   private:
-  typedef CFF1CSOpSet<CFF1CSOpSet_SubrSubset, SubrSubsetParam> SUPER;
+  typedef cff1_cs_opset_t<cff1_cs_opset_subr_subset_t, subr_subset_param_t> SUPER;
 };
 
-struct CFF1SubrSubsetter : SubrSubsetter<CFF1SubrSubsetter, CFF1Subrs, const OT::cff1::accelerator_subset_t, CFF1CSInterpEnv, CFF1CSOpSet_SubrSubset>
+struct cff1_subr_subsetter_t : subr_subsetter_t<cff1_subr_subsetter_t, CFF1Subrs, const OT::cff1::accelerator_subset_t, cff1_cs_interp_env_t, cff1_cs_opset_subr_subset_t>
 {
-  static void finalize_parsed_str (CFF1CSInterpEnv &env, SubrSubsetParam& param, ParsedCStr &charstring)
+  static void finalize_parsed_str (cff1_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
   {
     /* insert width at the beginning of the charstring as necessary */
     if (env.has_width)
@@ -406,7 +406,7 @@ struct CFF1SubrSubsetter : SubrSubsetter<CFF1SubrSubsetter, CFF1Subrs, const OT:
     param.current_parsed_str->set_parsed ();
     for (unsigned int i = 0; i < env.callStack.get_count (); i++)
     {
-      ParsedCStr  *parsed_str = param.get_parsed_str_for_context (env.callStack[i]);
+      parsed_cs_str_t  *parsed_str = param.get_parsed_str_for_context (env.callStack[i]);
       if (likely (parsed_str != nullptr))
 	parsed_str->set_parsed ();
       else
@@ -438,7 +438,7 @@ struct cff_subset_plan {
     subset_enc_supp_codes.init ();
     subset_charset_ranges.init ();
     sidmap.init ();
-    for (unsigned int i = 0; i < NameDictValues::ValCount; i++)
+    for (unsigned int i = 0; i < name_dict_values_t::ValCount; i++)
       topDictModSIDs[i] = CFF_UNDEF_SID;
   }
 
@@ -484,7 +484,7 @@ struct cff_subset_plan {
 
       if (code != last_code + 1)
       {
-	code_pair pair = { code, glyph };
+	code_pair_t pair = { code, glyph };
 	subset_enc_code_ranges.push (pair);
       }
       last_code = code;
@@ -495,7 +495,7 @@ struct cff_subset_plan {
 	encoding->get_supplement_codes (sid, supp_codes);
 	for (unsigned int i = 0; i < supp_codes.len; i++)
 	{
-	  code_pair pair = { supp_codes[i], sid };
+	  code_pair_t pair = { supp_codes[i], sid };
 	  subset_enc_supp_codes.push (pair);
 	}
 	supp_size += SuppEncoding::static_size * supp_codes.len;
@@ -537,7 +537,7 @@ struct cff_subset_plan {
 
       if (sid != last_sid + 1)
       {
-	code_pair pair = { sid, glyph };
+	code_pair_t pair = { sid, glyph };
 	subset_charset_ranges.push (pair);
       }
       last_sid = sid;
@@ -568,7 +568,7 @@ struct cff_subset_plan {
     if (unlikely (!sidmap.reset (acc.stringIndex->count)))
       return false;
 
-    for (unsigned int i = 0; i < NameDictValues::ValCount; i++)
+    for (unsigned int i = 0; i < name_dict_values_t::ValCount; i++)
     {
       unsigned int sid = acc.topDict.nameSIDs[i];
       if (sid != CFF_UNDEF_SID)
@@ -632,12 +632,12 @@ struct cff_subset_plan {
 	  topdict_mod.add_op (OpCode_charset);
       }
       offsets.topDictInfo.offset = final_size;
-      CFF1TopDict_OpSerializer topSzr;
+      cff1_top_dict_op_serializer_t topSzr;
       unsigned int topDictSize = TopDict::calculate_serialized_size (topdict_mod, topSzr);
       offsets.topDictInfo.offSize = calcOffSize(topDictSize);
       if (unlikely (offsets.topDictInfo.offSize > 4))
       	return false;
-      final_size += CFF1IndexOf<TopDict>::calculate_serialized_size<CFF1TopDictValuesMod>
+      final_size += CFF1IndexOf<TopDict>::calculate_serialized_size<cff1_top_dict_values_mod_t>
 						(offsets.topDictInfo.offSize,
 						 &topdict_mod, 1, topdict_sizes, topSzr);
     }
@@ -681,7 +681,7 @@ struct cff_subset_plan {
     if (desubroutinize)
     {
       /* Flatten global & local subrs */
-      SubrFlattener<const OT::cff1::accelerator_subset_t, CFF1CSInterpEnv, CFF1CSOpSet_Flatten>
+      subr_flattener_t<const OT::cff1::accelerator_subset_t, cff1_cs_interp_env_t, cff1_cs_opset_flatten_t>
 		    flattener(acc, plan->glyphs, plan->drop_hints);
       if (!flattener.flatten (subset_charstrings))
 	return false;
@@ -766,7 +766,7 @@ struct cff_subset_plan {
     /* FDArray (FDIndex) */
     if (acc.fdArray != &Null(CFF1FDArray)) {
       offsets.FDArrayInfo.offset = final_size;
-      CFF1FontDict_OpSerializer fontSzr;
+      cff1_font_dict_op_serializer_t fontSzr;
       unsigned int dictsSize = 0;
       for (unsigned int i = 0; i < acc.fontDicts.len; i++)
 	if (fdmap.includes (i))
@@ -795,12 +795,12 @@ struct cff_subset_plan {
       if (fdmap.includes (i))
       {
 	bool  has_localsubrs = offsets.localSubrsInfos[i].size > 0;
-	CFFPrivateDict_OpSerializer privSzr (desubroutinize, plan->drop_hints);
+	cff_private_dict_op_serializer_t privSzr (desubroutinize, plan->drop_hints);
 	unsigned int  priv_size = PrivateDict::calculate_serialized_size (acc.privateDicts[i], privSzr, has_localsubrs);
-	TableInfo  privInfo = { final_size, priv_size, 0 };
-	FontDictValuesMod fontdict_mod;
+	table_info_t  privInfo = { final_size, priv_size, 0 };
+	font_dict_values_mod_t fontdict_mod;
 	if (!acc.is_CID ())
-	  fontdict_mod.init ( &Null(CFF1FontDictValues), CFF_UNDEF_SID, privInfo );
+	  fontdict_mod.init ( &Null(cff1_font_dict_values_t), CFF_UNDEF_SID, privInfo );
 	else
 	  fontdict_mod.init ( &acc.fontDicts[i], sidmap[acc.fontDicts[i].fontName], privInfo );
 	fontdicts_mod.push (fontdict_mod);
@@ -825,23 +825,23 @@ struct cff_subset_plan {
 
   unsigned int	      final_size;
   hb_vector_t<unsigned int> topdict_sizes;
-  CFF1TopDictValuesMod      topdict_mod;
-  CFF1SubTableOffsets       offsets;
+  cff1_top_dict_values_mod_t      topdict_mod;
+  cff1_sub_table_offsets_t       offsets;
 
   unsigned int    num_glyphs;
   unsigned int    orig_fdcount;
   unsigned int    subset_fdcount;
   unsigned int    subset_fdselect_format;
-  hb_vector_t<code_pair>   subset_fdselect_ranges;
+  hb_vector_t<code_pair_t>   subset_fdselect_ranges;
 
   /* font dict index remap table from fullset FDArray to subset FDArray.
    * set to CFF_UNDEF_CODE if excluded from subset */
-  Remap   fdmap;
+  remap_t   fdmap;
 
-  StrBuffArray	    subset_charstrings;
-  StrBuffArray	    subset_globalsubrs;
-  hb_vector_t<StrBuffArray> subset_localsubrs;
-  hb_vector_t<FontDictValuesMod>  fontdicts_mod;
+  str_buff_vec_t	    subset_charstrings;
+  str_buff_vec_t	    subset_globalsubrs;
+  hb_vector_t<str_buff_vec_t> subset_localsubrs;
+  hb_vector_t<font_dict_values_mod_t>  fontdicts_mod;
 
   bool		    drop_hints;
 
@@ -849,18 +849,18 @@ struct cff_subset_plan {
   bool		    subset_encoding;
   uint8_t		 subset_enc_format;
   unsigned int	    subset_enc_num_codes;
-  RangeList	       subset_enc_code_ranges;
-  hb_vector_t<code_pair>  subset_enc_supp_codes;
+  range_list_t	       subset_enc_code_ranges;
+  hb_vector_t<code_pair_t>  subset_enc_supp_codes;
 
   uint8_t		 subset_charset_format;
-  RangeList	       subset_charset_ranges;
+  range_list_t	       subset_charset_ranges;
   bool		    subset_charset;
 
-  RemapSID		sidmap;
-  unsigned int	    topDictModSIDs[NameDictValues::ValCount];
+  remap_sid_t		sidmap;
+  unsigned int	    topDictModSIDs[name_dict_values_t::ValCount];
 
   bool		    desubroutinize;
-  CFF1SubrSubsetter       subr_subsetter;
+  cff1_subr_subsetter_t       subr_subsetter;
 };
 
 static inline bool _write_cff1 (const cff_subset_plan &plan,
@@ -898,8 +898,8 @@ static inline bool _write_cff1 (const cff_subset_plan &plan,
     assert (plan.offsets.topDictInfo.offset == c.head - c.start);
     CFF1IndexOf<TopDict> *dest = c.start_embed< CFF1IndexOf<TopDict> > ();
     if (dest == nullptr) return false;
-    CFF1TopDict_OpSerializer topSzr;
-    TopDictModifiers  modifier (plan.offsets, plan.topDictModSIDs);
+    cff1_top_dict_op_serializer_t topSzr;
+    top_dict_modifiers_t  modifier (plan.offsets, plan.topDictModSIDs);
     if (unlikely (!dest->serialize (&c, plan.offsets.topDictInfo.offSize,
 				    &plan.topdict_mod, 1,
 				    plan.topdict_sizes, topSzr, modifier)))
@@ -988,7 +988,7 @@ static inline bool _write_cff1 (const cff_subset_plan &plan,
     assert (plan.offsets.FDArrayInfo.offset == c.head - c.start);
     CFF1FDArray  *fda = c.start_embed<CFF1FDArray> ();
     if (unlikely (fda == nullptr)) return false;
-    CFF1FontDict_OpSerializer  fontSzr;
+    cff1_font_dict_op_serializer_t  fontSzr;
     if (unlikely (!fda->serialize (&c, plan.offsets.FDArrayInfo.offSize,
 				   plan.fontdicts_mod,
 				   fontSzr)))
@@ -1020,7 +1020,7 @@ static inline bool _write_cff1 (const cff_subset_plan &plan,
       if (unlikely (pd == nullptr)) return false;
       unsigned int priv_size = plan.fontdicts_mod[plan.fdmap[i]].privateDictInfo.size;
       bool result;
-      CFFPrivateDict_OpSerializer privSzr (plan.desubroutinize, plan.drop_hints);
+      cff_private_dict_op_serializer_t privSzr (plan.desubroutinize, plan.drop_hints);
       /* N.B. local subrs immediately follows its corresponding private dict. i.e., subr offset == private dict size */
       unsigned int  subroffset = (plan.offsets.localSubrsInfos[i].size > 0)? priv_size: 0;
       result = pd->serialize (&c, acc.privateDicts[i], privSzr, subroffset);

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -72,10 +72,10 @@ struct cff1_sub_table_offsets_t : cff_sub_table_offsets_t
   }
 
   unsigned int  nameIndexOffset;
-  table_info_t     stringIndexInfo;
+  table_info_t	stringIndexInfo;
   unsigned int  encodingOffset;
-  table_info_t     charsetInfo;
-  table_info_t     privateDictInfo;
+  table_info_t	charsetInfo;
+  table_info_t	privateDictInfo;
 };
 
 /* a copy of a parsed out cff1_top_dict_values_t augmented with additional operators */
@@ -824,9 +824,9 @@ struct cff_subset_plan {
   unsigned int get_final_size () const  { return final_size; }
 
   unsigned int	      final_size;
-  hb_vector_t<unsigned int> topdict_sizes;
-  cff1_top_dict_values_mod_t      topdict_mod;
-  cff1_sub_table_offsets_t       offsets;
+  hb_vector_t<unsigned int>	topdict_sizes;
+  cff1_top_dict_values_mod_t	topdict_mod;
+  cff1_sub_table_offsets_t	offsets;
 
   unsigned int    num_glyphs;
   unsigned int    orig_fdcount;
@@ -838,28 +838,28 @@ struct cff_subset_plan {
    * set to CFF_UNDEF_CODE if excluded from subset */
   remap_t   fdmap;
 
-  str_buff_vec_t	    subset_charstrings;
-  str_buff_vec_t	    subset_globalsubrs;
-  hb_vector_t<str_buff_vec_t> subset_localsubrs;
+  str_buff_vec_t		subset_charstrings;
+  str_buff_vec_t		subset_globalsubrs;
+  hb_vector_t<str_buff_vec_t>	subset_localsubrs;
   hb_vector_t<font_dict_values_mod_t>  fontdicts_mod;
 
-  bool		    drop_hints;
+  bool		drop_hints;
 
-  bool		    gid_renum;
-  bool		    subset_encoding;
-  uint8_t		 subset_enc_format;
-  unsigned int	    subset_enc_num_codes;
-  range_list_t	       subset_enc_code_ranges;
+  bool		gid_renum;
+  bool		subset_encoding;
+  uint8_t	subset_enc_format;
+  unsigned int	subset_enc_num_codes;
+  range_list_t	subset_enc_code_ranges;
   hb_vector_t<code_pair_t>  subset_enc_supp_codes;
 
-  uint8_t		 subset_charset_format;
-  range_list_t	       subset_charset_ranges;
-  bool		    subset_charset;
+  uint8_t	subset_charset_format;
+  range_list_t	subset_charset_ranges;
+  bool		subset_charset;
 
-  remap_sid_t		sidmap;
-  unsigned int	    topDictModSIDs[name_dict_values_t::ValCount];
+  remap_sid_t	sidmap;
+  unsigned int	topDictModSIDs[name_dict_values_t::ValCount];
 
-  bool		    desubroutinize;
+  bool		desubroutinize;
   cff1_subr_subsetter_t       subr_subsetter;
 };
 
@@ -1050,9 +1050,9 @@ static inline bool _write_cff1 (const cff_subset_plan &plan,
 
 static bool
 _hb_subset_cff1 (const OT::cff1::accelerator_subset_t  &acc,
-		const char		      *data,
-		hb_subset_plan_t		*plan,
-		hb_blob_t		       **prime /* OUT */)
+		const char		*data,
+		hb_subset_plan_t	*plan,
+		hb_blob_t		**prime /* OUT */)
 {
   cff_subset_plan cff_plan;
 

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -36,9 +36,9 @@ using namespace CFF;
 
 struct cff2_sub_table_offsets_t : cff_sub_table_offsets_t
 {
-  inline cff2_sub_table_offsets_t ()
-	: cff_sub_table_offsets_t (),
-	  varStoreOffset (0)
+  cff2_sub_table_offsets_t ()
+    : cff_sub_table_offsets_t (),
+      varStoreOffset (0)
   {}
 
   unsigned int  varStoreOffset;
@@ -46,9 +46,9 @@ struct cff2_sub_table_offsets_t : cff_sub_table_offsets_t
 
 struct cff2_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<>
 {
-  inline bool serialize (hb_serialize_context_t *c,
-			const op_str_t &opstr,
-			const cff2_sub_table_offsets_t &offsets) const
+  bool serialize (hb_serialize_context_t *c,
+		  const op_str_t &opstr,
+		  const cff2_sub_table_offsets_t &offsets) const
   {
     TRACE_SERIALIZE (this);
 
@@ -77,7 +77,7 @@ struct cff2_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<>
 
 struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatten_param_t>
 {
-  static inline void flush_args_and_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_args_and_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     switch (op)
     {
@@ -105,7 +105,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
     }
   }
 
-  static inline void flush_args (cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_args (cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     for (unsigned int i = 0; i < env.argStack.get_count ();)
     {
@@ -130,7 +130,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
     SUPER::flush_args (env, param);
   }
 
-  static inline void flatten_blends (const blend_arg_t &arg, unsigned int i, cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static void flatten_blends (const blend_arg_t &arg, unsigned int i, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     /* flatten the default values */
     str_encoder_t  encoder (param.flatStr);
@@ -157,7 +157,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
     encoder.encode_op (OpCode_blendcs);
   }
 
-  static inline void flush_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     switch (op)
     {
@@ -177,7 +177,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
 
 struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t, subr_subset_param_t>
 {
-  static inline void process_op (op_code_t op, cff2_cs_interp_env_t &env, subr_subset_param_t& param)
+  static void process_op (op_code_t op, cff2_cs_interp_env_t &env, subr_subset_param_t& param)
   {
     switch (op) {
 
@@ -208,9 +208,9 @@ struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t
   }
 
   protected:
-  static inline void process_call_subr (op_code_t op, cs_type_t type,
-				       cff2_cs_interp_env_t &env, subr_subset_param_t& param,
-				       cff2_biased_subrs_t& subrs, hb_set_t *closure)
+  static void process_call_subr (op_code_t op, cs_type_t type,
+				 cff2_cs_interp_env_t &env, subr_subset_param_t& param,
+				 cff2_biased_subrs_t& subrs, hb_set_t *closure)
   {
     byte_str_ref_t    str_ref = env.str_ref;
     env.callSubr (subrs, type);
@@ -225,7 +225,7 @@ struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t
 
 struct cff2_subr_subsetter_t : subr_subsetter_t<cff2_subr_subsetter_t, CFF2Subrs, const OT::cff2::accelerator_subset_t, cff2_cs_interp_env_t, cff2_cs_opset_subr_subset_t>
 {
-  static inline void finalize_parsed_str (cff2_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
+  static void finalize_parsed_str (cff2_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
   {
     /* vsindex is inserted at the beginning of the charstring as necessary */
     if (env.seen_vsindex ())
@@ -238,7 +238,7 @@ struct cff2_subr_subsetter_t : subr_subsetter_t<cff2_subr_subsetter_t, CFF2Subrs
 };
 
 struct cff2_subset_plan {
-  inline cff2_subset_plan ()
+  cff2_subset_plan ()
     : final_size (0),
       orig_fdcount (0),
       subset_fdcount(1),
@@ -254,7 +254,7 @@ struct cff2_subset_plan {
     privateDictInfos.init ();
   }
 
-  inline ~cff2_subset_plan ()
+  ~cff2_subset_plan ()
   {
     subset_fdselect_ranges.fini ();
     fdmap.fini ();
@@ -264,8 +264,8 @@ struct cff2_subset_plan {
     privateDictInfos.fini ();
   }
 
-  inline bool create (const OT::cff2::accelerator_subset_t &acc,
-		      hb_subset_plan_t *plan)
+  bool create (const OT::cff2::accelerator_subset_t &acc,
+	      hb_subset_plan_t *plan)
   {
     final_size = 0;
     orig_fdcount = acc.fdArray->count;
@@ -342,7 +342,7 @@ struct cff2_subset_plan {
     final_size += offsets.globalSubrsInfo.size;
 
     /* variation store */
-    if (acc.varStore != &Null(cff2_variation_store_t))
+    if (acc.varStore != &Null(CFF2VariationStore))
     {
       offsets.varStoreOffset = final_size;
       final_size += acc.varStore->get_size ();
@@ -412,26 +412,26 @@ struct cff2_subset_plan {
     return true;
   }
 
-  inline unsigned int get_final_size () const  { return final_size; }
+  unsigned int get_final_size () const  { return final_size; }
 
-  unsigned int			final_size;
-  cff2_sub_table_offsets_t	offsets;
+  unsigned int	final_size;
+  cff2_sub_table_offsets_t offsets;
 
-  unsigned int			orig_fdcount;
-  unsigned int			subset_fdcount;
-  unsigned int			subset_fdselect_format;
-  hb_vector_t<code_pair_t>	subset_fdselect_ranges;
+  unsigned int    orig_fdcount;
+  unsigned int    subset_fdcount;
+  unsigned int    subset_fdselect_format;
+  hb_vector_t<code_pair_t>   subset_fdselect_ranges;
 
   remap_t   fdmap;
 
-  str_buff_vec_t		subset_charstrings;
-  str_buff_vec_t		subset_globalsubrs;
-  hb_vector_t<str_buff_vec_t>	subset_localsubrs;
-  hb_vector_t<table_info_t>	privateDictInfos;
+  str_buff_vec_t	    subset_charstrings;
+  str_buff_vec_t	    subset_globalsubrs;
+  hb_vector_t<str_buff_vec_t> subset_localsubrs;
+  hb_vector_t<table_info_t>  privateDictInfos;
 
   bool	    drop_hints;
   bool	    desubroutinize;
-  cff2_subr_subsetter_t		subr_subsetter;
+  cff2_subr_subsetter_t       subr_subsetter;
 };
 
 static inline bool _write_cff2 (const cff2_subset_plan &plan,
@@ -477,10 +477,10 @@ static inline bool _write_cff2 (const cff2_subset_plan &plan,
   }
 
   /* variation store */
-  if (acc.varStore != &Null(cff2_variation_store_t))
+  if (acc.varStore != &Null(CFF2VariationStore))
   {
     assert (plan.offsets.varStoreOffset == c.head - c.start);
-    cff2_variation_store_t *dest = c.start_embed<cff2_variation_store_t> ();
+    CFF2VariationStore *dest = c.start_embed<CFF2VariationStore> ();
     if (unlikely (!dest->serialize (&c, acc.varStore)))
     {
       DEBUG_MSG (SUBSET, nullptr, "failed to serialize CFF2 Variation Store");

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -34,21 +34,21 @@
 
 using namespace CFF;
 
-struct CFF2SubTableOffsets : CFFSubTableOffsets
+struct cff2_sub_table_offsets_t : cff_sub_table_offsets_t
 {
-  CFF2SubTableOffsets ()
-    : CFFSubTableOffsets (),
+  cff2_sub_table_offsets_t ()
+    : cff_sub_table_offsets_t (),
       varStoreOffset (0)
   {}
 
   unsigned int  varStoreOffset;
 };
 
-struct CFF2TopDict_OpSerializer : CFFTopDict_OpSerializer<>
+struct cff2_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<>
 {
   bool serialize (hb_serialize_context_t *c,
-		  const OpStr &opstr,
-		  const CFF2SubTableOffsets &offsets) const
+		  const op_str_t &opstr,
+		  const cff2_sub_table_offsets_t &offsets) const
   {
     TRACE_SERIALIZE (this);
 
@@ -58,11 +58,11 @@ struct CFF2TopDict_OpSerializer : CFFTopDict_OpSerializer<>
 	return_trace (FontDict::serialize_offset4_op(c, opstr.op, offsets.varStoreOffset));
 
       default:
-	return_trace (CFFTopDict_OpSerializer<>::serialize (c, opstr, offsets));
+	return_trace (cff_top_dict_op_serializer_t<>::serialize (c, opstr, offsets));
     }
   }
 
-  unsigned int calculate_serialized_size (const OpStr &opstr) const
+  unsigned int calculate_serialized_size (const op_str_t &opstr) const
   {
     switch (opstr.op)
     {
@@ -70,14 +70,14 @@ struct CFF2TopDict_OpSerializer : CFFTopDict_OpSerializer<>
 	return OpCode_Size (OpCode_longintdict) + 4 + OpCode_Size (opstr.op);
 
       default:
-	return CFFTopDict_OpSerializer<>::calculate_serialized_size (opstr);
+	return cff_top_dict_op_serializer_t<>::calculate_serialized_size (opstr);
     }
   }
 };
 
-struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
+struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatten_param_t>
 {
-  static void flush_args_and_op (OpCode op, CFF2CSInterpEnv &env, FlattenParam& param)
+  static void flush_args_and_op (OpCode op, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     switch (op)
     {
@@ -105,11 +105,11 @@ struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
     }
   }
 
-  static void flush_args (CFF2CSInterpEnv &env, FlattenParam& param)
+  static void flush_args (cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     for (unsigned int i = 0; i < env.argStack.get_count ();)
     {
-      const BlendArg &arg = env.argStack[i];
+      const blend_arg_t &arg = env.argStack[i];
       if (arg.blending ())
       {
       	if (unlikely (!((arg.numValues > 0) && (env.argStack.get_count () >= arg.numValues))))
@@ -122,7 +122,7 @@ struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
       }
       else
       {
-	StrEncoder  encoder (param.flatStr);
+	str_encoder_t  encoder (param.flatStr);
 	encoder.encode_num (arg);
 	i++;
       }
@@ -130,13 +130,13 @@ struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
     SUPER::flush_args (env, param);
   }
 
-  static void flatten_blends (const BlendArg &arg, unsigned int i, CFF2CSInterpEnv &env, FlattenParam& param)
+  static void flatten_blends (const blend_arg_t &arg, unsigned int i, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     /* flatten the default values */
-    StrEncoder  encoder (param.flatStr);
+    str_encoder_t  encoder (param.flatStr);
     for (unsigned int j = 0; j < arg.numValues; j++)
     {
-      const BlendArg &arg1 = env.argStack[i + j];
+      const blend_arg_t &arg1 = env.argStack[i + j];
       if (unlikely (!((arg1.blending () && (arg.numValues == arg1.numValues) && (arg1.valueIndex == j) &&
 	      (arg1.deltas.len == env.get_region_count ())))))
       {
@@ -148,7 +148,7 @@ struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
     /* flatten deltas for each value */
     for (unsigned int j = 0; j < arg.numValues; j++)
     {
-      const BlendArg &arg1 = env.argStack[i + j];
+      const blend_arg_t &arg1 = env.argStack[i + j];
       for (unsigned int k = 0; k < arg1.deltas.len; k++)
 	encoder.encode_num (arg1.deltas[k]);
     }
@@ -157,7 +157,7 @@ struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
     encoder.encode_op (OpCode_blendcs);
   }
 
-  static void flush_op (OpCode op, CFF2CSInterpEnv &env, FlattenParam& param)
+  static void flush_op (OpCode op, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     switch (op)
     {
@@ -165,19 +165,19 @@ struct CFF2CSOpSet_Flatten : CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam>
       case OpCode_endchar:
 	return;
       default:
-	StrEncoder  encoder (param.flatStr);
+	str_encoder_t  encoder (param.flatStr);
 	encoder.encode_op (op);
     }
   }
 
   private:
-  typedef CFF2CSOpSet<CFF2CSOpSet_Flatten, FlattenParam> SUPER;
-  typedef CSOpSet<BlendArg, CFF2CSOpSet_Flatten, CFF2CSOpSet_Flatten, CFF2CSInterpEnv, FlattenParam> CSOPSET;
+  typedef cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatten_param_t> SUPER;
+  typedef cs_opset_t<blend_arg_t, cff2_cs_opset_flatten_t, cff2_cs_opset_flatten_t, cff2_cs_interp_env_t, flatten_param_t> CSOPSET;
 };
 
-struct CFF2CSOpSet_SubrSubset : CFF2CSOpSet<CFF2CSOpSet_SubrSubset, SubrSubsetParam>
+struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t, subr_subset_param_t>
 {
-  static void process_op (OpCode op, CFF2CSInterpEnv &env, SubrSubsetParam& param)
+  static void process_op (OpCode op, cff2_cs_interp_env_t &env, subr_subset_param_t& param)
   {
     switch (op) {
 
@@ -209,8 +209,8 @@ struct CFF2CSOpSet_SubrSubset : CFF2CSOpSet<CFF2CSOpSet_SubrSubset, SubrSubsetPa
 
   protected:
   static void process_call_subr (OpCode op, CSType type,
-				 CFF2CSInterpEnv &env, SubrSubsetParam& param,
-				 CFF2BiasedSubrs& subrs, hb_set_t *closure)
+				 cff2_cs_interp_env_t &env, subr_subset_param_t& param,
+				 cff2_biased_subrs_t& subrs, hb_set_t *closure)
   {
     byte_str_ref_t    str_ref = env.str_ref;
     env.callSubr (subrs, type);
@@ -220,17 +220,17 @@ struct CFF2CSOpSet_SubrSubset : CFF2CSOpSet<CFF2CSOpSet_SubrSubset, SubrSubsetPa
   }
 
   private:
-  typedef CFF2CSOpSet<CFF2CSOpSet_SubrSubset, SubrSubsetParam> SUPER;
+  typedef cff2_cs_opset_t<cff2_cs_opset_subr_subset_t, subr_subset_param_t> SUPER;
 };
 
-struct CFF2SubrSubsetter : SubrSubsetter<CFF2SubrSubsetter, CFF2Subrs, const OT::cff2::accelerator_subset_t, CFF2CSInterpEnv, CFF2CSOpSet_SubrSubset>
+struct cff2_subr_subsetter_t : subr_subsetter_t<cff2_subr_subsetter_t, CFF2Subrs, const OT::cff2::accelerator_subset_t, cff2_cs_interp_env_t, cff2_cs_opset_subr_subset_t>
 {
-  static void finalize_parsed_str (CFF2CSInterpEnv &env, SubrSubsetParam& param, ParsedCStr &charstring)
+  static void finalize_parsed_str (cff2_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
   {
     /* vsindex is inserted at the beginning of the charstring as necessary */
     if (env.seen_vsindex ())
     {
-      Number  ivs;
+      number_t  ivs;
       ivs.set_int ((int)env.get_ivs ());
       charstring.set_prefix (ivs, OpCode_vsindexcs);
     }
@@ -278,7 +278,7 @@ struct cff2_subset_plan {
 
     /* top dict */
     {
-      CFF2TopDict_OpSerializer topSzr;
+      cff2_top_dict_op_serializer_t topSzr;
       offsets.topDictInfo.size = TopDict::calculate_serialized_size (acc.topDict, topSzr);
       final_size += offsets.topDictInfo.size;
     }
@@ -286,7 +286,7 @@ struct cff2_subset_plan {
     if (desubroutinize)
     {
       /* Flatten global & local subrs */
-      SubrFlattener<const OT::cff2::accelerator_subset_t, CFF2CSInterpEnv, CFF2CSOpSet_Flatten>
+      subr_flattener_t<const OT::cff2::accelerator_subset_t, cff2_cs_interp_env_t, cff2_cs_opset_flatten_t>
 		    flattener(acc, plan->glyphs, plan->drop_hints);
       if (!flattener.flatten (subset_charstrings))
 	return false;
@@ -370,7 +370,7 @@ struct cff2_subset_plan {
     /* FDArray (FDIndex) */
     {
       offsets.FDArrayInfo.offset = final_size;
-      CFFFontDict_OpSerializer fontSzr;
+      cff_font_dict_op_serializer_t fontSzr;
       unsigned int dictsSize = 0;
       for (unsigned int i = 0; i < acc.fontDicts.len; i++)
 	if (fdmap.includes (i))
@@ -395,9 +395,9 @@ struct cff2_subset_plan {
       if (fdmap.includes (i))
       {
 	bool  has_localsubrs = offsets.localSubrsInfos[i].size > 0;
-	CFFPrivateDict_OpSerializer privSzr (desubroutinize, drop_hints);
+	cff_private_dict_op_serializer_t privSzr (desubroutinize, drop_hints);
 	unsigned int  priv_size = PrivateDict::calculate_serialized_size (acc.privateDicts[i], privSzr, has_localsubrs);
-	TableInfo  privInfo = { final_size, priv_size, 0 };
+	table_info_t  privInfo = { final_size, priv_size, 0 };
 	privateDictInfos.push (privInfo);
 	final_size += privInfo.size;
 
@@ -415,23 +415,23 @@ struct cff2_subset_plan {
   unsigned int get_final_size () const  { return final_size; }
 
   unsigned int	final_size;
-  CFF2SubTableOffsets offsets;
+  cff2_sub_table_offsets_t offsets;
 
   unsigned int    orig_fdcount;
   unsigned int    subset_fdcount;
   unsigned int    subset_fdselect_format;
-  hb_vector_t<code_pair>   subset_fdselect_ranges;
+  hb_vector_t<code_pair_t>   subset_fdselect_ranges;
 
-  Remap   fdmap;
+  remap_t   fdmap;
 
-  StrBuffArray	    subset_charstrings;
-  StrBuffArray	    subset_globalsubrs;
-  hb_vector_t<StrBuffArray> subset_localsubrs;
-  hb_vector_t<TableInfo>  privateDictInfos;
+  str_buff_vec_t	    subset_charstrings;
+  str_buff_vec_t	    subset_globalsubrs;
+  hb_vector_t<str_buff_vec_t> subset_localsubrs;
+  hb_vector_t<table_info_t>  privateDictInfos;
 
   bool	    drop_hints;
   bool	    desubroutinize;
-  CFF2SubrSubsetter       subr_subsetter;
+  cff2_subr_subsetter_t       subr_subsetter;
 };
 
 static inline bool _write_cff2 (const cff2_subset_plan &plan,
@@ -456,7 +456,7 @@ static inline bool _write_cff2 (const cff2_subset_plan &plan,
     assert (cff2->topDict == c.head - c.start);
     cff2->topDictSize.set (plan.offsets.topDictInfo.size);
     TopDict &dict = cff2 + cff2->topDict;
-    CFF2TopDict_OpSerializer topSzr;
+    cff2_top_dict_op_serializer_t topSzr;
     if (unlikely (!dict.serialize (&c, acc.topDict, topSzr, plan.offsets)))
     {
       DEBUG_MSG (SUBSET, nullptr, "failed to serialize CFF2 top dict");
@@ -507,7 +507,7 @@ static inline bool _write_cff2 (const cff2_subset_plan &plan,
     assert (plan.offsets.FDArrayInfo.offset == c.head - c.start);
     CFF2FDArray  *fda = c.start_embed<CFF2FDArray> ();
     if (unlikely (fda == nullptr)) return false;
-    CFFFontDict_OpSerializer  fontSzr;
+    cff_font_dict_op_serializer_t  fontSzr;
     if (unlikely (!fda->serialize (&c, plan.offsets.FDArrayInfo.offSize,
 				   acc.fontDicts, plan.subset_fdcount, plan.fdmap,
 				   fontSzr, plan.privateDictInfos)))
@@ -539,7 +539,7 @@ static inline bool _write_cff2 (const cff2_subset_plan &plan,
       if (unlikely (pd == nullptr)) return false;
       unsigned int priv_size = plan.privateDictInfos[plan.fdmap[i]].size;
       bool result;
-      CFFPrivateDict_OpSerializer privSzr (plan.desubroutinize, plan.drop_hints);
+      cff_private_dict_op_serializer_t privSzr (plan.desubroutinize, plan.drop_hints);
       /* N.B. local subrs immediately follows its corresponding private dict. i.e., subr offset == private dict size */
       unsigned int  subroffset = (plan.offsets.localSubrsInfos[i].size > 0)? priv_size: 0;
       result = pd->serialize (&c, acc.privateDicts[i], privSzr, subroffset);

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -202,7 +202,7 @@ struct CFF2CSOpSet_SubrSubset : CFF2CSOpSet<CFF2CSOpSet_SubrSubset, SubrSubsetPa
 
       default:
 	SUPER::process_op (op, env, param);
-	param.current_parsed_str->add_op (op, env.substr);
+	param.current_parsed_str->add_op (op, env.str_ref);
 	break;
     }
   }
@@ -212,9 +212,9 @@ struct CFF2CSOpSet_SubrSubset : CFF2CSOpSet<CFF2CSOpSet_SubrSubset, SubrSubsetPa
 				 CFF2CSInterpEnv &env, SubrSubsetParam& param,
 				 CFF2BiasedSubrs& subrs, hb_set_t *closure)
   {
-    byte_str_ref_t    substr = env.substr;
+    byte_str_ref_t    str_ref = env.str_ref;
     env.callSubr (subrs, type);
-    param.current_parsed_str->add_call_op (op, substr, env.context.subr_num);
+    param.current_parsed_str->add_call_op (op, str_ref, env.context.subr_num);
     hb_set_add (closure, env.context.subr_num);
     param.set_current_str (env, true);
   }

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -212,7 +212,7 @@ struct CFF2CSOpSet_SubrSubset : CFF2CSOpSet<CFF2CSOpSet_SubrSubset, SubrSubsetPa
 				 CFF2CSInterpEnv &env, SubrSubsetParam& param,
 				 CFF2BiasedSubrs& subrs, hb_set_t *closure)
   {
-    SubByteStr    substr = env.substr;
+    byte_str_ref_t    substr = env.substr;
     env.callSubr (subrs, type);
     param.current_parsed_str->add_call_op (op, substr, env.context.subr_num);
     hb_set_add (closure, env.context.subr_num);

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -77,7 +77,7 @@ struct cff2_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<>
 
 struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatten_param_t>
 {
-  static void flush_args_and_op (OpCode op, cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_args_and_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     switch (op)
     {
@@ -157,7 +157,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
     encoder.encode_op (OpCode_blendcs);
   }
 
-  static void flush_op (OpCode op, cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static void flush_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     switch (op)
     {
@@ -177,7 +177,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
 
 struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t, subr_subset_param_t>
 {
-  static void process_op (OpCode op, cff2_cs_interp_env_t &env, subr_subset_param_t& param)
+  static void process_op (op_code_t op, cff2_cs_interp_env_t &env, subr_subset_param_t& param)
   {
     switch (op) {
 
@@ -208,7 +208,7 @@ struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t
   }
 
   protected:
-  static void process_call_subr (OpCode op, CSType type,
+  static void process_call_subr (op_code_t op, cs_type_t type,
 				 cff2_cs_interp_env_t &env, subr_subset_param_t& param,
 				 cff2_biased_subrs_t& subrs, hb_set_t *closure)
   {

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -36,9 +36,9 @@ using namespace CFF;
 
 struct cff2_sub_table_offsets_t : cff_sub_table_offsets_t
 {
-  cff2_sub_table_offsets_t ()
-    : cff_sub_table_offsets_t (),
-      varStoreOffset (0)
+  inline cff2_sub_table_offsets_t ()
+	: cff_sub_table_offsets_t (),
+	  varStoreOffset (0)
   {}
 
   unsigned int  varStoreOffset;
@@ -46,9 +46,9 @@ struct cff2_sub_table_offsets_t : cff_sub_table_offsets_t
 
 struct cff2_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<>
 {
-  bool serialize (hb_serialize_context_t *c,
-		  const op_str_t &opstr,
-		  const cff2_sub_table_offsets_t &offsets) const
+  inline bool serialize (hb_serialize_context_t *c,
+			const op_str_t &opstr,
+			const cff2_sub_table_offsets_t &offsets) const
   {
     TRACE_SERIALIZE (this);
 
@@ -77,7 +77,7 @@ struct cff2_top_dict_op_serializer_t : cff_top_dict_op_serializer_t<>
 
 struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatten_param_t>
 {
-  static void flush_args_and_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static inline void flush_args_and_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     switch (op)
     {
@@ -105,7 +105,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
     }
   }
 
-  static void flush_args (cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static inline void flush_args (cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     for (unsigned int i = 0; i < env.argStack.get_count ();)
     {
@@ -130,7 +130,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
     SUPER::flush_args (env, param);
   }
 
-  static void flatten_blends (const blend_arg_t &arg, unsigned int i, cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static inline void flatten_blends (const blend_arg_t &arg, unsigned int i, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     /* flatten the default values */
     str_encoder_t  encoder (param.flatStr);
@@ -157,7 +157,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
     encoder.encode_op (OpCode_blendcs);
   }
 
-  static void flush_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
+  static inline void flush_op (op_code_t op, cff2_cs_interp_env_t &env, flatten_param_t& param)
   {
     switch (op)
     {
@@ -177,7 +177,7 @@ struct cff2_cs_opset_flatten_t : cff2_cs_opset_t<cff2_cs_opset_flatten_t, flatte
 
 struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t, subr_subset_param_t>
 {
-  static void process_op (op_code_t op, cff2_cs_interp_env_t &env, subr_subset_param_t& param)
+  static inline void process_op (op_code_t op, cff2_cs_interp_env_t &env, subr_subset_param_t& param)
   {
     switch (op) {
 
@@ -208,9 +208,9 @@ struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t
   }
 
   protected:
-  static void process_call_subr (op_code_t op, cs_type_t type,
-				 cff2_cs_interp_env_t &env, subr_subset_param_t& param,
-				 cff2_biased_subrs_t& subrs, hb_set_t *closure)
+  static inline void process_call_subr (op_code_t op, cs_type_t type,
+				       cff2_cs_interp_env_t &env, subr_subset_param_t& param,
+				       cff2_biased_subrs_t& subrs, hb_set_t *closure)
   {
     byte_str_ref_t    str_ref = env.str_ref;
     env.callSubr (subrs, type);
@@ -225,7 +225,7 @@ struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t
 
 struct cff2_subr_subsetter_t : subr_subsetter_t<cff2_subr_subsetter_t, CFF2Subrs, const OT::cff2::accelerator_subset_t, cff2_cs_interp_env_t, cff2_cs_opset_subr_subset_t>
 {
-  static void finalize_parsed_str (cff2_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
+  static inline void finalize_parsed_str (cff2_cs_interp_env_t &env, subr_subset_param_t& param, parsed_cs_str_t &charstring)
   {
     /* vsindex is inserted at the beginning of the charstring as necessary */
     if (env.seen_vsindex ())
@@ -238,7 +238,7 @@ struct cff2_subr_subsetter_t : subr_subsetter_t<cff2_subr_subsetter_t, CFF2Subrs
 };
 
 struct cff2_subset_plan {
-  cff2_subset_plan ()
+  inline cff2_subset_plan ()
     : final_size (0),
       orig_fdcount (0),
       subset_fdcount(1),
@@ -254,7 +254,7 @@ struct cff2_subset_plan {
     privateDictInfos.init ();
   }
 
-  ~cff2_subset_plan ()
+  inline ~cff2_subset_plan ()
   {
     subset_fdselect_ranges.fini ();
     fdmap.fini ();
@@ -264,8 +264,8 @@ struct cff2_subset_plan {
     privateDictInfos.fini ();
   }
 
-  bool create (const OT::cff2::accelerator_subset_t &acc,
-	      hb_subset_plan_t *plan)
+  inline bool create (const OT::cff2::accelerator_subset_t &acc,
+		      hb_subset_plan_t *plan)
   {
     final_size = 0;
     orig_fdcount = acc.fdArray->count;
@@ -342,7 +342,7 @@ struct cff2_subset_plan {
     final_size += offsets.globalSubrsInfo.size;
 
     /* variation store */
-    if (acc.varStore != &Null(CFF2VariationStore))
+    if (acc.varStore != &Null(cff2_variation_store_t))
     {
       offsets.varStoreOffset = final_size;
       final_size += acc.varStore->get_size ();
@@ -412,26 +412,26 @@ struct cff2_subset_plan {
     return true;
   }
 
-  unsigned int get_final_size () const  { return final_size; }
+  inline unsigned int get_final_size () const  { return final_size; }
 
-  unsigned int	final_size;
-  cff2_sub_table_offsets_t offsets;
+  unsigned int			final_size;
+  cff2_sub_table_offsets_t	offsets;
 
-  unsigned int    orig_fdcount;
-  unsigned int    subset_fdcount;
-  unsigned int    subset_fdselect_format;
-  hb_vector_t<code_pair_t>   subset_fdselect_ranges;
+  unsigned int			orig_fdcount;
+  unsigned int			subset_fdcount;
+  unsigned int			subset_fdselect_format;
+  hb_vector_t<code_pair_t>	subset_fdselect_ranges;
 
   remap_t   fdmap;
 
-  str_buff_vec_t	    subset_charstrings;
-  str_buff_vec_t	    subset_globalsubrs;
-  hb_vector_t<str_buff_vec_t> subset_localsubrs;
-  hb_vector_t<table_info_t>  privateDictInfos;
+  str_buff_vec_t		subset_charstrings;
+  str_buff_vec_t		subset_globalsubrs;
+  hb_vector_t<str_buff_vec_t>	subset_localsubrs;
+  hb_vector_t<table_info_t>	privateDictInfos;
 
   bool	    drop_hints;
   bool	    desubroutinize;
-  cff2_subr_subsetter_t       subr_subsetter;
+  cff2_subr_subsetter_t		subr_subsetter;
 };
 
 static inline bool _write_cff2 (const cff2_subset_plan &plan,
@@ -477,10 +477,10 @@ static inline bool _write_cff2 (const cff2_subset_plan &plan,
   }
 
   /* variation store */
-  if (acc.varStore != &Null(CFF2VariationStore))
+  if (acc.varStore != &Null(cff2_variation_store_t))
   {
     assert (plan.offsets.varStoreOffset == c.head - c.start);
-    CFF2VariationStore *dest = c.start_embed<CFF2VariationStore> ();
+    cff2_variation_store_t *dest = c.start_embed<cff2_variation_store_t> ();
     if (unlikely (!dest->serialize (&c, acc.varStore)))
     {
       DEBUG_MSG (SUBSET, nullptr, "failed to serialize CFF2 Variation Store");

--- a/src/hb-subset-cff2.hh
+++ b/src/hb-subset-cff2.hh
@@ -33,6 +33,6 @@
 
 HB_INTERNAL bool
 hb_subset_cff2 (hb_subset_plan_t *plan,
-	       hb_blob_t	**cff2_prime /* OUT */);
+	       hb_blob_t       **cff2_prime /* OUT */);
 
 #endif /* HB_SUBSET_CFF2_HH */

--- a/src/hb-subset-cff2.hh
+++ b/src/hb-subset-cff2.hh
@@ -33,6 +33,6 @@
 
 HB_INTERNAL bool
 hb_subset_cff2 (hb_subset_plan_t *plan,
-	       hb_blob_t       **cff2_prime /* OUT */);
+	       hb_blob_t	**cff2_prime /* OUT */);
 
 #endif /* HB_SUBSET_CFF2_HH */


### PR DESCRIPTION
Fixes issue #1496.

Reimplemented struct `ByteStr` in CFF code as `byte_str_t` based on `hb_ubytes_t`.

Uncamelized all non-table type names in CFF namespace, e.g., `CFF1TopDict_OpSerializer` to `cff1_top_dict_op_serializer_t`.
