### PR TITLE
Define HB_UNUSED for clang

### DIFF
--- a/src/hb.hh
+++ b/src/hb.hh
@@ -241,7 +241,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #define HB_CONST_FUNC
 #define HB_PRINTF_FUNC(format_idx, arg_idx)
 #endif
-#if defined(__GNUC__) && (__GNUC__ >= 4)
+#if defined(__GNUC__) && (__GNUC__ >= 4) || (__clang__)
 #define HB_UNUSED	__attribute__((unused))
 #elif defined(_MSC_VER) /* https://github.com/harfbuzz/harfbuzz/issues/635 */
 #define HB_UNUSED __pragma(warning(suppress: 4100 4101))


### PR DESCRIPTION
Before it results into:
```
C:\Users\iceflower\test\vcpkg\harfbuzz\src/hb-directwrite.cc(883,1): error :  unused function '_hb_directwrite_shape_experimental_width' [-Werror,-Wunused-function] [C:\Users\iceflower\test\vcpkg\harfbuzz\bui
ld\harfbuzz.vcxproj]
C:\Users\iceflower\test\vcpkg\harfbuzz\src/hb-directwrite.cc(883,1): error : In file included from C:\Users\iceflower\test\vcpkg\harfbuzz\src\harfbuzz.cc:46: [C:\Users\iceflower\test\vcpkg\harfbuzz\build\harfb
uzz.vcxproj]
C:\Users\iceflower\test\vcpkg\harfbuzz\src/hb-directwrite.cc(883,1): error : In file included from C:\Users\iceflower\test\vcpkg\harfbuzz\src/hb-unicode.cc:130: [C:\Users\iceflower\test\vcpkg\harfbuzz\build\ha
rfbuzz.vcxproj]
C:\Users\iceflower\test\vcpkg\harfbuzz\src/hb-directwrite.cc(883,1): error : In file included from C:\Users\iceflower\test\vcpkg\harfbuzz\src/hb-glib.h:34: [C:\Users\iceflower\test\vcpkg\harfbuzz\build\harfbuz
z.vcxproj]
C:\Users\iceflower\test\vcpkg\harfbuzz\src/hb-directwrite.cc(883,1): error : In file included from C:\Users\iceflower\test\vcpkg\installed\x64-windows\include\glib.h:30: [C:\Users\iceflower\test\vcpkg\harfbuzz
\build\harfbuzz.vcxproj]
C:\Users\iceflower\test\vcpkg\harfbuzz\src/hb-directwrite.cc(883,1): error : In file included from C:\Users\iceflower\test\vcpkg\installed\x64-windows\include\glib/galloca.h:32: [C:\Users\iceflower\test\vcpkg\
harfbuzz\build\harfbuzz.vcxproj]
```

Iam not sure if thats a correct fix. At least it works after that.