### PR TITLE
Don't use vsnprintf when HB_NO_BUFFER_MESSAGE is defined

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -2026,7 +2026,10 @@ hb_buffer_set_message_func (hb_buffer_t *buffer,
 bool
 hb_buffer_t::message_impl (hb_font_t *font, const char *fmt, va_list ap)
 {
+#ifdef HB_NO_BUFFER_MESSAGE
+  return false;
+#endif
   char buf[100];
-  vsnprintf (buf, sizeof (buf),  fmt, ap);
+  vsnprintf (buf, sizeof (buf), fmt, ap);
   return (bool) this->message_func (this, font, buf, this->message_data);
 }

--- a/src/hb-config.hh
+++ b/src/hb-config.hh
@@ -52,6 +52,7 @@
 #define HB_DISABLE_DEPRECATED
 #define HB_NDEBUG
 #define HB_NO_ATEXIT
+#define HB_NO_BUFFER_MESSAGE
 #define HB_NO_BUFFER_SERIALIZE
 #define HB_NO_BITMAP
 #define HB_NO_CFF


### PR DESCRIPTION
Fixes #1749