### PR TITLE
Use strtod in CFF::dict_opset_t::parse_bcd

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -38,6 +38,8 @@ HB_BASE_sources = \
 	hb-face.cc \
 	hb-face.hh \
 	hb-fallback-shape.cc \
+	hb-float.cc \
+	hb-float.hh \
 	hb-font.cc \
 	hb-font.hh \
 	hb-iter.hh \
@@ -241,6 +243,8 @@ HB_ICU_headers = hb-icu.h
 
 # Sources for libharfbuzz-subset
 HB_SUBSET_sources = \
+	hb-float.cc \
+	hb-float.hh \
 	hb-ot-cff1-table.cc \
 	hb-ot-cff2-table.cc \
 	hb-static.cc \

--- a/src/harfbuzz.cc
+++ b/src/harfbuzz.cc
@@ -6,6 +6,7 @@
 #include "hb-common.cc"
 #include "hb-face.cc"
 #include "hb-fallback-shape.cc"
+#include "hb-float.cc"
 #include "hb-font.cc"
 #include "hb-map.cc"
 #include "hb-ot-cff1-table.cc"

--- a/src/hb-cff-interp-dict-common.hh
+++ b/src/hb-cff-interp-dict-common.hh
@@ -27,6 +27,7 @@
 #define HB_CFF_INTERP_DICT_COMMON_HH
 
 #include "hb-cff-interp-common.hh"
+#include "hb-float.hh"
 #include <math.h>
 #include <float.h>
 
@@ -75,37 +76,6 @@ struct top_dict_values_t : dict_values_t<OPSTR>
   unsigned int  FDArrayOffset;
 };
 
-/* Compile time calculating 10^n for n = 2^i */
-constexpr double
-pow10_of_2i (unsigned int n)
-{
-  return n == 1 ? 10. : pow10_of_2i (n >> 1) * pow10_of_2i (n >> 1);
-}
-
-static const double powers_of_10[] =
-{
-  pow10_of_2i (0x100),
-  pow10_of_2i (0x80),
-  pow10_of_2i (0x40),
-  pow10_of_2i (0x20),
-  pow10_of_2i (0x10),
-  pow10_of_2i (0x8),
-  pow10_of_2i (0x4),
-  pow10_of_2i (0x2),
-  pow10_of_2i (0x1),
-};
-
-/* Works for x < 512 */
-inline double
-_hb_pow10 (unsigned int x)
-{
-  unsigned int mask = 0x100; /* Should be same with the first element  */
-  unsigned long result = 1;
-  const double *power = powers_of_10;
-  for (; mask; ++power, mask >>= 1) if (mask & x) result *= *power;
-  return result;
-}
-
 struct dict_opset_t : opset_t<number_t>
 {
   static void process_op (op_code_t op, interp_env_t<number_t>& env)
@@ -125,130 +95,67 @@ struct dict_opset_t : opset_t<number_t>
     }
   }
 
