### PR TITLE
[draw] Put current points on callbacks

### DIFF
--- a/src/hb-draw.h
+++ b/src/hb-draw.h
@@ -33,17 +33,6 @@
 
 HB_BEGIN_DECLS
 
-typedef void (*hb_draw_move_to_func_t) (hb_position_t to_x, hb_position_t to_y, void *user_data);
-typedef void (*hb_draw_line_to_func_t) (hb_position_t to_x, hb_position_t to_y, void *user_data);
-typedef void (*hb_draw_quadratic_to_func_t) (hb_position_t control_x, hb_position_t control_y,
-					     hb_position_t to_x, hb_position_t to_y,
-					     void *user_data);
-typedef void (*hb_draw_cubic_to_func_t) (hb_position_t control1_x, hb_position_t control1_y,
-					 hb_position_t control2_x, hb_position_t control2_y,
-					 hb_position_t to_x, hb_position_t to_y,
-					 void *user_data);
-typedef void (*hb_draw_close_path_func_t) (void *user_data);
-
 /**
  * hb_draw_funcs_t:
  *
@@ -55,6 +44,20 @@ typedef void (*hb_draw_close_path_func_t) (void *user_data);
  * Since: REPLACEME
  **/
 typedef struct hb_draw_funcs_t hb_draw_funcs_t;
+
+typedef void (*hb_draw_move_to_func_t) (const hb_draw_funcs_t *funcs, hb_position_t to_x, hb_position_t to_y, void *user_data);
+typedef void (*hb_draw_line_to_func_t) (const hb_draw_funcs_t *funcs, hb_position_t from_x, hb_position_t from_y,
+					hb_position_t to_x, hb_position_t to_y, void *user_data);
+typedef void (*hb_draw_quadratic_to_func_t) (const hb_draw_funcs_t *funcs, hb_position_t from_x, hb_position_t from_y,
+					     hb_position_t control_x, hb_position_t control_y,
+					     hb_position_t to_x, hb_position_t to_y,
+					     void *user_data);
+typedef void (*hb_draw_cubic_to_func_t) (const hb_draw_funcs_t *funcs, hb_position_t from_x, hb_position_t from_y,
+					 hb_position_t control1_x, hb_position_t control1_y,
+					 hb_position_t control2_x, hb_position_t control2_y,
+					 hb_position_t to_x, hb_position_t to_y,
+					 void *user_data);
+typedef void (*hb_draw_close_path_func_t) (const hb_draw_funcs_t *funcs, void *user_data);
 
 HB_EXTERN void
 hb_draw_funcs_set_move_to_func (hb_draw_funcs_t        *funcs,

--- a/src/hb-ot-glyf-table.hh
+++ b/src/hb-ot-glyf-table.hh
@@ -1043,36 +1043,6 @@ struct glyf
         add_gid_and_children (item.glyphIndex, gids_to_retain, depth);
     }
 
-    static void
-    _normal_quadratic_to_call (hb_font_t *font, const hb_draw_funcs_t *funcs,
-			       float from_x HB_UNUSED, float from_y HB_UNUSED,
-			       float control_x, float control_y,
-			       float to_x, float to_y,
-			       void *user_data)
-    {
-      funcs->quadratic_to (font->em_scalef_x (control_x), font->em_scalef_y (control_y),
-			   font->em_scalef_x (to_x), font->em_scalef_y (to_y),
-			   user_data);
-    }
-
-    static void
-    _translate_quadratic_to_cubic (hb_font_t *font, const hb_draw_funcs_t *funcs,
-				   float from_x, float from_y,
-				   float control_x, float control_y,
-				   float to_x, float to_y,
-				   void *user_data)
-    {
-      /* based on https://github.com/fonttools/fonttools/blob/a37dab3/Lib/fontTools/pens/basePen.py#L218 */
-      float mid1_x = from_x + 0.6666666667f * (control_x - from_x);
-      float mid1_y = from_y + 0.6666666667f * (control_y - from_y);
-      float mid2_x = to_x + 0.6666666667f * (control_x - to_x);
-      float mid2_y = to_y + 0.6666666667f * (control_y - to_y);
-      funcs->cubic_to (font->em_scalef_x (mid1_x), font->em_scalef_y (mid1_y),
-		       font->em_scalef_x (mid2_x), font->em_scalef_y (mid2_y),
-		       font->em_scalef_x (to_x), font->em_scalef_y (to_y),
-		       user_data);
-    }
-
     bool
     get_path (hb_font_t *font, hb_codepoint_t gid,
 	      const hb_draw_funcs_t *funcs, void *user_data) const
