### PR TITLE
Avoid stdint.h in Kernel module compiles

### DIFF
--- a/src/hb-common.h
+++ b/src/hb-common.h
@@ -63,6 +63,8 @@ typedef __int32 int32_t;
 typedef unsigned __int32 uint32_t;
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
+#elif defined (__KERNEL__)
+#  include <linux/types.h>
 #else
 #  include <stdint.h>
 #endif


### PR DESCRIPTION
I don't expect you like this :) Other than #1973 it is the only needed change, yet is more symbolic! (otherwise makes more sense to keep the patch locally, but is the only really specific needed thing) Both probably can be avoided if I avoid whole glibc headers, which I found can be avoided.