### PR TITLE
[dwrite] A new API, hb_directwrite_face_get_font_face

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -217,6 +217,14 @@ hb_coretext_font_get_ct_font
 </SECTION>
 
 <SECTION>
+<FILE>hb-directwrite</FILE>
+hb_directwrite_face_create
+hb_directwrite_face_get_font_face
+<SUBSECTION Private>
+hb_directwrite_shape_experimental_width
+</SECTION>
+
+<SECTION>
 <FILE>hb-face</FILE>
 hb_face_count
 hb_face_t
@@ -715,8 +723,6 @@ hb_unicode_script_func_t
 <FILE>hb-uniscribe</FILE>
 hb_uniscribe_font_get_hfont
 hb_uniscribe_font_get_logfontw
-<SUBSECTION Private>
-hb_directwrite_shape_experimental_width
 </SECTION>
 
 <SECTION>

--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -846,10 +846,23 @@ _hb_directwrite_shape (hb_shape_plan_t    *shape_plan,
 				     features, num_features, 0);
 }
 
-/*
- * Public [experimental] API
- */
-
+/**
+ * hb_directwrite_shape_experimental_width:
+ * Experimental API to test DirectWrite's justification algorithm.
+ *
+ * It inserts Kashida at wrong order so don't use the API ever.
+ *
+ * It doesn't work with cygwin/msys due to header bugs so one
+ * should use MSVC toolchain in order to use it for now.
+ *
+ * @font:
+ * @buffer:
+ * @features:
+ * @num_features:
+ * @width:
+ *
+ * Since: 1.4.2
+ **/
 hb_bool_t
 hb_directwrite_shape_experimental_width (hb_font_t          *font,
 					 hb_buffer_t        *buffer,
@@ -918,6 +931,7 @@ _hb_directwrite_font_release (void *data)
 /**
  * hb_directwrite_face_create:
  * @font_face:
+ *
  * Since: 2.4.0
  **/
 hb_face_t *
@@ -927,4 +941,16 @@ hb_directwrite_face_create (IDWriteFontFace *font_face)
     font_face->AddRef ();
   return hb_face_create_for_tables (reference_table, font_face,
 				    _hb_directwrite_font_release);
+}
+
+/**
+* hb_directwrite_face_get_font_face:
+* @face:
+*
+* Since: REPLACEME
+**/
+IDWriteFontFace *
+hb_directwrite_face_get_font_face (hb_face_t *face)
+{
+  return face->data.directwrite->fontFace;
 }

--- a/src/hb-directwrite.h
+++ b/src/hb-directwrite.h
@@ -37,6 +37,9 @@ hb_directwrite_shape_experimental_width (hb_font_t *font, hb_buffer_t *buffer,
 HB_EXTERN hb_face_t *
 hb_directwrite_face_create (IDWriteFontFace *font_face);
 
+HB_EXTERN IDWriteFontFace *
+hb_directwrite_face_get_font_face (hb_face_t *face);
+
 HB_END_DECLS
 
 #endif /* HB_DIRECTWRITE_H */


### PR DESCRIPTION
Can be useful when using HarfBuzz for font loading and shaping
but using DirectWrite for rendering.

Code I literally used for testing,
```C
﻿#include <DWrite_1.h>
#include <stdio.h>
#include <stdint.h>
#include <hb.h>
#include <hb-directwrite.h>

int main (int argc, char **argv)
{
  hb_blob_t *blob = hb_blob_create_from_file ("C:\\Windows\\Fonts\\tahoma.ttf");
  hb_face_t *hb_face = hb_face_create (blob, 0);
  IDWriteFontFace *fontFace = hb_directwrite_face_get_font_face (hb_face);
  hb_face_t *face = hb_directwrite_face_create (fontFace);

  printf ("%d == %d == %d", hb_face_get_glyph_count (hb_face), fontFace->GetGlyphCount(), hb_face_get_glyph_count (face));

  hb_face_destroy (face);
  scanf ("%d", new int);

  return 0;
}
```