@@ -1084,10 +1054,6 @@ struct glyf
       contour_point_vector_t all_points;
       if (unlikely (!get_points (font, gid, all_points))) return false;
       hb_array_t<contour_point_t> points = all_points.sub_array (0, all_points.length - 4);
-
-      void (*quad_to) (hb_font_t *, const hb_draw_funcs_t *,
-		       float, float, float, float, float, float,
-		       void *) = funcs->quadratic_to ? _normal_quadratic_to_call : _translate_quadratic_to_cubic;
 
       unsigned contour_start = 0;
       /* Learnt from https://github.com/opentypejs/opentype.js/blob/4e0bb99/src/tables/glyf.js#L222 */
@@ -1107,20 +1073,20 @@ struct glyf
 	if (curr->flag & Glyph::FLAG_ON_CURVE)
 	{
 	  prev_x = curr->x; prev_y = curr->y;
-	  funcs->move_to (font->em_scalef_x (prev_x), font->em_scalef_y (prev_y), user_data);
+	  funcs->move_to (funcs, font->em_scalef_x (prev_x), font->em_scalef_y (prev_y), user_data);
 	}
 	else
 	{
 	  if (next->flag & Glyph::FLAG_ON_CURVE)
 	  {
 	    prev_x = next->x; prev_y = next->y;
-	    funcs->move_to (font->em_scalef_x (prev_x), font->em_scalef_y (prev_y), user_data);
+	    funcs->move_to (funcs, font->em_scalef_x (prev_x), font->em_scalef_y (prev_y), user_data);
 	  }
 	  else
 	  {
 	    prev_x = (curr->x + next->x) / 2.f; prev_y = (curr->y + next->y) / 2.f;
 	    /* If both first and last points are off-curve, start at their middle. */
-            funcs->move_to (font->em_scalef_x (prev_x), font->em_scalef_y (prev_y), user_data);
+            funcs->move_to (funcs, font->em_scalef_x (prev_x), font->em_scalef_y (prev_y), user_data);
 	  }
 	}
 
@@ -1131,20 +1097,24 @@ struct glyf
 
 	  if (curr->flag & Glyph::FLAG_ON_CURVE)
 	  {
+	    funcs->line_to (funcs, font->em_scalef_x (prev_x), font->em_scalef_y (prev_y),
+			    font->em_scalef_x (curr->x), font->em_scalef_y (curr->y), user_data);
 	    prev_x = curr->x; prev_y = curr->y;
-	    funcs->line_to (font->em_scalef_x (curr->x), font->em_scalef_y (curr->y), user_data);
 	  }
 	  else
 	  {
 	    float to_x, to_y;
 	    if (next->flag & Glyph::FLAG_ON_CURVE) { to_x = next->x; to_y = next->y; }
 	    else { to_x = (curr->x + next->x) / 2.f; to_y = (curr->y + next->y) / 2.f; }
-	    quad_to (font, funcs, prev_x, prev_y, curr->x, curr->y, to_x, to_y, user_data);
+            funcs->quadratic_to (funcs, font->em_scalef_x (prev_x), font->em_scalef_y (prev_y),
+				 font->em_scalef_x (curr->x), font->em_scalef_y (curr->y),
+				 font->em_scalef_x (to_x), font->em_scalef_y (to_y),
+				 user_data);
 	    prev_x = to_x; prev_y = to_y;
 	  }
 	}
 	contour_start += contour_length;
-	funcs->close_path (user_data);
+	funcs->close_path (funcs, user_data);
       }
       return true;
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -130,20 +130,30 @@ struct user_data_t
   hb_position_t ascender;
 };
 
+#if defined(__GNUC__) && (__GNUC__ >= 4) || (__clang__)
+#define HB_UNUSED	__attribute__((unused))
+#else
+#define HB_UNUSED
+#endif
+
 static void
-move_to (hb_position_t to_x, hb_position_t to_y, user_data_t &user_data)
+move_to (const hb_draw_funcs_t *funcs HB_UNUSED, hb_position_t to_x, hb_position_t to_y, user_data_t &user_data)
 {
   fprintf (user_data.f, "M%d,%d", to_x, user_data.ascender - to_y);
 }
 
 static void
-line_to (hb_position_t to_x, hb_position_t to_y, user_data_t &user_data)
+line_to (const hb_draw_funcs_t *funcs HB_UNUSED,
+	 hb_position_t from_x HB_UNUSED, hb_position_t from_y HB_UNUSED,
+	 hb_position_t to_x, hb_position_t to_y, user_data_t &user_data)
 {
   fprintf (user_data.f, "L%d,%d", to_x, user_data.ascender - to_y);
 }
 
 static void