+  /* Turns CFF's BCD format into strtod understandable string */
   static double parse_bcd (byte_str_ref_t& str_ref)
   {
-    bool    neg = false;
-    double  int_part = 0;
-    uint64_t frac_part = 0;
-    uint32_t  frac_count = 0;
-    bool    exp_neg = false;
-    uint32_t  exp_part = 0;
-    bool    exp_overflow = false;
-    enum Part { INT_PART=0, FRAC_PART, EXP_PART } part = INT_PART;
+    hb_vector_t<char> buf;
     enum Nibble { DECIMAL=10, EXP_POS, EXP_NEG, RESERVED, NEG, END };
-    const uint64_t MAX_FRACT = 0xFFFFFFFFFFFFFull; /* 1^52-1 */
-    const uint32_t MAX_EXP = 0x7FFu; /* 1^11-1 */
-
-    double  value = 0.0;
     unsigned char byte = 0;
-    for (uint32_t i = 0;; i++)
+
+    if (unlikely (str_ref.in_error ())) goto fail;
+    for (unsigned i = 0;; i++)
     {
-      char d;
-      if ((i & 1) == 0)
+      char nibble;
+      if (!(i & 1))
       {
-	if (!str_ref.avail ())
-	{
-	  str_ref.set_error ();
-	  return 0.0;
-	}
+	if (!str_ref.avail ()) goto fail;
+
 	byte = str_ref[0];
 	str_ref.inc ();
-	d = byte >> 4;
+	nibble = byte >> 4;
       }
       else
-	d = byte & 0x0F;
+	nibble = byte & 0x0F;
 
-      switch (d)
+      switch (nibble)
       {
-	case RESERVED:
-	  str_ref.set_error ();
-	  return value;
+      case RESERVED:
+	goto fail;
 
-	case END:
-	  value = (double) (neg ? -int_part : int_part);
-	  if (frac_count > 0)
-	  {
-	    double frac = frac_part / _hb_pow10 (frac_count);
-	    if (neg) frac = -frac;
-	    value += frac;
-	  }
-	  if (unlikely (exp_overflow))
-	  {
-	    if (value == 0.0)
-	      return value;
-	    if (exp_neg)
-	      return neg ? -DBL_MIN : DBL_MIN;
-	    else
-	      return neg ? -DBL_MAX : DBL_MAX;
-	  }
-	  if (exp_part != 0)
-	  {
-	    if (exp_neg)
-	      value /= _hb_pow10 (exp_part);
-	    else
-	      value *= _hb_pow10 (exp_part);
-	  }
-	  return value;
+      case END:
+      {
+	const char *p = buf.arrayZ;
+	float pv;
+	if (unlikely (!parse_float (&p, p + buf.length, &pv))) goto fail;
+	return (double) pv;
+      }
 
-	case NEG:
-	  if (i != 0)
-	  {
-	    str_ref.set_error ();
-	    return 0.0;
-	  }
-	  neg = true;
-	  break;
+      case NEG:
+	buf.push ('-');
+	break;
 
-	case DECIMAL:
-	  if (part != INT_PART)
-	  {
-	    str_ref.set_error ();
-	    return value;
-	  }
-	  part = FRAC_PART;
-	  break;
+      case DECIMAL:
+	buf.push ('.');
+	break;
 
-	case EXP_NEG:
-	  exp_neg = true;
-	  HB_FALLTHROUGH;
+      case EXP_POS:
+	buf.push ('e');
+	break;
 
-	case EXP_POS:
-	  if (part == EXP_PART)
-	  {
-	    str_ref.set_error ();
-	    return value;
-	  }
-	  part = EXP_PART;
-	  break;
+      case EXP_NEG:
+	buf.push ('e');
+	buf.push ('-');
+	break;
 
-	default:
-	  switch (part) {
-	    default:
-	    case INT_PART:
-	      int_part = (int_part * 10) + d;
-	      break;
-
-	    case FRAC_PART:
-	      if (likely (frac_part <= MAX_FRACT / 10))
-	      {
-		frac_part = (frac_part * 10) + (unsigned)d;
-		frac_count++;
-	      }
-	      break;
-
-	    case EXP_PART:
-	      if (likely (exp_part * 10 + d <= MAX_EXP))
-	      {
-	      	exp_part = (exp_part * 10) + d;
-	      }
-	      else
-	      	exp_overflow = true;
-	      break;
-	  }
+      default:
+	buf.push ('0' + nibble);
+	break;
       }
     }
 
-    return value;
+fail:
+    str_ref.set_error ();
+    return .0;
   }
 
   static bool is_hint_op (op_code_t op)

--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -28,6 +28,8 @@
 
 #include "hb.hh"
 
+#include "hb-float.hh"
+
 #include "hb-machinery.hh"
 
 #include <locale.h>
@@ -759,89 +761,6 @@ parse_uint32 (const char **pp, const char *end, uint32_t *pv)
    * -1 turns into "big number"... */
   errno = 0;
   v = strtol (p, &pend, 10);
