### PR TITLE
[hb-ot-post-table]: Fixed memory leak in get_glyph_from_name()

### DIFF
--- a/src/hb-ot-post-table.hh
+++ b/src/hb-ot-post-table.hh
@@ -170,6 +170,8 @@ struct post
       hb_bytes_t st (name, len);
       const uint16_t *gid = (const uint16_t *) hb_bsearch (hb_addressof (st), gids, count,
 							   sizeof (gids[0]), cmp_key, (void *) this);
+      free(gids);
+
       if (gid)
       {
 	*glyph = *gid;


### PR DESCRIPTION
that on line 163, if the block is not entered, the gids block is not freed and that is indeed a memory leak.

Sign-off-by: Ramin Farajpour Cami <ramin.blackhat@gmail.com>