### PR TITLE
[DONTMERGE] Add operator= on IntType

### DIFF
--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -64,6 +64,8 @@ struct IntType
   typedef typename hb_signedness_int<hb_is_signed<Type>::value>::value wide_type;
 
   void set (wide_type i) { v.set (i); }
+  template <typename T>
+  IntType<Type, Size>& operator = (const T& v) { set (v); return *this; }
   operator wide_type () const { return v; }
   bool operator == (const IntType<Type,Size> &o) const { return (Type) v == (Type) o.v; }
   bool operator != (const IntType<Type,Size> &o) const { return !(*this == o); }


### PR DESCRIPTION
Before C++11 types with custom operator= were not allowed in unions.
I cannot replicate this error by passing -std=c++03 to gcc.
I know if I add a constructor, some of the bots will be unhappy.
Testing for operator= to see if this passes through.  I know way
back when, I removed operator= and added set() method because
someone complained.  But that was ten years ago I think.

Okay.  I see Oracle Studio compiler is failing:
https://circleci.com/gh/harfbuzz/harfbuzz/69225
Do we have to support that, or is Java switching to a newer version of that compiler that understands C++11? @prrace 