### PR TITLE
Add hb-render to view serialized buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,8 @@ extract_make_variable(HB_BASE_RAGEL_GENERATED_sources ${SRCSOURCES})
 
 extract_make_variable(HB_VIEW_sources ${UTILSOURCES})
 add_prefix_to_list(HB_VIEW_sources "${PROJECT_SOURCE_DIR}/util/")
+extract_make_variable(HB_RENDER_sources ${UTILSOURCES})
+add_prefix_to_list(HB_RENDER_sources "${PROJECT_SOURCE_DIR}/util/")
 extract_make_variable(HB_SHAPE_sources ${UTILSOURCES})
 add_prefix_to_list(HB_SHAPE_sources "${PROJECT_SOURCE_DIR}/util/")
 extract_make_variable(HB_SUBSET_CLI_sources ${UTILSOURCES})
@@ -761,6 +763,9 @@ if (HB_BUILD_UTILS)
 
   add_executable(hb-view ${HB_VIEW_sources})
   target_link_libraries(hb-view harfbuzz ${CAIRO_LIBRARIESNAMES})
+
+  add_executable(hb-render ${HB_RENDER_sources})
+  target_link_libraries(hb-render harfbuzz ${CAIRO_LIBRARIESNAMES})
 
   add_executable(hb-shape ${HB_SHAPE_sources})
   target_link_libraries(hb-shape harfbuzz)

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -41,7 +41,13 @@ hb_view_LDADD = \
 	$(CAIRO_LIBS) \
 	$(CAIRO_FT_LIBS) \
 	$(NULL)
-bin_PROGRAMS += hb-view
+hb_render_SOURCES = $(HB_RENDER_sources)
+hb_render_LDADD = \
+	$(LDADD) \
+	$(CAIRO_LIBS) \
+	$(CAIRO_FT_LIBS) \
+	$(NULL)
+bin_PROGRAMS += hb-view hb-render
 endif # HAVE_CAIRO_FT
 endif # HAVE_FREETYPE
 

--- a/util/Makefile.sources
+++ b/util/Makefile.sources
@@ -14,6 +14,22 @@ HB_VIEW_sources = \
 	view-cairo.hh \
 	$(NULL)
 
+HB_RENDER_sources = \
+	hb-render.cc \
+	options.cc \
+	options.hh \
+	main-font-text.hh \
+	deserialize-consumer.hh \
+	ansi-print.cc \
+	ansi-print.hh \
+	helper-cairo.cc \
+	helper-cairo.hh \
+	helper-cairo-ansi.cc \
+	helper-cairo-ansi.hh \
+	view-cairo.cc \
+	view-cairo.hh \
+	$(NULL)
+
 HB_SHAPE_sources = \
 	hb-shape.cc \
 	options.cc \

--- a/util/deserialize-consumer.hh
+++ b/util/deserialize-consumer.hh
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2019  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ */
+
+#ifndef HB_DESERIALIZE_CONSUMER_HH
+#define HB_DESERIALIZE_CONSUMER_HH
+
+#include "hb.hh"
+#include "options.hh"
+
+
+template <typename output_t>
+struct deserialize_consumer_t
+{
+  deserialize_consumer_t (option_parser_t *parser)
+			: failed (false),
+			  shaper (parser),
+			  output (parser),
+			  font (nullptr),
+			  buffer (nullptr) {}
+
+  void init (hb_buffer_t  *buffer_,
+	     const font_options_t *font_opts)
+  {
+    font = hb_font_reference (font_opts->get_font ());
+    failed = false;
+    buffer = hb_buffer_reference (buffer_);
+
+    output.init (buffer, font_opts);
+  }
+  void consume_line (const char   *text,
+		     unsigned int  text_len,
+		     const char   *text_before,
+		     const char   *text_after)
+  {
+    output.new_line ();
+
+    hb_buffer_deserialize_glyphs (buffer, text, text_len, &text, font, HB_BUFFER_SERIALIZE_FORMAT_TEXT);
+
+    output.consume_glyphs (buffer, text, text_len, shaper.utf8_clusters);
+  }
+  void finish (const font_options_t *font_opts)
+  {
+    output.finish (buffer, font_opts);
+    hb_font_destroy (font);
+    font = nullptr;
+    hb_buffer_destroy (buffer);
+    buffer = nullptr;
+  }
+
+  public:
+  bool failed;
+
+  protected:
+  shape_options_t shaper;
+  output_t output;
+
+  hb_font_t *font;
+  hb_buffer_t *buffer;
+};
+
+
+#endif

--- a/util/hb-render.cc
+++ b/util/hb-render.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2019  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ */
+
+#include "main-font-text.hh"
+#include "deserialize-consumer.hh"
+#include "view-cairo.hh"
+
+#define DEFAULT_FONT_SIZE 256
+#define SUBPIXEL_BITS 6
+
+int
+main (int argc, char **argv)
+{
+  main_font_text_t<deserialize_consumer_t<view_cairo_t>, DEFAULT_FONT_SIZE, SUBPIXEL_BITS> driver;
+  return driver.main (argc, argv);
+}

--- a/util/options.hh
+++ b/util/options.hh
@@ -446,6 +446,58 @@ struct shape_options_t : option_group_t
 };
 
 
+struct deserialize_options_t : option_group_t
+{
+  deserialize_options_t (option_parser_t *parser)
+  {
+    direction = language = script = nullptr;
+    bot = eot = preserve_default_ignorables = remove_default_ignorables = false;
+    features = nullptr;
+    num_features = 0;
+    shapers = nullptr;
+    utf8_clusters = false;
+    invisible_glyph = 0;
+    cluster_level = HB_BUFFER_CLUSTER_LEVEL_DEFAULT;
+    normalize_glyphs = false;
+    verify = false;
+    num_iterations = 1;
+
+    add_options (parser);
+  }
+  virtual ~deserialize_options_t ()
+  {
+    g_free (direction);
+    g_free (language);
+    g_free (script);
+    free (features);
+    g_strfreev (shapers);
+  }
+
+  void add_options (option_parser_t *parser);
+
+  /* Buffer properties */
+  char *direction;
+  char *language;
+  char *script;
+
+  /* Buffer flags */
+  hb_bool_t bot;
+  hb_bool_t eot;
+  hb_bool_t preserve_default_ignorables;
+  hb_bool_t remove_default_ignorables;
+
+  hb_feature_t *features;
+  unsigned int num_features;
+  char **shapers;
+  hb_bool_t utf8_clusters;
+  hb_codepoint_t invisible_glyph;
+  hb_buffer_cluster_level_t cluster_level;
+  hb_bool_t normalize_glyphs;
+  hb_bool_t verify;
+  unsigned int num_iterations;
+};
+
+
 struct font_options_t : option_group_t
 {
   font_options_t (option_parser_t *parser,


### PR DESCRIPTION
Fixes #1480

Occurred to me again while reading --trace output yesterday as I wanted something to see each level change so may something others may need also but the issue is serialized output doesn't contain font size so need some advice I guess.