### PR TITLE
Python 3 fixes to gen-os2-unicode-ranges.py

### DIFF
--- a/src/gen-os2-unicode-ranges.py
+++ b/src/gen-os2-unicode-ranges.py
@@ -10,8 +10,11 @@ import io
 import re
 import sys
 
-reload(sys)
-sys.setdefaultencoding('utf-8')
+try:
+	reload(sys)
+  sys.setdefaultencoding('utf-8')
+except NameError:
+  pass  # Python 3
 
 print ("""static OS2Range _hb_os2_unicode_ranges[] =
 {""")
@@ -32,12 +35,12 @@ with io.open(input_file, mode="r", encoding="utf-8") as f:
       current_bit = fields[0]
       fields = fields[1:]
     elif len(fields) > 3:
-      raise Error("bad input :(.")
+      raise Exception("bad input :(.")
 
     name = fields[0]
     ranges = re.split("-", fields[1])
     if len(ranges) != 2:
-      raise Error("bad input :(.")
+      raise Exception("bad input :(.")
 
     v = tuple((int(ranges[0], 16), int(ranges[1], 16), int(current_bit), name))
     all_ranges.append(v)

--- a/src/gen-os2-unicode-ranges.py
+++ b/src/gen-os2-unicode-ranges.py
@@ -11,7 +11,7 @@ import re
 import sys
 
 try:
-	reload(sys)
+  reload(sys)
   sys.setdefaultencoding('utf-8')
 except NameError:
   pass  # Python 3


### PR DESCRIPTION
In Python 3, __reload()__ was moved and __sys.setdefaultencoding()__ because the default is already utf-8.  Also __Error()__ is an _undefined name_ and __Exception()__ creates a generic exception.

