### PR TITLE
Search ot_languages with hb_sorted_array_t.bsearch

### DIFF
--- a/src/hb-array.hh
+++ b/src/hb-array.hh
@@ -208,28 +208,34 @@ struct hb_sorted_array_t :
   { return sub_array (start_offset, &seg_count); }
 
   template <typename T>
+  static int compar (const Type a, const T b)
+  {
+    return a.cmp (b);
+  }
+  template <typename T>
   Type *bsearch (const T &x, Type *not_found = nullptr)
   {
     unsigned int i;
     return bfind (x, &i) ? &this->arrayZ[i] : not_found;
   }
   template <typename T>
-  const Type *bsearch (const T &x, const Type *not_found = nullptr) const
+  const Type *bsearch (const T &x, const Type *not_found = nullptr, int (*cmp)(const Type, const T) = compar) const
   {
     unsigned int i;
-    return bfind (x, &i) ? &this->arrayZ[i] : not_found;
+    return bfind (x, &i, HB_BFIND_NOT_FOUND_DONT_STORE, (unsigned int) -1, cmp) ? &this->arrayZ[i] : not_found;
   }
   template <typename T>
   bool bfind (const T &x, unsigned int *i = nullptr,
 		     hb_bfind_not_found_t not_found = HB_BFIND_NOT_FOUND_DONT_STORE,
-		     unsigned int to_store = (unsigned int) -1) const
+		     unsigned int to_store = (unsigned int) -1,
+		     int (*cmp)(const Type, const T) = compar) const
   {
     int min = 0, max = (int) this->length - 1;
     const Type *array = this->arrayZ;
     while (min <= max)
     {
       int mid = ((unsigned int) min + (unsigned int) max) / 2;
-      int c = array[mid].cmp (x);
+      int c = cmp (array[mid], x);
       if (c < 0)
         max = mid - 1;
       else if (c > 0)
@@ -253,7 +259,7 @@ struct hb_sorted_array_t :
 	  break;
 
 	case HB_BFIND_NOT_FOUND_STORE_CLOSEST:
-	  if (max < 0 || (max < (int) this->length && array[max].cmp (x) > 0))
+	  if (max < 0 || (max < (int) this->length && cmp (array[max], x) > 0))
 	    max++;
 	  *i = max;
 	  break;

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -218,6 +218,13 @@ typedef struct {
   hb_tag_t tags[HB_OT_MAX_TAGS_PER_LANGUAGE];
 } LangTag;
 
+static int
+langtag_compare_first_component (const LangTag a,
+				 const char   *b)
+{
+  return lang_compare_first_component (b, a.language);
+}
+
 #include "hb-ot-tag-table.hh"
 
 /* The corresponding languages IDs for the following IDs are unclear,
@@ -263,9 +270,9 @@ hb_ot_tags_from_language (const char   *lang_str,
 	  ISALPHA (s[1]))
 	lang_str = s + 1;
     }
-    lang_tag = (LangTag *) bsearch (lang_str, ot_languages,
-				    ARRAY_LENGTH (ot_languages), sizeof (LangTag),
-				    lang_compare_first_component);
+    lang_tag = hb_sorted_array_t<const LangTag> (ot_languages).bsearch (lang_str,
+									nullptr,
+									langtag_compare_first_component);
     if (lang_tag)
     {
       unsigned int i;


### PR DESCRIPTION
As @behdad requested in #1602, this pull request changes `hb_ot_tags_from_language` to search `ot_languages` using the custom `hb_sorted_array_t.bsearch` instead of the standard C `bsearch`. This deserves a careful review because I haven’t had much experience with C++ templates.