### PR TITLE
memory leak fix in serializer

### DIFF
--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -194,6 +194,7 @@ struct hb_serialize_context_t
     if (unlikely (!obj)) return;
     current = current->next;
     revert (*obj);
+    obj->fini ();
     object_pool.free (obj);
   }
   objidx_t pop_pack ()


### PR DESCRIPTION
A fix for memory leak that stale links are not freed in pop_discard (). 
This will fix the memory leak issue detected in #1980 