### PR TITLE
Remove unnecessary check in hb_buffer_t::set_masks.

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -438,13 +438,6 @@ hb_buffer_t::set_masks (hb_mask_t    value,
   if (!mask)
     return;
 
-  if (cluster_start == 0 && cluster_end == (unsigned int)-1) {
-    unsigned int count = len;
-    for (unsigned int i = 0; i < count; i++)
-      info[i].mask = (info[i].mask & not_mask) | value;
-    return;
-  }
-
   unsigned int count = len;
   for (unsigned int i = 0; i < count; i++)
     if (cluster_start <= info[i].cluster && info[i].cluster < cluster_end)


### PR DESCRIPTION
Bounds are already checked by the caller.

Closes #2073