### PR TITLE
fix lealk with cff2::accelerator_templ_t::topDict

### DIFF
--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -496,6 +496,7 @@ struct cff2
     void fini ()
     {
       sc.end_processing ();
+      topDict.fini ();
       fontDicts.fini_deep ();
       privateDicts.fini_deep ();
       hb_blob_destroy (blob);


### PR DESCRIPTION
added a call `topDict::fini()` to `accelerator_templ_t::fini()`
(not fini_deep)