### PR TITLE
[indic] Remove superfluous ZWNJ check in final reorder of pre-base matras

### DIFF
--- a/src/hb-ot-shape-complex-indic.cc
+++ b/src/hb-ot-shape-complex-indic.cc
@@ -1199,9 +1199,14 @@ final_reordering_syllable (const hb_ot_shape_plan_t *plan,
 	      goto search;
 	    }
 	  }
-	  /* -> If ZWNJ follows this halant, position is moved after it. */
-	  if (info[new_pos + 1].indic_category() == OT_ZWNJ)
-	    new_pos++;
+	  /* -> If ZWNJ follows this halant, position is moved after it.
+	   *
+	   * IMPLEMENTATION NOTES:
+	   *
+	   * This is taken care of by the state-machine. A Halant,ZWNJ is a terminating
+	   * sequence for a consonant syllable; any pre-base matras occurring after it
+	   * will belong to the subsequent syllable.
+	   */
 	}
       }
       else


### PR DESCRIPTION
This is a minor change to a recent fix for #1070.

From what I can tell, it doesn't appear possible for a `Matra` to occur before a `Halant,ZWNJ` sequence, due to `Halant,ZWNJ` being a "terminating" sequence for the Indic state machine.

Using the Devanagari test case in the comments as an example, what we get from the sequence

```
U+091F,U+094D,U+200C,U+092F,U+093F
```

is ultimately two consonant syllables `U+091F,U+094D,U+200C` and `U+092F,U+093F`. `U+093F` gets reordered in front of the second syllable's base `U+092F`, so we effectively get this check for free.