### PR TITLE
Use correct return type in _unsafe_to_break_find_min_cluster.

### DIFF
--- a/src/hb-buffer.hh
+++ b/src/hb-buffer.hh
@@ -386,7 +386,7 @@ struct hb_buffer_t
     inf.cluster = cluster;
   }
 
-  int
+  unsigned int
   _unsafe_to_break_find_min_cluster (const hb_glyph_info_t *infos,
 				     unsigned int start, unsigned int end,
 				     unsigned int cluster) const


### PR DESCRIPTION
Cluster should be unsigned. I guess it can also lead to a precision loss on large numbers.