### PR TITLE
[ci] Use only CircleCI for macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,9 @@ jobs:
       xcode: "10.2.0"
     steps:
       - checkout
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install wget autoconf automake libtool pkg-config ragel freetype glib cairo
-      - run: ./autogen.sh --with-freetype --with-glib --with-gobject --with-cairo
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install wget autoconf automake libtool pkg-config ragel freetype glib cairo icu4c
+      - run: brew link --force icu4c
+      - run: export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig" && ./autogen.sh --with-freetype --with-glib --with-gobject --with-cairo --with-icu --with-coretext
       - run: make -j4
       - run: make check || .ci/fail.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,6 @@ matrix:
         - make
         - make check || .ci/fail.sh
 
-    - os: osx
-      compiler: clang
-      install:
-        - brew link --force icu4c
-      script:
-        - ./autogen.sh
-        - ./configure $CONFIGURE_OPTS --with-coretext
-        - make
-        - make check || .ci/fail.sh
-
 notifications:
   irc: "irc.freenode.org#harfbuzz"
   email: harfbuzz-bots-chatter@googlegroups.com
@@ -76,14 +66,6 @@ addons:
       - libicu-dev # for extra unicode functions
       - libgraphite2-dev # for extra shapers
       #- libgirepository1.0-dev # for gobject-introspection
-  homebrew:
-    packages:
-      - cairo
-      - freetype
-      - glib
-      - graphite2
-      - icu4c
-      #- gobject-introspection
 
   coverity_scan:
     project:


### PR DESCRIPTION
Fixes #1609 

I think this makes macos-10.14.3-aat-fonts on par with our current Travis CI