### PR TITLE
Canonically reorder U+0C55 and U+0C56

### DIFF
--- a/src/hb-unicode.hh
+++ b/src/hb-unicode.hh
@@ -326,11 +326,11 @@ DECLARE_NULL_INSTANCE (hb_unicode_funcs_t);
  *
  * Modify Telugu length marks (ccc=84, ccc=91).
  * These are the only matras in the main Indic scripts range that have
- * a non-zero ccc.  That makes them reorder with the Halant that is
- * ccc=9.  Just zero them, we don't need them in our Indic shaper.
+ * a non-zero ccc.  That makes them reorder with the Halant (ccc=9).
+ * Assign 5 and 6, which are otherwise unassigned.
  */
-#define HB_MODIFIED_COMBINING_CLASS_CCC84 0 /* length mark */
-#define HB_MODIFIED_COMBINING_CLASS_CCC91 0 /* ai length mark */
+#define HB_MODIFIED_COMBINING_CLASS_CCC84 5 /* length mark */
+#define HB_MODIFIED_COMBINING_CLASS_CCC91 6 /* ai length mark */
 
 /* Thai
  *


### PR DESCRIPTION
Setting ccc=0 for U+0C55 and U+0C56 prevents reordering, which means among a set of canonically equivalent strings like {<0C15, 0C4D, 0C56>, <0C15, 0C56, 0C4D>} some get dotted circles and some don’t. The original reason to override their classes was to make sure U+0C4D TELUGU SIGN VIRAMA doesn’t get reordered before them, to effect which it is sufficient to change their classes to anything less than 9.