[flake8](http://flake8.pycqa.org) testing of https://github.com/harfbuzz/harfbuzz on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/gen-use-table.py:163:19: F821 undefined name 'Number'
	return (UISC in [Number, Consonant, Consonant_Head_Letter,
                  ^
./src/gen-use-table.py:163:27: F821 undefined name 'Consonant'
	return (UISC in [Number, Consonant, Consonant_Head_Letter,
                          ^
./src/gen-use-table.py:163:38: F821 undefined name 'Consonant_Head_Letter'
	return (UISC in [Number, Consonant, Consonant_Head_Letter,
                                     ^
./src/gen-use-table.py:165:4: F821 undefined name 'Tone_Letter'
			Tone_Letter,
   ^
./src/gen-use-table.py:166:4: F821 undefined name 'Vowel_Independent'
			Vowel_Independent #SPEC-DRAFT
   ^
./src/gen-use-table.py:168:11: F821 undefined name 'Lo'
		(UGC == Lo and UISC in [Avagraha, Bindu, Consonant_Final, Consonant_Medial,
          ^
./src/gen-use-table.py:168:27: F821 undefined name 'Avagraha'
		(UGC == Lo and UISC in [Avagraha, Bindu, Consonant_Final, Consonant_Medial,
                          ^
./src/gen-use-table.py:168:37: F821 undefined name 'Bindu'
		(UGC == Lo and UISC in [Avagraha, Bindu, Consonant_Final, Consonant_Medial,
                                    ^
./src/gen-use-table.py:168:44: F821 undefined name 'Consonant_Final'
		(UGC == Lo and UISC in [Avagraha, Bindu, Consonant_Final, Consonant_Medial,
                                           ^
./src/gen-use-table.py:168:61: F821 undefined name 'Consonant_Medial'
		(UGC == Lo and UISC in [Avagraha, Bindu, Consonant_Final, Consonant_Medial,
                                                            ^
./src/gen-use-table.py:169:6: F821 undefined name 'Consonant_Subjoined'
					Consonant_Subjoined, Vowel, Vowel_Dependent]))
     ^
./src/gen-use-table.py:169:27: F821 undefined name 'Vowel'
					Consonant_Subjoined, Vowel, Vowel_Dependent]))
                          ^
./src/gen-use-table.py:169:34: F821 undefined name 'Vowel_Dependent'
					Consonant_Subjoined, Vowel, Vowel_Dependent]))
                                 ^
./src/gen-use-table.py:172:19: F821 undefined name 'Consonant_Dead'
	return (UISC in [Consonant_Dead, Modifying_Letter] or
                  ^
./src/gen-use-table.py:172:35: F821 undefined name 'Modifying_Letter'
	return (UISC in [Consonant_Dead, Modifying_Letter] or
                                  ^
./src/gen-use-table.py:173:11: F821 undefined name 'Po'
		(UGC == Po and not U in [0x104B, 0x104E, 0x2022, 0x111C8, 0x11A3F, 0x11A45, 0x11C44, 0x11C45]) or
          ^
./src/gen-use-table.py:177:17: F821 undefined name 'Brahmi_Joining_Number'
	return UISC == Brahmi_Joining_Number
                ^
./src/gen-use-table.py:179:13: F821 undefined name 'Consonant_Placeholder'
	if UISC == Consonant_Placeholder: return True #SPEC-DRAFT
            ^
./src/gen-use-table.py:186:19: F821 undefined name 'Consonant_Final'
	return ((UISC == Consonant_Final and UGC != Lo) or
                  ^
./src/gen-use-table.py:186:46: F821 undefined name 'Lo'
	return ((UISC == Consonant_Final and UGC != Lo) or
                                             ^
./src/gen-use-table.py:187:11: F821 undefined name 'Consonant_Initial_Postfixed'
		UISC == Consonant_Initial_Postfixed or
          ^
./src/gen-use-table.py:188:11: F821 undefined name 'Consonant_Succeeding_Repha'
		UISC == Consonant_Succeeding_Repha)
          ^
./src/gen-use-table.py:191:18: F821 undefined name 'Syllable_Modifier'
	return  UISC == Syllable_Modifier
                 ^
./src/gen-use-table.py:193:17: F821 undefined name 'Consonant_Medial'
	return UISC == Consonant_Medial and UGC != Lo
                ^
./src/gen-use-table.py:193:45: F821 undefined name 'Lo'
	return UISC == Consonant_Medial and UGC != Lo
                                            ^
./src/gen-use-table.py:195:18: F821 undefined name 'Nukta'
	return UISC in [Nukta, Gemination_Mark, Consonant_Killer]
                 ^
./src/gen-use-table.py:195:25: F821 undefined name 'Gemination_Mark'
	return UISC in [Nukta, Gemination_Mark, Consonant_Killer]
                        ^
./src/gen-use-table.py:195:42: F821 undefined name 'Consonant_Killer'
	return UISC in [Nukta, Gemination_Mark, Consonant_Killer]
                                         ^
./src/gen-use-table.py:198:17: F821 undefined name 'Consonant_Subjoined'
	return UISC == Consonant_Subjoined and UGC != Lo
                ^
./src/gen-use-table.py:198:48: F821 undefined name 'Lo'
	return UISC == Consonant_Subjoined and UGC != Lo
                                               ^
./src/gen-use-table.py:200:17: F821 undefined name 'Consonant_With_Stacker'
	return UISC == Consonant_With_Stacker
                ^
./src/gen-use-table.py:202:18: F821 undefined name 'Virama'
	return UISC in [Virama, Invisible_Stacker] and not is_HALANT_OR_VOWEL_MODIFIER(U, UISC, UGC)
                 ^
./src/gen-use-table.py:202:26: F821 undefined name 'Invisible_Stacker'
	return UISC in [Virama, Invisible_Stacker] and not is_HALANT_OR_VOWEL_MODIFIER(U, UISC, UGC)
                         ^
./src/gen-use-table.py:208:17: F821 undefined name 'Number_Joiner'
	return UISC == Number_Joiner
                ^
./src/gen-use-table.py:210:17: F821 undefined name 'Non_Joiner'
	return UISC == Non_Joiner
                ^
./src/gen-use-table.py:212:17: F821 undefined name 'Joiner'
	return UISC == Joiner
                ^
./src/gen-use-table.py:217:18: F821 undefined name 'Other'
	return (UISC == Other
                 ^
./src/gen-use-table.py:226:18: F821 undefined name 'Consonant_Preceding_Repha'
	return UISC in [Consonant_Preceding_Repha, Consonant_Prefixed]
                 ^
./src/gen-use-table.py:226:45: F821 undefined name 'Consonant_Prefixed'
	return UISC in [Consonant_Preceding_Repha, Consonant_Prefixed]
                                            ^
./src/gen-use-table.py:230:17: F821 undefined name 'So'
	return UGC in [So, Sc]
                ^
./src/gen-use-table.py:230:21: F821 undefined name 'Sc'
	return UGC in [So, Sc]
                    ^
./src/gen-use-table.py:237:18: F821 undefined name 'Pure_Killer'
	return (UISC == Pure_Killer or
                 ^
./src/gen-use-table.py:238:11: F821 undefined name 'Lo'
		(UGC != Lo and UISC in [Vowel, Vowel_Dependent] and U not in [0xAA29]))
          ^
./src/gen-use-table.py:238:27: F821 undefined name 'Vowel'
		(UGC != Lo and UISC in [Vowel, Vowel_Dependent] and U not in [0xAA29]))
                          ^
./src/gen-use-table.py:238:34: F821 undefined name 'Vowel_Dependent'
		(UGC != Lo and UISC in [Vowel, Vowel_Dependent] and U not in [0xAA29]))
                                 ^
./src/gen-use-table.py:241:19: F821 undefined name 'Tone_Mark'
	return (UISC in [Tone_Mark, Cantillation_Mark, Register_Shifter, Visarga] or
                  ^
./src/gen-use-table.py:241:30: F821 undefined name 'Cantillation_Mark'
	return (UISC in [Tone_Mark, Cantillation_Mark, Register_Shifter, Visarga] or
                             ^
./src/gen-use-table.py:241:49: F821 undefined name 'Register_Shifter'
	return (UISC in [Tone_Mark, Cantillation_Mark, Register_Shifter, Visarga] or
                                                ^
./src/gen-use-table.py:241:67: F821 undefined name 'Visarga'
	return (UISC in [Tone_Mark, Cantillation_Mark, Register_Shifter, Visarga] or
                                                                  ^
./src/gen-use-table.py:242:11: F821 undefined name 'Lo'
		(UGC != Lo and (UISC == Bindu or U in [0xAA29])))
          ^
./src/gen-use-table.py:242:27: F821 undefined name 'Bindu'
		(UGC != Lo and (UISC == Bindu or U in [0xAA29])))
                          ^
./src/gen-use-table.py:274:11: F821 undefined name 'Top'
		'Abv': [Top],
          ^
./src/gen-use-table.py:275:11: F821 undefined name 'Bottom'
		'Blw': [Bottom],
          ^
./src/gen-use-table.py:276:11: F821 undefined name 'Right'
		'Pst': [Right],
          ^
./src/gen-use-table.py:279:11: F821 undefined name 'Top'
		'Abv': [Top],
          ^
./src/gen-use-table.py:280:11: F821 undefined name 'Bottom'
		'Blw': [Bottom, Bottom_And_Left],
          ^
./src/gen-use-table.py:280:19: F821 undefined name 'Bottom_And_Left'
		'Blw': [Bottom, Bottom_And_Left],
                  ^
./src/gen-use-table.py:281:11: F821 undefined name 'Right'
		'Pst': [Right],
          ^
./src/gen-use-table.py:282:11: F821 undefined name 'Left'
		'Pre': [Left],
          ^
./src/gen-use-table.py:285:11: F821 undefined name 'Top'
		'Abv': [Top],
          ^
./src/gen-use-table.py:286:11: F821 undefined name 'Bottom'
		'Blw': [Bottom],
          ^
./src/gen-use-table.py:289:11: F821 undefined name 'Top'
		'Abv': [Top, Top_And_Bottom, Top_And_Bottom_And_Right, Top_And_Right],
          ^
./src/gen-use-table.py:289:16: F821 undefined name 'Top_And_Bottom'
		'Abv': [Top, Top_And_Bottom, Top_And_Bottom_And_Right, Top_And_Right],
               ^
./src/gen-use-table.py:289:32: F821 undefined name 'Top_And_Bottom_And_Right'
		'Abv': [Top, Top_And_Bottom, Top_And_Bottom_And_Right, Top_And_Right],
                               ^
./src/gen-use-table.py:289:58: F821 undefined name 'Top_And_Right'
		'Abv': [Top, Top_And_Bottom, Top_And_Bottom_And_Right, Top_And_Right],
                                                         ^
./src/gen-use-table.py:290:11: F821 undefined name 'Bottom'
		'Blw': [Bottom, Overstruck, Bottom_And_Right],
          ^
./src/gen-use-table.py:290:19: F821 undefined name 'Overstruck'
		'Blw': [Bottom, Overstruck, Bottom_And_Right],
                  ^
./src/gen-use-table.py:290:31: F821 undefined name 'Bottom_And_Right'
		'Blw': [Bottom, Overstruck, Bottom_And_Right],
                              ^
./src/gen-use-table.py:291:11: F821 undefined name 'Right'
		'Pst': [Right, Top_And_Left, Top_And_Left_And_Right, Left_And_Right],
          ^
./src/gen-use-table.py:291:18: F821 undefined name 'Top_And_Left'
		'Pst': [Right, Top_And_Left, Top_And_Left_And_Right, Left_And_Right],
                 ^
./src/gen-use-table.py:291:32: F821 undefined name 'Top_And_Left_And_Right'
		'Pst': [Right, Top_And_Left, Top_And_Left_And_Right, Left_And_Right],
                               ^
./src/gen-use-table.py:291:56: F821 undefined name 'Left_And_Right'
		'Pst': [Right, Top_And_Left, Top_And_Left_And_Right, Left_And_Right],
                                                       ^
./src/gen-use-table.py:292:11: F821 undefined name 'Left'
		'Pre': [Left],
          ^
./src/gen-use-table.py:295:11: F821 undefined name 'Top'
		'Abv': [Top],
          ^
./src/gen-use-table.py:296:11: F821 undefined name 'Bottom'
		'Blw': [Bottom, Overstruck],
          ^
./src/gen-use-table.py:296:19: F821 undefined name 'Overstruck'
		'Blw': [Bottom, Overstruck],
                  ^
./src/gen-use-table.py:297:11: F821 undefined name 'Right'
		'Pst': [Right],
          ^
./src/gen-use-table.py:298:11: F821 undefined name 'Left'
		'Pre': [Left],
          ^
./src/gen-use-table.py:301:11: F821 undefined name 'Top'
		'Abv': [Top],
          ^
./src/gen-use-table.py:302:11: F821 undefined name 'Bottom'
		'Blw': [Bottom],
          ^
./src/gen-use-table.py:319:26: F821 undefined name 'Vowel_Dependent'
		if U == 0x17DD: UISC = Vowel_Dependent
                         ^
./src/gen-use-table.py:320:36: F821 undefined name 'Cantillation_Mark'
		if 0x1CE2 <= U <= 0x1CE8: UISC = Cantillation_Mark
                                   ^
./src/gen-use-table.py:324:61: F821 undefined name 'Vowel_Dependent'
		if 0x0F18 <= U <= 0x0F19 or 0x0F3E <= U <= 0x0F3F: UISC = Vowel_Dependent
                                                            ^
./src/gen-use-table.py:325:36: F821 undefined name 'Tone_Mark'
		if 0x0F86 <= U <= 0x0F87: UISC = Tone_Mark
                                   ^
./src/gen-use-table.py:329:15: F821 undefined name 'Top'
			if UIPC == Top:
              ^
./src/gen-use-table.py:330:12: F821 undefined name 'Bottom'
				UIPC = Bottom
           ^
./src/gen-use-table.py:335:15: F821 undefined name 'Top'
			if UIPC == Top:
              ^
./src/gen-use-table.py:336:12: F821 undefined name 'Bottom'
				UIPC = Bottom
           ^
./src/gen-use-table.py:337:17: F821 undefined name 'Bottom'
			elif UIPC == Bottom:
                ^
./src/gen-use-table.py:338:12: F821 undefined name 'Top'
				UIPC = Top
           ^
./src/gen-use-table.py:341:36: F821 undefined name 'Nukta'
		if 0x1BF2 <= U <= 0x1BF3: UISC = Nukta; UIPC = Bottom
                                   ^
./src/gen-use-table.py:341:50: F821 undefined name 'Bottom'
		if 0x1BF2 <= U <= 0x1BF3: UISC = Nukta; UIPC = Bottom
                                                 ^
./src/gen-use-table.py:345:26: F821 undefined name 'Tone_Mark'
		if U == 0x1CED: UISC = Tone_Mark
                         ^
./src/gen-use-table.py:348:26: F821 undefined name 'Consonant_Final'
		if U == 0x1A7F: UISC = Consonant_Final; UIPC = Bottom
                         ^
./src/gen-use-table.py:348:50: F821 undefined name 'Bottom'
		if U == 0x1A7F: UISC = Consonant_Final; UIPC = Bottom
                                                 ^
./src/gen-use-table.py:351:26: F821 undefined name 'Cantillation_Mark'
		if U == 0x20F0: UISC = Cantillation_Mark; UIPC = Top
                         ^
./src/gen-use-table.py:351:52: F821 undefined name 'Top'
		if U == 0x20F0: UISC = Cantillation_Mark; UIPC = Top
                                                   ^
./src/gen-use-table.py:354:26: F821 undefined name 'Consonant_Medial'
		if U == 0xA8B4: UISC = Consonant_Medial
                         ^
./src/gen-use-table.py:357:27: F821 undefined name 'Gemination_Mark'
		if U == 0x11134: UISC = Gemination_Mark
                          ^
./src/gen-use-table.py:360:27: F821 undefined name 'Consonant_Final'
		if U == 0x111C9: UISC = Consonant_Final
                          ^
./src/gen-use-table.py:369:26: F821 undefined name 'Bottom'
		if U == 0x1B6C: UIPC = Bottom
                         ^
./src/gen-use-table.py:372:34: F821 undefined name 'Not_Applicable'
		if U in [0x953, 0x954]: UIPC = Not_Applicable
                                 ^
./src/gen-use-table.py:375:26: F821 undefined name 'Left'
		if U == 0x103C: UIPC = Left
                         ^
./src/gen-use-table.py:378:36: F821 undefined name 'Top'
		if 0xA926 <= U <= 0xA92A: UIPC = Top
                                   ^
./src/gen-use-table.py:379:27: F821 undefined name 'Bottom'
		if U == 0x111CA: UIPC = Bottom
                          ^
./src/gen-use-table.py:380:27: F821 undefined name 'Top'
		if U == 0x11300: UIPC = Top
                          ^
./src/gen-use-table.py:382:27: F821 undefined name 'Top'
		if U == 0x11302: UIPC = Top
                          ^
./src/gen-use-table.py:383:27: F821 undefined name 'Bottom'
		if U == 0x1133C: UIPC = Bottom
                          ^
./src/gen-use-table.py:384:27: F821 undefined name 'Left'
		if U == 0x1171E: UIPC = Left # Correct?!
                          ^
./src/gen-use-table.py:385:36: F821 undefined name 'Right'
		if 0x1CF2 <= U <= 0x1CF3: UIPC = Right
                                   ^
./src/gen-use-table.py:386:36: F821 undefined name 'Top'
		if 0x1CF8 <= U <= 0x1CF9: UIPC = Top
                                   ^
./src/gen-use-table.py:388:26: F821 undefined name 'Bottom'
		if U == 0x0A51: UIPC = Bottom
                         ^
./src/gen-use-table.py:390:20: F821 undefined name 'Not_Applicable'
		assert (UIPC in [Not_Applicable, Visual_Order_Left] or
                   ^
./src/gen-use-table.py:390:36: F821 undefined name 'Visual_Order_Left'
		assert (UIPC in [Not_Applicable, Visual_Order_Left] or
                                   ^
./src/gen-os2-unicode-ranges.py:13:1: F821 undefined name 'reload'
reload(sys)
^
./src/gen-os2-unicode-ranges.py:35:13: F821 undefined name 'Error'
      raise Error("bad input :(.")
            ^
./src/gen-os2-unicode-ranges.py:40:13: F821 undefined name 'Error'
      raise Error("bad input :(.")
            ^
./test/subset/subset_test_suite.py:58:10: F821 undefined name 'Error'
			raise Error("%s is not a directory." % output_dir)
         ^
./test/subset/generate-expected-outputs.py:15:66: E999 SyntaxError: invalid syntax
	print "Usage: generate-expected-outputs.py <test suite file> ..."
                                                                 ^
1     E999 SyntaxError: invalid syntax
118   F821 undefined name 'reload'
119
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree