### PR TITLE
CircleCI: Test for Python 3 syntax errors and undefined names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,8 @@ jobs:
     steps:
       - checkout
       - run: pacman --noconfirm -Syu freetype2 cairo icu gettext gobject-introspection gcc gcc-libs glib2 graphite pkg-config ragel python python-pip
-      - run: pip install fonttools
+      - run: pip install flake8 fonttools
+      - run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
       # C??FLAGS are not needed for a regular build
       - run: CFLAGS="-O0" CXXFLAGS="-O0" CPPFLAGS="-DHB_DEBUG" ./autogen.sh --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-graphite2
       - run: make -j32

--- a/src/gen-use-table.py
+++ b/src/gen-use-table.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
+# flake8: noqa
 
 from __future__ import print_function, division, absolute_import
 
-import io, sys
+import io
+import sys
 
 if len (sys.argv) != 5:
 	print ("usage: ./gen-use-table.py IndicSyllabicCategory.txt IndicPositionalCategory.txt UnicodeData.txt Blocks.txt", file=sys.stderr)

--- a/test/subset/subset_test_suite.py
+++ b/test/subset/subset_test_suite.py
@@ -55,7 +55,7 @@ class SubsetTestSuite:
 		if not os.path.exists(output_dir):
 			os.mkdir(output_dir)
 		if not os.path.isdir(output_dir):
-			raise Error("%s is not a directory." % output_dir)
+			raise Exception("%s is not a directory." % output_dir)
 
 		return output_dir
 


### PR DESCRIPTION
Catch missing imports and errors like #1520 and #1521

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree