### PR TITLE
Fix unary minus operator applied to unsigned int

### DIFF
--- a/src/hb-ot-color-sbix-table.hh
+++ b/src/hb-ot-color-sbix-table.hh
@@ -237,7 +237,7 @@ struct sbix
       extents->x_bearing = x_offset;
       extents->y_bearing = png.IHDR.height + y_offset;
       extents->width     = png.IHDR.width;
-      extents->height    = -png.IHDR.height;
+      extents->height    = -static_cast<int>(png.IHDR.height);
 
       /* Convert to font units. */
       if (strike_ppem)


### PR DESCRIPTION
Applying unary minus operator to unsigned int causes the following error on MSVS: error C4146
This patch fixes the error.