### PR TITLE
Revert "[Myanmar] Prevent reordering between Asat and Dot below"

### DIFF
--- a/src/hb-unicode.hh
+++ b/src/hb-unicode.hh
@@ -105,9 +105,6 @@ HB_UNICODE_FUNCS_IMPLEMENT_CALLBACKS_SIMPLE
   unsigned int
   modified_combining_class (hb_codepoint_t u)
   {
-    /* XXX This hack belongs to the Myanmar shaper. */
-    if (unlikely (u == 0x1037u)) u = 0x103Au;
-
     /* XXX This hack belongs to the USE shaper (for Tai Tham):
      * Reorder SAKOT to ensure it comes after any tone marks. */
     if (unlikely (u == 0x1A60u)) return 254;


### PR DESCRIPTION
This reverts commit 1c8654ead41ca746d577549c92d2a41c594ab639. It is a simpler alternative to #1778. I don’t think fonts should rely on input strings not being normalized.