### PR TITLE
[Docs] Add gtkdoc comments for low-level core APIs

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -359,6 +359,8 @@ hb_font_get_font_h_extents_func_t
 hb_font_get_font_v_extents_func_t
 hb_font_get_h_extents
 hb_font_get_v_extents
+hb_font_extents_t
+hb_glyph_extents_t
 </SECTION>
 
 <SECTION>

--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -333,7 +333,7 @@ hb_blob_get_length (hb_blob_t *blob)
  *
  * Fetches the data from a blob.
  *
- * Returns: (transfer none) (array length=length):
+ * Returns: (transfer none) (array length=length): the byte data of @blob.
  *
  * Since: 0.9.2
  **/

--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -234,7 +234,7 @@ hb_blob_destroy (hb_blob_t *blob)
 
 /**
  * hb_blob_set_user_data: (skip)
- * @blob: a blob
+ * @blob: An #hb_blob_t
  * @key: The user-data key to set
  * @data: A pointer to the user data to set
  * @destroy: A callback to call when @data is not needed anymore
@@ -242,7 +242,7 @@ hb_blob_destroy (hb_blob_t *blob)
  *
  * Attaches a user-data key/data pair to the specified blob.
  *
- * Return value: %true if success, false otherwise
+ * Return value: %true if success, %false otherwise
  *
  * Since: 0.9.2
  **/
@@ -566,7 +566,7 @@ _open_resource_fork (const char *file_name, hb_mapped_file_t *file)
  * Creates a new blob containing the data from the
  * specified binary font file.
  *
- * Returns: A hb_blob_t pointer with the content of the file
+ * Returns: An #hb_blob_t pointer with the content of the file
  *
  * Since: 1.7.7
  **/

