### PR TITLE
Implement meta table parsing

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -88,6 +88,7 @@ HB_BASE_sources = \
 	hb-ot-math-table.hh \
 	hb-ot-math.cc \
 	hb-ot-maxp-table.hh \
+	hb-ot-meta-table.hh \
 	hb-ot-metrics.cc \
 	hb-ot-metrics.hh \
 	hb-ot-name-language-static.hh \

--- a/src/hb-ot-face-table-list.hh
+++ b/src/hb-ot-face-table-list.hh
@@ -62,6 +62,7 @@ HB_OT_ACCELERATOR (OT, name)
 #ifndef HB_NO_STAT
 HB_OT_TABLE (OT, STAT)
 #endif
+HB_OT_TABLE (OT, meta)
 
 /* Vertical layout. */
 HB_OT_TABLE (OT, vhea)

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -48,6 +48,7 @@
 #include "hb-ot-layout-gpos-table.hh"
 #include "hb-ot-layout-base-table.hh" // Just so we compile it; unused otherwise.
 #include "hb-ot-layout-jstf-table.hh" // Just so we compile it; unused otherwise.
+#include "hb-ot-meta-table.hh" // Just so we compile it; unused otherwise.
 #include "hb-ot-name-table.hh"
 #include "hb-ot-os2-table.hh"
 
@@ -108,7 +109,7 @@ hb_ot_layout_has_machine_kerning (hb_face_t *face)
  *
  * Tests whether a face has any cross-stream kerning (i.e., kerns
  * that make adjustments perpendicular to the direction of the text
- * flow: Y adjustments in horizontal text or X adjustments in 
+ * flow: Y adjustments in horizontal text or X adjustments in
  * vertical text) in the 'kern' table.
  *
  * Does NOT examine the GPOS table.
@@ -285,7 +286,7 @@ hb_ot_layout_has_glyph_classes (hb_face_t *face)
  *
  * Fetches the GDEF class of the requested glyph in the specified face.
  *
- * Return value: The #hb_ot_layout_glyph_class_t glyph class of the given code 
+ * Return value: The #hb_ot_layout_glyph_class_t glyph class of the given code
  * point in the GDEF table of the face.
  *
  * Since: 0.9.7
@@ -329,7 +330,7 @@ hb_ot_layout_get_glyphs_in_class (hb_face_t                  *face,
  * @point_array: (out) (array length=point_count): The array of attachment points found for the query
  *
  * Fetches a list of all attachment points for the specified glyph in the GDEF
- * table of the face. The list returned will begin at the offset provided. 
+ * table of the face. The list returned will begin at the offset provided.
  *
  * Useful if the client program wishes to cache the list.
  *
@@ -979,7 +980,7 @@ hb_ot_layout_feature_get_lookups (hb_face_t    *face,
  * @face: #hb_face_t to work upon
  * @table_tag: HB_OT_TAG_GSUB or HB_OT_TAG_GPOS
  *
- * Fetches the total number of lookups enumerated in the specified 
+ * Fetches the total number of lookups enumerated in the specified
  * face's GSUB table or GPOS table.
  *
  * Since: 0.9.22
@@ -1187,7 +1188,7 @@ hb_ot_layout_collect_features (hb_face_t      *face,
  * table or GPOS table, underneath the specified scripts, languages, and
  * features. If no list of scripts is provided, all scripts will be queried.
  * If no list of languages is provided, all languages will be queried. If no
- * list of features is provided, all features will be queried. 
+ * list of features is provided, all features will be queried.
  *
  * Since: 0.9.8
  **/
@@ -1581,7 +1582,7 @@ hb_ot_layout_position_finish_offsets (hb_font_t *font, hb_buffer_t *buffer)
  * as used here are defined as pertaining only to fonts within a font family that differ
  * specifically in their respective size ranges; other ways to differentiate fonts within
  * a subfamily are not covered by the `size` feature.
- * 
+ *
  * For more information on this distinction, see the `size` documentation at
  * https://docs.microsoft.com/en-us/typography/opentype/spec/features_pt#tag-39size39
  *
@@ -1723,7 +1724,7 @@ hb_ot_layout_feature_get_name_ids (hb_face_t       *face,
  *       returned. This function can be called with incrementally larger start_offset
  *       until the char_count output value is lower than its input value, or the size
  *       of the characters array can be increased.</note>
- * 
+ *
  * Return value: Number of total sample characters in the cvXX feature.
  *
  * Since: 2.0.0

--- a/src/hb-ot-meta-table.hh
+++ b/src/hb-ot-meta-table.hh
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2019  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#ifndef HB_OT_META_TABLE_HH
+#define HB_OT_META_TABLE_HH
+
+#include "hb-open-type.hh"
+
+/*
+ * meta -- Metadata Table
+ * https://docs.microsoft.com/en-us/typography/opentype/spec/meta
+ * https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6meta.html
+ */
+#define HB_OT_TAG_meta HB_TAG('m','e','t','a')
+
+
+namespace OT {
+
+
+struct DataMap
+{
+  bool sanitize (hb_sanitize_context_t *c, const void *base) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (likely (c->check_struct (this) &&
+			  dataZ.sanitize (c, base, dataLength)));
+  }
+
+  protected:
+  Tag		tag;		/* A tag indicating the type of metadata. */
+  LOffsetTo<UnsizedArrayOf<HBUINT8>>
+		dataZ;		/* Offset in bytes from the beginning of the
+				 * metadata table to the data for this tag. */
+  HBUINT32	dataLength;	/* Length of the data. The data is not required to
+				 * be padded to any byte boundary. */
+  public:
+  DEFINE_SIZE_STATIC (12);
+};
+
+struct meta
+{
+  static constexpr hb_tag_t tableTag = HB_OT_TAG_meta;
+
+  bool sanitize (hb_sanitize_context_t *c) const
+  {
+    TRACE_SANITIZE (this);
+    return_trace (likely (c->check_struct (this) &&
+			  version == 1 &&
+			  dataMaps.sanitize (c, this)));
+  }
+
+  protected:
+  HBUINT32	version;	/* Version number of the metadata table — set to 1. */
+  HBUINT32	flags;		/* Flags — currently unused; set to 0. */
+  HBUINT32	dataOffset;	/* Per Apple specification:
+				 * Offset from the beginning of the table to the data.
+				 * Per OT specification:
+				 * Reserved. Not used; should be set to 0. */
+  LArrayOf<DataMap>
+		dataMaps;	/* Array of data map records. */
+  public:
+  DEFINE_SIZE_ARRAY (16, dataMaps);
+};
+
+} /* namespace OT */
+
+
+#endif /* HB_OT_META_TABLE_HH */


### PR DESCRIPTION
As "Determining whether a font is CJK (Chinese, Japanese, or Korean) or not, as in the second-last “Else” clause above, can be done by checking the 'dlng' entry (if present) of the 'meta' table, the CJK-related bits of the OS/2.ulUnicodeRange fields, or the OS/2.ulCodePageRange fields." on https://docs.microsoft.com/en-us/typography/opentype/spec/baselinetags#ideographic-em-box we need to parse and understand this table to check if a font is CJK. Fortunately it is already implemented on fonttools https://github.com/fonttools/fonttools/blob/master/Lib/fontTools/ttLib/tables/_m_e_t_a.py