### PR TITLE
Make harfbuzz working on all existing versions of Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -376,7 +376,7 @@ if test "x$with_directwrite" = "xyes" -a "x$have_directwrite" != "xtrue"; then
 fi
 if $have_directwrite; then
 	DIRECTWRITE_CXXFLAGS=
-	DIRECTWRITE_LIBS="-ldwrite"
+	DIRECTWRITE_LIBS=
 	AC_SUBST(DIRECTWRITE_CXXFLAGS)
 	AC_SUBST(DIRECTWRITE_LIBS)
 	AC_DEFINE(HAVE_DIRECTWRITE, 1, [Have DirectWrite library])

--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -167,8 +167,8 @@ _hb_directwrite_shaper_face_data_create (hb_face_t *face)
     return nullptr; \
   } HB_STMT_END
 
-  data->dwrite_dll = LoadLibrary(TEXT("DWRITE"));
-  if (data->dwrite_dll == NULL)
+  data->dwrite_dll = LoadLibrary (TEXT ("DWRITE"));
+  if (unlikely (!data->dwrite_dll))
     FAIL ("Cannot find DWrite.DLL");
 
   t_DWriteCreateFactory p_DWriteCreateFactory;
@@ -179,13 +179,13 @@ _hb_directwrite_shaper_face_data_create (hb_face_t *face)
 #endif
 
   p_DWriteCreateFactory = (t_DWriteCreateFactory)
-	GetProcAddress(data->dwrite_dll, "DWriteCreateFactory");
+			  GetProcAddress (data->dwrite_dll, "DWriteCreateFactory");
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 
-  if (p_DWriteCreateFactory == NULL)
+  if (unlikely (!p_DWriteCreateFactory))
     FAIL ("Cannot find DWriteCreateFactory().");
 
   HRESULT hr;
@@ -193,9 +193,9 @@ _hb_directwrite_shaper_face_data_create (hb_face_t *face)
   // TODO: factory and fontFileLoader should be cached separately
   IDWriteFactory* dwriteFactory;
   hr = p_DWriteCreateFactory (DWRITE_FACTORY_TYPE_SHARED, __uuidof (IDWriteFactory),
-		       (IUnknown**) &dwriteFactory);
+			      (IUnknown**) &dwriteFactory);
 
-  if (hr != S_OK)
+  if (unlikely (hr != S_OK))
     FAIL ("Failed to run DWriteCreateFactory().");
 
   hb_blob_t *blob = hb_face_reference_blob (face);
@@ -257,8 +257,8 @@ _hb_directwrite_shaper_face_data_destroy (hb_directwrite_face_data_t *data)
     delete data->fontFileStream;
   if (data->faceBlob)
     hb_blob_destroy (data->faceBlob);
-  if (data->dwrite_dll != NULL)
-    FreeLibrary(data->dwrite_dll);
+  if (data->dwrite_dll)
+    FreeLibrary (data->dwrite_dll);
   if (data)
     delete data;
 }

--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -28,7 +28,7 @@
 
 #include "hb-shaper-impl.hh"
 
-#include <DWrite_1.h>
+#include <dwrite_1.h>
 
 #include "hb-directwrite.h"
 

--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -173,8 +173,18 @@ _hb_directwrite_shaper_face_data_create (hb_face_t *face)
 
   t_DWriteCreateFactory p_DWriteCreateFactory;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+
   p_DWriteCreateFactory = (t_DWriteCreateFactory)
 	GetProcAddress(data->dwrite_dll, "DWriteCreateFactory");
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
   if (p_DWriteCreateFactory == NULL)
     FAIL ("Cannot find DWriteCreateFactory().");
 


### PR DESCRIPTION
I discovered that harfbuzz is blocking the execution of KICAD EDA (http://kicad-pcb.org/) on Windows XP.
This happens because the library is linked for loading DWRITE.DLL implicitely, which works fine on Windows 7 but this blocks the execution on older versions, since this library does not exists.
I would like to suggest a minimal change for checking at runtime the presence of DirectWrite support on the running platform. Together with this fix, I also included few little improvements (check return value of the creator and fix case of included PSDK file names), which are descripted in the commits.
I hope that you will find this useful.

Sincerely.