--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -156,7 +156,7 @@ hb_blob_create_sub_blob (hb_blob_t    *parent,
  *
  * Makes a writable copy of @blob.
  *
- * Return value: New blob, or nullptr if allocation failed.
+ * Return value: The new blob, or nullptr if allocation failed
  *
  * Since: 1.8.0
  **/
@@ -182,7 +182,7 @@ hb_blob_copy_writable_or_fail (hb_blob_t *blob)
  *
  * See TODO:link object types for more information.
  *
- * Return value: (transfer full): the empty blob.
+ * Return value: (transfer full): The empty blob.
  *
  * Since: 0.9.2
  **/
@@ -234,13 +234,15 @@ hb_blob_destroy (hb_blob_t *blob)
 
 /**
  * hb_blob_set_user_data: (skip)
- * @blob: a blob.
- * @key: key for data to set.
- * @data: data to set.
- * @destroy: callback to call when @data is not needed anymore.
- * @replace: whether to replace an existing data with the same key.
+ * @blob: a blob
+ * @key: The user-data key to set
+ * @data: A pointer to the user data to set
+ * @destroy: A callback to call when @data is not needed anymore
+ * @replace: Whether to replace an existing data with the same key
  *
- * Return value:
+ * Attaches a user-data key/data pair to the specified blob.
+ *
+ * Return value: %true if success, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -256,12 +258,13 @@ hb_blob_set_user_data (hb_blob_t          *blob,
 
 /**
  * hb_blob_get_user_data: (skip)
- * @blob: a blob.
- * @key: key for data to get.
+ * @blob: a blob
+ * @key: The user-data key to query
  *
+ * Fetches the user data associated with the specified key,
+ * attached to the specified font-functions structure.
  *
- *
- * Return value: (transfer none):
+ * Return value: (transfer none): A pointer to the user data
  *
  * Since: 0.9.2
  **/
@@ -275,9 +278,9 @@ hb_blob_get_user_data (hb_blob_t          *blob,
 
 /**
  * hb_blob_make_immutable:
- * @blob: a blob.
+ * @blob: a blob
  *
- *
+ * Makes a blob immutable.
  *
  * Since: 0.9.2
  **/
@@ -294,9 +297,9 @@ hb_blob_make_immutable (hb_blob_t *blob)
  * hb_blob_is_immutable:
  * @blob: a blob.
  *
+ * Tests whether a blob is immutable.
  *
- *
- * Return value: TODO
+ * Return value: %true if @blob is immutable, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -311,9 +314,9 @@ hb_blob_is_immutable (hb_blob_t *blob)
  * hb_blob_get_length:
  * @blob: a blob.
  *
+ * Fetches the length of a blob's data.
  *
- *
- * Return value: the length of blob data in bytes.
+ * Return value: the length of @blob data in bytes.
  *
  * Since: 0.9.2
  **/
@@ -326,9 +329,9 @@ hb_blob_get_length (hb_blob_t *blob)
 /**
  * hb_blob_get_data:
  * @blob: a blob.
- * @length: (out):
+ * @length: (out): The length in bytes of the data retrieved
  *
- *
+ * Fetches the data from a blob.
  *
  * Returns: (transfer none) (array length=length):
  *
@@ -558,7 +561,10 @@ _open_resource_fork (const char *file_name, hb_mapped_file_t *file)
 
 /**
  * hb_blob_create_from_file:
- * @file_name: font filename.
+ * @file_name: A font filename
+ *
+ * Creates a new blob containing the data from the
+ * specified binary font file.
  *
  * Returns: A hb_blob_t pointer with the content of the file
  *

--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -58,7 +58,7 @@
  * @length: Length of @data in bytes.
  * @mode: Memory mode for @data.
  * @user_data: Data parameter to pass to @destroy.
- * @destroy: Callback to call when @data is not needed anymore.
+ * @destroy: (optional): Callback to call when @data is not needed anymore.
  *
  * Creates a new "blob" object wrapping @data.  The @mode parameter is used
  * to negotiate ownership and lifecycle of @data.
@@ -237,7 +237,7 @@ hb_blob_destroy (hb_blob_t *blob)
  * @blob: An #hb_blob_t
  * @key: The user-data key to set
  * @data: A pointer to the user data to set
- * @destroy: A callback to call when @data is not needed anymore
+ * @destroy: (optional): A callback to call when @data is not needed anymore
  * @replace: Whether to replace an existing data with the same key
  *
  * Attaches a user-data key/data pair to the specified blob.

--- a/src/hb-blob.h
+++ b/src/hb-blob.h
@@ -36,25 +36,34 @@
 HB_BEGIN_DECLS
 
 
-/*
- * Note re various memory-modes:
+/**
+ * hb_memory_mode_t:
+ * @HB_MEMORY_MODE_DUPLICATE
+ * @HB_MEMORY_MODE_READONLY
+ * @HB_MEMORY_MODE_WRITABLE
+ * @HB_MEMORY_MODE_READONLY_MAY_MAKE_WRITABLE
+ *
+ * Data type holding the memory modes available to
+ * client programs.
+ *
+ * Regarding these various memory-modes:
  *
  * - In no case shall the HarfBuzz client modify memory
  *   that is passed to HarfBuzz in a blob.  If there is
- *   any such possibility, MODE_DUPLICATE should be used
+ *   any such possibility, @HB_MEMORY_MODE_DUPLICATE should be used
  *   such that HarfBuzz makes a copy immediately,
  *
- * - Use MODE_READONLY otherwise, unless you really really
+ * - Use @HB_MEMORY_MODE_READONLY otherwise, unless you really really
  *   really know what you are doing,
  *
- * - MODE_WRITABLE is appropriate if you really made a
+ * - @HB_MEMORY_MODE_WRITABLE is appropriate if you really made a
  *   copy of data solely for the purpose of passing to
  *   HarfBuzz and doing that just once (no reuse!),
  *
- * - If the font is mmap()ed, it's ok to use
- *   READONLY_MAY_MAKE_WRITABLE, however, using that mode
- *   correctly is very tricky.  Use MODE_READONLY instead.
- */
+ * - If the font is mmap()ed, it's okay to use
+ *   @HB_MEMORY_READONLY_MAY_MAKE_WRITABLE, however, using that mode
+ *   correctly is very tricky.  Use @HB_MEMORY_MODE_READONLY instead.
+ **/
 typedef enum {
   HB_MEMORY_MODE_DUPLICATE,
   HB_MEMORY_MODE_READONLY,
@@ -62,6 +71,14 @@ typedef enum {
   HB_MEMORY_MODE_READONLY_MAY_MAKE_WRITABLE
 } hb_memory_mode_t;
 
+/**
+ * hb_blob_t:
+ *
+ * Data type for blobs. A blob wraps a chunk of binary
+ * data and facilitates its lifecycle management between
+ * a client program and HarfBuzz.
+ *
+ **/
 typedef struct hb_blob_t hb_blob_t;
 
 HB_EXTERN hb_blob_t *

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -37,8 +37,9 @@
  * @short_description: Input and output buffers
  * @include: hb.h
  *
- * Buffers serve dual role in HarfBuzz; they hold the input characters that are
- * passed to hb_shape(), and after shaping they hold the output glyphs.
+ * Buffers serve a dual role in HarfBuzz; before shaping, they hold
+ * the input characters that are passed to hb_shape(), and after
+ * shaping they hold the output glyphs.
  **/
 
 
@@ -705,9 +706,9 @@ hb_buffer_create ()
 /**
  * hb_buffer_get_empty:
  *
+ * Fetches an empty #hb_buffer_t.
  *
- *
- * Return value: (transfer full):
+ * Return value: (transfer full): The empty buffer
  *
  * Since: 0.9.2
  **/
@@ -719,7 +720,7 @@ hb_buffer_get_empty ()
 
 /**
  * hb_buffer_reference: (skip)
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Increases the reference count on @buffer by one. This prevents @buffer from
  * being destroyed until a matching call to hb_buffer_destroy() is made.
@@ -737,7 +738,7 @@ hb_buffer_reference (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_destroy: (skip)
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Deallocate the @buffer.
  * Decreases the reference count on @buffer by one. If the result is zero, then
@@ -764,15 +765,15 @@ hb_buffer_destroy (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_set_user_data: (skip)
- * @buffer: an #hb_buffer_t.
- * @key:
- * @data:
- * @destroy:
- * @replace:
+ * @buffer: An #hb_buffer_t
+ * @key: The user-data key
+ * @data: A pointer to the user data
+ * @destroy: A callback to call when @data is not needed anymore
+ * @replace: Whether to replace an existing data with the same key
  *
+ * Attaches a user-data key/data pair to the specified buffer. 
  *
- *
- * Return value:
+ * Return value: %true if success, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -788,12 +789,13 @@ hb_buffer_set_user_data (hb_buffer_t        *buffer,
 
 /**
  * hb_buffer_get_user_data: (skip)
- * @buffer: an #hb_buffer_t.
- * @key:
+ * @buffer: An #hb_buffer_t
+ * @key: The user-data key to query
  *
+ * Fetches the user data associated with the specified key,
+ * attached to the specified buffer.
  *
- *
- * Return value:
+ * Return value: A pointer to the user data
  *
  * Since: 0.9.2
  **/
@@ -807,11 +809,11 @@ hb_buffer_get_user_data (hb_buffer_t        *buffer,
 
 /**
  * hb_buffer_set_content_type:
- * @buffer: an #hb_buffer_t.
- * @content_type: the type of buffer contents to set
+ * @buffer: An #hb_buffer_t
+ * @content_type: The type of buffer contents to set
  *
- * Sets the type of @buffer contents, buffers are either empty, contain
- * characters (before shaping) or glyphs (the result of shaping).
+ * Sets the type of @buffer contents. Buffers are either empty, contain
+ * characters (before shaping), or contain glyphs (the result of shaping).
  *
  * Since: 0.9.5
  **/
@@ -824,12 +826,13 @@ hb_buffer_set_content_type (hb_buffer_t              *buffer,
 
 /**
  * hb_buffer_get_content_type:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
- * see hb_buffer_set_content_type().
+ * Fetches the type of @buffer contents. Buffers are either empty, contain
+ * characters (before shaping), or contain glyphs (the result of shaping).
  *
  * Return value:
- * The type of @buffer contents.
+ * The type of @buffer contents
  *
  * Since: 0.9.5
  **/
@@ -842,10 +845,11 @@ hb_buffer_get_content_type (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_set_unicode_funcs:
- * @buffer: an #hb_buffer_t.
- * @unicode_funcs:
+ * @buffer: An #hb_buffer_t
+ * @unicode_funcs: The Unicode-functions structure
  *
- *
+ * Sets the Unicode-functions structure of a buffer to
+ * @unicode_funcs.
  *
  * Since: 0.9.2
  **/
@@ -866,11 +870,11 @@ hb_buffer_set_unicode_funcs (hb_buffer_t        *buffer,
 
 /**
  * hb_buffer_get_unicode_funcs:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
+ * Fetches the Unicode-functions structure of a buffer.
  *
- *
- * Return value:
+ * Return value: The Unicode-functions structure
  *
  * Since: 0.9.2
  **/
@@ -882,7 +886,7 @@ hb_buffer_get_unicode_funcs (hb_buffer_t        *buffer)
 
 /**
  * hb_buffer_set_direction:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  * @direction: the #hb_direction_t of the @buffer
  *
  * Set the text flow direction of the buffer. No shaping can happen without
@@ -908,7 +912,7 @@ hb_buffer_set_direction (hb_buffer_t    *buffer,
 
 /**
  * hb_buffer_get_direction:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * See hb_buffer_set_direction()
  *
@@ -925,8 +929,8 @@ hb_buffer_get_direction (hb_buffer_t    *buffer)
 
 /**
  * hb_buffer_set_script:
- * @buffer: an #hb_buffer_t.
- * @script: an #hb_script_t to set.
+ * @buffer: An #hb_buffer_t
+ * @script: An #hb_script_t to set.
  *
  * Sets the script of @buffer to @script.
  *
@@ -952,12 +956,12 @@ hb_buffer_set_script (hb_buffer_t *buffer,
 
 /**
  * hb_buffer_get_script:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
- * See hb_buffer_set_script().
+ * Fetches the script of @buffer.
  *
  * Return value:
- * The #hb_script_t of the @buffer.
+ * The #hb_script_t of the @buffer
  *
  * Since: 0.9.2
  **/
@@ -969,8 +973,8 @@ hb_buffer_get_script (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_set_language:
- * @buffer: an #hb_buffer_t.
- * @language: an hb_language_t to set.
+ * @buffer: An #hb_buffer_t
+ * @language: An hb_language_t to set
  *
  * Sets the language of @buffer to @language.
  *
@@ -996,7 +1000,7 @@ hb_buffer_set_language (hb_buffer_t   *buffer,
 
 /**
  * hb_buffer_get_language:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * See hb_buffer_set_language().
  *
@@ -1013,8 +1017,8 @@ hb_buffer_get_language (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_set_segment_properties:
- * @buffer: an #hb_buffer_t.
- * @props: an #hb_segment_properties_t to use.
+ * @buffer: An #hb_buffer_t
+ * @props: An #hb_segment_properties_t to use
  *
  * Sets the segment properties of the buffer, a shortcut for calling
  * hb_buffer_set_direction(), hb_buffer_set_script() and
@@ -1034,8 +1038,8 @@ hb_buffer_set_segment_properties (hb_buffer_t *buffer,
 
 /**
  * hb_buffer_get_segment_properties:
- * @buffer: an #hb_buffer_t.
- * @props: (out): the output #hb_segment_properties_t.
+ * @buffer: An #hb_buffer_t
+ * @props: (out): The output #hb_segment_properties_t
  *
  * Sets @props to the #hb_segment_properties_t of @buffer.
  *
@@ -1051,8 +1055,8 @@ hb_buffer_get_segment_properties (hb_buffer_t *buffer,
 
 /**
  * hb_buffer_set_flags:
- * @buffer: an #hb_buffer_t.
- * @flags: the buffer flags to set.
+ * @buffer: An #hb_buffer_t
+ * @flags: The buffer flags to set
  *
  * Sets @buffer flags to @flags. See #hb_buffer_flags_t.
  *
@@ -1070,12 +1074,12 @@ hb_buffer_set_flags (hb_buffer_t       *buffer,
 
 /**
  * hb_buffer_get_flags:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
- * See hb_buffer_set_flags().
+ * Fetches the #hb_buffer_flags_t for @buffer.
  *
  * Return value:
- * The @buffer flags.
+ * The @buffer flags
  *
  * Since: 0.9.7
  **/
@@ -1087,10 +1091,12 @@ hb_buffer_get_flags (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_set_cluster_level:
- * @buffer: an #hb_buffer_t.
- * @cluster_level:
+ * @buffer: An #hb_buffer_t
+ * @cluster_level: The cluster level to set on the buffer
  *
- *
+ * Sets the cluster level of a buffer. The #hb_buffer_cluster_level_t
+ * dictates one aspect of how HarfBuzz will treat non-base characters 
+ * during shaping.
  *
  * Since: 0.9.42
  **/
@@ -1106,11 +1112,13 @@ hb_buffer_set_cluster_level (hb_buffer_t               *buffer,
 
 /**
  * hb_buffer_get_cluster_level:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
+ * Fetches the cluster level of a buffer. The #hb_buffer_cluster_level_t
+ * dictates one aspect of how HarfBuzz will treat non-base characters 
+ * during shaping.
  *
- *
- * Return value:
+ * Return value: The cluster level of @buffer
  *
  * Since: 0.9.42
  **/
@@ -1123,7 +1131,7 @@ hb_buffer_get_cluster_level (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_set_replacement_codepoint:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  * @replacement: the replacement #hb_codepoint_t
  *
  * Sets the #hb_codepoint_t that replaces invalid entries for a given encoding
@@ -1145,12 +1153,13 @@ hb_buffer_set_replacement_codepoint (hb_buffer_t    *buffer,
 
 /**
  * hb_buffer_get_replacement_codepoint:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
- * See hb_buffer_set_replacement_codepoint().
+ * Fetches the #hb_codepoint_t that replaces invalid entries for a given encoding
+ * when adding text to @buffer.
  *
  * Return value:
- * The @buffer replacement #hb_codepoint_t.
+ * The @buffer replacement #hb_codepoint_t
  *
  * Since: 0.9.31
  **/
@@ -1163,7 +1172,7 @@ hb_buffer_get_replacement_codepoint (hb_buffer_t    *buffer)
 
 /**
  * hb_buffer_set_invisible_glyph:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  * @invisible: the invisible #hb_codepoint_t
  *
  * Sets the #hb_codepoint_t that replaces invisible characters in
@@ -1185,12 +1194,12 @@ hb_buffer_set_invisible_glyph (hb_buffer_t    *buffer,
 
 /**
  * hb_buffer_get_invisible_glyph:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * See hb_buffer_set_invisible_glyph().
  *
  * Return value:
- * The @buffer invisible #hb_codepoint_t.
+ * The @buffer invisible #hb_codepoint_t
  *
  * Since: 2.0.0
  **/
@@ -1203,7 +1212,7 @@ hb_buffer_get_invisible_glyph (hb_buffer_t    *buffer)
 
 /**
  * hb_buffer_reset:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Resets the buffer to its initial status, as if it was just newly created
  * with hb_buffer_create().
@@ -1218,7 +1227,7 @@ hb_buffer_reset (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_clear_contents:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Similar to hb_buffer_reset(), but does not clear the Unicode functions and
  * the replacement code point.
@@ -1233,13 +1242,13 @@ hb_buffer_clear_contents (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_pre_allocate:
- * @buffer: an #hb_buffer_t.
- * @size: number of items to pre allocate.
+ * @buffer: An #hb_buffer_t
+ * @size: Number of items to pre allocate.
  *
  * Pre allocates memory for @buffer to fit at least @size number of items.
  *
  * Return value:
- * %true if @buffer memory allocation succeeded, %false otherwise.
+ * %true if @buffer memory allocation succeeded, %false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1251,7 +1260,7 @@ hb_buffer_pre_allocate (hb_buffer_t *buffer, unsigned int size)
 
 /**
  * hb_buffer_allocation_successful:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Check if allocating memory for the buffer succeeded.
  *
@@ -1268,9 +1277,9 @@ hb_buffer_allocation_successful (hb_buffer_t  *buffer)
 
 /**
  * hb_buffer_add:
- * @buffer: an #hb_buffer_t.
- * @codepoint: a Unicode code point.
- * @cluster: the cluster value of @codepoint.
+ * @buffer: An #hb_buffer_t
+ * @codepoint: A Unicode code point.
+ * @cluster: The cluster value of @codepoint.
  *
  * Appends a character with the Unicode value of @codepoint to @buffer, and
  * gives it the initial cluster value of @cluster. Clusters can be any thing
@@ -1294,8 +1303,8 @@ hb_buffer_add (hb_buffer_t    *buffer,
 
 /**
  * hb_buffer_set_length:
- * @buffer: an #hb_buffer_t.
- * @length: the new length of @buffer.
+ * @buffer: An #hb_buffer_t
+ * @length: The new length of @buffer
  *
  * Similar to hb_buffer_pre_allocate(), but clears any new items added at the
  * end.
@@ -1336,7 +1345,7 @@ hb_buffer_set_length (hb_buffer_t  *buffer,
 
 /**
  * hb_buffer_get_length:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Returns the number of items in the buffer.
  *
@@ -1354,8 +1363,8 @@ hb_buffer_get_length (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_get_glyph_infos:
- * @buffer: an #hb_buffer_t.
- * @length: (out): output array length.
+ * @buffer: An #hb_buffer_t
+ * @length: (out): The output-array length.
  *
  * Returns @buffer glyph information array.  Returned pointer
  * is valid as long as @buffer contents are not modified.
@@ -1378,8 +1387,8 @@ hb_buffer_get_glyph_infos (hb_buffer_t  *buffer,
 
 /**
  * hb_buffer_get_glyph_positions:
- * @buffer: an #hb_buffer_t.
- * @length: (out): output length.
+ * @buffer: An #hb_buffer_t
+ * @length: (out): The output length
  *
  * Returns @buffer glyph position array.  Returned pointer
  * is valid as long as @buffer contents are not modified.
@@ -1424,12 +1433,12 @@ hb_buffer_has_positions (hb_buffer_t  *buffer)
 
 /**
  * hb_glyph_info_get_glyph_flags:
- * @info: a #hb_glyph_info_t.
+ * @info: a #hb_glyph_info_t
  *
  * Returns glyph flags encoded within a #hb_glyph_info_t.
  *
  * Return value:
- * The #hb_glyph_flags_t encoded within @info.
+ * The #hb_glyph_flags_t encoded within @info
  *
  * Since: 1.5.0
  **/
@@ -1441,7 +1450,7 @@ hb_glyph_flags_t
 
 /**
  * hb_buffer_reverse:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Reverses buffer contents.
  *
@@ -1455,11 +1464,11 @@ hb_buffer_reverse (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_reverse_range:
- * @buffer: an #hb_buffer_t.
- * @start: start index.
- * @end: end index.
+ * @buffer: An #hb_buffer_t
+ * @start: start index
+ * @end: end index
  *
- * Reverses buffer contents between start to end.
+ * Reverses buffer contents between @start and @end.
  *
  * Since: 0.9.41
  **/
@@ -1472,7 +1481,7 @@ hb_buffer_reverse_range (hb_buffer_t *buffer,
 
 /**
  * hb_buffer_reverse_clusters:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Reverses buffer clusters.  That is, the buffer contents are
  * reversed, then each cluster (consecutive items having the
@@ -1488,7 +1497,7 @@ hb_buffer_reverse_clusters (hb_buffer_t *buffer)
 
 /**
  * hb_buffer_guess_segment_properties:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Sets unset buffer segment properties based on buffer Unicode
  * contents.  If buffer is not empty, it must have content type
@@ -1590,12 +1599,12 @@ hb_buffer_add_utf (hb_buffer_t  *buffer,
 
 /**
  * hb_buffer_add_utf8:
- * @buffer: an #hb_buffer_t.
- * @text: (array length=text_length) (element-type uint8_t): an array of UTF-8
+ * @buffer: An #hb_buffer_t
+ * @text: (array length=text_length) (element-type uint8_t): An array of UTF-8
  *               characters to append.
- * @text_length: the length of the @text, or -1 if it is %NULL terminated.
- * @item_offset: the offset of the first character to add to the @buffer.
- * @item_length: the number of characters to add to the @buffer, or -1 for the
+ * @text_length: The length of the @text, or -1 if it is %NULL terminated.
+ * @item_offset: The offset of the first character to add to the @buffer.
+ * @item_length: The number of characters to add to the @buffer, or -1 for the
  *               end of @text (assuming it is %NULL terminated).
  *
  * See hb_buffer_add_codepoints().
@@ -1617,12 +1626,12 @@ hb_buffer_add_utf8 (hb_buffer_t  *buffer,
 
 /**
  * hb_buffer_add_utf16:
- * @buffer: an #hb_buffer_t.
- * @text: (array length=text_length): an array of UTF-16 characters to append.
- * @text_length: the length of the @text, or -1 if it is %NULL terminated.
- * @item_offset: the offset of the first character to add to the @buffer.
- * @item_length: the number of characters to add to the @buffer, or -1 for the
- *               end of @text (assuming it is %NULL terminated).
+ * @buffer: An #hb_buffer_t
+ * @text: (array length=text_length): An array of UTF-16 characters to append
+ * @text_length: The length of the @text, or -1 if it is %NULL terminated
+ * @item_offset: The offset of the first character to add to the @buffer
+ * @item_length: The number of characters to add to the @buffer, or -1 for the
+ *               end of @text (assuming it is %NULL terminated)
  *
  * See hb_buffer_add_codepoints().
  *
@@ -1643,12 +1652,12 @@ hb_buffer_add_utf16 (hb_buffer_t    *buffer,
 
 /**
  * hb_buffer_add_utf32:
- * @buffer: an #hb_buffer_t.
- * @text: (array length=text_length): an array of UTF-32 characters to append.
- * @text_length: the length of the @text, or -1 if it is %NULL terminated.
- * @item_offset: the offset of the first character to add to the @buffer.
- * @item_length: the number of characters to add to the @buffer, or -1 for the
- *               end of @text (assuming it is %NULL terminated).
+ * @buffer: An #hb_buffer_t
+ * @text: (array length=text_length): An array of UTF-32 characters to append
+ * @text_length: The length of the @text, or -1 if it is %NULL terminated
+ * @item_offset: The offset of the first character to add to the @buffer
+ * @item_length: The number of characters to add to the @buffer, or -1 for the
+ *               end of @text (assuming it is %NULL terminated)
  *
  * See hb_buffer_add_codepoints().
  *
@@ -1669,13 +1678,13 @@ hb_buffer_add_utf32 (hb_buffer_t    *buffer,
 
 /**
  * hb_buffer_add_latin1:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  * @text: (array length=text_length) (element-type uint8_t): an array of UTF-8
- *               characters to append.
- * @text_length: the length of the @text, or -1 if it is %NULL terminated.
- * @item_offset: the offset of the first character to add to the @buffer.
+ *               characters to append
+ * @text_length: the length of the @text, or -1 if it is %NULL terminated
+ * @item_offset: the offset of the first character to add to the @buffer
  * @item_length: the number of characters to add to the @buffer, or -1 for the
- *               end of @text (assuming it is %NULL terminated).
+ *               end of @text (assuming it is %NULL terminated)
  *
  * Similar to hb_buffer_add_codepoints(), but allows only access to first 256
  * Unicode code points that can fit in 8-bit strings.
@@ -1731,8 +1740,8 @@ hb_buffer_add_codepoints (hb_buffer_t          *buffer,
 
 /**
  * hb_buffer_append:
- * @buffer: an #hb_buffer_t.
- * @source: source #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
+ * @source: source #hb_buffer_t
  * @start: start index into source buffer to copy.  Use 0 to copy from start of buffer.
  * @end: end index into source buffer to copy.  Use @HB_FEATURE_GLOBAL_END to copy to end of buffer.
  *
@@ -1838,7 +1847,7 @@ normalize_glyphs_cluster (hb_buffer_t *buffer,
 
 /**
  * hb_buffer_normalize_glyphs:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  *
  * Reorders a glyph buffer to have canonical in-cluster glyph order / position.
  * The resulting clusters should behave identical to pre-reordering clusters.
@@ -1984,7 +1993,7 @@ hb_buffer_diff (hb_buffer_t *buffer,
 #ifndef HB_NO_BUFFER_MESSAGE
 /**
  * hb_buffer_set_message_func:
- * @buffer: an #hb_buffer_t.
+ * @buffer: An #hb_buffer_t
  * @func: (closure user_data) (destroy destroy) (scope notified):
  * @user_data:
  * @destroy:

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -773,7 +773,7 @@ hb_buffer_destroy (hb_buffer_t *buffer)
  *
  * Attaches a user-data key/data pair to the specified buffer. 
  *
- * Return value: %true if success, false otherwise
+ * Return value: %true if success, %false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1076,7 +1076,7 @@ hb_buffer_set_flags (hb_buffer_t       *buffer,
  * hb_buffer_get_flags:
  * @buffer: An #hb_buffer_t
  *
- * Fetches the #hb_buffer_flags_t for @buffer.
+ * Fetches the #hb_buffer_flags_t of @buffer.
  *
  * Return value:
  * The @buffer flags

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -768,7 +768,7 @@ hb_buffer_destroy (hb_buffer_t *buffer)
  * @buffer: An #hb_buffer_t
  * @key: The user-data key
  * @data: A pointer to the user data
- * @destroy: A callback to call when @data is not needed anymore
+ * @destroy: (optional): A callback to call when @data is not needed anymore
  * @replace: Whether to replace an existing data with the same key
  *
  * Attaches a user-data key/data pair to the specified buffer. 
@@ -795,7 +795,7 @@ hb_buffer_set_user_data (hb_buffer_t        *buffer,
  * Fetches the user data associated with the specified key,
  * attached to the specified buffer.
  *
- * Return value: A pointer to the user data
+ * Return value: (transfer-none): A pointer to the user data
  *
  * Since: 0.9.2
  **/

--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -314,6 +314,23 @@ hb_buffer_get_flags (hb_buffer_t *buffer);
  * @HB_BUFFER_CLUSTER_LEVEL_CHARACTERS: Don't group cluster values.
  * @HB_BUFFER_CLUSTER_LEVEL_DEFAULT: Default cluster level,
  *   equal to @HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES.
+ * 
+ * Data type for holding HarfBuzz's clustering behavior options. The cluster level
+ * dictates one aspect of how HarfBuzz will treat non-base characters 
+ * during shaping.
+ *
+ * In @HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES, non-base
+ * characters are merged into the cluster of the base character that precedes them.
+ *
+ * In @HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS, non-base characters are initially
+ * assigned their own cluster values, which are not merged into preceding base
+ * clusters. This allows HarfBuzz to perform additional operations like reorder
+ * sequences of adjacent marks.
+ *
+ * @HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES is the default, because it maintains
+ * backward compatibility with older versions of HarfBuzz. New client programs that
+ * do not need to maintain such backward compatibility are recommended to use
+ * @HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS instead of the default.
  *
  * Since: 0.9.42
  */

--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -524,8 +524,9 @@ hb_script_to_iso15924_tag (hb_script_t script)
  * Fetches the #hb_direction_t of a script when it is
  * set horizontally. All right-to-left scripts will return
  * #HB_DIRECTION_RTL. All left-to-right scripts will return
- * #HB_DIRECTION_LTR. Scripts that cannot be written
- * horizontally will return #HB_DIRECTION_INVALID.
+ * #HB_DIRECTION_LTR.  Scripts that can be written either
+ * horizontally or vertically will return #HB_DIRECTION_INVALID.
+ * Unknown scripts will return #HB_DIRECTION_LTR.
  *
  * Return value: The horizontal #hb_direction_t of @script
  *

--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -86,12 +86,15 @@ _hb_options_init ()
 
 /**
  * hb_tag_from_string:
- * @str: (array length=len) (element-type uint8_t):
- * @len:
+ * @str: (array length=len) (element-type uint8_t): String to convert
+ * @len: Length of @str, or -1 if it is %NULL-terminated
  *
+ * Converts a string into an #hb_tag_t. Valid tags
+ * are four characters. Shorter input strings will be
+ * padded with spaces. Longer input strings will be
+ * truncated.
  *
- *
- * Return value:
+ * Return value: The #hb_tag_t corresponding to @str
  *
  * Since: 0.9.2
  **/
@@ -116,10 +119,11 @@ hb_tag_from_string (const char *str, int len)
 
 /**
  * hb_tag_to_string:
- * @tag:
- * @buf: (out caller-allocates) (array fixed-size=4) (element-type uint8_t):
+ * @tag: #hb_tag_t to convert
+ * @buf: (out caller-allocates) (array fixed-size=4) (element-type uint8_t): Converted string
  *
- *
+ * Converts an #hb_tag_t to a string and returns it in @buf. 
+ * Strings will be four characters long.
  *
  * Since: 0.9.5
  **/
@@ -144,12 +148,17 @@ const char direction_strings[][4] = {
 
 /**
  * hb_direction_from_string:
- * @str: (array length=len) (element-type uint8_t):
- * @len:
+ * @str: (array length=len) (element-type uint8_t): String to convert
+ * @len: Length of @str, or -1 if it is %NULL-terminated
  *
+ * Converts a string to an #hb_direction_t. 
  *
+ * Matching is loose and applies only to the first letter. For
+ * examples, "LTR" and "left-to-right" will both return #HB_DIRECTION_LTR.
  *
- * Return value:
+ * Unmatched strings will return #HB_DIRECTION_INVALID.
+ * 
+ * Return value: The #hb_direction_t matching @str
  *
  * Since: 0.9.2
  **/
@@ -172,11 +181,11 @@ hb_direction_from_string (const char *str, int len)
 
 /**
  * hb_direction_to_string:
- * @direction:
+ * @direction: The #hb_direction_t to convert
  *
+ * Converts an #hb_direction_t to a string.
  *
- *
- * Return value: (transfer none):
+ * Return value: (transfer none): The string corresponding to @direction
  *
  * Since: 0.9.2
  **/
@@ -367,9 +376,9 @@ hb_language_from_string (const char *str, int len)
 
 /**
  * hb_language_to_string:
- * @language: an #hb_language_t to convert.
+ * @language: The #hb_language_t to convert
  *
- * See hb_language_from_string().
+ * Converts an #hb_language_t to a string.
  *
  * Return value: (transfer none):
  * A %NULL-terminated string representing the @language. Must not be freed by
@@ -388,16 +397,17 @@ hb_language_to_string (hb_language_t language)
 /**
  * hb_language_get_default:
  *
- * Get default language from current locale.
+ * Fetch the default language from current locale.
  *
- * Note that the first time this function is called, it calls
+ * <note>Note that the first time this function is called, it calls
  * "setlocale (LC_CTYPE, nullptr)" to fetch current locale.  The underlying
  * setlocale function is, in many implementations, NOT threadsafe.  To avoid
  * problems, call this function once before multiple threads can call it.
  * This function is only used from hb_buffer_guess_segment_properties() by
- * HarfBuzz itself.
+ * HarfBuzz itself.</note>
  *
- * Return value: (transfer none):
+ * Return value: (transfer none): The default language of the locale as
+ * an #hb_language_t
  *
  * Since: 0.9.2
  **/
@@ -494,7 +504,7 @@ hb_script_from_string (const char *str, int len)
  * hb_script_to_iso15924_tag:
  * @script: an #hb_script_t to convert.
  *
- * See hb_script_from_iso15924_tag().
+ * Converts an #hb_script_t to a corresponding ISO 15924 script tag.
  *
  * Return value:
  * An #hb_tag_t representing an ISO 15924 script tag.
@@ -509,11 +519,15 @@ hb_script_to_iso15924_tag (hb_script_t script)
 
 /**
  * hb_script_get_horizontal_direction:
- * @script:
+ * @script: The #hb_script_t to query
  *
+ * Fetches the #hb_direction_t of a script when it is
+ * set horizontally. All right-to-left scripts will return
+ * #HB_DIRECTION_RTL. All left-to-right scripts will return
+ * #HB_DIRECTION_LTR. Scripts that cannot be written
+ * horizontally will return #HB_DIRECTION_INVALID.
  *
- *
- * Return value:
+ * Return value: The horizontal #hb_direction_t of @script
  *
  * Since: 0.9.2
  **/
@@ -618,9 +632,9 @@ hb_script_get_horizontal_direction (hb_script_t script)
 
 /**
  * hb_version:
- * @major: (out): Library major version component.
- * @minor: (out): Library minor version component.
- * @micro: (out): Library micro version component.
+ * @major: (out): Library major version component
+ * @minor: (out): Library minor version component
+ * @micro: (out): Library micro version component
  *
  * Returns library version as three integer components.
  *
@@ -641,7 +655,7 @@ hb_version (unsigned int *major,
  *
  * Returns library version as a string with three components.
  *
- * Return value: library version string.
+ * Return value: Library version string
  *
  * Since: 0.9.2
  **/
@@ -653,13 +667,15 @@ hb_version_string ()
 
 /**
  * hb_version_atleast:
- * @major:
- * @minor:
- * @micro:
+ * @major: Library major version component
+ * @minor: Library minor version component
+ * @micro: Library micro version component
  *
+ * Tests the library version against a minimum value,
+ * as three integer components.
  *
- *
- * Return value:
+ * Return value: True if the library is equal to or greater than
+ * the test value, false otherwise
  *
  * Since: 0.9.30
  **/
@@ -888,7 +904,7 @@ parse_one_feature (const char **pp, const char *end, hb_feature_t *feature)
  * </informaltable>
  *
  * Return value:
- * %true if @str is successfully parsed, %false otherwise.
+ * %true if @str is successfully parsed, %false otherwise
  *
  * Since: 0.9.5
  **/

--- a/src/hb-common.h
+++ b/src/hb-common.h
@@ -136,8 +136,8 @@ typedef union _hb_var_int_t {
 /**
  * hb_tag_t:
  * 
- * Data type for tag identifiers. Tags are arrays of four
- * bytes, each of which holds a character. 
+ * Data type for tag identifiers. Tags are four
+ * byte integers, each byte representing a character.
  *
  * Tags are used to identify tables, design-variation axes,
  * scripts, languages, font features, and baselines with
@@ -236,8 +236,8 @@ hb_direction_to_string (hb_direction_t direction);
  * HB_DIRECTION_IS_FORWARD:
  * @dir: #hb_direction_t to test
  *
- * Tests whether a text direction is forward. Requires
- * that the direction be valid.
+ * Tests whether a text direction moves forward (from left to right, or from
+ * top to bottom). Requires that the direction be valid.
  *
  **/
 #define HB_DIRECTION_IS_FORWARD(dir)	((((unsigned int) (dir)) & ~2U) == 4)
@@ -245,8 +245,8 @@ hb_direction_to_string (hb_direction_t direction);
  * HB_DIRECTION_IS_BACKWARD:
  * @dir: #hb_direction_t to test
  *
- * Tests whether a text direction is backward. Requires
- * that the direction be valid.
+ * Tests whether a text direction moves backward (from right to left, or from
+ * bottom to top). Requires that the direction be valid.
  *
  **/
 #define HB_DIRECTION_IS_BACKWARD(dir)	((((unsigned int) (dir)) & ~2U) == 5)
@@ -433,11 +433,9 @@ hb_language_get_default (void);
  * @HB_SCRIPT_NYIAKENG_PUACHUE_HMONG
  * @HB_SCRIPT_WANCHO
  * @HB_SCRIPT_INVALID: #HB_TAG_NONE
- * @_HB_SCRIPT_MAX_VALUE: Dummy value
- * @_HB_SCRIPT_MAX_VALUE_SIGNED: Dummy value
  *
  * Data type for scripts. Each #hb_script_t's value is an #hb_tag_t corresponding
- * to the four-letter values defined at https://unicode.org/iso15924/ .
+ * to the four-letter values defined by [ISO 15924](https://unicode.org/iso15924/).
  *
  * See also the Script (sc) property of the Unicode Character Database.
  *

--- a/src/hb-common.h
+++ b/src/hb-common.h
@@ -88,11 +88,37 @@ typedef unsigned __int64 uint64_t;
 
 HB_BEGIN_DECLS
 
-
+/**
+ * hb_bool_t:
+ * 
+ * Data type for booleans.
+ *
+ **/
 typedef int hb_bool_t;
 
+/**
+ * hb_codepoint_t:
+ * 
+ * Data type for holding Unicode codepoints. Also
+ * used to hold glyph IDs.
+ *
+ **/
 typedef uint32_t hb_codepoint_t;
+/**
+ * hb_position_t:
+ * 
+ * Data type for holding a single coordinate value.
+ * Contour points and other multi-dimensional data are
+ * stored as tuples of #hb_position_t's.
+ *
+ **/
 typedef int32_t hb_position_t;
+/**
+ * hb_mask_t:
+ * 
+ * Data type for bitmasks.
+ *
+ **/
 typedef uint32_t hb_mask_t;
 
 typedef union _hb_var_int_t {
@@ -107,9 +133,33 @@ typedef union _hb_var_int_t {
 
 /* hb_tag_t */
 
+/**
+ * hb_tag_t:
+ * 
+ * Data type for tag identifiers. Tags are arrays of four
+ * bytes, each of which holds a character. 
+ *
+ * Tags are used to identify tables, design-variation axes,
+ * scripts, languages, font features, and baselines with
+ * human-readable names.
+ *
+ **/
 typedef uint32_t hb_tag_t;
 
+/**
+ * HB_TAG:
+ *
+ * Constructs an #hb_tag_t from four characters.
+ *
+ **/
 #define HB_TAG(c1,c2,c3,c4) ((hb_tag_t)((((uint32_t)(c1)&0xFF)<<24)|(((uint32_t)(c2)&0xFF)<<16)|(((uint32_t)(c3)&0xFF)<<8)|((uint32_t)(c4)&0xFF)))
+
+/**
+ * HB_UNTAG:
+ *
+ * Extracts the characters from an #hb_tag_t.
+ *
+ **/
 #define HB_UNTAG(tag)   (uint8_t)(((tag)>>24)&0xFF), (uint8_t)(((tag)>>16)&0xFF), (uint8_t)(((tag)>>8)&0xFF), (uint8_t)((tag)&0xFF)
 
 #define HB_TAG_NONE HB_TAG(0,0,0,0)
@@ -132,6 +182,13 @@ hb_tag_to_string (hb_tag_t tag, char *buf);
  * @HB_DIRECTION_RTL: Text is set horizontally from right to left.
  * @HB_DIRECTION_TTB: Text is set vertically from top to bottom.
  * @HB_DIRECTION_BTT: Text is set vertically from bottom to top.
+ *
+ * The direction of a text segment or buffer.
+ * 
+ * A segment can also be tested for horizontal or vertical
+ * orientation (irrespective of specific direction) with 
+ * HB_DIRECTION_IS_HORIZONTAL() or HB_DIRECTION_IS_VERTICAL().
+ *
  */
 typedef enum {
   HB_DIRECTION_INVALID = 0,
@@ -148,12 +205,59 @@ hb_direction_from_string (const char *str, int len);
 HB_EXTERN const char *
 hb_direction_to_string (hb_direction_t direction);
 
+/**
+ * HB_DIRECTION_IS_VALID:
+ * @dir: #hb_direction_t to test
+ *
+ * Tests whether a text direction is valid.
+ *
+ **/
 #define HB_DIRECTION_IS_VALID(dir)	((((unsigned int) (dir)) & ~3U) == 4)
 /* Direction must be valid for the following */
+/**
+ * HB_DIRECTION_IS_HORIZONTAL:
+ * @dir: #hb_direction_t to test
+ *
+ * Tests whether a text direction is horizontal. Requires
+ * that the direction be valid.
+ *
+ **/
 #define HB_DIRECTION_IS_HORIZONTAL(dir)	((((unsigned int) (dir)) & ~1U) == 4)
+/**
+ * HB_DIRECTION_IS_VERTICAL:
+ * @dir: #hb_direction_t to test
+ *
+ * Tests whether a text direction is vertical. Requires
+ * that the direction be valid.
+ *
+ **/
 #define HB_DIRECTION_IS_VERTICAL(dir)	((((unsigned int) (dir)) & ~1U) == 6)
+/**
+ * HB_DIRECTION_IS_FORWARD:
+ * @dir: #hb_direction_t to test
+ *
+ * Tests whether a text direction is forward. Requires
+ * that the direction be valid.
+ *
+ **/
 #define HB_DIRECTION_IS_FORWARD(dir)	((((unsigned int) (dir)) & ~2U) == 4)
+/**
+ * HB_DIRECTION_IS_BACKWARD:
+ * @dir: #hb_direction_t to test
+ *
+ * Tests whether a text direction is backward. Requires
+ * that the direction be valid.
+ *
+ **/
 #define HB_DIRECTION_IS_BACKWARD(dir)	((((unsigned int) (dir)) & ~2U) == 5)
+/**
+ * HB_DIRECTION_REVERSE:
+ * @dir: #hb_direction_t to reverse
+ *
+ * Reverses a text direction. Requires that the direction
+ * be valid.
+ *
+ **/
 #define HB_DIRECTION_REVERSE(dir)	((hb_direction_t) (((unsigned int) (dir)) ^ 1))
 
 
@@ -173,7 +277,171 @@ HB_EXTERN hb_language_t
 hb_language_get_default (void);
 
 
-/* hb_script_t */
+/**
+ * hb_script_t:
+ * @HB_SCRIPT_COMMON: HB_TAG ('Z','y','y','y')
+ * @HB_SCRIPT_INHERITED: HB_TAG ('Z','i','n','h')
+ * @HB_SCRIPT_UNKNOWN: HB_TAG ('Z','z','z','z')
+ * @HB_SCRIPT_ARABIC
+ * @HB_SCRIPT_ARMENIAN
+ * @HB_SCRIPT_BENGALI
+ * @HB_SCRIPT_CYRILLIC
+ * @HB_SCRIPT_DEVANAGARI
+ * @HB_SCRIPT_GEORGIAN
+ * @HB_SCRIPT_GREEK
+ * @HB_SCRIPT_GUJARATI
+ * @HB_SCRIPT_GURMUKHI
+ * @HB_SCRIPT_HANGUL
+ * @HB_SCRIPT_HAN
+ * @HB_SCRIPT_HEBREW
+ * @HB_SCRIPT_HIRAGANA
+ * @HB_SCRIPT_KANNADA
+ * @HB_SCRIPT_KATAKANA
+ * @HB_SCRIPT_LAO
+ * @HB_SCRIPT_LATIN
+ * @HB_SCRIPT_MALAYALAM
+ * @HB_SCRIPT_ORIYA
+ * @HB_SCRIPT_TAMIL
+ * @HB_SCRIPT_TELUGU
+ * @HB_SCRIPT_THAI
+ * @HB_SCRIPT_TIBETAN
+ * @HB_SCRIPT_BOPOMOFO
+ * @HB_SCRIPT_BRAILLE
+ * @HB_SCRIPT_CANADIAN_SYLLABICS
+ * @HB_SCRIPT_CHEROKEE
+ * @HB_SCRIPT_ETHIOPIC
+ * @HB_SCRIPT_KHMER
+ * @HB_SCRIPT_MONGOLIAN
+ * @HB_SCRIPT_MYANMAR
+ * @HB_SCRIPT_OGHAM
+ * @HB_SCRIPT_RUNIC
+ * @HB_SCRIPT_SINHALA
+ * @HB_SCRIPT_SYRIAC
+ * @HB_SCRIPT_THAANA
+ * @HB_SCRIPT_YI
+ * @HB_SCRIPT_DESERET
+ * @HB_SCRIPT_GOTHIC
+ * @HB_SCRIPT_OLD_ITALIC
+ * @HB_SCRIPT_BUHID
+ * @HB_SCRIPT_HANUNOO
+ * @HB_SCRIPT_TAGALOG
+ * @HB_SCRIPT_TAGBANWA
+ * @HB_SCRIPT_CYPRIOT
+ * @HB_SCRIPT_LIMBU
+ * @HB_SCRIPT_LINEAR_B
+ * @HB_SCRIPT_OSMANYA
+ * @HB_SCRIPT_SHAVIAN
+ * @HB_SCRIPT_TAI_LE
+ * @HB_SCRIPT_UGARITIC
+ * @HB_SCRIPT_BUGINESE
+ * @HB_SCRIPT_COPTIC
+ * @HB_SCRIPT_GLAGOLITIC
+ * @HB_SCRIPT_KHAROSHTHI
+ * @HB_SCRIPT_NEW_TAI_LUE
+ * @HB_SCRIPT_OLD_PERSIAN
+ * @HB_SCRIPT_SYLOTI_NAGRI
+ * @HB_SCRIPT_TIFINAGH
+ * @HB_SCRIPT_BALINESE
+ * @HB_SCRIPT_CUNEIFORM
+ * @HB_SCRIPT_NKO
+ * @HB_SCRIPT_PHAGS_PA
+ * @HB_SCRIPT_PHOENICIAN
+ * @HB_SCRIPT_CARIAN
+ * @HB_SCRIPT_CHAM
+ * @HB_SCRIPT_KAYAH_LI
+ * @HB_SCRIPT_LEPCHA
+ * @HB_SCRIPT_LYCIAN
+ * @HB_SCRIPT_LYDIAN
+ * @HB_SCRIPT_OL_CHIKI
+ * @HB_SCRIPT_REJANG
+ * @HB_SCRIPT_SAURASHTRA
+ * @HB_SCRIPT_SUNDANESE
+ * @HB_SCRIPT_VAI
+ * @HB_SCRIPT_AVESTAN
+ * @HB_SCRIPT_BAMUM
+ * @HB_SCRIPT_EGYPTIAN_HIEROGLYPHS
+ * @HB_SCRIPT_IMPERIAL_ARAMAIC
+ * @HB_SCRIPT_INSCRIPTIONAL_PAHLAVI
+ * @HB_SCRIPT_INSCRIPTIONAL_PARTHIAN
+ * @HB_SCRIPT_JAVANESE
+ * @HB_SCRIPT_KAITHI
+ * @HB_SCRIPT_LISU
+ * @HB_SCRIPT_MEETEI_MAYEK
+ * @HB_SCRIPT_OLD_SOUTH_ARABIAN
+ * @HB_SCRIPT_OLD_TURKIC
+ * @HB_SCRIPT_SAMARITAN
+ * @HB_SCRIPT_TAI_THAM
+ * @HB_SCRIPT_TAI_VIET
+ * @HB_SCRIPT_BATAK
+ * @HB_SCRIPT_BRAHMI
+ * @HB_SCRIPT_MANDAIC
+ * @HB_SCRIPT_CHAKMA
+ * @HB_SCRIPT_MEROITIC_CURSIVE
+ * @HB_SCRIPT_MEROITIC_HIEROGLYPHS
+ * @HB_SCRIPT_MIAO
+ * @HB_SCRIPT_SHARADA
+ * @HB_SCRIPT_SORA_SOMPENG
+ * @HB_SCRIPT_TAKRI
+ * @HB_SCRIPT_BASSA_VAH
+ * @HB_SCRIPT_CAUCASIAN_ALBANIAN
+ * @HB_SCRIPT_DUPLOYAN
+ * @HB_SCRIPT_ELBASAN
+ * @HB_SCRIPT_GRANTHA
+ * @HB_SCRIPT_KHOJKI
+ * @HB_SCRIPT_KHUDAWADI
+ * @HB_SCRIPT_LINEAR_A
+ * @HB_SCRIPT_MAHAJANI
+ * @HB_SCRIPT_MANICHAEAN
+ * @HB_SCRIPT_MENDE_KIKAKUI
+ * @HB_SCRIPT_MODI
+ * @HB_SCRIPT_MRO
+ * @HB_SCRIPT_NABATAEAN
+ * @HB_SCRIPT_OLD_NORTH_ARABIAN
+ * @HB_SCRIPT_OLD_PERMIC
+ * @HB_SCRIPT_PAHAWH_HMONG
+ * @HB_SCRIPT_PALMYRENE
+ * @HB_SCRIPT_PAU_CIN_HAU
+ * @HB_SCRIPT_PSALTER_PAHLAVI
+ * @HB_SCRIPT_SIDDHAM
+ * @HB_SCRIPT_TIRHUTA
+ * @HB_SCRIPT_WARANG_CITI
+ * @HB_SCRIPT_AHOM
+ * @HB_SCRIPT_ANATOLIAN_HIEROGLYPHS
+ * @HB_SCRIPT_HATRAN
+ * @HB_SCRIPT_MULTANI
+ * @HB_SCRIPT_OLD_HUNGARIAN
+ * @HB_SCRIPT_SIGNWRITING
+ * @HB_SCRIPT_ADLAM
+ * @HB_SCRIPT_BHAIKSUKI
+ * @HB_SCRIPT_MARCHEN
+ * @HB_SCRIPT_OSAGE
+ * @HB_SCRIPT_TANGUT
+ * @HB_SCRIPT_NEWA
+ * @HB_SCRIPT_MASARAM_GONDI
+ * @HB_SCRIPT_NUSHU
+ * @HB_SCRIPT_SOYOMBO
+ * @HB_SCRIPT_ZANABAZAR_SQUARE
+ * @HB_SCRIPT_DOGRA
+ * @HB_SCRIPT_GUNJALA_GONDI
+ * @HB_SCRIPT_HANIFI_ROHINGYA
+ * @HB_SCRIPT_MAKASAR
+ * @HB_SCRIPT_MEDEFAIDRIN
+ * @HB_SCRIPT_OLD_SOGDIAN
+ * @HB_SCRIPT_SOGDIAN
+ * @HB_SCRIPT_ELYMAIC
+ * @HB_SCRIPT_NANDINAGARI
+ * @HB_SCRIPT_NYIAKENG_PUACHUE_HMONG
+ * @HB_SCRIPT_WANCHO
+ * @HB_SCRIPT_INVALID: #HB_TAG_NONE
+ * @_HB_SCRIPT_MAX_VALUE: Dummy value
+ * @_HB_SCRIPT_MAX_VALUE_SIGNED: Dummy value
+ *
+ * Data type for scripts. Each #hb_script_t's value is an #hb_tag_t corresponding
+ * to the four-letter values defined at https://unicode.org/iso15924/ .
+ *
+ * See also the Script (sc) property of the Unicode Character Database.
+ *
+ **/
 
 /* https://unicode.org/iso15924/ */
 /* https://docs.google.com/spreadsheets/d/1Y90M0Ie3MUJ6UVCRDOypOtijlMDLNNyyLk36T6iMu0o */
@@ -410,6 +678,12 @@ hb_script_get_horizontal_direction (hb_script_t script);
 
 /* User data */
 
+/**
+ * hb_user_data_key_t:
+ *
+ * Data structure for holding user-data keys.
+ *
+ **/
 typedef struct hb_user_data_key_t {
   /*< private >*/
   char unused;
@@ -435,10 +709,10 @@ typedef void (*hb_destroy_func_t) (void *user_data);
 
 /**
  * hb_feature_t:
- * @tag: a feature tag
- * @value: 0 disables the feature, non-zero (usually 1) enables the feature.
- * For features implemented as lookup type 3 (like 'salt') the @value is a one
- * based index into the alternates.
+ * @tag: The #hb_tag_t tag of the feature
+ * @value: The value of the feature. 0 disables the feature, non-zero (usually
+ * 1) enables the feature.  For features implemented as lookup type 3 (like
+ * 'salt') the @value is a one based index into the alternates.
  * @start: the cluster to start applying this feature setting (inclusive).
  * @end: the cluster to end applying this feature setting (exclusive).
  *
@@ -465,7 +739,13 @@ hb_feature_to_string (hb_feature_t *feature,
 
 /**
  * hb_variation_t:
+ * @tag: The #hb_tag_t tag of the variation-axis name
+ * @value: The value of the variation axis
  *
+ * Data type for holding variation data. Registered OpenType
+ * variation-axis tags are listed at
+ * https://docs.microsoft.com/en-us/typography/opentype/spec/dvaraxisreg
+ * 
  * Since: 1.4.2
  */
 typedef struct hb_variation_t {
@@ -484,7 +764,8 @@ hb_variation_to_string (hb_variation_t *variation,
 /**
  * hb_color_t:
  *
- * Data type for holding color values.
+ * Data type for holding color values. Colors are eight bits per
+ * channel RGB plus alpha transparency.
  *
  * Since: 2.1.0
  */

--- a/src/hb-face.cc
+++ b/src/hb-face.cc
@@ -304,7 +304,7 @@ hb_face_destroy (hb_face_t *face)
  *
  * Attaches a user-data key/data pair to the given face object. 
  *
- * Return value: %true if success, false otherwise
+ * Return value: %true if success, %false otherwise
  *
  * Since: 0.9.2
  **/

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -796,8 +796,6 @@ hb_font_get_v_extents (hb_font_t         *font,
  * Fetches the glyph ID for a Unicode code point in the specified
  * font, with an optional variation selector.
  *
- * This version of the function is higher-level and supports fallback behavior.
- * 
  * If @variation_selector is 0, calls hb_font_get_nominal_glyph();
  * otherwise calls hb_font_get_variation_glyph().
  *
@@ -1030,6 +1028,9 @@ hb_font_get_glyph_v_origin (hb_font_t      *font,
  * Fetches the kerning-adjustment value for a glyph-pair in
  * the specified font, in horizontal text segments.
  *
+ * <note>It handles legacy kerning only (as returned by the corresponding
+ * #hb_font_funcs_t function).</note>
+ *
  * Return value: The kerning adjustment value
  *
  * Since: 0.9.2
@@ -1051,6 +1052,9 @@ hb_font_get_glyph_h_kerning (hb_font_t      *font,
  *
  * Fetches the kerning-adjustment value for a glyph-pair in
  * the specified font, in vertical text segments.
+ *
+ * <note>It handles legacy kerning only (as returned by the corresponding
+ * #hb_font_funcs_t function).</note>
  *
  * Return value: The kerning adjustment value
  *
@@ -1404,7 +1408,6 @@ hb_font_get_glyph_contour_point_for_origin (hb_font_t      *font,
   return font->get_glyph_contour_point_for_origin (glyph, point_index, direction, x, y);
 }
 
-/* Generates gidDDD if glyph has no name. */
 /**
  * hb_font_glyph_to_string:
  * @font: #hb_font_t to work upon
@@ -1415,8 +1418,8 @@ hb_font_get_glyph_contour_point_for_origin (hb_font_t      *font,
  * Fetches the name of the specified glyph ID in @font and returns
  * it in string @s.
  *
- * If the glyph ID has no name in @font, a string of the form "gidDDD" is
- * generated.
+ * If the glyph ID has no name in @font, a string of the form `gidDDD` is
+ * generated, with `DDD` being the glyph ID.
  *
  * Since: 0.9.2
  **/
@@ -1429,7 +1432,6 @@ hb_font_glyph_to_string (hb_font_t      *font,
   font->glyph_to_string (glyph, s, size);
 }
 
-/* Parses gidDDD and uniUUUU strings automatically. */
 /**
  * hb_font_glyph_from_string:
  * @font: #hb_font_t to work upon
@@ -1438,7 +1440,7 @@ hb_font_glyph_to_string (hb_font_t      *font,
  * @glyph: (out): The glyph ID corresponding to the string requested
  *
  * Fetches the glyph ID from @font that matches the specified string.
- * Strings of the format "gidDDD" or "uniUUUU" are parsed automatically.
+ * Strings of the format `gidDDD` or `uniUUUU` are parsed automatically.
  *
  * <note>Note: @len == -1 means the string is null-terminated.</note>
  *
@@ -1449,7 +1451,7 @@ hb_font_glyph_to_string (hb_font_t      *font,
 hb_bool_t
 hb_font_glyph_from_string (hb_font_t      *font,
 			   const char     *s,
-			   int             len, /* -1 means nul-terminated */
+			   int             len,
 			   hb_codepoint_t *glyph)
 {
   return font->glyph_from_string (s, len, glyph);
@@ -1941,7 +1943,7 @@ hb_font_get_scale (hb_font_t *font,
  * @x_ppem: Horizontal ppem value to assign
  * @y_ppem: Vertical ppem value to assign
  *
- * Sets the horizontal and vertical points-per-em (ppem) of a font. 
+ * Sets the horizontal and vertical pixels-per-em (ppem) of a font. 
  *
  * Since: 0.9.2
  **/

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -43,10 +43,12 @@
  * @short_description: Font objects
  * @include: hb.h
  *
- * Font objects represent a font face at a certain size and other
- * parameters (pixels per EM, points per EM, variation settings.)
- * Fonts are created from font faces, and are used as input to
- * hb_shape() among other things.
+ * Functions for working with font objects.
+ *
+ * A font object represents a font face at a specific size and with
+ * certain other parameters (pixels-per-EM, points-per-EM, variation
+ * settings) specified. Font objects are created from font face
+ * objects, and are used as input to hb_shape(), among other things.
  **/
 
 
@@ -55,19 +57,19 @@
  */
 
 static hb_bool_t
-hb_font_get_font_h_extents_nil (hb_font_t *font HB_UNUSED,
-				void *font_data HB_UNUSED,
+hb_font_get_font_h_extents_nil (hb_font_t         *font HB_UNUSED,
+				void              *font_data HB_UNUSED,
 				hb_font_extents_t *extents,
-				void *user_data HB_UNUSED)
+				void              *user_data HB_UNUSED)
 {
   memset (extents, 0, sizeof (*extents));
   return false;
 }
 static hb_bool_t
-hb_font_get_font_h_extents_default (hb_font_t *font,
-				    void *font_data HB_UNUSED,
+hb_font_get_font_h_extents_default (hb_font_t         *font,
+				    void              *font_data HB_UNUSED,
 				    hb_font_extents_t *extents,
-				    void *user_data HB_UNUSED)
+				    void              *user_data HB_UNUSED)
 {
   hb_bool_t ret = font->parent->get_font_h_extents (extents);
   if (ret) {
@@ -79,19 +81,19 @@ hb_font_get_font_h_extents_default (hb_font_t *font,
 }
 
 static hb_bool_t
-hb_font_get_font_v_extents_nil (hb_font_t *font HB_UNUSED,
-				void *font_data HB_UNUSED,
+hb_font_get_font_v_extents_nil (hb_font_t         *font HB_UNUSED,
+				void              *font_data HB_UNUSED,
 				hb_font_extents_t *extents,
-				void *user_data HB_UNUSED)
+				void              *user_data HB_UNUSED)
 {
   memset (extents, 0, sizeof (*extents));
   return false;
 }
 static hb_bool_t
-hb_font_get_font_v_extents_default (hb_font_t *font,
-				    void *font_data HB_UNUSED,
+hb_font_get_font_v_extents_default (hb_font_t         *font,
+				    void              *font_data HB_UNUSED,
 				    hb_font_extents_t *extents,
-				    void *user_data HB_UNUSED)
+				    void              *user_data HB_UNUSED)
 {
   hb_bool_t ret = font->parent->get_font_v_extents (extents);
   if (ret) {
@@ -103,21 +105,21 @@ hb_font_get_font_v_extents_default (hb_font_t *font,
 }
 
 static hb_bool_t
-hb_font_get_nominal_glyph_nil (hb_font_t *font HB_UNUSED,
-			       void *font_data HB_UNUSED,
-			       hb_codepoint_t unicode HB_UNUSED,
+hb_font_get_nominal_glyph_nil (hb_font_t      *font HB_UNUSED,
+			       void           *font_data HB_UNUSED,
+			       hb_codepoint_t  unicode HB_UNUSED,
 			       hb_codepoint_t *glyph,
-			       void *user_data HB_UNUSED)
+			       void           *user_data HB_UNUSED)
 {
   *glyph = 0;
   return false;
 }
 static hb_bool_t
-hb_font_get_nominal_glyph_default (hb_font_t *font,
-				   void *font_data HB_UNUSED,
-				   hb_codepoint_t unicode,
+hb_font_get_nominal_glyph_default (hb_font_t      *font,
+				   void           *font_data HB_UNUSED,
+				   hb_codepoint_t  unicode,
 				   hb_codepoint_t *glyph,
-				   void *user_data HB_UNUSED)
+				   void           *user_data HB_UNUSED)
 {
   if (font->has_nominal_glyphs_func_set ())
   {
@@ -128,14 +130,14 @@ hb_font_get_nominal_glyph_default (hb_font_t *font,
 
 #define hb_font_get_nominal_glyphs_nil hb_font_get_nominal_glyphs_default
 static unsigned int
-hb_font_get_nominal_glyphs_default (hb_font_t *font,
-				    void *font_data HB_UNUSED,
-				    unsigned int count,
+hb_font_get_nominal_glyphs_default (hb_font_t            *font,
+				    void                 *font_data HB_UNUSED,
+				    unsigned int          count,
 				    const hb_codepoint_t *first_unicode,
-				    unsigned int unicode_stride,
-				    hb_codepoint_t *first_glyph,
-				    unsigned int glyph_stride,
-				    void *user_data HB_UNUSED)
+				    unsigned int          unicode_stride,
+				    hb_codepoint_t       *first_glyph,
+				    unsigned int          glyph_stride,
+				    void                 *user_data HB_UNUSED)
 {
   if (font->has_nominal_glyph_func_set ())
   {
@@ -156,41 +158,41 @@ hb_font_get_nominal_glyphs_default (hb_font_t *font,
 }
 
 static hb_bool_t
-hb_font_get_variation_glyph_nil (hb_font_t *font HB_UNUSED,
-				 void *font_data HB_UNUSED,
-				 hb_codepoint_t unicode HB_UNUSED,
-				 hb_codepoint_t variation_selector HB_UNUSED,
+hb_font_get_variation_glyph_nil (hb_font_t      *font HB_UNUSED,
+				 void           *font_data HB_UNUSED,
+				 hb_codepoint_t  unicode HB_UNUSED,
+				 hb_codepoint_t  variation_selector HB_UNUSED,
 				 hb_codepoint_t *glyph,
-				 void *user_data HB_UNUSED)
+				 void           *user_data HB_UNUSED)
 {
   *glyph = 0;
   return false;
 }
 static hb_bool_t
-hb_font_get_variation_glyph_default (hb_font_t *font,
-				     void *font_data HB_UNUSED,
-				     hb_codepoint_t unicode,
-				     hb_codepoint_t variation_selector,
+hb_font_get_variation_glyph_default (hb_font_t      *font,
+				     void           *font_data HB_UNUSED,
+				     hb_codepoint_t  unicode,
+				     hb_codepoint_t  variation_selector,
 				     hb_codepoint_t *glyph,
-				     void *user_data HB_UNUSED)
+				     void           *user_data HB_UNUSED)
 {
   return font->parent->get_variation_glyph (unicode, variation_selector, glyph);
 }
 
 
 static hb_position_t
-hb_font_get_glyph_h_advance_nil (hb_font_t *font,
-				 void *font_data HB_UNUSED,
-				 hb_codepoint_t glyph HB_UNUSED,
-				 void *user_data HB_UNUSED)
+hb_font_get_glyph_h_advance_nil (hb_font_t      *font,
+				 void           *font_data HB_UNUSED,
+				 hb_codepoint_t  glyph HB_UNUSED,
+				 void           *user_data HB_UNUSED)
 {
   return font->x_scale;
 }
 static hb_position_t
-hb_font_get_glyph_h_advance_default (hb_font_t *font,
-				     void *font_data HB_UNUSED,
-				     hb_codepoint_t glyph,
-				     void *user_data HB_UNUSED)
+hb_font_get_glyph_h_advance_default (hb_font_t      *font,
+				     void           *font_data HB_UNUSED,
+				     hb_codepoint_t  glyph,
+				     void           *user_data HB_UNUSED)
 {
   if (font->has_glyph_h_advances_func_set ())
   {
@@ -202,19 +204,19 @@ hb_font_get_glyph_h_advance_default (hb_font_t *font,
 }
 
 static hb_position_t
-hb_font_get_glyph_v_advance_nil (hb_font_t *font,
-				 void *font_data HB_UNUSED,
-				 hb_codepoint_t glyph HB_UNUSED,
-				 void *user_data HB_UNUSED)
+hb_font_get_glyph_v_advance_nil (hb_font_t      *font,
+				 void           *font_data HB_UNUSED,
+				 hb_codepoint_t  glyph HB_UNUSED,
+				 void           *user_data HB_UNUSED)
 {
   /* TODO use font_extents.ascender+descender */
   return font->y_scale;
 }
 static hb_position_t
-hb_font_get_glyph_v_advance_default (hb_font_t *font,
-				     void *font_data HB_UNUSED,
-				     hb_codepoint_t glyph,
-				     void *user_data HB_UNUSED)
+hb_font_get_glyph_v_advance_default (hb_font_t      *font,
+				     void           *font_data HB_UNUSED,
+				     hb_codepoint_t  glyph,
+				     void           *user_data HB_UNUSED)
 {
   if (font->has_glyph_v_advances_func_set ())
   {
@@ -227,14 +229,14 @@ hb_font_get_glyph_v_advance_default (hb_font_t *font,
 
 #define hb_font_get_glyph_h_advances_nil hb_font_get_glyph_h_advances_default
 static void
-hb_font_get_glyph_h_advances_default (hb_font_t* font,
-				      void* font_data HB_UNUSED,
-				      unsigned int count,
+hb_font_get_glyph_h_advances_default (hb_font_t*            font,
+				      void*                 font_data HB_UNUSED,
+				      unsigned int          count,
 				      const hb_codepoint_t *first_glyph,
-				      unsigned int glyph_stride,
-				      hb_position_t *first_advance,
-				      unsigned int advance_stride,
-				      void *user_data HB_UNUSED)
+				      unsigned int          glyph_stride,
+				      hb_position_t        *first_advance,
+				      unsigned int          advance_stride,
+				      void                 *user_data HB_UNUSED)
 {
   if (font->has_glyph_h_advance_func_set ())
   {
@@ -259,14 +261,14 @@ hb_font_get_glyph_h_advances_default (hb_font_t* font,
 
 #define hb_font_get_glyph_v_advances_nil hb_font_get_glyph_v_advances_default
 static void
-hb_font_get_glyph_v_advances_default (hb_font_t* font,
-				      void* font_data HB_UNUSED,
-				      unsigned int count,
+hb_font_get_glyph_v_advances_default (hb_font_t*            font,
+				      void*                 font_data HB_UNUSED,
+				      unsigned int          count,
 				      const hb_codepoint_t *first_glyph,
-				      unsigned int glyph_stride,
-				      hb_position_t *first_advance,
-				      unsigned int advance_stride,
-				      void *user_data HB_UNUSED)
+				      unsigned int          glyph_stride,
+				      hb_position_t        *first_advance,
+				      unsigned int          advance_stride,
+				      void                 *user_data HB_UNUSED)
 {
   if (font->has_glyph_v_advance_func_set ())
   {
@@ -290,23 +292,23 @@ hb_font_get_glyph_v_advances_default (hb_font_t* font,
 }
 
 static hb_bool_t
-hb_font_get_glyph_h_origin_nil (hb_font_t *font HB_UNUSED,
-				void *font_data HB_UNUSED,
-				hb_codepoint_t glyph HB_UNUSED,
-				hb_position_t *x,
-				hb_position_t *y,
-				void *user_data HB_UNUSED)
+hb_font_get_glyph_h_origin_nil (hb_font_t      *font HB_UNUSED,
+				void           *font_data HB_UNUSED,
+				hb_codepoint_t  glyph HB_UNUSED,
+				hb_position_t  *x,
+				hb_position_t  *y,
+				void           *user_data HB_UNUSED)
 {
   *x = *y = 0;
   return true;
 }
 static hb_bool_t
-hb_font_get_glyph_h_origin_default (hb_font_t *font,
-				    void *font_data HB_UNUSED,
-				    hb_codepoint_t glyph,
-				    hb_position_t *x,
-				    hb_position_t *y,
-				    void *user_data HB_UNUSED)
+hb_font_get_glyph_h_origin_default (hb_font_t      *font,
+				    void           *font_data HB_UNUSED,
+				    hb_codepoint_t  glyph,
+				    hb_position_t  *x,
+				    hb_position_t  *y,
+				    void           *user_data HB_UNUSED)
 {
   hb_bool_t ret = font->parent->get_glyph_h_origin (glyph, x, y);
   if (ret)
@@ -315,23 +317,23 @@ hb_font_get_glyph_h_origin_default (hb_font_t *font,
 }
 
 static hb_bool_t
-hb_font_get_glyph_v_origin_nil (hb_font_t *font HB_UNUSED,
-				void *font_data HB_UNUSED,
-				hb_codepoint_t glyph HB_UNUSED,
-				hb_position_t *x,
-				hb_position_t *y,
-				void *user_data HB_UNUSED)
+hb_font_get_glyph_v_origin_nil (hb_font_t      *font HB_UNUSED,
+				void           *font_data HB_UNUSED,
+				hb_codepoint_t  glyph HB_UNUSED,
+				hb_position_t  *x,
+				hb_position_t  *y,
+				void           *user_data HB_UNUSED)
 {
   *x = *y = 0;
   return false;
 }
 static hb_bool_t
-hb_font_get_glyph_v_origin_default (hb_font_t *font,
-				    void *font_data HB_UNUSED,
-				    hb_codepoint_t glyph,
-				    hb_position_t *x,
-				    hb_position_t *y,
-				    void *user_data HB_UNUSED)
+hb_font_get_glyph_v_origin_default (hb_font_t      *font,
+				    void           *font_data HB_UNUSED,
+				    hb_codepoint_t  glyph,
+				    hb_position_t  *x,
+				    hb_position_t  *y,
+				    void           *user_data HB_UNUSED)
 {
   hb_bool_t ret = font->parent->get_glyph_v_origin (glyph, x, y);
   if (ret)
@@ -340,61 +342,61 @@ hb_font_get_glyph_v_origin_default (hb_font_t *font,
 }
 
 static hb_position_t
-hb_font_get_glyph_h_kerning_nil (hb_font_t *font HB_UNUSED,
-				 void *font_data HB_UNUSED,
-				 hb_codepoint_t left_glyph HB_UNUSED,
-				 hb_codepoint_t right_glyph HB_UNUSED,
-				 void *user_data HB_UNUSED)
+hb_font_get_glyph_h_kerning_nil (hb_font_t      *font HB_UNUSED,
+				 void           *font_data HB_UNUSED,
+				 hb_codepoint_t  left_glyph HB_UNUSED,
+				 hb_codepoint_t  right_glyph HB_UNUSED,
+				 void           *user_data HB_UNUSED)
 {
   return 0;
 }
 static hb_position_t
-hb_font_get_glyph_h_kerning_default (hb_font_t *font,
-				     void *font_data HB_UNUSED,
-				     hb_codepoint_t left_glyph,
-				     hb_codepoint_t right_glyph,
-				     void *user_data HB_UNUSED)
+hb_font_get_glyph_h_kerning_default (hb_font_t      *font,
+				     void           *font_data HB_UNUSED,
+				     hb_codepoint_t  left_glyph,
+				     hb_codepoint_t  right_glyph,
+				     void           *user_data HB_UNUSED)
 {
   return font->parent_scale_x_distance (font->parent->get_glyph_h_kerning (left_glyph, right_glyph));
 }
 
 #ifndef HB_DISABLE_DEPRECATED
 static hb_position_t
-hb_font_get_glyph_v_kerning_nil (hb_font_t *font HB_UNUSED,
-				 void *font_data HB_UNUSED,
-				 hb_codepoint_t top_glyph HB_UNUSED,
-				 hb_codepoint_t bottom_glyph HB_UNUSED,
-				 void *user_data HB_UNUSED)
+hb_font_get_glyph_v_kerning_nil (hb_font_t      *font HB_UNUSED,
+				 void           *font_data HB_UNUSED,
+				 hb_codepoint_t  top_glyph HB_UNUSED,
+				 hb_codepoint_t  bottom_glyph HB_UNUSED,
+				 void           *user_data HB_UNUSED)
 {
   return 0;
 }
 static hb_position_t
-hb_font_get_glyph_v_kerning_default (hb_font_t *font,
-				     void *font_data HB_UNUSED,
-				     hb_codepoint_t top_glyph,
-				     hb_codepoint_t bottom_glyph,
-				     void *user_data HB_UNUSED)
+hb_font_get_glyph_v_kerning_default (hb_font_t      *font,
+				     void           *font_data HB_UNUSED,
+				     hb_codepoint_t  top_glyph,
+				     hb_codepoint_t  bottom_glyph,
+				     void           *user_data HB_UNUSED)
 {
   return font->parent_scale_y_distance (font->parent->get_glyph_v_kerning (top_glyph, bottom_glyph));
 }
 #endif
 
 static hb_bool_t
-hb_font_get_glyph_extents_nil (hb_font_t *font HB_UNUSED,
-			       void *font_data HB_UNUSED,
-			       hb_codepoint_t glyph HB_UNUSED,
+hb_font_get_glyph_extents_nil (hb_font_t          *font HB_UNUSED,
+			       void               *font_data HB_UNUSED,
+			       hb_codepoint_t      glyph HB_UNUSED,
 			       hb_glyph_extents_t *extents,
-			       void *user_data HB_UNUSED)
+			       void               *user_data HB_UNUSED)
 {
   memset (extents, 0, sizeof (*extents));
   return false;
 }
 static hb_bool_t
-hb_font_get_glyph_extents_default (hb_font_t *font,
-				   void *font_data HB_UNUSED,
-				   hb_codepoint_t glyph,
+hb_font_get_glyph_extents_default (hb_font_t          *font,
+				   void               *font_data HB_UNUSED,
+				   hb_codepoint_t      glyph,
 				   hb_glyph_extents_t *extents,
-				   void *user_data HB_UNUSED)
+				   void               *user_data HB_UNUSED)
 {
   hb_bool_t ret = font->parent->get_glyph_extents (glyph, extents);
   if (ret) {
@@ -405,25 +407,25 @@ hb_font_get_glyph_extents_default (hb_font_t *font,
 }
 
 static hb_bool_t
-hb_font_get_glyph_contour_point_nil (hb_font_t *font HB_UNUSED,
-				     void *font_data HB_UNUSED,
-				     hb_codepoint_t glyph HB_UNUSED,
-				     unsigned int point_index HB_UNUSED,
-				     hb_position_t *x,
-				     hb_position_t *y,
-				     void *user_data HB_UNUSED)
+hb_font_get_glyph_contour_point_nil (hb_font_t      *font HB_UNUSED,
+				     void           *font_data HB_UNUSED,
+				     hb_codepoint_t  glyph HB_UNUSED,
+				     unsigned int    point_index HB_UNUSED,
+				     hb_position_t  *x,
+				     hb_position_t  *y,
+				     void           *user_data HB_UNUSED)
 {
   *x = *y = 0;
   return false;
 }
 static hb_bool_t
-hb_font_get_glyph_contour_point_default (hb_font_t *font,
-					 void *font_data HB_UNUSED,
-					 hb_codepoint_t glyph,
-					 unsigned int point_index,
-					 hb_position_t *x,
-					 hb_position_t *y,
-					 void *user_data HB_UNUSED)
+hb_font_get_glyph_contour_point_default (hb_font_t      *font,
+					 void           *font_data HB_UNUSED,
+					 hb_codepoint_t  glyph,
+					 unsigned int    point_index,
+					 hb_position_t  *x,
+					 hb_position_t  *y,
+					 void           *user_data HB_UNUSED)
 {
   hb_bool_t ret = font->parent->get_glyph_contour_point (glyph, point_index, x, y);
   if (ret)
@@ -432,42 +434,45 @@ hb_font_get_glyph_contour_point_default (hb_font_t *font,
 }
 
 static hb_bool_t
-hb_font_get_glyph_name_nil (hb_font_t *font HB_UNUSED,
-			    void *font_data HB_UNUSED,
-			    hb_codepoint_t glyph HB_UNUSED,
-			    char *name, unsigned int size,
-			    void *user_data HB_UNUSED)
+hb_font_get_glyph_name_nil (hb_font_t      *font HB_UNUSED,
+			    void           *font_data HB_UNUSED,
+			    hb_codepoint_t  glyph HB_UNUSED,
+			    char           *name,
+			    unsigned int    size,
+			    void           *user_data HB_UNUSED)
 {
   if (size) *name = '\0';
   return false;
 }
 static hb_bool_t
-hb_font_get_glyph_name_default (hb_font_t *font,
-				void *font_data HB_UNUSED,
-				hb_codepoint_t glyph,
-				char *name, unsigned int size,
-				void *user_data HB_UNUSED)
+hb_font_get_glyph_name_default (hb_font_t      *font,
+				void           *font_data HB_UNUSED,
+				hb_codepoint_t  glyph,
+				char           *name,
+				unsigned int    size,
+				void           *user_data HB_UNUSED)
 {
   return font->parent->get_glyph_name (glyph, name, size);
 }
 
 static hb_bool_t
-hb_font_get_glyph_from_name_nil (hb_font_t *font HB_UNUSED,
-				 void *font_data HB_UNUSED,
-				 const char *name HB_UNUSED,
-				 int len HB_UNUSED, /* -1 means nul-terminated */
+hb_font_get_glyph_from_name_nil (hb_font_t      *font HB_UNUSED,
+				 void           *font_data HB_UNUSED,
+				 const char     *name HB_UNUSED,
+				 int             len HB_UNUSED, /* -1 means nul-terminated */
 				 hb_codepoint_t *glyph,
-				 void *user_data HB_UNUSED)
+				 void           *user_data HB_UNUSED)
 {
   *glyph = 0;
   return false;
 }
 static hb_bool_t
-hb_font_get_glyph_from_name_default (hb_font_t *font,
-				     void *font_data HB_UNUSED,
-				     const char *name, int len, /* -1 means nul-terminated */
+hb_font_get_glyph_from_name_default (hb_font_t      *font,
+				     void           *font_data HB_UNUSED,
+				     const char     *name,
+				     int             len, /* -1 means nul-terminated */
 				     hb_codepoint_t *glyph,
-				     void *user_data HB_UNUSED)
+				     void           *user_data HB_UNUSED)
 {
   return font->parent->get_glyph_from_name (name, len, glyph);
 }
@@ -728,7 +733,7 @@ hb_font_t::has_func (unsigned int i)
  * Since: 1.1.3
  **/
 hb_bool_t
-hb_font_get_h_extents (hb_font_t *font,
+hb_font_get_h_extents (hb_font_t         *font,
 		       hb_font_extents_t *extents)
 {
   return font->get_font_h_extents (extents);
@@ -746,7 +751,7 @@ hb_font_get_h_extents (hb_font_t *font,
  * Since: 1.1.3
  **/
 hb_bool_t
-hb_font_get_v_extents (hb_font_t *font,
+hb_font_get_v_extents (hb_font_t         *font,
 		       hb_font_extents_t *extents)
 {
   return font->get_font_v_extents (extents);
@@ -766,8 +771,9 @@ hb_font_get_v_extents (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph (hb_font_t *font,
-		   hb_codepoint_t unicode, hb_codepoint_t variation_selector,
+hb_font_get_glyph (hb_font_t      *font,
+		   hb_codepoint_t  unicode,
+		   hb_codepoint_t  variation_selector,
 		   hb_codepoint_t *glyph)
 {
   if (unlikely (variation_selector))
@@ -788,8 +794,8 @@ hb_font_get_glyph (hb_font_t *font,
  * Since: 1.2.3
  **/
 hb_bool_t
-hb_font_get_nominal_glyph (hb_font_t *font,
-			   hb_codepoint_t unicode,
+hb_font_get_nominal_glyph (hb_font_t      *font,
+			   hb_codepoint_t  unicode,
 			   hb_codepoint_t *glyph)
 {
   return font->get_nominal_glyph (unicode, glyph);
@@ -832,8 +838,9 @@ hb_font_get_nominal_glyphs (hb_font_t *font,
  * Since: 1.2.3
  **/
 hb_bool_t
-hb_font_get_variation_glyph (hb_font_t *font,
-			     hb_codepoint_t unicode, hb_codepoint_t variation_selector,
+hb_font_get_variation_glyph (hb_font_t      *font,
+			     hb_codepoint_t  unicode,
+			     hb_codepoint_t  variation_selector,
 			     hb_codepoint_t *glyph)
 {
   return font->get_variation_glyph (unicode, variation_selector, glyph);
@@ -851,8 +858,8 @@ hb_font_get_variation_glyph (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_position_t
-hb_font_get_glyph_h_advance (hb_font_t *font,
-			     hb_codepoint_t glyph)
+hb_font_get_glyph_h_advance (hb_font_t      *font,
+			     hb_codepoint_t  glyph)
 {
   return font->get_glyph_h_advance (glyph);
 }
@@ -869,8 +876,8 @@ hb_font_get_glyph_h_advance (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_position_t
-hb_font_get_glyph_v_advance (hb_font_t *font,
-			     hb_codepoint_t glyph)
+hb_font_get_glyph_v_advance (hb_font_t      *font,
+			     hb_codepoint_t  glyph)
 {
   return font->get_glyph_v_advance (glyph);
 }
@@ -884,12 +891,12 @@ hb_font_get_glyph_v_advance (hb_font_t *font,
  * Since: 1.8.6
  **/
 void
-hb_font_get_glyph_h_advances (hb_font_t* font,
-			      unsigned int count,
+hb_font_get_glyph_h_advances (hb_font_t*            font,
+			      unsigned int          count,
 			      const hb_codepoint_t *first_glyph,
-			      unsigned glyph_stride,
-			      hb_position_t *first_advance,
-			      unsigned advance_stride)
+			      unsigned              glyph_stride,
+			      hb_position_t        *first_advance,
+			      unsigned              advance_stride)
 {
   font->get_glyph_h_advances (count, first_glyph, glyph_stride, first_advance, advance_stride);
 }
@@ -902,12 +909,12 @@ hb_font_get_glyph_h_advances (hb_font_t* font,
  * Since: 1.8.6
  **/
 void
-hb_font_get_glyph_v_advances (hb_font_t* font,
-			      unsigned int count,
+hb_font_get_glyph_v_advances (hb_font_t*            font,
+			      unsigned int          count,
 			      const hb_codepoint_t *first_glyph,
-			      unsigned glyph_stride,
-			      hb_position_t *first_advance,
-			      unsigned advance_stride)
+			      unsigned              glyph_stride,
+			      hb_position_t        *first_advance,
+			      unsigned              advance_stride)
 {
   font->get_glyph_v_advances (count, first_glyph, glyph_stride, first_advance, advance_stride);
 }
@@ -926,9 +933,10 @@ hb_font_get_glyph_v_advances (hb_font_t* font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph_h_origin (hb_font_t *font,
-			    hb_codepoint_t glyph,
-			    hb_position_t *x, hb_position_t *y)
+hb_font_get_glyph_h_origin (hb_font_t      *font,
+			    hb_codepoint_t  glyph,
+			    hb_position_t  *x,
+			    hb_position_t  *y)
 {
   return font->get_glyph_h_origin (glyph, x, y);
 }
@@ -947,9 +955,10 @@ hb_font_get_glyph_h_origin (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph_v_origin (hb_font_t *font,
-			    hb_codepoint_t glyph,
-			    hb_position_t *x, hb_position_t *y)
+hb_font_get_glyph_v_origin (hb_font_t      *font,
+			    hb_codepoint_t  glyph,
+			    hb_position_t  *x,
+			    hb_position_t  *y)
 {
   return font->get_glyph_v_origin (glyph, x, y);
 }
@@ -967,8 +976,9 @@ hb_font_get_glyph_v_origin (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_position_t
-hb_font_get_glyph_h_kerning (hb_font_t *font,
-			     hb_codepoint_t left_glyph, hb_codepoint_t right_glyph)
+hb_font_get_glyph_h_kerning (hb_font_t      *font,
+			     hb_codepoint_t  left_glyph,
+			     hb_codepoint_t  right_glyph)
 {
   return font->get_glyph_h_kerning (left_glyph, right_glyph);
 }
@@ -988,8 +998,9 @@ hb_font_get_glyph_h_kerning (hb_font_t *font,
  * Deprecated: 2.0.0
  **/
 hb_position_t
-hb_font_get_glyph_v_kerning (hb_font_t *font,
-			     hb_codepoint_t top_glyph, hb_codepoint_t bottom_glyph)
+hb_font_get_glyph_v_kerning (hb_font_t      *font,
+			     hb_codepoint_t  top_glyph,
+			     hb_codepoint_t  bottom_glyph)
 {
   return font->get_glyph_v_kerning (top_glyph, bottom_glyph);
 }
@@ -1008,8 +1019,8 @@ hb_font_get_glyph_v_kerning (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph_extents (hb_font_t *font,
-			   hb_codepoint_t glyph,
+hb_font_get_glyph_extents (hb_font_t          *font,
+			   hb_codepoint_t      glyph,
 			   hb_glyph_extents_t *extents)
 {
   return font->get_glyph_extents (glyph, extents);
@@ -1030,9 +1041,11 @@ hb_font_get_glyph_extents (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph_contour_point (hb_font_t *font,
-				 hb_codepoint_t glyph, unsigned int point_index,
-				 hb_position_t *x, hb_position_t *y)
+hb_font_get_glyph_contour_point (hb_font_t      *font,
+				 hb_codepoint_t  glyph,
+				 unsigned int    point_index,
+				 hb_position_t  *x,
+				 hb_position_t  *y)
 {
   return font->get_glyph_contour_point (glyph, point_index, x, y);
 }
@@ -1051,9 +1064,10 @@ hb_font_get_glyph_contour_point (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph_name (hb_font_t *font,
-			hb_codepoint_t glyph,
-			char *name, unsigned int size)
+hb_font_get_glyph_name (hb_font_t      *font,
+			hb_codepoint_t  glyph,
+			char           *name,
+			unsigned int    size)
 {
   return font->get_glyph_name (glyph, name, size);
 }
@@ -1072,8 +1086,9 @@ hb_font_get_glyph_name (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph_from_name (hb_font_t *font,
-			     const char *name, int len, /* -1 means nul-terminated */
+hb_font_get_glyph_from_name (hb_font_t      *font,
+			     const char     *name,
+			     int             len, /* -1 means nul-terminated */
 			     hb_codepoint_t *glyph)
 {
   return font->get_glyph_from_name (name, len, glyph);
@@ -1093,8 +1108,8 @@ hb_font_get_glyph_from_name (hb_font_t *font,
  * Since: 1.1.3
  **/
 void
-hb_font_get_extents_for_direction (hb_font_t *font,
-				   hb_direction_t direction,
+hb_font_get_extents_for_direction (hb_font_t         *font,
+				   hb_direction_t     direction,
 				   hb_font_extents_t *extents)
 {
   return font->get_extents_for_direction (direction, extents);
@@ -1112,10 +1127,11 @@ hb_font_get_extents_for_direction (hb_font_t *font,
  * Since: 0.9.2
  **/
 void
-hb_font_get_glyph_advance_for_direction (hb_font_t *font,
-					 hb_codepoint_t glyph,
-					 hb_direction_t direction,
-					 hb_position_t *x, hb_position_t *y)
+hb_font_get_glyph_advance_for_direction (hb_font_t      *font,
+					 hb_codepoint_t  glyph,
+					 hb_direction_t  direction,
+					 hb_position_t  *x,
+					 hb_position_t  *y)
 {
   return font->get_glyph_advance_for_direction (glyph, direction, x, y);
 }
@@ -1129,13 +1145,13 @@ hb_font_get_glyph_advance_for_direction (hb_font_t *font,
  * Since: 1.8.6
  **/
 HB_EXTERN void
-hb_font_get_glyph_advances_for_direction (hb_font_t* font,
-					  hb_direction_t direction,
-					  unsigned int count,
+hb_font_get_glyph_advances_for_direction (hb_font_t*            font,
+					  hb_direction_t        direction,
+					  unsigned int          count,
 					  const hb_codepoint_t *first_glyph,
-					  unsigned glyph_stride,
-					  hb_position_t *first_advance,
-					  unsigned advance_stride)
+					  unsigned              glyph_stride,
+					  hb_position_t        *first_advance,
+					  unsigned              advance_stride)
 {
   font->get_glyph_advances_for_direction (direction, count, first_glyph, glyph_stride, first_advance, advance_stride);
 }
@@ -1153,10 +1169,11 @@ hb_font_get_glyph_advances_for_direction (hb_font_t* font,
  * Since: 0.9.2
  **/
 void
-hb_font_get_glyph_origin_for_direction (hb_font_t *font,
-					hb_codepoint_t glyph,
-					hb_direction_t direction,
-					hb_position_t *x, hb_position_t *y)
+hb_font_get_glyph_origin_for_direction (hb_font_t      *font,
+					hb_codepoint_t  glyph,
+					hb_direction_t  direction,
+					hb_position_t  *x,
+					hb_position_t  *y)
 {
   return font->get_glyph_origin_for_direction (glyph, direction, x, y);
 }
@@ -1174,10 +1191,11 @@ hb_font_get_glyph_origin_for_direction (hb_font_t *font,
  * Since: 0.9.2
  **/
 void
-hb_font_add_glyph_origin_for_direction (hb_font_t *font,
-					hb_codepoint_t glyph,
-					hb_direction_t direction,
-					hb_position_t *x, hb_position_t *y)
+hb_font_add_glyph_origin_for_direction (hb_font_t      *font,
+					hb_codepoint_t  glyph,
+					hb_direction_t  direction,
+					hb_position_t  *x,
+					hb_position_t  *y)
 {
   return font->add_glyph_origin_for_direction (glyph, direction, x, y);
 }
@@ -1195,10 +1213,11 @@ hb_font_add_glyph_origin_for_direction (hb_font_t *font,
  * Since: 0.9.2
  **/
 void
-hb_font_subtract_glyph_origin_for_direction (hb_font_t *font,
-					     hb_codepoint_t glyph,
-					     hb_direction_t direction,
-					     hb_position_t *x, hb_position_t *y)
+hb_font_subtract_glyph_origin_for_direction (hb_font_t      *font,
+					     hb_codepoint_t  glyph,
+					     hb_direction_t  direction,
+					     hb_position_t  *x,
+					     hb_position_t  *y)
 {
   return font->subtract_glyph_origin_for_direction (glyph, direction, x, y);
 }
@@ -1217,10 +1236,12 @@ hb_font_subtract_glyph_origin_for_direction (hb_font_t *font,
  * Since: 0.9.2
  **/
 void
-hb_font_get_glyph_kerning_for_direction (hb_font_t *font,
-					 hb_codepoint_t first_glyph, hb_codepoint_t second_glyph,
-					 hb_direction_t direction,
-					 hb_position_t *x, hb_position_t *y)
+hb_font_get_glyph_kerning_for_direction (hb_font_t      *font,
+					 hb_codepoint_t  first_glyph,
+					 hb_codepoint_t  second_glyph,
+					 hb_direction_t  direction,
+					 hb_position_t  *x,
+					 hb_position_t  *y)
 {
   return font->get_glyph_kerning_for_direction (first_glyph, second_glyph, direction, x, y);
 }
@@ -1239,9 +1260,9 @@ hb_font_get_glyph_kerning_for_direction (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph_extents_for_origin (hb_font_t *font,
-				      hb_codepoint_t glyph,
-				      hb_direction_t direction,
+hb_font_get_glyph_extents_for_origin (hb_font_t          *font,
+				      hb_codepoint_t      glyph,
+				      hb_direction_t      direction,
 				      hb_glyph_extents_t *extents)
 {
   return font->get_glyph_extents_for_origin (glyph, direction, extents);
@@ -1263,10 +1284,12 @@ hb_font_get_glyph_extents_for_origin (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_get_glyph_contour_point_for_origin (hb_font_t *font,
-					    hb_codepoint_t glyph, unsigned int point_index,
-					    hb_direction_t direction,
-					    hb_position_t *x, hb_position_t *y)
+hb_font_get_glyph_contour_point_for_origin (hb_font_t      *font,
+					    hb_codepoint_t  glyph,
+					    unsigned int    point_index,
+					    hb_direction_t  direction,
+					    hb_position_t  *x,
+					    hb_position_t  *y)
 {
   return font->get_glyph_contour_point_for_origin (glyph, point_index, direction, x, y);
 }
@@ -1284,9 +1307,10 @@ hb_font_get_glyph_contour_point_for_origin (hb_font_t *font,
  * Since: 0.9.2
  **/
 void
-hb_font_glyph_to_string (hb_font_t *font,
-			 hb_codepoint_t glyph,
-			 char *s, unsigned int size)
+hb_font_glyph_to_string (hb_font_t      *font,
+			 hb_codepoint_t  glyph,
+			 char           *s,
+			 unsigned int    size)
 {
   font->glyph_to_string (glyph, s, size);
 }
@@ -1306,8 +1330,9 @@ hb_font_glyph_to_string (hb_font_t *font,
  * Since: 0.9.2
  **/
 hb_bool_t
-hb_font_glyph_from_string (hb_font_t *font,
-			   const char *s, int len, /* -1 means nul-terminated */
+hb_font_glyph_from_string (hb_font_t      *font,
+			   const char     *s,
+			   int             len, /* -1 means nul-terminated */
 			   hb_codepoint_t *glyph)
 {
   return font->glyph_from_string (s, len, glyph);
@@ -1757,8 +1782,8 @@ hb_font_set_funcs_data (hb_font_t         *font,
  **/
 void
 hb_font_set_scale (hb_font_t *font,
-		   int x_scale,
-		   int y_scale)
+		   int        x_scale,
+		   int        y_scale)
 {
   if (hb_object_is_immutable (font))
     return;
@@ -1780,8 +1805,8 @@ hb_font_set_scale (hb_font_t *font,
  **/
 void
 hb_font_get_scale (hb_font_t *font,
-		   int *x_scale,
-		   int *y_scale)
+		   int       *x_scale,
+		   int       *y_scale)
 {
   if (x_scale) *x_scale = font->x_scale;
   if (y_scale) *y_scale = font->y_scale;
@@ -1798,9 +1823,9 @@ hb_font_get_scale (hb_font_t *font,
  * Since: 0.9.2
  **/
 void
-hb_font_set_ppem (hb_font_t *font,
-		  unsigned int x_ppem,
-		  unsigned int y_ppem)
+hb_font_set_ppem (hb_font_t    *font,
+		  unsigned int  x_ppem,
+		  unsigned int  y_ppem)
 {
   if (hb_object_is_immutable (font))
     return;
@@ -1820,7 +1845,7 @@ hb_font_set_ppem (hb_font_t *font,
  * Since: 0.9.2
  **/
 void
-hb_font_get_ppem (hb_font_t *font,
+hb_font_get_ppem (hb_font_t    *font,
 		  unsigned int *x_ppem,
 		  unsigned int *y_ppem)
 {
@@ -1840,7 +1865,8 @@ hb_font_get_ppem (hb_font_t *font,
  * Since: 1.6.0
  **/
 void
-hb_font_set_ptem (hb_font_t *font, float ptem)
+hb_font_set_ptem (hb_font_t *font,
+		  float      ptem)
 {
   if (hb_object_is_immutable (font))
     return;
@@ -1875,9 +1901,9 @@ hb_font_get_ptem (hb_font_t *font)
  * Since: 1.4.2
  */
 void
-hb_font_set_variations (hb_font_t *font,
+hb_font_set_variations (hb_font_t            *font,
 			const hb_variation_t *variations,
-			unsigned int variations_length)
+			unsigned int          variations_length)
 {
   if (hb_object_is_immutable (font))
     return;
@@ -1923,9 +1949,9 @@ hb_font_set_variations (hb_font_t *font,
  * Since: 1.4.2
  */
 void
-hb_font_set_var_coords_design (hb_font_t *font,
-			       const float *coords,
-			       unsigned int coords_length)
+hb_font_set_var_coords_design (hb_font_t    *font,
+			       const float  *coords,
+			       unsigned int  coords_length)
 {
   if (hb_object_is_immutable (font))
     return;
@@ -1980,9 +2006,9 @@ hb_font_set_var_named_instance (hb_font_t *font,
  * Since: 1.4.2
  */
 void
-hb_font_set_var_coords_normalized (hb_font_t *font,
-				   const int *coords, /* 2.14 normalized */
-				   unsigned int coords_length)
+hb_font_set_var_coords_normalized (hb_font_t    *font,
+				   const int    *coords, /* 2.14 normalized */
+				   unsigned int  coords_length)
 {
   if (hb_object_is_immutable (font))
     return;
@@ -2023,7 +2049,7 @@ hb_font_set_var_coords_normalized (hb_font_t *font,
  * Since: 1.4.2
  */
 const int *
-hb_font_get_var_coords_normalized (hb_font_t *font,
+hb_font_get_var_coords_normalized (hb_font_t    *font,
 				   unsigned int *length)
 {
   if (length)
@@ -2115,23 +2141,23 @@ trampoline_destroy (void *user_data)
 typedef hb_trampoline_t<hb_font_get_glyph_func_t> hb_font_get_glyph_trampoline_t;
 
 static hb_bool_t
-hb_font_get_nominal_glyph_trampoline (hb_font_t *font,
-				      void *font_data,
-				      hb_codepoint_t unicode,
+hb_font_get_nominal_glyph_trampoline (hb_font_t      *font,
+				      void           *font_data,
+				      hb_codepoint_t  unicode,
 				      hb_codepoint_t *glyph,
-				      void *user_data)
+				      void           *user_data)
 {
   hb_font_get_glyph_trampoline_t *trampoline = (hb_font_get_glyph_trampoline_t *) user_data;
   return trampoline->func (font, font_data, unicode, 0, glyph, trampoline->closure.user_data);
 }
 
 static hb_bool_t
-hb_font_get_variation_glyph_trampoline (hb_font_t *font,
-					void *font_data,
-					hb_codepoint_t unicode,
-					hb_codepoint_t variation_selector,
+hb_font_get_variation_glyph_trampoline (hb_font_t      *font,
+					void           *font_data,
+					hb_codepoint_t  unicode,
+					hb_codepoint_t  variation_selector,
 					hb_codepoint_t *glyph,
-					void *user_data)
+					void           *user_data)
 {
   hb_font_get_glyph_trampoline_t *trampoline = (hb_font_get_glyph_trampoline_t *) user_data;
   return trampoline->func (font, font_data, unicode, variation_selector, glyph, trampoline->closure.user_data);
@@ -2151,9 +2177,10 @@ hb_font_get_variation_glyph_trampoline (hb_font_t *font,
  * Deprecated: 1.2.3
  **/
 void
-hb_font_funcs_set_glyph_func (hb_font_funcs_t *ffuncs,
-			      hb_font_get_glyph_func_t func,
-			      void *user_data, hb_destroy_func_t destroy)
+hb_font_funcs_set_glyph_func (hb_font_funcs_t          *ffuncs,
+			      hb_font_get_glyph_func_t  func,
+			      void                     *user_data,
+			      hb_destroy_func_t         destroy)
 {
   if (hb_object_is_immutable (ffuncs))
   {

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -46,9 +46,17 @@
  * Functions for working with font objects.
  *
  * A font object represents a font face at a specific size and with
- * certain other parameters (pixels-per-EM, points-per-EM, variation
+ * certain other parameters (pixels-per-em, points-per-em, variation
  * settings) specified. Font objects are created from font face
  * objects, and are used as input to hb_shape(), among other things.
+ *
+ * Client programs can optionally pass in their own functions that
+ * implement the basic, lower-level queries of font objects. This set
+ * of font functions is defined by the virtual methods in
+ * #hb_font_funcs_t.
+ *
+ * HarfBuzz provides a built-in set of lightweight default
+ * functions for each method in #hb_font_funcs_t.
  **/
 
 
@@ -65,6 +73,7 @@ hb_font_get_font_h_extents_nil (hb_font_t         *font HB_UNUSED,
   memset (extents, 0, sizeof (*extents));
   return false;
 }
+
 static hb_bool_t
 hb_font_get_font_h_extents_default (hb_font_t         *font,
 				    void              *font_data HB_UNUSED,
@@ -89,6 +98,7 @@ hb_font_get_font_v_extents_nil (hb_font_t         *font HB_UNUSED,
   memset (extents, 0, sizeof (*extents));
   return false;
 }
+
 static hb_bool_t
 hb_font_get_font_v_extents_default (hb_font_t         *font,
 				    void              *font_data HB_UNUSED,
@@ -114,6 +124,7 @@ hb_font_get_nominal_glyph_nil (hb_font_t      *font HB_UNUSED,
   *glyph = 0;
   return false;
 }
+
 static hb_bool_t
 hb_font_get_nominal_glyph_default (hb_font_t      *font,
 				   void           *font_data HB_UNUSED,
@@ -129,6 +140,7 @@ hb_font_get_nominal_glyph_default (hb_font_t      *font,
 }
 
 #define hb_font_get_nominal_glyphs_nil hb_font_get_nominal_glyphs_default
+
 static unsigned int
 hb_font_get_nominal_glyphs_default (hb_font_t            *font,
 				    void                 *font_data HB_UNUSED,
@@ -168,6 +180,7 @@ hb_font_get_variation_glyph_nil (hb_font_t      *font HB_UNUSED,
   *glyph = 0;
   return false;
 }
+
 static hb_bool_t
 hb_font_get_variation_glyph_default (hb_font_t      *font,
 				     void           *font_data HB_UNUSED,
@@ -188,6 +201,7 @@ hb_font_get_glyph_h_advance_nil (hb_font_t      *font,
 {
   return font->x_scale;
 }
+
 static hb_position_t
 hb_font_get_glyph_h_advance_default (hb_font_t      *font,
 				     void           *font_data HB_UNUSED,
@@ -212,6 +226,7 @@ hb_font_get_glyph_v_advance_nil (hb_font_t      *font,
   /* TODO use font_extents.ascender+descender */
   return font->y_scale;
 }
+
 static hb_position_t
 hb_font_get_glyph_v_advance_default (hb_font_t      *font,
 				     void           *font_data HB_UNUSED,
@@ -228,6 +243,7 @@ hb_font_get_glyph_v_advance_default (hb_font_t      *font,
 }
 
 #define hb_font_get_glyph_h_advances_nil hb_font_get_glyph_h_advances_default
+
 static void
 hb_font_get_glyph_h_advances_default (hb_font_t*            font,
 				      void*                 font_data HB_UNUSED,
@@ -302,6 +318,7 @@ hb_font_get_glyph_h_origin_nil (hb_font_t      *font HB_UNUSED,
   *x = *y = 0;
   return true;
 }
+
 static hb_bool_t
 hb_font_get_glyph_h_origin_default (hb_font_t      *font,
 				    void           *font_data HB_UNUSED,
@@ -327,6 +344,7 @@ hb_font_get_glyph_v_origin_nil (hb_font_t      *font HB_UNUSED,
   *x = *y = 0;
   return false;
 }
+
 static hb_bool_t
 hb_font_get_glyph_v_origin_default (hb_font_t      *font,
 				    void           *font_data HB_UNUSED,
@@ -350,6 +368,7 @@ hb_font_get_glyph_h_kerning_nil (hb_font_t      *font HB_UNUSED,
 {
   return 0;
 }
+
 static hb_position_t
 hb_font_get_glyph_h_kerning_default (hb_font_t      *font,
 				     void           *font_data HB_UNUSED,
@@ -370,6 +389,7 @@ hb_font_get_glyph_v_kerning_nil (hb_font_t      *font HB_UNUSED,
 {
   return 0;
 }
+
 static hb_position_t
 hb_font_get_glyph_v_kerning_default (hb_font_t      *font,
 				     void           *font_data HB_UNUSED,
@@ -391,6 +411,7 @@ hb_font_get_glyph_extents_nil (hb_font_t          *font HB_UNUSED,
   memset (extents, 0, sizeof (*extents));
   return false;
 }
+
 static hb_bool_t
 hb_font_get_glyph_extents_default (hb_font_t          *font,
 				   void               *font_data HB_UNUSED,
@@ -418,6 +439,7 @@ hb_font_get_glyph_contour_point_nil (hb_font_t      *font HB_UNUSED,
   *x = *y = 0;
   return false;
 }
+
 static hb_bool_t
 hb_font_get_glyph_contour_point_default (hb_font_t      *font,
 					 void           *font_data HB_UNUSED,
@@ -444,6 +466,7 @@ hb_font_get_glyph_name_nil (hb_font_t      *font HB_UNUSED,
   if (size) *name = '\0';
   return false;
 }
+
 static hb_bool_t
 hb_font_get_glyph_name_default (hb_font_t      *font,
 				void           *font_data HB_UNUSED,
@@ -466,6 +489,7 @@ hb_font_get_glyph_from_name_nil (hb_font_t      *font HB_UNUSED,
   *glyph = 0;
   return false;
 }
+
 static hb_bool_t
 hb_font_get_glyph_from_name_default (hb_font_t      *font,
 				     void           *font_data HB_UNUSED,
@@ -526,9 +550,9 @@ static const hb_font_funcs_t _hb_font_funcs_default = {
 /**
  * hb_font_funcs_create: (Xconstructor)
  *
+ * Creates a new #hb_font_funcs_t structure of font functions.
  *
- *
- * Return value: (transfer full):
+ * Return value: (transfer full): The font-functions structure
  *
  * Since: 0.9.2
  **/
@@ -548,9 +572,9 @@ hb_font_funcs_create ()
 /**
  * hb_font_funcs_get_empty:
  *
+ * Fetches an empty font-functions structure.
  *
- *
- * Return value: (transfer full):
+ * Return value: (transfer full): The font-functions structure
  *
  * Since: 0.9.2
  **/
@@ -562,11 +586,11 @@ hb_font_funcs_get_empty ()
 
 /**
  * hb_font_funcs_reference: (skip)
- * @ffuncs: font functions.
+ * @ffuncs: The font-functions structure
  *
+ * Increases the reference count on a font-functions structure.
  *
- *
- * Return value:
+ * Return value: The font-functions structure
  *
  * Since: 0.9.2
  **/
@@ -578,9 +602,11 @@ hb_font_funcs_reference (hb_font_funcs_t *ffuncs)
 
 /**
  * hb_font_funcs_destroy: (skip)
- * @ffuncs: font functions.
+ * @ffuncs: The font-functions structure
  *
- *
+ * Decreases the reference count on a font-functions structure. When
+ * the reference count reaches zero, the font-functions structure is
+ * destroyed, freeing all memory.
  *
  * Since: 0.9.2
  **/
@@ -599,15 +625,15 @@ hb_font_funcs_destroy (hb_font_funcs_t *ffuncs)
 
 /**
  * hb_font_funcs_set_user_data: (skip)
- * @ffuncs: font functions.
- * @key:
- * @data:
- * @destroy:
- * @replace:
+ * @ffuncs: The font-functions structure
+ * @key: The user-data key to set
+ * @data: A pointer to the user data set
+ * @destroy: (optional): A callback to call when @data is not needed anymore
+ * @replace: Whether to replace an existing data with the same key
  *
+ * Attaches a user-data key/data pair to the specified font-functions structure. 
  *
- *
- * Return value:
+ * Return value: %true if success, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -615,7 +641,7 @@ hb_bool_t
 hb_font_funcs_set_user_data (hb_font_funcs_t    *ffuncs,
 			     hb_user_data_key_t *key,
 			     void *              data,
-			     hb_destroy_func_t   destroy,
+			     hb_destroy_func_t   destroy /* May be NULL. */,
 			     hb_bool_t           replace)
 {
   return hb_object_set_user_data (ffuncs, key, data, destroy, replace);
@@ -623,12 +649,13 @@ hb_font_funcs_set_user_data (hb_font_funcs_t    *ffuncs,
 
 /**
  * hb_font_funcs_get_user_data: (skip)
- * @ffuncs: font functions.
- * @key:
+ * @ffuncs: The font-functions structure
+ * @key: The user-data key to query
  *
+ * Fetches the user data associated with the specified key,
+ * attached to the specified font-functions structure.
  *
- *
- * Return value: (transfer none):
+ * Return value: (transfer none): A pointer to the user data
  *
  * Since: 0.9.2
  **/
@@ -642,9 +669,9 @@ hb_font_funcs_get_user_data (hb_font_funcs_t    *ffuncs,
 
 /**
  * hb_font_funcs_make_immutable:
- * @ffuncs: font functions.
+ * @ffuncs: The font-functions structure
  *
- *
+ * Makes a font-functions structure immutable.
  *
  * Since: 0.9.2
  **/
@@ -659,11 +686,11 @@ hb_font_funcs_make_immutable (hb_font_funcs_t *ffuncs)
 
 /**
  * hb_font_funcs_is_immutable:
- * @ffuncs: font functions.
+ * @ffuncs: The font-functions structure
  *
+ * Tests whether a font-functions structure is immutable.
  *
- *
- * Return value:
+ * Return value: %true if @ffuncs is immutable, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -723,12 +750,13 @@ hb_font_t::has_func (unsigned int i)
 
 /**
  * hb_font_get_h_extents:
- * @font: a font.
- * @extents: (out):
+ * @font: #hb_font_t to work upon
+ * @extents: (out): The font extents retrieved
  *
+ * Fetches the extents for a specified font, in horizontal
+ * text segments.
  *
- *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 1.1.3
  **/
@@ -741,12 +769,13 @@ hb_font_get_h_extents (hb_font_t         *font,
 
 /**
  * hb_font_get_v_extents:
- * @font: a font.
- * @extents: (out):
+ * @font: #hb_font_t to work upon
+ * @extents: (out): The font extents retrieved
  *
+ * Fetches the extents for a specified font, in vertical
+ * text segments.
  *
- *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 1.1.3
  **/
@@ -759,14 +788,20 @@ hb_font_get_v_extents (hb_font_t         *font,
 
 /**
  * hb_font_get_glyph:
- * @font: a font.
- * @unicode:
- * @variation_selector:
- * @glyph: (out):
+ * @font: #hb_font_t to work upon
+ * @unicode: The Unicode code point to query
+ * @variation_selector: (optional): A variation-selector code point
+ * @glyph: (out): The glyph ID retrieved
  *
+ * Fetches the glyph ID for a Unicode code point in the specified
+ * font, with an optional variation selector.
  *
+ * This version of the function is higher-level and supports fallback behavior.
+ * 
+ * If @variation_selector is 0, calls hb_font_get_nominal_glyph();
+ * otherwise calls hb_font_get_variation_glyph().
  *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -783,13 +818,18 @@ hb_font_get_glyph (hb_font_t      *font,
 
 /**
  * hb_font_get_nominal_glyph:
- * @font: a font.
- * @unicode:
- * @glyph: (out):
+ * @font: #hb_font_t to work upon
+ * @unicode: The Unicode code point to query
+ * @glyph: (out): The glyph ID retrieved
  *
+ * Fetches the nominal glyph ID for a Unicode code point in the
+ * specified font. 
  *
+ * This version of the function should not be used to fetch glyph IDs
+ * for code points modified by variation selectors. For variation-selector
+ * support, user hb_font_get_variation_glyph() or use hb_font_get_glyph().
  *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 1.2.3
  **/
@@ -826,14 +866,16 @@ hb_font_get_nominal_glyphs (hb_font_t *font,
 
 /**
  * hb_font_get_variation_glyph:
- * @font: a font.
- * @unicode:
- * @variation_selector:
- * @glyph: (out):
+ * @font: #hb_font_t to work upon
+ * @unicode: The Unicode code point to query
+ * @variation_selector: The  variation-selector code point to query
+ * @glyph: (out): The glyph ID retrieved
  *
+ * Fetches the glyph ID for a Unicode code point when followed by
+ * by the specified variation-selector code point, in the specified
+ * font.
  *
- *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 1.2.3
  **/
@@ -848,12 +890,13 @@ hb_font_get_variation_glyph (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_h_advance:
- * @font: a font.
- * @glyph:
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
  *
+ * Fetches the advance for a glyph ID in the specified font,
+ * for horizontal text segments.
  *
- *
- * Return value:
+ * Return value: The advance of @glyph within @font
  *
  * Since: 0.9.2
  **/
@@ -866,12 +909,13 @@ hb_font_get_glyph_h_advance (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_v_advance:
- * @font: a font.
- * @glyph:
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
  *
+ * Fetches the advance for a glyph ID in the specified font,
+ * for vertical text segments.
  *
- *
- * Return value:
+ * Return value: The advance of @glyph within @font
  *
  * Since: 0.9.2
  **/
@@ -884,9 +928,15 @@ hb_font_get_glyph_v_advance (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_h_advances:
- * @font: a font.
+ * @font: #hb_font_t to work upon
+ * @count: The number of glyph IDs in the sequence queried
+ * @first_glyph: The first glyph ID to query
+ * @glyph_stride: The stride between successive glyph IDs
+ * @first_advance: (out): The first advance retrieved
+ * @advance_stride: (out): The stride between successive advances
  *
- *
+ * Fetches the advances for a sequence of glyph IDs in the specified
+ * font, for horizontal text segments. 
  *
  * Since: 1.8.6
  **/
@@ -902,9 +952,15 @@ hb_font_get_glyph_h_advances (hb_font_t*            font,
 }
 /**
  * hb_font_get_glyph_v_advances:
- * @font: a font.
+ * @font: #hb_font_t to work upon
+ * @count: The number of glyph IDs in the sequence queried
+ * @first_glyph: The first glyph ID to query
+ * @glyph_stride: The stride between successive glyph IDs
+ * @first_advance: (out): The first advance retrieved
+ * @advance_stride: (out): The stride between successive advances
  *
- *
+ * Fetches the advances for a sequence of glyph IDs in the specified
+ * font, for vertical text segments.  
  *
  * Since: 1.8.6
  **/
@@ -921,14 +977,15 @@ hb_font_get_glyph_v_advances (hb_font_t*            font,
 
 /**
  * hb_font_get_glyph_h_origin:
- * @font: a font.
- * @glyph:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @x: (out): The X coordinate of the origin
+ * @y: (out): The Y coordinate of the origin
  *
+ * Fetches the (X,Y) coordinates of the origin for a glyph ID
+ * in the specified font, for horizontal text segments.
  *
- *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -943,14 +1000,15 @@ hb_font_get_glyph_h_origin (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_v_origin:
- * @font: a font.
- * @glyph:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @x: (out): The X coordinate of the origin
+ * @y: (out): The Y coordinate of the origin
  *
+ * Fetches the (X,Y) coordinates of the origin for a glyph ID
+ * in the specified font, for vertical text segments.
  *
- *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -965,13 +1023,14 @@ hb_font_get_glyph_v_origin (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_h_kerning:
- * @font: a font.
- * @left_glyph:
- * @right_glyph:
+ * @font: #hb_font_t to work upon
+ * @left_glyph: The glyph ID of the left glyph in the glyph pair
+ * @right_glyph: The glyph ID of the right glyph in the glyph pair
  *
+ * Fetches the kerning-adjustment value for a glyph-pair in
+ * the specified font, in horizontal text segments.
  *
- *
- * Return value:
+ * Return value: The kerning adjustment value
  *
  * Since: 0.9.2
  **/
@@ -986,13 +1045,14 @@ hb_font_get_glyph_h_kerning (hb_font_t      *font,
 #ifndef HB_DISABLE_DEPRECATED
 /**
  * hb_font_get_glyph_v_kerning:
- * @font: a font.
- * @top_glyph:
- * @bottom_glyph:
+ * @font: #hb_font_t to work upon
+ * @top_glyph: The glyph ID of the top glyph in the glyph pair
+ * @bottom_glyph: The glyph ID of the bottom glyph in the glyph pair
  *
+ * Fetches the kerning-adjustment value for a glyph-pair in
+ * the specified font, in vertical text segments.
  *
- *
- * Return value:
+ * Return value: The kerning adjustment value
  *
  * Since: 0.9.2
  * Deprecated: 2.0.0
@@ -1008,13 +1068,14 @@ hb_font_get_glyph_v_kerning (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_extents:
- * @font: a font.
- * @glyph:
- * @extents: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @extents: (out): The #hb_glyph_extents_t retrieved
  *
+ * Fetches the #hb_glyph_extents_t data for a glyph ID
+ * in the specified font.
  *
- *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1028,15 +1089,16 @@ hb_font_get_glyph_extents (hb_font_t          *font,
 
 /**
  * hb_font_get_glyph_contour_point:
- * @font: a font.
- * @glyph:
- * @point_index:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @point_index: The contour-point index to query
+ * @x: (out): The X value retrieved for the contour point
+ * @y: (out): The Y value retrieved for the contour point
  *
+ * Fetches the (x,y) coordinates of a specified contour-point index
+ * in the specified glyph, within the specified font.
  *
- *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1052,14 +1114,14 @@ hb_font_get_glyph_contour_point (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_name:
- * @font: a font.
- * @glyph:
- * @name: (array length=size):
- * @size:
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @name: (out) (array length=size): Name string retrieved for the glyph ID
+ * @size: Length of the glyph-name string retrieved
  *
+ * Fetches the glyph-name string for a glyph ID in the specified @font.
  *
- *
- * Return value:
+ * Return value: %true if data found, zero otherwise
  *
  * Since: 0.9.2
  **/
@@ -1074,14 +1136,16 @@ hb_font_get_glyph_name (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_from_name:
- * @font: a font.
- * @name: (array length=len):
- * @len:
- * @glyph: (out):
+ * @font: #hb_font_t to work upon
+ * @name: (array length=len): The name string to query
+ * @len: The length of the name queried
+ * @glyph: (out): The glyph ID retrieved
  *
+ * Fetches the glyph ID that corresponds to a name string in the specified @font.
  *
+ * <note>Note: @len == -1 means the name string is null-terminated.</note>
  *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1099,11 +1163,15 @@ hb_font_get_glyph_from_name (hb_font_t      *font,
 
 /**
  * hb_font_get_extents_for_direction:
- * @font: a font.
- * @direction:
- * @extents: (out):
+ * @font: #hb_font_t to work upon
+ * @direction: The direction of the text segment
+ * @extents: (out): The #hb_glyph_extents_t retrieved
  *
+ * Fetches the extents for a font in a text segment of the
+ * specified direction.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
  * Since: 1.1.3
  **/
@@ -1116,13 +1184,17 @@ hb_font_get_extents_for_direction (hb_font_t         *font,
 }
 /**
  * hb_font_get_glyph_advance_for_direction:
- * @font: a font.
- * @glyph:
- * @direction:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @direction: The direction of the text segment
+ * @x: (out): The horizontal advance retrieved
+ * @y: (out):  The vertical advance retrieved
  *
+ * Fetches the advance for a glyph ID from the specified font,
+ * in a text segment of the specified direction.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
  * Since: 0.9.2
  **/
@@ -1137,10 +1209,19 @@ hb_font_get_glyph_advance_for_direction (hb_font_t      *font,
 }
 /**
  * hb_font_get_glyph_advances_for_direction:
- * @font: a font.
- * @direction:
+ * @font: #hb_font_t to work upon
+ * @direction: The direction of the text segment
+ * @count: The number of glyph IDs in the sequence queried
+ * @first_glyph: The first glyph ID to query
+ * @glyph_stride: The stride between successive glyph IDs
+ * @first_advance: (out): The first advance retrieved
+ * @advance_stride: (out): The stride between successive advances
  *
+ * Fetches the advances for a sequence of glyph IDs in the specified
+ * font, in a text segment of the specified direction.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
  * Since: 1.8.6
  **/
@@ -1158,13 +1239,17 @@ hb_font_get_glyph_advances_for_direction (hb_font_t*            font,
 
 /**
  * hb_font_get_glyph_origin_for_direction:
- * @font: a font.
- * @glyph:
- * @direction:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @direction: The direction of the text segment
+ * @x: (out): The X coordinate retrieved for the origin
+ * @y: (out): The Y coordinate retrieved for the origin
  *
+ * Fetches the (X,Y) coordinates of the origin for a glyph in
+ * the specified font.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
  * Since: 0.9.2
  **/
@@ -1180,13 +1265,19 @@ hb_font_get_glyph_origin_for_direction (hb_font_t      *font,
 
 /**
  * hb_font_add_glyph_origin_for_direction:
- * @font: a font.
- * @glyph:
- * @direction:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @direction: The direction of the text segment
+ * @x: (inout): Input = The original X coordinate 
+ *     Output = The X coordinate plus the X-coordinate of the origin
+ * @y: (inout): Input = The original Y coordinate
+ *     Output = The Y coordinate plus the Y-coordinate of the origin
  *
+ * Adds the origin coordinates to an (X,Y) point coordinate, in
+ * the specified glyph ID in the specified font.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
  * Since: 0.9.2
  **/
@@ -1202,13 +1293,19 @@ hb_font_add_glyph_origin_for_direction (hb_font_t      *font,
 
 /**
  * hb_font_subtract_glyph_origin_for_direction:
- * @font: a font.
- * @glyph:
- * @direction:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @direction: The direction of the text segment
+ * @x: (inout): Input = The original X coordinate 
+ *     Output = The X coordinate minus the X-coordinate of the origin
+ * @y: (inout): Input = The original Y coordinate
+ *     Output = The Y coordinate minus the Y-coordinate of the origin
  *
+ * Subtracts the origin coordinates from an (X,Y) point coordinate,
+ * in the specified glyph ID in the specified font.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
  * Since: 0.9.2
  **/
@@ -1224,14 +1321,17 @@ hb_font_subtract_glyph_origin_for_direction (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_kerning_for_direction:
- * @font: a font.
- * @first_glyph:
- * @second_glyph:
- * @direction:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @first_glyph: The glyph ID of the first glyph in the glyph pair to query
+ * @second_glyph: The glyph ID of the second glyph in the glyph pair to query
+ * @direction: The direction of the text segment
+ * @x: (out): The horizontal kerning-adjustment value retrieved
+ * @y: (out): The vertical kerning-adjustment value retrieved
  *
+ * Fetches the kerning-adjustment value for a glyph-pair in the specified font.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
  * Since: 0.9.2
  **/
@@ -1248,14 +1348,19 @@ hb_font_get_glyph_kerning_for_direction (hb_font_t      *font,
 
 /**
  * hb_font_get_glyph_extents_for_origin:
- * @font: a font.
- * @glyph:
- * @direction:
- * @extents: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @direction: The direction of the text segment
+ * @extents: (out): The #hb_glyph_extents_t retrieved
  *
+ * Fetches the #hb_glyph_extents_t data for a glyph ID
+ * in the specified font, with respect to the origin in
+ * a text segment in the specified direction.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1270,16 +1375,21 @@ hb_font_get_glyph_extents_for_origin (hb_font_t          *font,
 
 /**
  * hb_font_get_glyph_contour_point_for_origin:
- * @font: a font.
- * @glyph:
- * @point_index:
- * @direction:
- * @x: (out):
- * @y: (out):
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @point_index: The contour-point index to query
+ * @direction: The direction of the text segment
+ * @x: (out): The X value retrieved for the contour point
+ * @y: (out): The Y value retrieved for the contour point
  *
+ * Fetches the (X,Y) coordinates of a specified contour-point index
+ * in the specified glyph ID in the specified font, with respect
+ * to the origin in a text segment in the specified direction.
  *
+ * Calls the appropriate direction-specific variant (horizontal
+ * or vertical) depending on the value of @direction.
  *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1297,12 +1407,16 @@ hb_font_get_glyph_contour_point_for_origin (hb_font_t      *font,
 /* Generates gidDDD if glyph has no name. */
 /**
  * hb_font_glyph_to_string:
- * @font: a font.
- * @glyph:
- * @s: (array length=size):
- * @size:
+ * @font: #hb_font_t to work upon
+ * @glyph: The glyph ID to query
+ * @s: (out) (array length=size): The string containing the glyph name
+ * @size: Length of string @s
  *
+ * Fetches the name of the specified glyph ID in @font and returns
+ * it in string @s.
  *
+ * If the glyph ID has no name in @font, a string of the form "gidDDD" is
+ * generated.
  *
  * Since: 0.9.2
  **/
@@ -1318,14 +1432,17 @@ hb_font_glyph_to_string (hb_font_t      *font,
 /* Parses gidDDD and uniUUUU strings automatically. */
 /**
  * hb_font_glyph_from_string:
- * @font: a font.
- * @s: (array length=len) (element-type uint8_t):
- * @len:
- * @glyph: (out):
+ * @font: #hb_font_t to work upon
+ * @s: (array length=len) (element-type uint8_t): string to query
+ * @len: The length of the string @s
+ * @glyph: (out): The glyph ID corresponding to the string requested
  *
+ * Fetches the glyph ID from @font that matches the specified string.
+ * Strings of the format "gidDDD" or "uniUUUU" are parsed automatically.
  *
+ * <note>Note: @len == -1 means the string is null-terminated.</note>
  *
- * Return value:
+ * Return value: %true if data found, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1394,9 +1511,9 @@ _hb_font_create (hb_face_t *face)
  * hb_font_create: (Xconstructor)
  * @face: a face.
  *
+ * Constructs a new font object from the specified face.
  *
- *
- * Return value: (transfer full):
+ * Return value: (transfer full): The new font object
  *
  * Since: 0.9.2
  **/
@@ -1429,11 +1546,12 @@ _hb_font_adopt_var_coords (hb_font_t *font,
 
 /**
  * hb_font_create_sub_font:
- * @parent: parent font.
+ * @parent: The parent font object
  *
+ * Constructs a sub-font font object from the specified @parent font,
+ * replicating the parent's properties.
  *
- *
- * Return value: (transfer full):
+ * Return value: (transfer full): The new sub-font font object
  *
  * Since: 0.9.2
  **/
@@ -1481,9 +1599,9 @@ hb_font_create_sub_font (hb_font_t *parent)
 /**
  * hb_font_get_empty:
  *
+ * Fetches the empty font object.
  *
- *
- * Return value: (transfer full)
+ * Return value: (transfer full): The empty font object
  *
  * Since: 0.9.2
  **/
@@ -1495,11 +1613,11 @@ hb_font_get_empty ()
 
 /**
  * hb_font_reference: (skip)
- * @font: a font.
+ * @font: #hb_font_t to work upon
  *
+ * Increases the reference count on the given font object.
  *
- *
- * Return value: (transfer full):
+ * Return value: (transfer full): The @font object
  *
  * Since: 0.9.2
  **/
@@ -1511,9 +1629,11 @@ hb_font_reference (hb_font_t *font)
 
 /**
  * hb_font_destroy: (skip)
- * @font: a font.
+ * @font: #hb_font_t to work upon
  *
- *
+ * Decreases the reference count on the given font object. When the
+ * reference count reaches zero, the font is destroyed,
+ * freeing all memory.
  *
  * Since: 0.9.2
  **/
@@ -1539,13 +1659,13 @@ hb_font_destroy (hb_font_t *font)
 
 /**
  * hb_font_set_user_data: (skip)
- * @font: a font.
- * @key:
- * @data:
- * @destroy:
- * @replace:
+ * @font: #hb_font_t to work upon
+ * @key: The user-data key 
+ * @data: A pointer to the user data
+ * @destroy: (optional): A callback to call when @data is not needed anymore
+ * @replace: Whether to replace an existing data with the same key
  *
- *
+ * Attaches a user-data key/data pair to the specified font object. 
  *
  * Return value:
  *
@@ -1555,7 +1675,7 @@ hb_bool_t
 hb_font_set_user_data (hb_font_t          *font,
 		       hb_user_data_key_t *key,
 		       void *              data,
-		       hb_destroy_func_t   destroy,
+		       hb_destroy_func_t   destroy /* May be NULL. */,
 		       hb_bool_t           replace)
 {
   return hb_object_set_user_data (font, key, data, destroy, replace);
@@ -1563,12 +1683,13 @@ hb_font_set_user_data (hb_font_t          *font,
 
 /**
  * hb_font_get_user_data: (skip)
- * @font: a font.
- * @key:
+ * @font: #hb_font_t to work upon
+ * @key: The user-data key to query
  *
+ * Fetches the user-data object associated with the specified key,
+ * attached to the specified font object.
  *
- *
- * Return value: (transfer none):
+ * Return value: (transfer none): Pointer to the user data
  *
  * Since: 0.9.2
  **/
@@ -1581,9 +1702,9 @@ hb_font_get_user_data (hb_font_t          *font,
 
 /**
  * hb_font_make_immutable:
- * @font: a font.
+ * @font: #hb_font_t to work upon
  *
- *
+ * Makes @font immutable.
  *
  * Since: 0.9.2
  **/
@@ -1601,11 +1722,11 @@ hb_font_make_immutable (hb_font_t *font)
 
 /**
  * hb_font_is_immutable:
- * @font: a font.
+ * @font: #hb_font_t to work upon
  *
+ * Tests whether a font object is immutable.
  *
- *
- * Return value:
+ * Return value: %true if @font is immutable, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -1617,10 +1738,10 @@ hb_font_is_immutable (hb_font_t *font)
 
 /**
  * hb_font_set_parent:
- * @font: a font.
- * @parent: new parent.
+ * @font: #hb_font_t to work upon
+ * @parent: The parent font object to assign
  *
- * Sets parent font of @font.
+ * Sets the parent font of @font.
  *
  * Since: 1.0.5
  **/
@@ -1643,11 +1764,11 @@ hb_font_set_parent (hb_font_t *font,
 
 /**
  * hb_font_get_parent:
- * @font: a font.
+ * @font: #hb_font_t to work upon
  *
+ * Fetches the parent font of @font.
  *
- *
- * Return value: (transfer none):
+ * Return value: (transfer none): The parent font object
  *
  * Since: 0.9.2
  **/
@@ -1659,10 +1780,10 @@ hb_font_get_parent (hb_font_t *font)
 
 /**
  * hb_font_set_face:
- * @font: a font.
- * @face: new face.
+ * @font: #hb_font_t to work upon
+ * @face: The #hb_face_t to assign
  *
- * Sets font-face of @font.
+ * Sets @face as the font-face value of @font.
  *
  * Since: 1.4.3
  **/
@@ -1687,11 +1808,11 @@ hb_font_set_face (hb_font_t *font,
 
 /**
  * hb_font_get_face:
- * @font: a font.
+ * @font: #hb_font_t to work upon
  *
+ * Fetches the face associated with the specified font object.
  *
- *
- * Return value: (transfer none):
+ * Return value: (transfer none): The #hb_face_t value
  *
  * Since: 0.9.2
  **/
@@ -1704,12 +1825,13 @@ hb_font_get_face (hb_font_t *font)
 
 /**
  * hb_font_set_funcs:
- * @font: a font.
+ * @font: #hb_font_t to work upon
  * @klass: (closure font_data) (destroy destroy) (scope notified):
- * @font_data:
- * @destroy:
+ * @font_data: Data to attach to @font
+ * @destroy: (optional): The function to call when @font_data is not needed anymore
  *
- *
+ * Replaces the font-functions structure attached to a font, updating
+ * the font's user-data with @font-data and the @destroy callback.
  *
  * Since: 0.9.2
  **/
@@ -1717,7 +1839,7 @@ void
 hb_font_set_funcs (hb_font_t         *font,
 		   hb_font_funcs_t   *klass,
 		   void              *font_data,
-		   hb_destroy_func_t  destroy)
+		   hb_destroy_func_t  destroy /* May be NULL. */)
 {
   if (hb_object_is_immutable (font))
   {
@@ -1741,18 +1863,19 @@ hb_font_set_funcs (hb_font_t         *font,
 
 /**
  * hb_font_set_funcs_data:
- * @font: a font.
- * @font_data: (destroy destroy) (scope notified):
- * @destroy:
+ * @font: #hb_font_t to work upon
+ * @font_data: (destroy destroy) (scope notified): Data to attach to @font
+ * @destroy: (optional): The function to call when @font_data is not needed anymore
  *
- *
+ * Replaces the user data attached to a font, updating the font's 
+ * @destroy callback.
  *
  * Since: 0.9.2
  **/
 void
 hb_font_set_funcs_data (hb_font_t         *font,
-			void              *font_data,
-			hb_destroy_func_t  destroy)
+		        void              *font_data,
+		        hb_destroy_func_t  destroy /* May be NULL. */)
 {
   /* Destroy user_data? */
   if (hb_object_is_immutable (font))
@@ -1772,11 +1895,11 @@ hb_font_set_funcs_data (hb_font_t         *font,
 
 /**
  * hb_font_set_scale:
- * @font: a font.
- * @x_scale:
- * @y_scale:
+ * @font: #hb_font_t to work upon
+ * @x_scale: Horizontal scale value to assign
+ * @y_scale: Vertical scale value to assign
  *
- *
+ * Sets the horizontal and vertical scale of a font.
  *
  * Since: 0.9.2
  **/
@@ -1795,11 +1918,11 @@ hb_font_set_scale (hb_font_t *font,
 
 /**
  * hb_font_get_scale:
- * @font: a font.
- * @x_scale: (out):
- * @y_scale: (out):
+ * @font: #hb_font_t to work upon
+ * @x_scale: (out): Horizontal scale value
+ * @y_scale: (out): Vertical scale value
  *
- *
+ * Fetches the horizontal and vertical scale of a font.
  *
  * Since: 0.9.2
  **/
@@ -1814,11 +1937,11 @@ hb_font_get_scale (hb_font_t *font,
 
 /**
  * hb_font_set_ppem:
- * @font: a font.
- * @x_ppem:
- * @y_ppem:
+ * @font: #hb_font_t to work upon
+ * @x_ppem: Horizontal ppem value to assign
+ * @y_ppem: Vertical ppem value to assign
  *
- *
+ * Sets the horizontal and vertical points-per-em (ppem) of a font. 
  *
  * Since: 0.9.2
  **/
@@ -1836,11 +1959,11 @@ hb_font_set_ppem (hb_font_t    *font,
 
 /**
  * hb_font_get_ppem:
- * @font: a font.
- * @x_ppem: (out):
- * @y_ppem: (out):
+ * @font: #hb_font_t to work upon
+ * @x_ppem: (out): Horizontal ppem value
+ * @y_ppem: (out): Vertical ppem value
  *
- *
+ * Fetches the horizontal and vertical points-per-em (ppem) of a font. 
  *
  * Since: 0.9.2
  **/
@@ -1855,12 +1978,13 @@ hb_font_get_ppem (hb_font_t    *font,
 
 /**
  * hb_font_set_ptem:
- * @font: a font.
+ * @font: #hb_font_t to work upon
  * @ptem: font size in points.
  *
- * Sets "point size" of the font.  Set to 0 to unset.
+ * Sets the "point size" of a font. Set to zero to unset.
+ * Used in CoreText to implement optical sizing.
  *
- * There are 72 points in an inch.
+ * <note>Note: There are 72 points in an inch.</note>
  *
  * Since: 1.6.0
  **/
@@ -1876,11 +2000,12 @@ hb_font_set_ptem (hb_font_t *font,
 
 /**
  * hb_font_get_ptem:
- * @font: a font.
+ * @font: #hb_font_t to work upon
  *
- * Gets the "point size" of the font.  A value of 0 means unset.
+ * Fetches the "point size" of a font. Used in CoreText to
+ * implement optical sizing.
  *
- * Return value: Point size.
+ * Return value: Point size.  A value of zero means "not set."
  *
  * Since: 0.9.2
  **/
@@ -1897,6 +2022,11 @@ hb_font_get_ptem (hb_font_t *font)
 
 /**
  * hb_font_set_variations:
+ * @font: #hb_font_t to work upon
+ * @variations: (array length=variations_length): Array of variation settings to apply
+ * @variations_length: Number of variations to apply
+ *
+ * Applies a list of font-variation settings to a font.
  *
  * Since: 1.4.2
  */
@@ -1945,6 +2075,12 @@ hb_font_set_variations (hb_font_t            *font,
 
 /**
  * hb_font_set_var_coords_design:
+ * @font: #hb_font_t to work upon
+ * @coords: (array length=coords_length): Array of variation coordinates to apply
+ * @coords_length: Number of coordinates to apply
+ *
+ * Applies a list of variation coordinates (in design-space units)
+ * to a font.
  *
  * Since: 1.4.2
  */
@@ -2002,6 +2138,14 @@ hb_font_set_var_named_instance (hb_font_t *font,
 
 /**
  * hb_font_set_var_coords_normalized:
+ * @font: #hb_font_t to work upon
+ * @coords: (array length=coords_length): Array of variation coordinates to apply
+ * @coords_length: Number of coordinates to apply
+ *
+ * Applies a list of variation coordinates (in normalized units)
+ * to a font.
+ *
+ * <note>Note: Coordinates should be normalized to 2.14.</note>
  *
  * Since: 1.4.2
  */
@@ -2042,6 +2186,11 @@ hb_font_set_var_coords_normalized (hb_font_t    *font,
 
 /**
  * hb_font_get_var_coords_normalized:
+ * @font: #hb_font_t to work upon
+ * @length: Number of coordinates retrieved
+ *
+ * Fetches the list of normalized variation coordinates currently
+ * set on a font.
  *
  * Return value is valid as long as variation coordinates of the font
  * are not modified.
@@ -2165,10 +2314,10 @@ hb_font_get_variation_glyph_trampoline (hb_font_t      *font,
 
 /**
  * hb_font_funcs_set_glyph_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified): callback function.
- * @user_data: data to pass to @func.
- * @destroy: function to call when @user_data is not needed anymore.
+ * @ffuncs: The font-functions structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): callback function
+ * @user_data: data to pass to @func
+ * @destroy: (optional): function to call when @user_data is not needed anymore
  *
  * Deprecated.  Use hb_font_funcs_set_nominal_glyph_func() and
  * hb_font_funcs_set_variation_glyph_func() instead.
@@ -2180,7 +2329,7 @@ void
 hb_font_funcs_set_glyph_func (hb_font_funcs_t          *ffuncs,
 			      hb_font_get_glyph_func_t  func,
 			      void                     *user_data,
-			      hb_destroy_func_t         destroy)
+			      hb_destroy_func_t         destroy /* May be NULL. */)
 {
   if (hb_object_is_immutable (ffuncs))
   {

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -633,7 +633,7 @@ hb_font_funcs_destroy (hb_font_funcs_t *ffuncs)
  *
  * Attaches a user-data key/data pair to the specified font-functions structure. 
  *
- * Return value: %true if success, false otherwise
+ * Return value: %true if success, %false otherwise
  *
  * Since: 0.9.2
  **/

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -404,7 +404,7 @@ typedef hb_bool_t (*hb_font_get_glyph_from_name_func_t) (hb_font_t *font, void *
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_font_h_extents_func_t.
  *
@@ -420,7 +420,7 @@ hb_font_funcs_set_font_h_extents_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_font_v_extents_func_t.
  *
@@ -436,7 +436,7 @@ hb_font_funcs_set_font_v_extents_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_nominal_glyph_func_t.
  *
@@ -452,7 +452,7 @@ hb_font_funcs_set_nominal_glyph_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_nominal_glyphs_func_t.
  *
@@ -468,7 +468,7 @@ hb_font_funcs_set_nominal_glyphs_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_variation_glyph_func_t.
  *
@@ -484,7 +484,7 @@ hb_font_funcs_set_variation_glyph_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_h_advance_func_t.
  *
@@ -500,7 +500,7 @@ hb_font_funcs_set_glyph_h_advance_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_v_advance_func_t.
  *
@@ -516,7 +516,7 @@ hb_font_funcs_set_glyph_v_advance_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_h_advances_func_t.
  *
@@ -532,7 +532,7 @@ hb_font_funcs_set_glyph_h_advances_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_v_advances_func_t.
  *
@@ -548,7 +548,7 @@ hb_font_funcs_set_glyph_v_advances_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_h_origin_func_t.
  *
@@ -564,7 +564,7 @@ hb_font_funcs_set_glyph_h_origin_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_v_origin_func_t.
  *
@@ -596,7 +596,7 @@ hb_font_funcs_set_glyph_h_kerning_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_extents_func_t.
  *
@@ -612,7 +612,7 @@ hb_font_funcs_set_glyph_extents_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_contour_point_func_t.
  *
@@ -628,7 +628,7 @@ hb_font_funcs_set_glyph_contour_point_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_name_func_t.
  *
@@ -644,7 +644,7 @@ hb_font_funcs_set_glyph_name_func (hb_font_funcs_t *ffuncs,
  * @ffuncs: A font-function structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_font_get_glyph_from_name_func_t.
  *

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -45,6 +45,19 @@ typedef struct hb_font_t hb_font_t;
  * hb_font_funcs_t
  */
 
+/**
+ * hb_font_funcs_t:
+ *
+ * Data type containing a set of virtual methods used for
+ * working on #hb_font_t font objects.
+ *
+ * HarfBuzz provides a lightweight default function for each of 
+ * the methods in #hb_font_funcs_t. Client programs can implement
+ * their own replacements for the individual font functions, as
+ * needed, and replace the default by calling the setter for a
+ * method.
+ *
+ **/
 typedef struct hb_font_funcs_t hb_font_funcs_t;
 
 HB_EXTERN hb_font_funcs_t *
@@ -81,7 +94,17 @@ hb_font_funcs_is_immutable (hb_font_funcs_t *ffuncs);
 
 /* font and glyph extents */
 
-/* Note that typically ascender is positive and descender negative in coordinate systems that grow up. */
+/**
+ * hb_font_extents_t:
+ * @ascender: The height of typographic ascenders.
+ * @descender: The depth of typographic descenders.
+ * @line_gap: The suggested line-spacing gap.
+ *
+ * Font-wide extent values, measured in font units.
+ *
+ * Note that typically @ascender is positive and @descender
+ * negative, in coordinate systems that grow up.
+ **/
 typedef struct hb_font_extents_t {
   hb_position_t ascender; /* typographic ascender. */
   hb_position_t descender; /* typographic descender. */
@@ -98,7 +121,17 @@ typedef struct hb_font_extents_t {
   hb_position_t reserved1;
 } hb_font_extents_t;
 
-/* Note that height is negative in coordinate systems that grow up. */
+/**
+ * hb_glyph_extents_t:
+ * @x_bearing: Distance from the x-origin to the left extremum of the glyph.
+ * @y_bearing: Distance from the top extremum of the glyph to the y-origin.
+ * @width: Distance from the left extremum of the glyph to the right extremum.
+ * @height: Distance from the top extremum of the glyph to the bottom extremum.
+ *
+ * Glyph extent values, measured in font units.
+ *
+ * Note that @height is negative, in coordinate systems that grow up.
+ **/
 typedef struct hb_glyph_extents_t {
   hb_position_t x_bearing; /* left side of glyph from origin. */
   hb_position_t y_bearing; /* top side of glyph from origin. */
@@ -111,19 +144,72 @@ typedef struct hb_glyph_extents_t {
 typedef hb_bool_t (*hb_font_get_font_extents_func_t) (hb_font_t *font, void *font_data,
 						       hb_font_extents_t *extents,
 						       void *user_data);
+
+/**
+ * hb_font_get_font_h_extents_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the extents for a font, in horizontal-direction
+ * text segments. Extents must be returned in an #hb_glyph_extents output
+ * parameter.
+ * 
+ **/
 typedef hb_font_get_font_extents_func_t hb_font_get_font_h_extents_func_t;
+
+/**
+ * hb_font_get_font_v_extents_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the extents for a font, in vertical-direction
+ * text segments. Extents must be returned in an #hb_glyph_extents output
+ * parameter.
+ * 
+ **/
 typedef hb_font_get_font_extents_func_t hb_font_get_font_v_extents_func_t;
 
 
+/**
+ * hb_font_get_nominal_glyph_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the nominal glyph ID for a specified Unicode code
+ * point. Glyph IDs must be returned in a #hb_codepoint_t output parameter.
+ * 
+ **/
 typedef hb_bool_t (*hb_font_get_nominal_glyph_func_t) (hb_font_t *font, void *font_data,
 						       hb_codepoint_t unicode,
 						       hb_codepoint_t *glyph,
 						       void *user_data);
+
+/**
+ * hb_font_get_variation_glyph_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the glyph ID for a specified Unicode code point
+ * followed by a specified Variation Selector code point. Glyph IDs must be
+ * returned in a #hb_codepoint_t output parameter.
+ * 
+ **/
 typedef hb_bool_t (*hb_font_get_variation_glyph_func_t) (hb_font_t *font, void *font_data,
 							 hb_codepoint_t unicode, hb_codepoint_t variation_selector,
 							 hb_codepoint_t *glyph,
 							 void *user_data);
 
+
+/**
+ * hb_font_get_nominal_glyphs_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the nominal glyph IDs for a sequence of
+ * Unicode code points. Glyph IDs must be returned in a #hb_codepoint_t
+ * output parameter.
+ * 
+ **/
 typedef unsigned int (*hb_font_get_nominal_glyphs_func_t) (hb_font_t *font, void *font_data,
 							   unsigned int count,
 							   const hb_codepoint_t *first_unicode,
@@ -132,13 +218,51 @@ typedef unsigned int (*hb_font_get_nominal_glyphs_func_t) (hb_font_t *font, void
 							   unsigned int glyph_stride,
 							   void *user_data);
 
-
+/**
+ * hb_font_get_glyph_advance_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the advance for a specified glyph. The
+ * method must return an #hb_position_t.
+ * 
+ **/
 typedef hb_position_t (*hb_font_get_glyph_advance_func_t) (hb_font_t *font, void *font_data,
 							   hb_codepoint_t glyph,
 							   void *user_data);
+
+/**
+ * hb_font_get_glyph_h_advance_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the advance for a specified glyph, in
+ * horizontal-direction text segments. Advances must be returned in
+ * an #hb_position_t output parameter.
+ * 
+ **/
 typedef hb_font_get_glyph_advance_func_t hb_font_get_glyph_h_advance_func_t;
+
+/**
+ * hb_font_get_glyph_v_advance_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the advance for a specified glyph, in
+ * vertical-direction text segments. Advances must be returned in
+ * an #hb_position_t output parameter.
+ * 
+ **/
 typedef hb_font_get_glyph_advance_func_t hb_font_get_glyph_v_advance_func_t;
 
+/**
+ * hb_font_get_glyph_advances_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the advances for a sequence of glyphs.
+ * 
+ **/
 typedef void (*hb_font_get_glyph_advances_func_t) (hb_font_t* font, void* font_data,
 						   unsigned int count,
 						   const hb_codepoint_t *first_glyph,
@@ -146,14 +270,66 @@ typedef void (*hb_font_get_glyph_advances_func_t) (hb_font_t* font, void* font_d
 						   hb_position_t *first_advance,
 						   unsigned advance_stride,
 						   void *user_data);
+
+/**
+ * hb_font_get_glyph_h_advances_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the advances for a sequence of glyphs, in
+ * horizontal-direction text segments.
+ * 
+ **/
 typedef hb_font_get_glyph_advances_func_t hb_font_get_glyph_h_advances_func_t;
+
+/**
+ * hb_font_get_glyph_v_advances_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the advances for a sequence of glyphs, in
+ * vertical-direction text segments.
+ * 
+ **/
 typedef hb_font_get_glyph_advances_func_t hb_font_get_glyph_v_advances_func_t;
 
+/**
+ * hb_font_get_glyph_origin_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the (X,Y) coordinates (in font units) of the
+ * origin for a glyph. Each coordinate must be returned in an #hb_position_t
+ * output parameter.
+ * 
+ **/
 typedef hb_bool_t (*hb_font_get_glyph_origin_func_t) (hb_font_t *font, void *font_data,
 						      hb_codepoint_t glyph,
 						      hb_position_t *x, hb_position_t *y,
 						      void *user_data);
+
+/**
+ * hb_font_get_glyph_h_origin_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the (X,Y) coordinates (in font units) of the
+ * origin for a glyph, in horizontal-direction text segments. Each
+ * coordinate must be returned in an #hb_position_t output parameter.
+ * 
+ **/
 typedef hb_font_get_glyph_origin_func_t hb_font_get_glyph_h_origin_func_t;
+
+/**
+ * hb_font_get_glyph_v_origin_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the (X,Y) coordinates (in font units) of the
+ * origin for a glyph, in vertical-direction text segments. Each coordinate
+ * must be returned in an #hb_position_t output parameter.
+ * 
+ **/
 typedef hb_font_get_glyph_origin_func_t hb_font_get_glyph_v_origin_func_t;
 
 typedef hb_position_t (*hb_font_get_glyph_kerning_func_t) (hb_font_t *font, void *font_data,
@@ -162,20 +338,59 @@ typedef hb_position_t (*hb_font_get_glyph_kerning_func_t) (hb_font_t *font, void
 typedef hb_font_get_glyph_kerning_func_t hb_font_get_glyph_h_kerning_func_t;
 
 
+/**
+ * hb_font_get_glyph_extents_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the extents for a specified glyph. Extents must be 
+ * returned in an #hb_glyph_extents output parameter.
+ * 
+ **/
 typedef hb_bool_t (*hb_font_get_glyph_extents_func_t) (hb_font_t *font, void *font_data,
 						       hb_codepoint_t glyph,
 						       hb_glyph_extents_t *extents,
 						       void *user_data);
+
+/**
+ * hb_font_get_glyph_contour_point_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the (X,Y) coordinates (in font units) for a
+ * specified contour point in a glyph. Each coordinate must be returned as
+ * an #hb_position_t output parameter.
+ * 
+ **/
 typedef hb_bool_t (*hb_font_get_glyph_contour_point_func_t) (hb_font_t *font, void *font_data,
 							     hb_codepoint_t glyph, unsigned int point_index,
 							     hb_position_t *x, hb_position_t *y,
 							     void *user_data);
 
 
+/**
+ * hb_font_get_glyph_name_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the glyph name that corresponds to a
+ * glyph ID. The name should be returned in a string output parameter.
+ * 
+ **/
 typedef hb_bool_t (*hb_font_get_glyph_name_func_t) (hb_font_t *font, void *font_data,
 						    hb_codepoint_t glyph,
 						    char *name, unsigned int size,
 						    void *user_data);
+
+/**
+ * hb_font_get_glyph_from_name_func_t:
+ *
+ * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
+ *
+ * This method should retrieve the glyph ID that corresponds to a glyph-name
+ * string. 
+ * 
+ **/
 typedef hb_bool_t (*hb_font_get_glyph_from_name_func_t) (hb_font_t *font, void *font_data,
 							 const char *name, int len, /* -1 means nul-terminated */
 							 hb_codepoint_t *glyph,
@@ -186,12 +401,12 @@ typedef hb_bool_t (*hb_font_get_glyph_from_name_func_t) (hb_font_t *font, void *
 
 /**
  * hb_font_funcs_set_font_h_extents_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_font_h_extents_func_t.
  *
  * Since: 1.1.2
  **/
@@ -202,12 +417,12 @@ hb_font_funcs_set_font_h_extents_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_font_v_extents_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_font_v_extents_func_t.
  *
  * Since: 1.1.2
  **/
@@ -218,12 +433,12 @@ hb_font_funcs_set_font_v_extents_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_nominal_glyph_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_nominal_glyph_func_t.
  *
  * Since: 1.2.3
  **/
@@ -234,12 +449,12 @@ hb_font_funcs_set_nominal_glyph_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_nominal_glyphs_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_nominal_glyphs_func_t.
  *
  * Since: 2.0.0
  **/
@@ -250,12 +465,12 @@ hb_font_funcs_set_nominal_glyphs_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_variation_glyph_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_variation_glyph_func_t.
  *
  * Since: 1.2.3
  **/
@@ -266,12 +481,12 @@ hb_font_funcs_set_variation_glyph_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_h_advance_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_h_advance_func_t.
  *
  * Since: 0.9.2
  **/
@@ -282,12 +497,12 @@ hb_font_funcs_set_glyph_h_advance_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_v_advance_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_v_advance_func_t.
  *
  * Since: 0.9.2
  **/
@@ -298,12 +513,12 @@ hb_font_funcs_set_glyph_v_advance_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_h_advances_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_h_advances_func_t.
  *
  * Since: 1.8.6
  **/
@@ -314,12 +529,12 @@ hb_font_funcs_set_glyph_h_advances_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_v_advances_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_v_advances_func_t.
  *
  * Since: 1.8.6
  **/
@@ -330,12 +545,12 @@ hb_font_funcs_set_glyph_v_advances_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_h_origin_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_h_origin_func_t.
  *
  * Since: 0.9.2
  **/
@@ -346,12 +561,12 @@ hb_font_funcs_set_glyph_h_origin_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_v_origin_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_v_origin_func_t.
  *
  * Since: 0.9.2
  **/
@@ -378,12 +593,12 @@ hb_font_funcs_set_glyph_h_kerning_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_extents_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_extents_func_t.
  *
  * Since: 0.9.2
  **/
@@ -394,12 +609,12 @@ hb_font_funcs_set_glyph_extents_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_contour_point_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_contour_point_func_t.
  *
  * Since: 0.9.2
  **/
@@ -410,12 +625,12 @@ hb_font_funcs_set_glyph_contour_point_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_name_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_name_func_t.
  *
  * Since: 0.9.2
  **/
@@ -426,12 +641,12 @@ hb_font_funcs_set_glyph_name_func (hb_font_funcs_t *ffuncs,
 
 /**
  * hb_font_funcs_set_glyph_from_name_func:
- * @ffuncs: font functions.
- * @func: (closure user_data) (destroy destroy) (scope notified):
- * @user_data:
- * @destroy:
+ * @ffuncs: A font-function structure
+ * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
+ * @user_data: Data to pass to @func
+ * @destroy: The function to call when @user_data is not needed anymore
  *
- *
+ * Sets the implementation function for #hb_font_get_glyph_from_name_func_t.
  *
  * Since: 0.9.2
  **/

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -106,9 +106,9 @@ hb_font_funcs_is_immutable (hb_font_funcs_t *ffuncs);
  * negative, in coordinate systems that grow up.
  **/
 typedef struct hb_font_extents_t {
-  hb_position_t ascender; /* typographic ascender. */
-  hb_position_t descender; /* typographic descender. */
-  hb_position_t line_gap; /* suggested line spacing gap. */
+  hb_position_t ascender;
+  hb_position_t descender;
+  hb_position_t line_gap;
   /*< private >*/
   hb_position_t reserved9;
   hb_position_t reserved8;
@@ -133,10 +133,10 @@ typedef struct hb_font_extents_t {
  * Note that @height is negative, in coordinate systems that grow up.
  **/
 typedef struct hb_glyph_extents_t {
-  hb_position_t x_bearing; /* left side of glyph from origin. */
-  hb_position_t y_bearing; /* top side of glyph from origin. */
-  hb_position_t width; /* distance from left to right side. */
-  hb_position_t height; /* distance from top to bottom side. */
+  hb_position_t x_bearing;
+  hb_position_t y_bearing;
+  hb_position_t width;
+  hb_position_t height;
 } hb_glyph_extents_t;
 
 /* func types */

--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -661,7 +661,7 @@ _hb_ft_reference_table (hb_face_t *face HB_UNUSED, hb_tag_t tag, void *user_data
 /**
  * hb_ft_face_create:
  * @ft_face: (destroy destroy) (scope notified): FT_Face to work upon
- * @destroy: A callback to call when the face object is not needed anymore
+ * @destroy: (optional): A callback to call when the face object is not needed anymore
  *
  * Creates an #hb_face_t face object from the specified FT_Face.
  *

--- a/src/hb-map.cc
+++ b/src/hb-map.cc
@@ -117,7 +117,7 @@ hb_map_destroy (hb_map_t *map)
  * @map: A map
  * @key: The user-data key to set
  * @data: A pointer to the user data to set
- * @destroy: A callback to call when @data is not needed anymore
+ * @destroy: (optional): A callback to call when @data is not needed anymore
  * @replace: Whether to replace an existing data with the same key
  *
  * Attaches a user-data key/data pair to the specified map.

--- a/src/hb-map.cc
+++ b/src/hb-map.cc
@@ -122,7 +122,7 @@ hb_map_destroy (hb_map_t *map)
  *
  * Attaches a user-data key/data pair to the specified map.
  *
- * Return value: %true if success, false otherwise
+ * Return value: %true if success, %false otherwise
  *
  * Since: 1.7.7
  **/

--- a/src/hb-map.cc
+++ b/src/hb-map.cc
@@ -42,7 +42,9 @@
 /**
  * hb_map_create: (Xconstructor)
  *
- * Return value: (transfer full):
+ * Creates a new, initially empty map.
+ *
+ * Return value: (transfer full): The new #hb_map_t
  *
  * Since: 1.7.7
  **/
@@ -62,7 +64,9 @@ hb_map_create ()
 /**
  * hb_map_get_empty:
  *
- * Return value: (transfer full):
+ * Fetches the singleton empty #hb_map_t.
+ *
+ * Return value: (transfer full): The empty #hb_map_t
  *
  * Since: 1.7.7
  **/
@@ -74,9 +78,11 @@ hb_map_get_empty ()
 
 /**
  * hb_map_reference: (skip)
- * @map: a map.
+ * @map: A map
  *
- * Return value: (transfer full):
+ * Increases the reference count on a map.
+ *
+ * Return value: (transfer full): The map
  *
  * Since: 1.7.7
  **/
@@ -88,7 +94,11 @@ hb_map_reference (hb_map_t *map)
 
 /**
  * hb_map_destroy: (skip)
- * @map: a map.
+ * @map: A map
+ *
+ * Decreases the reference count on a map. When
+ * the reference count reaches zero, the map is
+ * destroyed, freeing all memory.
  *
  * Since: 1.7.7
  **/
@@ -104,13 +114,15 @@ hb_map_destroy (hb_map_t *map)
 
 /**
  * hb_map_set_user_data: (skip)
- * @map: a map.
- * @key:
- * @data:
- * @destroy:
- * @replace:
+ * @map: A map
+ * @key: The user-data key to set
+ * @data: A pointer to the user data to set
+ * @destroy: A callback to call when @data is not needed anymore
+ * @replace: Whether to replace an existing data with the same key
  *
- * Return value:
+ * Attaches a user-data key/data pair to the specified map.
+ *
+ * Return value: %true if success, false otherwise
  *
  * Since: 1.7.7
  **/
@@ -126,10 +138,13 @@ hb_map_set_user_data (hb_map_t           *map,
 
 /**
  * hb_map_get_user_data: (skip)
- * @map: a map.
- * @key:
+ * @map: A map
+ * @key: The user-data key to query
  *
- * Return value: (transfer none):
+ * Fetches the user data associated with the specified key,
+ * attached to the specified map.
+ *
+ * Return value: (transfer none): A pointer to the user data
  *
  * Since: 1.7.7
  **/
@@ -143,11 +158,11 @@ hb_map_get_user_data (hb_map_t           *map,
 
 /**
  * hb_map_allocation_successful:
- * @map: a map.
+ * @map: A map
  *
+ * Tests whether memory allocation for a set was successful.
  *
- *
- * Return value:
+ * Return value: %true if allocation succeeded, false otherwise
  *
  * Since: 1.7.7
  **/
@@ -160,11 +175,11 @@ hb_map_allocation_successful (const hb_map_t  *map)
 
 /**
  * hb_map_set:
- * @map: a map.
- * @key:
- * @value:
+ * @map: A map
+ * @key: The key to store in the map
+ * @value: The value to store for @key
  *
- *
+ * Stores @key:@value in the map.
  *
  * Since: 1.7.7
  **/
@@ -178,10 +193,10 @@ hb_map_set (hb_map_t       *map,
 
 /**
  * hb_map_get:
- * @map: a map.
- * @key:
+ * @map: A map
+ * @key: The key to query
  *
- *
+ * Fetches the value stored for @key in @map.
  *
  * Since: 1.7.7
  **/
@@ -194,10 +209,10 @@ hb_map_get (const hb_map_t *map,
 
 /**
  * hb_map_del:
- * @map: a map.
- * @key:
+ * @map: A map
+ * @key: The key to delete
  *
- *
+ * Removes @key and its stored value from @map.
  *
  * Since: 1.7.7
  **/
@@ -210,10 +225,12 @@ hb_map_del (hb_map_t       *map,
 
 /**
  * hb_map_has:
- * @map: a map.
- * @key:
+ * @map: A map
+ * @key: The key to query
  *
+ * Tests whether @key is an element of @map.
  *
+ * Return value: %true if @key is found in @map, false otherwise
  *
  * Since: 1.7.7
  **/
@@ -227,9 +244,9 @@ hb_map_has (const hb_map_t *map,
 
 /**
  * hb_map_clear:
- * @map: a map.
+ * @map: A map
  *
- *
+ * Clears out the contents of @map.
  *
  * Since: 1.7.7
  **/
@@ -241,9 +258,11 @@ hb_map_clear (hb_map_t *map)
 
 /**
  * hb_map_is_empty:
- * @map: a map.
+ * @map: A map
  *
+ * Tests whether @map is empty (contains no elements).
  *
+ * Return value: %true if @map is empty
  *
  * Since: 1.7.7
  **/
@@ -255,9 +274,11 @@ hb_map_is_empty (const hb_map_t *map)
 
 /**
  * hb_map_get_population:
- * @map: a map.
+ * @map: A map
  *
+ * Returns the number of key-value pairs in the map.
  *
+ * Return value: The population of @map
  *
  * Since: 1.7.7
  **/

--- a/src/hb-map.h
+++ b/src/hb-map.h
@@ -41,6 +41,12 @@ HB_BEGIN_DECLS
  */
 #define HB_MAP_VALUE_INVALID ((hb_codepoint_t) -1)
 
+/**
+ * hb_map_t:
+ *
+ * Data type for holding integer-to-integer hash maps.
+ *
+ **/
 typedef struct hb_map_t hb_map_t;
 
 

--- a/src/hb-set.cc
+++ b/src/hb-set.cc
@@ -30,11 +30,11 @@
 /**
  * SECTION:hb-set
  * @title: hb-set
- * @short_description: Object representing a set of integers
+ * @short_description: Objects representing a set of integers
  * @include: hb.h
  *
  * Set objects represent a mathematical set of integer values.  They are
- * used in non-shaping API to query certain set of characters or glyphs,
+ * used in non-shaping APIs to query certain sets of characters or glyphs,
  * or other integer values.
  **/
 
@@ -42,7 +42,9 @@
 /**
  * hb_set_create: (Xconstructor)
  *
- * Return value: (transfer full):
+ * Creates a new, initially empty set.
+ *
+ * Return value: (transfer full): The new #hb_set_t
  *
  * Since: 0.9.2
  **/
@@ -62,7 +64,9 @@ hb_set_create ()
 /**
  * hb_set_get_empty:
  *
- * Return value: (transfer full):
+ * Fetches the singleton empty #hb_set_t.
+ *
+ * Return value: (transfer full): The empty #hb_set_t
  *
  * Since: 0.9.2
  **/
@@ -74,9 +78,11 @@ hb_set_get_empty ()
 
 /**
  * hb_set_reference: (skip)
- * @set: a set.
+ * @set: A set
  *
- * Return value: (transfer full):
+ * Increases the reference count on a set.
+ *
+ * Return value: (transfer full): The set
  *
  * Since: 0.9.2
  **/
@@ -88,7 +94,11 @@ hb_set_reference (hb_set_t *set)
 
 /**
  * hb_set_destroy: (skip)
- * @set: a set.
+ * @set: A set
+ *
+ * Decreases the reference count on a set. When
+ * the reference count reaches zero, the set is
+ * destroyed, freeing all memory.
  *
  * Since: 0.9.2
  **/
@@ -104,13 +114,15 @@ hb_set_destroy (hb_set_t *set)
 
 /**
  * hb_set_set_user_data: (skip)
- * @set: a set.
- * @key:
- * @data:
- * @destroy:
- * @replace:
+ * @set: A set
+ * @key: The user-data key to set
+ * @data: A pointer to the user data to set
+ * @destroy: A callback to call when @data is not needed anymore
+ * @replace: Whether to replace an existing data with the same key
  *
- * Return value:
+ * Attaches a user-data key/data pair to the specified set.
+ *
+ * Return value: %true if success, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -126,10 +138,13 @@ hb_set_set_user_data (hb_set_t           *set,
 
 /**
  * hb_set_get_user_data: (skip)
- * @set: a set.
- * @key:
+ * @set: A set
+ * @key: The user-data key to query
  *
- * Return value: (transfer none):
+ * Fetches the user data associated with the specified key,
+ * attached to the specified set.
+ *
+ * Return value: (transfer none): A pointer to the user data
  *
  * Since: 0.9.2
  **/
@@ -143,11 +158,11 @@ hb_set_get_user_data (hb_set_t           *set,
 
 /**
  * hb_set_allocation_successful:
- * @set: a set.
+ * @set: A set
  *
+ * Tests whether memory allocation for a set was successful.
  *
- *
- * Return value:
+ * Return value: %true if allocation succeeded, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -159,9 +174,9 @@ hb_set_allocation_successful (const hb_set_t  *set)
 
 /**
  * hb_set_clear:
- * @set: a set.
+ * @set: A set
  *
- *
+ * Clears out the contents of a set.
  *
  * Since: 0.9.2
  **/
@@ -175,9 +190,9 @@ hb_set_clear (hb_set_t *set)
  * hb_set_is_empty:
  * @set: a set.
  *
+ * Tests whether a set is empty (contains no elements).
  *
- *
- * Return value:
+ * Return value: %true if @set is empty
  *
  * Since: 0.9.7
  **/
@@ -189,12 +204,12 @@ hb_set_is_empty (const hb_set_t *set)
 
 /**
  * hb_set_has:
- * @set: a set.
- * @codepoint:
+ * @set: A set
+ * @codepoint: The element to query
  *
+ * Tests whether @codepoint belongs to @set.
  *
- *
- * Return value:
+ * Return value: %true if @codepoint is in @set, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -207,10 +222,10 @@ hb_set_has (const hb_set_t *set,
 
 /**
  * hb_set_add:
- * @set: a set.
- * @codepoint:
+ * @set: A set
+ * @codepoint: The element to add to @set
  *
- *
+ * Adds @codepoint to @set.
  *
  * Since: 0.9.2
  **/
@@ -223,11 +238,12 @@ hb_set_add (hb_set_t       *set,
 
 /**
  * hb_set_add_range:
- * @set: a set.
- * @first:
- * @last:
+ * @set: A set
+ * @first: The first element to add to @set
+ * @last: The final element to add to @set
  *
- *
+ * Adds all of the elements from @first to @last
+ * (inclusive) to @set.
  *
  * Since: 0.9.7
  **/
@@ -241,10 +257,10 @@ hb_set_add_range (hb_set_t       *set,
 
 /**
  * hb_set_del:
- * @set: a set.
- * @codepoint:
+ * @set: A set
+ * @codepoint: Removes @codepoint from @set
  *
- *
+ * Removes @codepoint from @set.
  *
  * Since: 0.9.2
  **/
@@ -257,11 +273,12 @@ hb_set_del (hb_set_t       *set,
 
 /**
  * hb_set_del_range:
- * @set: a set.
- * @first:
- * @last:
+ * @set: A set
+ * @first: The first element to remove from @set
+ * @last: The final element to remove from @set
  *
- *
+ * Removes all of the elements from @first to @last
+ * (inclusive) from @set.
  *
  * Since: 0.9.7
  **/
@@ -275,10 +292,11 @@ hb_set_del_range (hb_set_t       *set,
 
 /**
  * hb_set_is_equal:
- * @set: a set.
- * @other: other set.
+ * @set: A set
+ * @other: Another set
  *
- *
+ * Tests whether @set and @other are equal (contain the same
+ * elements).
  *
  * Return value: %TRUE if the two sets are equal, %FALSE otherwise.
  *
@@ -293,10 +311,10 @@ hb_set_is_equal (const hb_set_t *set,
 
 /**
  * hb_set_is_subset:
- * @set: a set.
- * @larger_set: other set.
+ * @set: A set
+ * @larger_set: Another set
  *
- *
+ * Tests whether @set is a subset of @larger_set.
  *
  * Return value: %TRUE if the @set is a subset of (or equal to) @larger_set, %FALSE otherwise.
  *
@@ -311,10 +329,10 @@ hb_set_is_subset (const hb_set_t *set,
 
 /**
  * hb_set_set:
- * @set: a set.
- * @other:
+ * @set: A set
+ * @other: Another set
  *
- *
+ * Makes the contents of @set equal to the contents of @other.
  *
  * Since: 0.9.2
  **/
@@ -327,10 +345,10 @@ hb_set_set (hb_set_t       *set,
 
 /**
  * hb_set_union:
- * @set: a set.
- * @other:
+ * @set: A set
+ * @other: Another set
  *
- *
+ * Makes @set the union of @set and @other.
  *
  * Since: 0.9.2
  **/
@@ -343,10 +361,10 @@ hb_set_union (hb_set_t       *set,
 
 /**
  * hb_set_intersect:
- * @set: a set.
- * @other:
+ * @set: A set
+ * @other: Another set
  *
- *
+ * Makes @set the intersection of @set and @other.
  *
  * Since: 0.9.2
  **/
@@ -359,10 +377,10 @@ hb_set_intersect (hb_set_t       *set,
 
 /**
  * hb_set_subtract:
- * @set: a set.
- * @other:
+ * @set: A set
+ * @other: Another set
  *
- *
+ * Subtracts the contents of @other from @set.
  *
  * Since: 0.9.2
  **/
@@ -375,10 +393,11 @@ hb_set_subtract (hb_set_t       *set,
 
 /**
  * hb_set_symmetric_difference:
- * @set: a set.
- * @other:
+ * @set: A set
+ * @other: Another set
  *
- *
+ * Makes @set the symmetric difference of @set
+ * and @other.
  *
  * Since: 0.9.2
  **/
@@ -392,9 +411,9 @@ hb_set_symmetric_difference (hb_set_t       *set,
 #ifndef HB_DISABLE_DEPRECATED
 /**
  * hb_set_invert:
- * @set: a set.
+ * @set: A set
  *
- *
+ * Inverts the contents of @set.
  *
  * Since: 0.9.10
  *
@@ -408,11 +427,11 @@ hb_set_invert (hb_set_t *set HB_UNUSED)
 
 /**
  * hb_set_get_population:
- * @set: a set.
+ * @set: A set
  *
- * Returns the number of numbers in the set.
+ * Returns the number of elements in the set.
  *
- * Return value: set population.
+ * Return value: The population of @set
  *
  * Since: 0.9.7
  **/
@@ -424,11 +443,11 @@ hb_set_get_population (const hb_set_t *set)
 
 /**
  * hb_set_get_min:
- * @set: a set.
+ * @set: A set
  *
- * Finds the minimum number in the set.
+ * Finds the smallest element in the set.
  *
- * Return value: minimum of the set, or %HB_SET_VALUE_INVALID if set is empty.
+ * Return value: minimum of @set, or %HB_SET_VALUE_INVALID if @set is empty.
  *
  * Since: 0.9.7
  **/
@@ -440,11 +459,11 @@ hb_set_get_min (const hb_set_t *set)
 
 /**
  * hb_set_get_max:
- * @set: a set.
+ * @set: A set
  *
- * Finds the maximum number in the set.
+ * Finds the largest element in the set.
  *
- * Return value: minimum of the set, or %HB_SET_VALUE_INVALID if set is empty.
+ * Return value: maximum of @set, or %HB_SET_VALUE_INVALID if @set is empty.
  *
  * Since: 0.9.7
  **/
@@ -456,14 +475,15 @@ hb_set_get_max (const hb_set_t *set)
 
 /**
  * hb_set_next:
- * @set: a set.
- * @codepoint: (inout):
+ * @set: A set
+ * @codepoint: (inout): Input = Code point to query
+ *             Output = Code point retrieved
  *
- * Gets the next number in @set that is greater than current value of @codepoint.
+ * Fetches the next element in @set that is greater than current value of @codepoint.
  *
  * Set @codepoint to %HB_SET_VALUE_INVALID to get started.
  *
- * Return value: whether there was a next value.
+ * Return value: %true if there was a next value, false otherwise
  *
  * Since: 0.9.2
  **/
@@ -476,14 +496,15 @@ hb_set_next (const hb_set_t *set,
 
 /**
  * hb_set_previous:
- * @set: a set.
- * @codepoint: (inout):
+ * @set: A set
+ * @codepoint: (inout): Input = Code point to query
+ *             Output = Code point retrieved
  *
- * Gets the previous number in @set that is lower than current value of @codepoint.
+ * Fetches the previous element in @set that is lower than current value of @codepoint.
  *
  * Set @codepoint to %HB_SET_VALUE_INVALID to get started.
  *
- * Return value: whether there was a previous value.
+ * Return value: %true if there was a previous value, false otherwise
  *
  * Since: 1.8.0
  **/
@@ -496,16 +517,17 @@ hb_set_previous (const hb_set_t *set,
 
 /**
  * hb_set_next_range:
- * @set: a set.
- * @first: (out): output first codepoint in the range.
- * @last: (inout): input current last and output last codepoint in the range.
+ * @set: A set
+ * @first: (out): The first code point in the range
+ * @last: (inout): Input = The current last code point in the range
+ *         Output = The last code point in the range
  *
- * Gets the next consecutive range of numbers in @set that
+ * Fetches the next consecutive range of elements in @set that
  * are greater than current value of @last.
  *
  * Set @last to %HB_SET_VALUE_INVALID to get started.
  *
- * Return value: whether there was a next range.
+ * Return value: %true if there was a next range, false otherwise
  *
  * Since: 0.9.7
  **/
@@ -519,16 +541,17 @@ hb_set_next_range (const hb_set_t *set,
 
 /**
  * hb_set_previous_range:
- * @set: a set.
- * @first: (inout): input current first and output first codepoint in the range.
- * @last: (out): output last codepoint in the range.
+ * @set: A set
+ * @first: (inout): Input = The current first code point in the range
+ *         Output = The first code point in the range
+ * @last: (out): The last code point in the range
  *
- * Gets the previous consecutive range of numbers in @set that
- * are less than current value of @first.
+ * Fetches the previous consecutive range of elements in @set that
+ * are greater than current value of @last.
  *
  * Set @first to %HB_SET_VALUE_INVALID to get started.
  *
- * Return value: whether there was a previous range.
+ * Return value: %true if there was a previous range, false otherwise
  *
  * Since: 1.8.0
  **/

--- a/src/hb-set.cc
+++ b/src/hb-set.cc
@@ -122,7 +122,7 @@ hb_set_destroy (hb_set_t *set)
  *
  * Attaches a user-data key/data pair to the specified set.
  *
- * Return value: %true if success, false otherwise
+ * Return value: %true if success, %false otherwise
  *
  * Since: 0.9.2
  **/

--- a/src/hb-set.cc
+++ b/src/hb-set.cc
@@ -117,7 +117,7 @@ hb_set_destroy (hb_set_t *set)
  * @set: A set
  * @key: The user-data key to set
  * @data: A pointer to the user data to set
- * @destroy: A callback to call when @data is not needed anymore
+ * @destroy: (optional): A callback to call when @data is not needed anymore
  * @replace: Whether to replace an existing data with the same key
  *
  * Attaches a user-data key/data pair to the specified set.

--- a/src/hb-set.h
+++ b/src/hb-set.h
@@ -41,6 +41,15 @@ HB_BEGIN_DECLS
  */
 #define HB_SET_VALUE_INVALID ((hb_codepoint_t) -1)
 
+/**
+ * hb_set_t:
+ *
+ * Data type for holding a set of integers. #hb_set_t's are
+ * used to gather and contain glyph IDs, Unicode code
+ * points, and various other collections of discrete 
+ * values.
+ *
+ **/
 typedef struct hb_set_t hb_set_t;
 
 

--- a/src/hb-shape-plan.cc
+++ b/src/hb-shape-plan.cc
@@ -329,7 +329,7 @@ hb_shape_plan_destroy (hb_shape_plan_t *shape_plan)
  * @shape_plan: A shaping plan
  * @key: The user-data key to set
  * @data: A pointer to the user data
- * @destroy: A callback to call when @data is not needed anymore
+ * @destroy: (optional): A callback to call when @data is not needed anymore
  * @replace: Whether to replace an existing data with the same key
  *
  * Attaches a user-data key/data pair to the given shaping plan. 

--- a/src/hb-unicode.cc
+++ b/src/hb-unicode.cc
@@ -276,7 +276,7 @@ hb_unicode_funcs_destroy (hb_unicode_funcs_t *ufuncs)
  * @ufuncs: The Unicode-functions structure
  * @key: The user-data key
  * @data: A pointer to the user data
- * @destroy: A callback to call when @data is not needed anymore
+ * @destroy: (optional): A callback to call when @data is not needed anymore
  * @replace: Whether to replace an existing data with the same key
  *
  * Attaches a user-data key/data pair to the specified Unicode-functions structure. 

--- a/src/hb-unicode.cc
+++ b/src/hb-unicode.cc
@@ -281,7 +281,7 @@ hb_unicode_funcs_destroy (hb_unicode_funcs_t *ufuncs)
  *
  * Attaches a user-data key/data pair to the specified Unicode-functions structure. 
  *
- * Return value: %true if success, false otherwise
+ * Return value: %true if success, %false otherwise
  *
  * Since: 0.9.2
  **/

--- a/src/hb-unicode.h
+++ b/src/hb-unicode.h
@@ -431,7 +431,7 @@ typedef hb_bool_t			(*hb_unicode_decompose_func_t)		(hb_unicode_funcs_t *ufuncs,
  * @ufuncs: A Unicode-functions structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_unicode_combining_class_func_t.
  *
@@ -447,7 +447,7 @@ hb_unicode_funcs_set_combining_class_func (hb_unicode_funcs_t *ufuncs,
  * @ufuncs: A Unicode-functions structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_unicode_general_category_func_t.
  *
@@ -463,7 +463,7 @@ hb_unicode_funcs_set_general_category_func (hb_unicode_funcs_t *ufuncs,
  * @ufuncs: A Unicode-functions structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_unicode_mirroring_func_t.
  *
@@ -479,7 +479,7 @@ hb_unicode_funcs_set_mirroring_func (hb_unicode_funcs_t *ufuncs,
  * @ufuncs: A Unicode-functions structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_unicode_script_func_t.
  *
@@ -495,7 +495,7 @@ hb_unicode_funcs_set_script_func (hb_unicode_funcs_t *ufuncs,
  * @ufuncs: A Unicode-functions structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_unicode_compose_func_t.
  *
@@ -511,7 +511,7 @@ hb_unicode_funcs_set_compose_func (hb_unicode_funcs_t *ufuncs,
  * @ufuncs: A Unicode-functions structure
  * @func: (closure user_data) (destroy destroy) (scope notified): The callback function to assign
  * @user_data: Data to pass to @func
- * @destroy: The function to call when @user_data is not needed anymore
+ * @destroy: (optional): The function to call when @user_data is not needed anymore
  *
  * Sets the implementation function for #hb_unicode_decompose_func_t.
  *


### PR DESCRIPTION
This fills in and adds GTK-Doc inline documentation for several lower-level APIs, namely hb-set, hb-map, hb-common, hb-blob, and hb-buffer. It also propagates some small changes in capitalization and punctuation to existing GTK-Doc comments to look better in the final generated HTML output.