### PR TITLE
[dwrite] hb_directwrite_face_create, a new API

### DIFF
--- a/src/hb-directwrite.h
+++ b/src/hb-directwrite.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015  Ebrahim Byagowi
+ * Copyright © 2015-2019  Ebrahim Byagowi
  *
  *  This is part of HarfBuzz, a text shaping library.
  *
@@ -33,6 +33,9 @@ HB_EXTERN hb_bool_t
 hb_directwrite_shape_experimental_width (hb_font_t *font, hb_buffer_t *buffer,
 					 const hb_feature_t *features,
 					 unsigned int num_features, float width);
+
+HB_EXTERN hb_face_t *
+hb_directwrite_face_create (IDWriteFontFace *font_face);
 
 HB_END_DECLS
 


### PR DESCRIPTION
It makes a hb_face_t from IDWriteFontFace, useful when using
DirectWrite facilities for font selection, loading and rendering
but using harfbuzz for shaping.

Fixes #1575

<details><summary>The code I've used for testing</summary>

```C
﻿#include <DWrite_1.h>
#include <stdio.h>
#include <stdint.h>
#include <hb.h>
#include <hb-directwrite.h>

class DWriteFontFileLoader : public IDWriteFontFileLoader
{
private:
	IDWriteFontFileStream *mFontFileStream;
public:
	DWriteFontFileLoader(IDWriteFontFileStream *fontFileStream)
	{
		mFontFileStream = fontFileStream;
	}

	// IUnknown interface
	IFACEMETHOD(QueryInterface) (IID const& iid, OUT void** ppObject)
	{
		return S_OK;
	}
	IFACEMETHOD_(ULONG, AddRef) () { return 1; }
	IFACEMETHOD_(ULONG, Release) () { return 1; }

	// IDWriteFontFileLoader methods
	virtual HRESULT STDMETHODCALLTYPE
		CreateStreamFromKey(void const* fontFileReferenceKey,
			uint32_t fontFileReferenceKeySize,
			OUT IDWriteFontFileStream** fontFileStream)
	{
		*fontFileStream = mFontFileStream;
		return S_OK;
	}

	virtual ~DWriteFontFileLoader() {}
};

class DWriteFontFileStream : public IDWriteFontFileStream
{
private:
	uint8_t *mData;
	uint32_t mSize;
public:
	DWriteFontFileStream(uint8_t *aData, uint32_t aSize)
	{
		mData = aData;
		mSize = aSize;
	}

	// IUnknown interface
	IFACEMETHOD(QueryInterface) (IID const& iid, OUT void** ppObject)
	{
		return S_OK;
	}
	IFACEMETHOD_(ULONG, AddRef) () { return 1; }
	IFACEMETHOD_(ULONG, Release) () { return 1; }

	// IDWriteFontFileStream methods
	virtual HRESULT STDMETHODCALLTYPE
		ReadFileFragment(void const** fragmentStart,
			UINT64 fileOffset,
			UINT64 fragmentSize,
			OUT void** fragmentContext)
	{
		// We are required to do bounds checking.
		if (fileOffset + fragmentSize > mSize) return E_FAIL;

		// truncate the 64 bit fileOffset to size_t sized index into mData
		size_t index = static_cast<size_t> (fileOffset);

		// We should be alive for the duration of this.
		*fragmentStart = &mData[index];
		*fragmentContext = nullptr;
		return S_OK;
	}

	virtual void STDMETHODCALLTYPE
		ReleaseFileFragment(void* fragmentContext) {}

	virtual HRESULT STDMETHODCALLTYPE
		GetFileSize(OUT UINT64* fileSize)
	{
		*fileSize = mSize;
		return S_OK;
	}

	virtual HRESULT STDMETHODCALLTYPE
		GetLastWriteTime(OUT UINT64* lastWriteTime) { return E_NOTIMPL; }

	virtual ~DWriteFontFileStream() {}
};

int main(int argc, char **argv) {
	IDWriteFactory* dwriteFactory;
	DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof (IDWriteFactory),
		(IUnknown**)&dwriteFactory);

	HRESULT hr;
	hb_blob_t *blob = hb_blob_create_from_file ("C:\\Windows\\Fonts\\tahoma.ttf");
	DWriteFontFileStream *fontFileStream;
	fontFileStream = new DWriteFontFileStream((uint8_t *)hb_blob_get_data(blob, nullptr),
		hb_blob_get_length(blob));

	DWriteFontFileLoader *fontFileLoader = new DWriteFontFileLoader(fontFileStream);
	dwriteFactory->RegisterFontFileLoader(fontFileLoader);

	IDWriteFontFile *fontFile;
	uint64_t fontFileKey = 0;
	hr = dwriteFactory->CreateCustomFontFileReference(&fontFileKey, sizeof(fontFileKey),
		fontFileLoader, &fontFile);

	IDWriteFontFace *fontFace;

	BOOL isSupported;
	DWRITE_FONT_FILE_TYPE fileType;
	DWRITE_FONT_FACE_TYPE faceType;
	uint32_t numberOfFaces;
	hr = fontFile->Analyze(&isSupported, &fileType, &faceType, &numberOfFaces);

	dwriteFactory->CreateFontFace(faceType, 1, &fontFile, 0,
		DWRITE_FONT_SIMULATIONS_NONE, &fontFace);

	hb_face_t *face = hb_directwrite_face_create (fontFace);
	//hb_face_t *face = hb_face_create(blob, 0);

	printf ("%d", hb_face_get_glyph_count (face));

	hb_face_destroy (face);
	scanf ("%d", new int);

	return 0;
}
```

</details>