### PR TITLE
Remove hb_directwrite_shape_experimental_width public API

### DIFF
--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -879,29 +879,12 @@ _hb_directwrite_shape (hb_shape_plan_t    *shape_plan,
 				     features, num_features, 0);
 }
 
-/**
- * hb_directwrite_shape_experimental_width:
- * Experimental API to test DirectWrite's justification algorithm.
- *
- * It inserts Kashida at wrong order so don't use the API ever.
- *
- * It doesn't work with cygwin/msys due to header bugs so one
- * should use MSVC toolchain in order to use it for now.
- *
- * @font:
- * @buffer:
- * @features:
- * @num_features:
- * @width:
- *
- * Since: 1.4.2
- **/
-hb_bool_t
-hb_directwrite_shape_experimental_width (hb_font_t          *font,
-					 hb_buffer_t        *buffer,
-					 const hb_feature_t *features,
-					 unsigned int        num_features,
-					 float               width)
+HB_UNUSED static bool
+_hb_directwrite_shape_experimental_width (hb_font_t          *font,
+					  hb_buffer_t        *buffer,
+					  const hb_feature_t *features,
+					  unsigned int        num_features,
+					  float               width)
 {
   static const char *shapers = "directwrite";
   hb_shape_plan_t *shape_plan;

--- a/src/hb-directwrite.h
+++ b/src/hb-directwrite.h
@@ -29,11 +29,6 @@
 
 HB_BEGIN_DECLS
 
-HB_EXTERN hb_bool_t
-hb_directwrite_shape_experimental_width (hb_font_t *font, hb_buffer_t *buffer,
-					 const hb_feature_t *features,
-					 unsigned int num_features, float width);
-
 HB_EXTERN hb_face_t *
 hb_directwrite_face_create (IDWriteFontFace *font_face);
 


### PR DESCRIPTION
I've specially exposed the API as I didn't know how to embed harfbuzz
easily elsewhere but now with harfbuzz.cc it has become very easy
and I don't like to see its use anywhere as it has a bad naming and
its Kashida adding is bogus and only useful to check where it should
be added not visually useful.

https://github.com/harfbuzz/harfbuzz/issues/1849#issuecomment-515232748 related