### PR TITLE
Fix page_map corruption in hb_set_t during process().

### DIFF
--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -452,21 +452,23 @@ struct hb_set_t
 
   void compact (unsigned int length)
   {
-    hb_hashmap_t<uint32_t, uint32_t> old_index_to_page_map_index;
+    hb_vector_t<uint32_t> old_index_to_page_map_index;
+    old_index_to_page_map_index.resize(pages.length);
+    for (uint32_t i = 0; i < old_index_to_page_map_index.length; i++)
+      old_index_to_page_map_index[i] = 0xFFFFFFFF;
 
-    for (unsigned int i = 0; i < length; i++) {
-      old_index_to_page_map_index.set (page_map[i].index, i);
-    }
+    for (uint32_t i = 0; i < length; i++)
+      old_index_to_page_map_index[page_map[i].index] =  i;
 
     compact_pages (old_index_to_page_map_index);
   }
 
-  void compact_pages (const hb_hashmap_t<uint32_t, uint32_t>& old_index_to_page_map_index)
+  void compact_pages (const hb_vector_t<uint32_t>& old_index_to_page_map_index)
   {
     unsigned int write_index = 0;
     for (unsigned int i = 0; i < pages.length; i++)
     {
-      if (!old_index_to_page_map_index.has (i)) continue;
+      if (old_index_to_page_map_index[i] == 0xFFFFFFFF) continue;
 
       if (write_index < i)
         pages[write_index] = pages[i];

--- a/test/api/test-set.c
+++ b/test/api/test-set.c
@@ -135,6 +135,81 @@ test_set_basic (void)
 //   printf ("}\n");
 // }
 
+static void test_set_intersect_empty (void)
+{
+  hb_set_t* a = hb_set_create ();
+  hb_set_add (a, 3585);
+  hb_set_add (a, 21333);
+  hb_set_add (a, 24405);
+
+  hb_set_t* b = hb_set_create();
+  hb_set_add (b, 21483);
+  hb_set_add (b, 24064);
+
+  hb_set_intersect (a, b);
+  g_assert (hb_set_is_empty (a));
+
+  hb_set_destroy (a);
+  hb_set_destroy (b);
+
+
+  a = hb_set_create ();
+  hb_set_add (a, 16777216);
+
+  b = hb_set_create();
+  hb_set_add (b, 0);
+
+  hb_set_intersect (a, b);
+  g_assert (hb_set_is_empty (a));
+
+  hb_set_destroy (a);
+  hb_set_destroy (b);
+}
+
+static void test_set_intersect_page_reduction (void)
+{
+  hb_set_t* a = hb_set_create ();
+  hb_set_add (a, 3585);
+  hb_set_add (a, 21333);
+  hb_set_add (a, 24405);
+
+  hb_set_t* b = hb_set_create();
+  hb_set_add (b, 3585);
+  hb_set_add (b, 24405);
+
+  hb_set_intersect(a, b);
+  g_assert (hb_set_is_equal (a, b));
+
+  hb_set_destroy (a);
+  hb_set_destroy (b);
+}
+
+static void test_set_union (void)
+{
+  hb_set_t* a = hb_set_create();
+  hb_set_add (a, 3585);
+  hb_set_add (a, 21333);
+  hb_set_add (a, 24405);
+
+  hb_set_t* b = hb_set_create();
+  hb_set_add (b, 21483);
+  hb_set_add (b, 24064);
+
+  hb_set_t* u = hb_set_create ();
+  hb_set_add (u, 3585);
+  hb_set_add (u, 21333);
+  hb_set_add (u, 21483);
+  hb_set_add (u, 24064);
+  hb_set_add (u, 24405);
+
+  hb_set_union(b, a);
+  g_assert (hb_set_is_equal (u, b));
+
+  hb_set_destroy (a);
+  hb_set_destroy (b);
+  hb_set_destroy (u);
+}
+
 static void
 test_set_algebra (void)
 {
@@ -404,6 +479,10 @@ main (int argc, char **argv)
   hb_test_add (test_set_algebra);
   hb_test_add (test_set_iter);
   hb_test_add (test_set_empty);
+
+  hb_test_add (test_set_intersect_empty);
+  hb_test_add (test_set_intersect_page_reduction);
+  hb_test_add (test_set_union);
 
   return hb_test_run();
 }


### PR DESCRIPTION
If a process operation results in less pages then the current set has, it will likely corrupt the page_map since it overwrites page_map entries ahead of where it's processing. This fixes that problem by always writing updated entries at the end of the page_map and then compacting and cleaning up orphaned entries at the end of process().