### PR TITLE
add bimap test

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -374,7 +374,7 @@ dump_use_data_SOURCES = dump-use-data.cc hb-ot-shape-complex-use-table.cc
 dump_use_data_CPPFLAGS = $(HBCFLAGS)
 dump_use_data_LDADD = libharfbuzz.la $(HBLIBS)
 
-COMPILED_TESTS = test-algs test-iter test-meta test-ot-tag test-unicode-ranges
+COMPILED_TESTS = test-algs test-iter test-meta test-ot-tag test-unicode-ranges test-bimap
 COMPILED_TESTS_CPPFLAGS = $(HBCFLAGS) -DMAIN -UNDEBUG
 COMPILED_TESTS_LDADD = libharfbuzz.la $(HBLIBS)
 check_PROGRAMS += $(COMPILED_TESTS)
@@ -399,6 +399,10 @@ test_ot_tag_LDADD = $(COMPILED_TESTS_LDADD)
 test_unicode_ranges_SOURCES = test-unicode-ranges.cc
 test_unicode_ranges_CPPFLAGS = $(COMPILED_TESTS_CPPFLAGS)
 test_unicode_ranges_LDADD = $(COMPILED_TESTS_LDADD)
+
+test_bimap_SOURCES = test-bimap.cc hb-static.cc
+test_bimap_CPPFLAGS = $(COMPILED_TESTS_CPPFLAGS)
+test_bimap_LDADD = $(COMPILED_TESTS_LDADD)
 
 TESTS_ENVIRONMENT = \
 	srcdir="$(srcdir)" \

--- a/src/hb-bimap.hh
+++ b/src/hb-bimap.hh
@@ -28,6 +28,7 @@
 #define HB_BIMAP_HH
 
 #include "hb.hh"
+#include "hb-map.hh"
 
 /* Bi-directional map */
 struct hb_bimap_t
@@ -57,6 +58,8 @@ struct hb_bimap_t
 
   void set (hb_codepoint_t lhs, hb_codepoint_t rhs)
   {
+    if (unlikely (lhs == HB_MAP_VALUE_INVALID)) return;
+    if (unlikely (rhs == HB_MAP_VALUE_INVALID)) { del (lhs); return; }
     forw_map.set (lhs, rhs);
     back_map.set (rhs, lhs);
   }
@@ -131,6 +134,7 @@ struct hb_inc_bimap_t : hb_bimap_t
   
     work.qsort (cmp_id);
   
+    clear ();
     for (hb_codepoint_t rhs = 0; rhs < count; rhs++)
       set (work[rhs], rhs);
   }

--- a/src/test-bimap.cc
+++ b/src/test-bimap.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2019  Adobe, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Adobe Author(s): Michiharu Ariza
+ */
+
+#include "hb.hh"
+#include "hb-bimap.hh"
+
+int
+main (int argc, char **argv)
+{
+  hb_bimap_t	bm;
+
+  assert (bm.is_empty () == true);
+  bm.set (1, 4);
+  bm.set (2, 5);
+  bm.set (3, 6);
+  assert (bm.get_population () == 3);
+  assert (bm.has (1) == true);
+  assert (bm.has (4) == false);
+  assert (bm[2] == 5);
+  assert (bm.backward (6) == 3);
+  bm.del (1);
+  assert (bm.has (1) == false);
+  assert (bm.has (3) == true);
+  bm.clear ();
+  assert (bm.get_population () == 0);
+
+  hb_inc_bimap_t  ibm;
+
+  assert (ibm.add (13) == 0);
+  assert (ibm.add (8) == 1);
+  assert (ibm.add (10) == 2);
+  assert (ibm.add (8) == 1);
+  assert (ibm.add (7) == 3);
+  assert (ibm.get_population () == 4);
+  assert (ibm[7] == 3);
+
+  ibm.sort ();
+  assert (ibm.get_population () == 4);
+  assert (ibm[7] == 0);
+  assert (ibm[13] == 3);
+
+  ibm.identity (3);
+  assert (ibm.get_population () == 3);
+  assert (ibm[0] == 0);
+  assert (ibm[1] == 1);
+  assert (ibm[2] == 2);
+  assert (ibm.backward (0) == 0);
+  assert (ibm.backward (1) == 1);
+  assert (ibm.backward (2) == 2);
+  assert (ibm.has (4) == false);
+
+  return 0;
+}


### PR DESCRIPTION
fixed a bug in `hb_inc_bimap_t::sort()` exposed by the test
modified `hb_bimap_t::set()` to delete an existing entry if given an invalid value. ignore call if given an invalid key
edited `hb-bimap.hh` to include `hb-map.hh` as 'hb.hh` doesn't include it for us
