### PR TITLE
fix FDSelect fuzzing bug

### DIFF
--- a/src/hb-subset-cff-common.cc
+++ b/src/hb-subset-cff-common.cc
@@ -153,7 +153,7 @@ serialize_fdselect_3_4 (hb_serialize_context_t *c,
   TRACE_SERIALIZE (this);
   FDSELECT3_4 *p = c->allocate_size<FDSELECT3_4> (size);
   if (unlikely (p == nullptr)) return_trace (false);
-  p->nRanges.set (fdselect_ranges.length);
+  p->nRanges ().set (fdselect_ranges.length);
   for (unsigned int i = 0; i < fdselect_ranges.length; i++)
   {
     p->ranges[i].first.set (fdselect_ranges[i].glyph);


### PR DESCRIPTION
Rewrote struct FDSelect3_4.ranges as ArrayOf
Updated FDSelect3_4::sanitize () to call ranges.sanitize ()
nRanges now a function to return a reference to ranges.len