### PR TITLE
Fix unary minus operator applied to unsigned int

### DIFF
--- a/src/hb-ot-color-cbdt-table.hh
+++ b/src/hb-ot-color-cbdt-table.hh
@@ -56,7 +56,7 @@ struct SmallGlyphMetrics
     extents->x_bearing = font->em_scale_x (bearingX);
     extents->y_bearing = font->em_scale_y (bearingY);
     extents->width = font->em_scale_x (width);
-    extents->height = font->em_scale_y (-height);
+    extents->height = font->em_scale_y (-static_cast<int>(height));
   }
 
   HBUINT8	height;


### PR DESCRIPTION
Applying unary minus operator to unsigned int causes the following error on MSVS: error C4146
This patch fixes the error.