### PR TITLE
Turn create_from_file into an empty call if HB_NO_OPEN is defined

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -677,4 +677,10 @@ fread_fail_without_close:
   free (data);
   return hb_blob_get_empty ();
 }
-#endif /* !HB_NO_OPEN */
+#else /* !HB_NO_OPEN */
+hb_blob_t *
+hb_blob_create_from_file (const char *file_name)
+{
+  return hb_blob_get_empty ();
+}
+#endif


### PR DESCRIPTION
Let's decide which to pick, this or #1791