### PR TITLE
Replace create_from_file with empty blob if HB_NO_OPEN is defined

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -38,6 +38,10 @@
 
 using namespace OT;
 
+#ifdef HB_NO_OPEN
+#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#endif
+
 int
 main (int argc, char **argv)
 {

--- a/src/test-buffer-serialize.cc
+++ b/src/test-buffer-serialize.cc
@@ -34,6 +34,10 @@
 
 #include <stdio.h>
 
+#ifdef HB_NO_OPEN
+#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#endif
+
 int
 main (int argc, char **argv)
 {

--- a/src/test-gpos-size-params.cc
+++ b/src/test-gpos-size-params.cc
@@ -31,6 +31,10 @@
 
 #include <stdio.h>
 
+#ifdef HB_NO_OPEN
+#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#endif
+
 int
 main (int argc, char **argv)
 {

--- a/src/test-gsub-would-substitute.cc
+++ b/src/test-gsub-would-substitute.cc
@@ -35,6 +35,10 @@
 #include "hb-ft.h"
 #endif
 
+#ifdef HB_NO_OPEN
+#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#endif
+
 int
 main (int argc, char **argv)
 {

--- a/src/test-ot-color.cc
+++ b/src/test-ot-color.cc
@@ -27,6 +27,10 @@
 
 #include <cairo.h>
 
+#ifdef HB_NO_OPEN
+#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#endif
+
 #if !defined(HB_NO_COLOR) && defined(CAIRO_HAS_SVG_SURFACE)
 
 #include "hb-ot.h"

--- a/src/test-ot-name.cc
+++ b/src/test-ot-name.cc
@@ -30,6 +30,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifdef HB_NO_OPEN
+#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#endif
+
 int
 main (int argc, char **argv)
 {

--- a/src/test.cc
+++ b/src/test.cc
@@ -34,6 +34,10 @@
 #include "hb-ft.h"
 #endif
 
+#ifdef HB_NO_OPEN
+#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#endif
+
 int
 main (int argc, char **argv)
 {


### PR DESCRIPTION
In order to compile the library however HB_NO_OPEN is also needed in CFLAGS... let me revert the change so we decide which to pick