### PR TITLE
Clamp max_ops to upper bound in hb-sanitize.hh

### DIFF
--- a/src/hb-sanitize.hh
+++ b/src/hb-sanitize.hh
@@ -189,8 +189,9 @@ struct hb_sanitize_context_t :
   void start_processing ()
   {
     reset_object ();
-    this->max_ops = hb_max ((unsigned int) (this->end - this->start) * HB_SANITIZE_MAX_OPS_FACTOR,
-			 (unsigned) HB_SANITIZE_MAX_OPS_MIN);
+    this->max_ops = hb_min (hb_max ((unsigned int) (this->end - this->start) * HB_SANITIZE_MAX_OPS_FACTOR,
+				    (unsigned) HB_SANITIZE_MAX_OPS_MIN),
+			    (unsigned) HB_SANITIZE_MAX_OPS_MAX);
     this->edit_count = 0;
     this->debug_depth = 0;
 

--- a/src/hb-sanitize.hh
+++ b/src/hb-sanitize.hh
@@ -189,9 +189,12 @@ struct hb_sanitize_context_t :
   void start_processing ()
   {
     reset_object ();
-    this->max_ops = hb_min (hb_max ((unsigned int) (this->end - this->start) * HB_SANITIZE_MAX_OPS_FACTOR,
-				    (unsigned) HB_SANITIZE_MAX_OPS_MIN),
-			    (unsigned) HB_SANITIZE_MAX_OPS_MAX);
+    if (unlikely (hb_unsigned_mul_overflows (this->end - this->start, HB_SANITIZE_MAX_OPS_FACTOR)))
+      this->max_ops = HB_SANITIZE_MAX_OPS_MAX;
+    else
+      this->max_ops = hb_min (hb_max ((unsigned int) (this->end - this->start) * HB_SANITIZE_MAX_OPS_FACTOR,
+				      (unsigned) HB_SANITIZE_MAX_OPS_MIN),
+			      (unsigned) HB_SANITIZE_MAX_OPS_MAX);
     this->edit_count = 0;
     this->debug_depth = 0;
 


### PR DESCRIPTION
Alternative fix for the problem in #2079: Never make `max_ops` bigger than `HB_SANITIVE_MAX_OPS_MAX`, especially keeping the value small enough to avoid overflows.