### PR TITLE
[Docs] Add gtk-doc comments for hb-ot-var

### DIFF
--- a/src/hb-ot-var.cc
+++ b/src/hb-ot-var.cc
@@ -117,7 +117,7 @@ hb_ot_var_get_axes (hb_face_t        *face,
  * in the specified face.
  *
  * Since: 1.4.2
- * Deprecated: 2.2.0 - use #hb_ot_var_find_axis_info instead
+ * Deprecated: 2.2.0 - use hb_ot_var_find_axis_info() instead
  **/
 hb_bool_t
 hb_ot_var_find_axis (hb_face_t        *face,

--- a/src/hb-ot-var.cc
+++ b/src/hb-ot-var.cc
@@ -52,11 +52,11 @@
 
 /**
  * hb_ot_var_has_data:
- * @face: #hb_face_t to test
+ * @face: The #hb_face_t to work on
  *
- * This function allows to verify the presence of OpenType variation data on the face.
+ * Tests whether a face includes any OpenType variation data in the 'fvar' table.
  *
- * Return value: true if face has a `fvar' table and false otherwise
+ * Return value: true if data found, false otherwise
  *
  * Since: 1.4.2
  **/
@@ -68,6 +68,11 @@ hb_ot_var_has_data (hb_face_t *face)
 
 /**
  * hb_ot_var_get_axis_count:
+ * @face: The #hb_face_t to work on
+ *
+ * Fetches the number of OpenType variation axes included in the face. 
+ *
+ * Return value: the number of variation axes defined
  *
  * Since: 1.4.2
  **/
@@ -80,9 +85,17 @@ hb_ot_var_get_axis_count (hb_face_t *face)
 #ifndef HB_DISABLE_DEPRECATED
 /**
  * hb_ot_var_get_axes:
+ * @face: #hb_face_t to work upon
+ * @start_offset: offset of the first lookup to retrieve
+ * @axes_count: (inout) (allow-none): Input = the maximum number of variation axes to return;
+ *                Output = the actual number of variation axes returned (may be zero)
+ * @axes_array: (out) (array length=axes_count): The array of variation axes found
+ *
+ * Fetches a list of all variation axes in the specified face. The list returned will begin
+ * at the offset provided.
  *
  * Since: 1.4.2
- * Deprecated: 2.2.0
+ * Deprecated: 2.2.0 - use #hb_ot_var_get_axis_infos instead
  **/
 unsigned int
 hb_ot_var_get_axes (hb_face_t        *face,
@@ -95,9 +108,16 @@ hb_ot_var_get_axes (hb_face_t        *face,
 
 /**
  * hb_ot_var_find_axis:
+ * @face: #hb_face_t to work upon
+ * @axis_tag: The #hb_tag_t of the variation axis to query
+ * @axis_index: The index of the variation axis
+ * @axis_info: (out): The #hb_ot_var_axis_info_t of the axis tag queried
+ *
+ * Fetches the variation-axis information corresponding to the specified axis tag
+ * in the specified face.
  *
  * Since: 1.4.2
- * Deprecated: 2.2.0
+ * Deprecated: 2.2.0 - use #hb_ot_var_find_axis_info instead
  **/
 hb_bool_t
 hb_ot_var_find_axis (hb_face_t        *face,
@@ -111,6 +131,16 @@ hb_ot_var_find_axis (hb_face_t        *face,
 
 /**
  * hb_ot_var_get_axis_infos:
+ * @face: #hb_face_t to work upon
+ * @start_offset: offset of the first lookup to retrieve
+ * @axes_count: (inout) (allow-none): Input = the maximum number of variation axes to return;
+ *                Output = the actual number of variation axes returned (may be zero)
+ * @axes_array: (out) (array length=axes_count): The array of variation axes found
+ *
+ * Fetches a list of all variation axes in the specified face. The list returned will begin
+ * at the offset provided.
+ *
+ * Return value: the number of variation axes in the face
  *
  * Since: 2.2.0
  **/
@@ -125,6 +155,14 @@ hb_ot_var_get_axis_infos (hb_face_t             *face,
 
 /**
  * hb_ot_var_find_axis_info:
+ * @face: #hb_face_t to work upon
+ * @axis_tag: The #hb_tag_t of the variation axis to query
+ * @axis_info: (out): The #hb_ot_var_axis_info_t of the axis tag queried
+ *
+ * Fetches the variation-axis information corresponding to the specified axis tag
+ * in the specified face.
+ *
+ * Return value: true if data found, false otherwise
  *
  * Since: 2.2.0
  **/
@@ -141,12 +179,34 @@ hb_ot_var_find_axis_info (hb_face_t             *face,
  * Named instances.
  */
 
+/**
+ * hb_ot_var_get_named_instance_count:
+ * @face: The #hb_face_t to work on
+ *
+ * Fetches the number of named instances included in the face. 
+ *
+ * Return value: the number of named instances defined
+ *
+ * Since: 2.2.0
+ **/
 unsigned int
 hb_ot_var_get_named_instance_count (hb_face_t *face)
 {
   return face->table.fvar->get_instance_count ();
 }
 
+/**
+ * hb_ot_var_named_instance_get_subfamily_name_id:
+ * @face: The #hb_face_t to work on
+ * @instance_index: The index of the named instance to query
+ *
+ * Fetches the 'name' table Name ID that provides display names for
+ * the "Subfamily name" defined for the given named instance in the face.
+ *
+ * Return value: the Name ID found for the Subfamily name
+ *
+ * Since: 2.2.0
+ **/
 hb_ot_name_id_t
 hb_ot_var_named_instance_get_subfamily_name_id (hb_face_t   *face,
 						unsigned int instance_index)
@@ -154,6 +214,18 @@ hb_ot_var_named_instance_get_subfamily_name_id (hb_face_t   *face,
   return face->table.fvar->get_instance_subfamily_name_id (instance_index);
 }
 
+/**
+ * hb_ot_var_named_instance_get_postscript_name_id:
+ * @face: The #hb_face_t to work on
+ * @instance_index: The index of the named instance to query
+ *
+ * Fetches the 'name' table Name ID that provides display names for
+ * the "PostScript name" defined for the given named instance in the face.
+ *
+ * Return value: the Name ID found for the PostScript name
+ *
+ * Since: 2.2.0
+ **/
 hb_ot_name_id_t
 hb_ot_var_named_instance_get_postscript_name_id (hb_face_t  *face,
 						unsigned int instance_index)
@@ -161,6 +233,21 @@ hb_ot_var_named_instance_get_postscript_name_id (hb_face_t  *face,
   return face->table.fvar->get_instance_postscript_name_id (instance_index);
 }
 
+/**
+ * hb_ot_var_named_instance_get_design_coords:
+ * @face: The #hb_face_t to work on
+ * @instance_index: The index of the named instance to query
+ * @coords_length: (inout) (allow-none): Input = the maximum number of coordinates to return;
+ *                 Output = the actual number of coordinates returned (may be zero)
+ * @coords: (out) (array length=coords_length): The array of coordinates found for the query
+ *
+ * Fetches the design-space coordinates corresponding to the given
+ * named instance in the face.
+ *
+ * Return value: the number of variation axes in the face
+ *
+ * Since: 2.2.0
+ **/
 unsigned int
 hb_ot_var_named_instance_get_design_coords (hb_face_t    *face,
 					    unsigned int  instance_index,
@@ -173,6 +260,13 @@ hb_ot_var_named_instance_get_design_coords (hb_face_t    *face,
 
 /**
  * hb_ot_var_normalize_variations:
+ * @face: The #hb_face_t to work on
+ * @variations: The array of variations to normalize
+ * @variations_length: The number of variations to normalize
+ * @coords: (out) (array length=coords_length): The array of normalized coordinates 
+ * @coords_length: The length of the coordinate array
+ *
+ * Normalizes all of the coordinates in the given list of variation axes.
  *
  * Since: 1.4.2
  **/
@@ -200,6 +294,17 @@ hb_ot_var_normalize_variations (hb_face_t            *face,
 
 /**
  * hb_ot_var_normalize_coords:
+ * @face: The #hb_face_t to work on
+ * @coords_length: The length of the coordinate array
+ * @design_coords: The design-space coordinates to normalize
+ * @normalized_coords: (out): The normalized coordinates
+ *
+ * Normalizes the given design-space coordinates. The minimum and maximum
+ * values for the axis are mapped to the interval [-1,1], with the default
+ * axis value mapped to 0.
+ *
+ * Any additional scaling defined in the face's `avar` table is also
+ * applied, as described at https://docs.microsoft.com/en-us/typography/opentype/spec/avar
  *
  * Since: 1.4.2
  **/

--- a/src/hb-ot-var.cc
+++ b/src/hb-ot-var.cc
@@ -54,7 +54,7 @@
  * hb_ot_var_has_data:
  * @face: The #hb_face_t to work on
  *
- * Tests whether a face includes any OpenType variation data in the 'fvar' table.
+ * Tests whether a face includes any OpenType variation data in the `fvar` table.
  *
  * Return value: true if data found, false otherwise
  *
@@ -95,7 +95,7 @@ hb_ot_var_get_axis_count (hb_face_t *face)
  * at the offset provided.
  *
  * Since: 1.4.2
- * Deprecated: 2.2.0 - use #hb_ot_var_get_axis_infos instead
+ * Deprecated: 2.2.0: use hb_ot_var_get_axis_infos() instead
  **/
 unsigned int
 hb_ot_var_get_axes (hb_face_t        *face,
@@ -200,7 +200,7 @@ hb_ot_var_get_named_instance_count (hb_face_t *face)
  * @face: The #hb_face_t to work on
  * @instance_index: The index of the named instance to query
  *
- * Fetches the 'name' table Name ID that provides display names for
+ * Fetches the `name` table Name ID that provides display names for
  * the "Subfamily name" defined for the given named instance in the face.
  *
  * Return value: the Name ID found for the Subfamily name
@@ -219,7 +219,7 @@ hb_ot_var_named_instance_get_subfamily_name_id (hb_face_t   *face,
  * @face: The #hb_face_t to work on
  * @instance_index: The index of the named instance to query
  *
- * Fetches the 'name' table Name ID that provides display names for
+ * Fetches the `name` table Name ID that provides display names for
  * the "PostScript name" defined for the given named instance in the face.
  *
  * Return value: the Name ID found for the PostScript name

--- a/src/hb-ot-var.cc
+++ b/src/hb-ot-var.cc
@@ -89,7 +89,7 @@ hb_ot_var_get_axis_count (hb_face_t *face)
  * @start_offset: offset of the first lookup to retrieve
  * @axes_count: (inout) (allow-none): Input = the maximum number of variation axes to return;
  *                Output = the actual number of variation axes returned (may be zero)
- * @axes_array: (out) (array length=axes_count): The array of variation axes found
+ * @axes_array: (out caller-allocates) (array length=axes_count): The array of variation axes found
  *
  * Fetches a list of all variation axes in the specified face. The list returned will begin
  * at the offset provided.
@@ -135,7 +135,7 @@ hb_ot_var_find_axis (hb_face_t        *face,
  * @start_offset: offset of the first lookup to retrieve
  * @axes_count: (inout) (allow-none): Input = the maximum number of variation axes to return;
  *                Output = the actual number of variation axes returned (may be zero)
- * @axes_array: (out) (array length=axes_count): The array of variation axes found
+ * @axes_array: (out caller-allocates) (array length=axes_count): The array of variation axes found
  *
  * Fetches a list of all variation axes in the specified face. The list returned will begin
  * at the offset provided.

--- a/src/hb-ot-var.h
+++ b/src/hb-ot-var.h
@@ -35,11 +35,36 @@
 
 HB_BEGIN_DECLS
 
-
+/**
+ * hb_tag_t:
+ * @HB_OT_TAG_VAR_AXIS_ITALIC: Registered tag for the roman/italic axis
+ */
 #define HB_OT_TAG_VAR_AXIS_ITALIC	HB_TAG('i','t','a','l')
+
+/**
+ * hb_tag_t:
+ * @HB_OT_TAG_VAR_AXIS_OPTICAL_SIZE: Registered tag for the optical-size axis
+ *
+ * <note>Note: The optical-size axis supersedes the OpenType `size` feature.</note>
+ */
 #define HB_OT_TAG_VAR_AXIS_OPTICAL_SIZE	HB_TAG('o','p','s','z')
+
+/**
+ * hb_tag_t:
+ * @HB_OT_TAG_VAR_AXIS_SLANT: Registered tag for the slant axis
+ */
 #define HB_OT_TAG_VAR_AXIS_SLANT	HB_TAG('s','l','n','t')
+
+/**
+ * hb_tag_t:
+ * @HB_OT_TAG_VAR_AXIS_WIDTH: Registered tag for the width axis
+ */
 #define HB_OT_TAG_VAR_AXIS_WIDTH	HB_TAG('w','d','t','h')
+
+/**
+ * hb_tag_t:
+ * @HB_OT_TAG_VAR_AXIS_WEIGHT: Registered tag for the weight axis
+ */
 #define HB_OT_TAG_VAR_AXIS_WEIGHT	HB_TAG('w','g','h','t')
 
 
@@ -73,6 +98,20 @@ typedef enum { /*< flags >*/
 
 /**
  * hb_ot_var_axis_info_t:
+ * @axis_index: Index of the axis in the variation-axis array
+ * @tag: The #hb_tag_t tag identifying the design variation of the axis
+ * @name_id: The `name` table Name ID that provides display names for the axis
+ * @flags: The #hb_ot_var_axis_flags_t flags for the axis
+ * @min_value: The mininum value on the variation axis that the font covers
+ * @default_value: The position on the variation axis corresponding to the font's defaults
+ * @max_value: The maximum value on the variation axis that the font covers
+ * 
+ * Data type for holding variation-axis values.
+ *
+ * The minimum, default, and maximum values are in un-normalized, user scales.
+ *
+ * <note>Note: at present, the only flag defined for @flags is
+ * #HB_OT_VAR_AXIS_FLAG_HIDDEN.</note>
  *
  * Since: 2.2.0
  */


### PR DESCRIPTION
This adds GTK-Doc comments and annotations for hb-ot-var.cc and .h.