### PR TITLE
[cmake] Fix CMake build on newer CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,8 +142,8 @@ endif ()
 
 ## Extract variables from Makefile files
 function (extract_make_variable variable makefile_source)
-  string(REGEX MATCH "${variable} = ([^$]+)\\$" temp ${makefile_source})
-  string(REGEX MATCHALL "[^ \n\t\\]+" listVar ${CMAKE_MATCH_1})
+  string(REGEX MATCH "${variable} = ([^$]+)\\$" temp "${makefile_source}")
+  string(REGEX MATCHALL "[^ \n\t\\]+" listVar "${CMAKE_MATCH_1}")
   set (${variable} ${listVar} PARENT_SCOPE)
 endfunction ()
 


### PR DESCRIPTION
Unfortunately, newer CMake versions die during regex variable extraction, causing the build to fail.

This is caused by the lack of escaping used around variables in the extract_make_variable function, causing these variables to be automatically unwrapped into empty strings.

```
CMake Error at CMakeLists.txt:106 (string):
  string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:118 (extract_make_variable)```