### PR TITLE
coretext: remove trailing macro from SCRATCH_RESTORE

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -980,7 +980,7 @@ resize_and_retry:
 
 #define SCRATCH_RESTORE() \
   scratch_size = scratch_size_saved; \
-  scratch = scratch_saved;
+  scratch = scratch_saved
 
       { /* Setup glyphs */
         SCRATCH_SAVE();


### PR DESCRIPTION
Follows up on #1783. While 10bac21bb5b25cf20c2198934e99e444625dfd97 fixed this for `FAIL`, it didn't touch `SCRATCH_RESTORE`, a coretext.cc-only macro which was also affected by the same issue.