### PR TITLE
[util] Add --reverse and --reverse-clusters options

### DIFF
--- a/util/options.cc
+++ b/util/options.cc
@@ -427,6 +427,8 @@ shape_options_t::add_options (option_parser_t *parser)
     {"utf8-clusters",	0, 0, G_OPTION_ARG_NONE,	&this->utf8_clusters,		"Use UTF8 byte indices, not char indices",	nullptr},
     {"cluster-level",	0, 0, G_OPTION_ARG_INT,		&this->cluster_level,		"Cluster merging level (default: 0)",	"0/1/2"},
     {"normalize-glyphs",0, 0, G_OPTION_ARG_NONE,	&this->normalize_glyphs,	"Rearrange glyph clusters in nominal order",	nullptr},
+    {"reverse",		0, 0, G_OPTION_ARG_NONE,	&this->reverse,			"Reverse output glyphs",	nullptr},
+    {"reverse-clusters",0, 0, G_OPTION_ARG_NONE,	&this->reverse_clusters,	"Reverse output clusters",	nullptr},
     {"verify",		0, 0, G_OPTION_ARG_NONE,	&this->verify,			"Perform sanity checks on shaping results",	nullptr},
     {"num-iterations", 'n', 0, G_OPTION_ARG_INT,		&this->num_iterations,		"Run shaper N times (default: 1)",	"N"},
     {nullptr}

--- a/util/options.hh
+++ b/util/options.hh
@@ -160,6 +160,8 @@ struct shape_options_t : option_group_t
     invisible_glyph = 0;
     cluster_level = HB_BUFFER_CLUSTER_LEVEL_DEFAULT;
     normalize_glyphs = false;
+    reverse = false;
+    reverse_clusters = false;
     verify = false;
     num_iterations = 1;
 
@@ -248,6 +250,12 @@ struct shape_options_t : option_group_t
 
     if (normalize_glyphs)
       hb_buffer_normalize_glyphs (buffer);
+
+    if (reverse)
+      hb_buffer_reverse (buffer);
+
+    if (reverse_clusters)
+      hb_buffer_reverse_clusters (buffer);
 
     if (verify && !verify_buffer (buffer, text_buffer, font, error))
       goto fail;
@@ -442,6 +450,8 @@ struct shape_options_t : option_group_t
   hb_codepoint_t invisible_glyph;
   hb_buffer_cluster_level_t cluster_level;
   hb_bool_t normalize_glyphs;
+  hb_bool_t reverse;
+  hb_bool_t reverse_clusters;
   hb_bool_t verify;
   unsigned int num_iterations;
 };


### PR DESCRIPTION
Calling the corresponding hb_buffer_* functions, can be handy for testing.