### PR TITLE
Add missing cairo-svg dependency to test-ot-color

### DIFF
--- a/src/test-ot-color.cc
+++ b/src/test-ot-color.cc
@@ -25,7 +25,9 @@
 
 #include "hb.hh"
 
-#ifndef HB_NO_COLOR
+#include <cairo.h>
+
+#if !defined(HB_NO_COLOR) && defined(CAIRO_HAS_SVG_SURFACE)
 
 #include "hb-ot.h"
 
@@ -35,7 +37,6 @@
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 
-#include <cairo.h>
 #include <cairo-ft.h>
 #include <cairo-svg.h>
 


### PR DESCRIPTION
Should fix:
```
test-ot-color.cc:40:10: fatal error: cairo-svg.h: No such file or directory
   40 | #include <cairo-svg.h>
      |          ^~~~~~~~~~~~~
```