### PR TITLE
Fix rewinding

### DIFF
--- a/src/hb-iter.hh
+++ b/src/hb-iter.hh
@@ -409,7 +409,7 @@ struct hb_filter_iter_t :
   __item_t__ __item__ () const { return *it; }
   bool __more__ () const { return bool (it); }
   void __next__ () { do ++it; while (it && !hb_has (p.get (), hb_get (f.get (), *it))); }
-  void __prev__ () { --it; }
+  void __prev__ () { do --it; while (it && !hb_has (p.get (), hb_get (f.get (), *it))); }
   hb_filter_iter_t __end__ () const { return hb_filter_iter_t (it.end (), p, f); }
   bool operator != (const hb_filter_iter_t& o) const
   { return it != o.it || p != o.p || f != o.f; }


### PR DESCRIPTION
`__forward__` decreases the length of an array iterator. `__rewind__` also decreases it! That means that any code of the form `p = p - 1` where `p` is backed by an array iterator will get the wrong item from the array and eventually drain the iterator. This has the potential to cause much confusion and frustration. My fix is to keep track of the length of the array before the current index.

`__next__` advances to the next item of a filter iterator that satisfied the predicate. `__prev__` rewinds to the previous item without checking the predicate. My fix is to loop until the predicate is satisfied.