### PR TITLE
Make hb_sanitize_context_t::max_ops unsigned

### DIFF
--- a/src/hb-sanitize.hh
+++ b/src/hb-sanitize.hh
@@ -160,7 +160,7 @@ struct hb_sanitize_context_t :
   }
   unsigned int get_num_glyphs () { return num_glyphs; }
 
-  void set_max_ops (int max_ops_) { max_ops = max_ops_; }
+  void set_max_ops (unsigned int max_ops_) { max_ops = max_ops_; }
 
   template <typename T>
   void set_object (const T *obj)
@@ -376,7 +376,7 @@ struct hb_sanitize_context_t :
 
   mutable unsigned int debug_depth;
   const char *start, *end;
-  mutable int max_ops;
+  mutable unsigned int max_ops;
   private:
   bool writable;
   unsigned int edit_count;


### PR DESCRIPTION
Currently `max_ops` in `hb_sanitize_context_t` is signed, but in `...::start_processing` an unsigned value is assigned:

```
    this->max_ops = hb_max ((unsigned int) (this->end - this->start) * HB_SANITIZE_MAX_OPS_FACTOR,
			 (unsigned) HB_SANITIZE_MAX_OPS_MIN);

```

If `this->end - this->start` is big enough, then `(this->end - this->start) * HB_SANITIZE_MAX_OPS_FACTOR` can not be represented in a signed `int` and the assignment overflows, leading to negative values in `max_ops`. Of course, then a font will no longer load correctly. There are at least two possible fixes for this: Just make `max_ops` unsigned (negative values don't make sense there anyway and the comparisons with `0` are written such that they still work with  unsigned values) or use `hb_min((unsigned) HB_SANITIVE_MAX_OPS_MAX, ...)` before assigning to `->max_ops` to provide an upper bound for the value.

I used the first approach here because I wasn't sure if `max_ops` should be limited to `HB_SANITIVE_MAX_OPS_MAX` or if that constant only has meaning for special fonts.

The original issue had appeared in https://github.com/latex3/luaotfload/issues/126 but can be reproduced without LuaTeX:

Download SourceHanNotoCJK.ttc from https://github.com/adobe-fonts/source-han-super-otc/releases (~390MiB) and try

```
hb-shape --font-file /path/to/SourceHanNotoCJK.ttc --face-index 17 "中國哲學書電子化計劃"
```
On my system this gives only a collection of GID 0 glyphs:
```
[gid0=0+1000|gid0=1+1000|gid0=2+1000|gid0=3+1000|gid0=4+1000|gid0=5+1000|gid0=6+1000|gid0=7+1000|gid0=8+1000|gid0=9+1000]
```
the same font in `hb-view` gives `hb-view: FT_New_Memory_Face fail`.