-quadratic_to (hb_position_t control_x, hb_position_t control_y,
+quadratic_to (const hb_draw_funcs_t *funcs HB_UNUSED,
+	      hb_position_t from_x HB_UNUSED, hb_position_t from_y HB_UNUSED,
+	      hb_position_t control_x, hb_position_t control_y,
 	      hb_position_t to_x, hb_position_t to_y,
 	      user_data_t &user_data)
 {
@@ -152,7 +162,9 @@ quadratic_to (hb_position_t control_x, hb_position_t control_y,
 }
 
 static void
-cubic_to (hb_position_t control1_x, hb_position_t control1_y,
+cubic_to (const hb_draw_funcs_t *funcs HB_UNUSED,
+	  hb_position_t from_x HB_UNUSED, hb_position_t from_y HB_UNUSED,
+	  hb_position_t control1_x, hb_position_t control1_y,
 	  hb_position_t control2_x, hb_position_t control2_y,
 	  hb_position_t to_x, hb_position_t to_y,
 	  user_data_t &user_data)
@@ -163,7 +175,7 @@ cubic_to (hb_position_t control1_x, hb_position_t control1_y,
 }
 
 static void
-close_path (user_data_t &user_data)
+close_path (const hb_draw_funcs_t *funcs HB_UNUSED, user_data_t &user_data)
 {
   fprintf (user_data.f, "Z");
 }

--- a/test/api/test-draw.c
+++ b/test/api/test-draw.c
@@ -94,7 +94,7 @@ test_itoa (void)
 }
 
 static void
-move_to (hb_position_t to_x, hb_position_t to_y, user_data_t *user_data)
+move_to (hb_destroy_func_t *funcs HB_UNUSED, hb_position_t to_x, hb_position_t to_y, user_data_t *user_data)
 {
   /* 4 = command character space + comma + array starts with 0 index + nul character space */
   if (user_data->consumed + 2 * ITOA_BUF_SIZE + 4 > user_data->size) return;
@@ -105,7 +105,8 @@ move_to (hb_position_t to_x, hb_position_t to_y, user_data_t *user_data)
 }
 
 static void
-line_to (hb_position_t to_x, hb_position_t to_y, user_data_t *user_data)
+line_to (hb_destroy_func_t *funcs HB_UNUSED, hb_position_t from_x HB_UNUSED, hb_position_t from_y HB_UNUSED,
+	 hb_position_t to_x, hb_position_t to_y, user_data_t *user_data)
 {
   if (user_data->consumed + 2 * ITOA_BUF_SIZE + 4 > user_data->size) return;
   user_data->str[user_data->consumed++] = 'L';
@@ -115,7 +116,8 @@ line_to (hb_position_t to_x, hb_position_t to_y, user_data_t *user_data)
 }
 
 static void
-quadratic_to (hb_position_t control_x, hb_position_t control_y,
+quadratic_to (hb_destroy_func_t *funcs HB_UNUSED, hb_position_t from_x HB_UNUSED, hb_position_t from_y HB_UNUSED,
+	      hb_position_t control_x, hb_position_t control_y,
 	      hb_position_t to_x, hb_position_t to_y,
 	      user_data_t *user_data)
 {
@@ -132,7 +134,8 @@ quadratic_to (hb_position_t control_x, hb_position_t control_y,
 }
 
 static void
-cubic_to (hb_position_t control1_x, hb_position_t control1_y,
+cubic_to (hb_destroy_func_t *funcs HB_UNUSED, hb_position_t from_x HB_UNUSED, hb_position_t from_y HB_UNUSED,
+	  hb_position_t control1_x, hb_position_t control1_y,
 	  hb_position_t control2_x, hb_position_t control2_y,
 	  hb_position_t to_x, hb_position_t to_y,
 	  user_data_t *user_data)
@@ -153,7 +156,7 @@ cubic_to (hb_position_t control1_x, hb_position_t control1_y,
 }
 
 static void
-close_path (user_data_t *user_data)
+close_path (hb_destroy_func_t *funcs HB_UNUSED, user_data_t *user_data)
 {
   if (user_data->consumed + 2 > user_data->size) return;
   user_data->str[user_data->consumed++] = 'Z';


### PR DESCRIPTION
Another draft like #2142, this makes callbacks themselves ugly but usable for quadratic to cubic or curve to lines usecases or make it possible to be called from outside (that would be ugly also as client has to pass current point). I don't happy about putting hb_draw_funcs_t on the call but it was needed for translating calls, avoidable if we user_data somehow on funcs object so no need for passing both.