### PR TITLE
fix leak with subset_enc_supp_codes

### DIFF
--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -453,7 +453,7 @@ struct cff_subset_plan {
     subset_localsubrs.fini_deep ();
     fontdicts_mod.fini ();
     subset_enc_code_ranges.fini ();
-    subset_enc_supp_codes.init ();
+    subset_enc_supp_codes.fini ();
     subset_charset_ranges.fini ();
     sidmap.fini ();
     fontdicts_mod.fini ();


### PR DESCRIPTION
This is a fix for oss-fuzz issue 12310.

`cff_subset_plan::~cff_subset_plan` forgot to call `subset_enc_supp_codes::fini` instead was calling `init`, likely failed to edit after copy&paste. Bummer.

