### PR TITLE
Extract an avoid errno compile flag

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -48,7 +48,6 @@
 #endif /* HAVE_SYS_MMAN_H */
 
 #include <stdio.h>
-#include <errno.h>
 #include <stdlib.h>
 
 

--- a/src/hb-config.hh
+++ b/src/hb-config.hh
@@ -58,6 +58,7 @@
 #define HB_NO_BITMAP
 #define HB_NO_CFF
 #define HB_NO_COLOR
+#define HB_NO_ERRNO
 #define HB_NO_FACE_COLLECT_UNICODES
 #define HB_NO_GETENV
 #define HB_NO_HINTING

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -180,7 +180,6 @@
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -355,7 +354,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #    endif
 #    if _WIN32_WCE < 0x800
 #      define HB_NO_SETLOCALE
-static int errno = 0; /* Use something better? */
+#      define HB_NO_ERRNO
 #    endif
 #  elif defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
 #    ifndef HB_NO_GETENV
@@ -369,6 +368,12 @@ static int errno = 0; /* Use something better? */
 
 #ifdef HB_NO_GETENV
 #define getenv(Name) nullptr
+#endif
+
+#ifdef HB_NO_ERRNO
+static int errno = 0; /* Use something better? */
+#else
+#include <errno.h>
 #endif
 
 #if defined(HAVE_ATEXIT) && !defined(HB_USE_ATEXIT)


### PR DESCRIPTION
The fact this was already in use for old versions of _WIN32_WCE made me more confident that this can reside in main repo itself, useful in harfbuzz.js but more needed in the brand new harfbuzz-kernel.