### PR TITLE
Cast long->size_t to ensure comparison of similar types

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -70,7 +70,7 @@ _hb_options_init ()
         p = c + strlen (c);
 
 #define OPTION(name, symbol) \
-	if (0 == strncmp (c, name, p - c) && strlen (name) == p - c) do { u.opts.symbol = true; } while (0)
+	if (0 == strncmp (c, name, p - c) && strlen (name) == static_cast<size_t>(p - c)) do { u.opts.symbol = true; } while (0)
 
       OPTION ("uniscribe-bug-compatible", uniscribe_bug_compatible);
       OPTION ("aat", aat);


### PR DESCRIPTION
When compiling this for Flutter, we are seeing a failure with comparing `unsigned long` with `long`.