### PR TITLE
This makes minor changes to allow building HarfBuzz with

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -400,7 +400,7 @@ hb_bit_storage (T v)
     return sizeof (unsigned long long) * 8 - __builtin_clzll (v);
 #endif
 
-#if (defined(_MSC_VER) && _MSC_VER >= 1500) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && _MSC_VER >= 1500) || (defined(__MINGW32__) && (__GNUC__ < 4))
   if (sizeof (T) <= sizeof (unsigned int))
   {
     unsigned long where;
@@ -474,7 +474,7 @@ hb_ctz (T v)
     return __builtin_ctzll (v);
 #endif
 
-#if (defined(_MSC_VER) && _MSC_VER >= 1500) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && _MSC_VER >= 1500) || (defined(__MINGW32__) && (__GNUC__ < 4))
   if (sizeof (T) <= sizeof (unsigned int))
   {
     unsigned long where;

--- a/src/hb-atomic.hh
+++ b/src/hb-atomic.hh
@@ -107,7 +107,7 @@ _hb_atomic_ptr_impl_cmplexch (const void **P, const void *O_, const void *N)
 
 static inline void _hb_memory_barrier ()
 {
-#ifndef MemoryBarrier
+#if !defined(MemoryBarrier) && !defined(__MINGW32_VERSION)
   /* MinGW has a convoluted history of supporting MemoryBarrier. */
   LONG dummy = 0;
   InterlockedExchange (&dummy, 1);

--- a/src/hb-uniscribe.cc
+++ b/src/hb-uniscribe.cc
@@ -31,6 +31,10 @@
 #include <usp10.h>
 #include <rpc.h>
 
+#ifndef E_NOT_SUFFICIENT_BUFFER
+#define E_NOT_SUFFICIENT_BUFFER HRESULT_FROM_WIN32 (ERROR_INSUFFICIENT_BUFFER)
+#endif
+
 #include "hb-uniscribe.h"
 
 #include "hb-open-file.hh"

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -183,7 +183,14 @@
 #include <stdarg.h>
 
 #if (defined(_MSC_VER) && _MSC_VER >= 1500) || defined(__MINGW32__)
+#ifdef __MINGW32_VERSION
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
+#include <windows.h>
+#else
 #include <intrin.h>
+#endif
 #endif
 
 #define HB_PASTE1(a,b) a##b


### PR DESCRIPTION
mingw.org's MinGW.

src/hb-algs.hh: Don't compile _BitScanForward and _BitScanReverse
for GCC >= 4.  mingw.org's MinGW doesn't have these functions.

src/hb-atomic.hh: MemoryBarrier does exist in mingw.org's MinGW,
but it is not a macro, it is an inline function.  __MINGW32_VERSION
is a macro that exists only in mingw.org's MinGW, so conditioning
on it should not affect MinGW64, where MemoryBarrier is a macro.

src/hb-uniscribe.cc: Define E_NOT_SUFFICIENT_BUFFER if it is not
defined (mingw.org's MinGW doesn't).

src/hb.hh: Don't include intrin.h for mingw.org's MinGW, since that
header is not available; instead, include windows.h.  Conditioned
on __MINGW32_VERSION to avoid affecting MinGW64.