### PR TITLE
Move HB_NO_SETLOCALE to closer place to its to unbreak HB_TINY build

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -35,6 +35,9 @@
 #include <xlocale.h>
 #endif
 
+#ifdef HB_NO_SETLOCALE
+#define setlocale(Category, Locale) "C"
+#endif
 
 /**
  * SECTION:hb-common

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -372,10 +372,6 @@ static int errno = 0; /* Use something better? */
 #  endif
 #endif
 
-#ifdef HB_NO_SETLOCALE
-#define setlocale(Category, Locale) "C"
-#endif
-
 #ifdef HB_NO_GETENV
 #define getenv(Name) nullptr
 #endif


### PR DESCRIPTION
The only use is in this file, or `#include <locale.h>` should be moved to hb.hh which this seems more efficient