### PR TITLE
Support xlclang++ on AIX.

### DIFF
--- a/src/hb-atomic.hh
+++ b/src/hb-atomic.hh
@@ -184,7 +184,7 @@ static inline bool _hb_compare_and_swap_ptr (void **P, void *O, void *N)
 #endif
 
 
-#elif !defined(HB_NO_MT) && defined(_AIX) && defined(__IBMCPP__)
+#elif !defined(HB_NO_MT) && defined(_AIX) && (defined(__IBMCPP__) || defined(__ibmxl__))
 
 #include <builtins.h>
 


### PR DESCRIPTION
I'd like to fix build with xlclang++ on AIX which defines `__ibmxl__` but not `__IBMCPP__`.