-  if (errno || p == pend)
-    return false;
-
-  *pv = v;
-  *pp += pend - p;
-  return true;
-}
-
-#if defined (HAVE_NEWLOCALE) && defined (HAVE_STRTOD_L)
-#define USE_XLOCALE 1
-#define HB_LOCALE_T locale_t
-#define HB_CREATE_LOCALE(locName) newlocale (LC_ALL_MASK, locName, nullptr)
-#define HB_FREE_LOCALE(loc) freelocale (loc)
-#elif defined(_MSC_VER)
-#define USE_XLOCALE 1
-#define HB_LOCALE_T _locale_t
-#define HB_CREATE_LOCALE(locName) _create_locale (LC_ALL, locName)
-#define HB_FREE_LOCALE(loc) _free_locale (loc)
-#define strtod_l(a, b, c) _strtod_l ((a), (b), (c))
-#endif
-
-#ifdef USE_XLOCALE
-
-#if HB_USE_ATEXIT
-static void free_static_C_locale ();
-#endif
-
-static struct hb_C_locale_lazy_loader_t : hb_lazy_loader_t<hb_remove_pointer<HB_LOCALE_T>,
-							  hb_C_locale_lazy_loader_t>
-{
-  static HB_LOCALE_T create ()
-  {
-    HB_LOCALE_T C_locale = HB_CREATE_LOCALE ("C");
-
-#if HB_USE_ATEXIT
-    atexit (free_static_C_locale);
-#endif
-
-    return C_locale;
-  }
-  static void destroy (HB_LOCALE_T p)
-  {
-    HB_FREE_LOCALE (p);
-  }
-  static HB_LOCALE_T get_null ()
-  {
-    return nullptr;
-  }
-} static_C_locale;
-
-#if HB_USE_ATEXIT
-static
-void free_static_C_locale ()
-{
-  static_C_locale.free_instance ();
-}
-#endif
-
-static HB_LOCALE_T
-get_C_locale ()
-{
-  return static_C_locale.get_unconst ();
-}
-#endif /* USE_XLOCALE */
-
-static bool
-parse_float (const char **pp, const char *end, float *pv)
-{
-  char buf[32];
-  unsigned int len = hb_min (ARRAY_LENGTH (buf) - 1, (unsigned int) (end - *pp));
-  strncpy (buf, *pp, len);
-  buf[len] = '\0';
-
-  char *p = buf;
-  char *pend = p;
-  float v;
-
-  errno = 0;
-#ifdef USE_XLOCALE
-  v = strtod_l (p, &pend, get_C_locale ());
-#else
-  v = strtod (p, &pend);
-#endif
   if (errno || p == pend)
     return false;
 

--- a/src/hb-float.cc
+++ b/src/hb-float.cc
@@ -1,0 +1,116 @@
+
+/*
+ * Copyright © 2019  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ */
+
+#include "hb-float.hh"
+#include "hb-machinery.hh"
+
+#include <locale.h>
+#ifdef HAVE_XLOCALE_H
+#include <xlocale.h>
+#endif
+
+#if defined (HAVE_NEWLOCALE) && defined (HAVE_STRTOD_L)
+#define USE_XLOCALE 1
+#define HB_LOCALE_T locale_t
+#define HB_CREATE_LOCALE(locName) newlocale (LC_ALL_MASK, locName, nullptr)
+#define HB_FREE_LOCALE(loc) freelocale (loc)
+#elif defined(_MSC_VER)
+#define USE_XLOCALE 1
+#define HB_LOCALE_T _locale_t
+#define HB_CREATE_LOCALE(locName) _create_locale (LC_ALL, locName)
+#define HB_FREE_LOCALE(loc) _free_locale (loc)
+#define strtod_l(a, b, c) _strtod_l ((a), (b), (c))
+#endif
+
+#ifdef USE_XLOCALE
+
+#if HB_USE_ATEXIT
+static void free_static_C_locale ();
+#endif
+
+static struct hb_C_locale_lazy_loader_t : hb_lazy_loader_t<hb_remove_pointer<HB_LOCALE_T>,
+							  hb_C_locale_lazy_loader_t>
+{
+  static HB_LOCALE_T create ()
+  {
+    HB_LOCALE_T C_locale = HB_CREATE_LOCALE ("C");
+
+#if HB_USE_ATEXIT
+    atexit (free_static_C_locale);
+#endif
+
+    return C_locale;
+  }
+  static void destroy (HB_LOCALE_T p)
+  {
+    HB_FREE_LOCALE (p);
+  }
+  static HB_LOCALE_T get_null ()
+  {
+    return nullptr;
+  }
+} static_C_locale;
+
+#if HB_USE_ATEXIT
+static
+void free_static_C_locale ()
+{
+  static_C_locale.free_instance ();
+}
+#endif
+
+static HB_LOCALE_T
+get_C_locale ()
+{
+  return static_C_locale.get_unconst ();
+}
+#endif /* USE_XLOCALE */
+
+bool
+parse_float (const char **pp, const char *end, float *pv)
+{
+  char buf[32];
+  unsigned int len = hb_min (ARRAY_LENGTH (buf) - 1, (unsigned int) (end - *pp));
+  strncpy (buf, *pp, len);
+  buf[len] = '\0';
+
+  char *p = buf;
+  char *pend = p;
+  float v;
+
+  errno = 0;
+#ifdef USE_XLOCALE
+  v = strtod_l (p, &pend, get_C_locale ());
+#else
+  v = strtod (p, &pend);
+#endif
+  if (errno || p == pend)
+    return false;
+
+  *pv = v;
+  *pp += pend - p;
+  return true;
+}

--- a/src/hb-float.hh
+++ b/src/hb-float.hh
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2019  Ebrahim Byagowi
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ */
+
+#ifndef HB_FLOAT_HH
+#define HB_FLOAT_HH
+
+#include "hb.hh"
+
+HB_INTERNAL bool
+parse_float (const char **pp, const char *end, float *pv);
+
+#endif /* HB_FLOAT_HH */


### PR DESCRIPTION
Changed my mind :) It makes parse_bcd much cleaner, like [afdko](https://github.com/adobe-type-tools/afdko/blob/c5ca6c1586a4ea09c9026e5c287586096ca351a8/c/public/lib/source/cffread/cffread.c#L731)