### PR TITLE
Fix C++20 compile warning on implicit capture of this with '=' default capture

### DIFF
--- a/src/hb-ot-layout-gpos-table.hh
+++ b/src/hb-ot-layout-gpos-table.hh
@@ -733,7 +733,7 @@ struct PairPosFormat1
     + hb_zip (this+coverage, pairSet)
     | hb_filter (*glyphs, hb_first)
     | hb_map (hb_second)
-    | hb_map ([=] (const OffsetTo<PairSet> &_)
+    | hb_map ([glyphs, this] (const OffsetTo<PairSet> &_)
 	      { return (this+_).intersects (glyphs, valueFormat); })
     | hb_any
     ;


### PR DESCRIPTION
Happens when compiled with `-std=c++2a`, the fix just makes the captures explicit to resolve the issue. Just adding `this` in addition to `=` doesn't work in C++11.

```
src/hb-ot-layout-gpos-table.hh:737:18: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
              { return (this+_).intersects (glyphs, valueFormat); })
                        ^
src/hb-ot-layout-gpos-table.hh:736:16: note: add an explicit capture of 'this' to capture '*this' by reference
    | hb_map ([=] (const OffsetTo<PairSet> &_)
               ^
                , this
```