### PR TITLE
[draw] Add hb_draw_funcs_is_immutable and hb_draw_funcs_make_immutable

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -231,6 +231,8 @@ hb_draw_move_to_func_t
 hb_draw_quadratic_to_func_t
 hb_draw_funcs_create
 hb_draw_funcs_destroy
+hb_draw_funcs_is_immutable
+hb_draw_funcs_make_immutable
 hb_draw_funcs_reference
 hb_draw_funcs_set_close_path_func
 hb_draw_funcs_set_cubic_to_func

--- a/src/hb-draw.cc
+++ b/src/hb-draw.cc
@@ -187,6 +187,38 @@ hb_draw_funcs_destroy (hb_draw_funcs_t *funcs)
 }
 
 /**
+ * hb_draw_funcs_make_immutable:
+ * @funcs: draw functions
+ *
+ * Makes funcs object immutable.
+ *
+ * Since: REPLACEME
+ **/
+void
+hb_draw_funcs_make_immutable (hb_draw_funcs_t *funcs)
+{
+  if (hb_object_is_immutable (funcs))
+    return;
+
+  hb_object_make_immutable (funcs);
+}
+
+/**
+ * hb_draw_funcs_is_immutable:
+ * @funcs: draw functions
+ *
+ * Checks whether funcs is immutable.
+ *
+ * Returns: If is immutable.
+ * Since: REPLACEME
+ **/
+hb_bool_t
+hb_draw_funcs_is_immutable (hb_draw_funcs_t *funcs)
+{
+  return hb_object_is_immutable (funcs);
+}
+
+/**
  * hb_font_draw_glyph:
  * @font: a font object
  * @glyph: a glyph id

--- a/src/hb-draw.h
+++ b/src/hb-draw.h
@@ -85,6 +85,12 @@ hb_draw_funcs_reference (hb_draw_funcs_t *funcs);
 HB_EXTERN void
 hb_draw_funcs_destroy (hb_draw_funcs_t *funcs);
 
+HB_EXTERN void
+hb_draw_funcs_make_immutable (hb_draw_funcs_t *funcs);
+
+HB_EXTERN hb_bool_t
+hb_draw_funcs_is_immutable (hb_draw_funcs_t *funcs);
+
 HB_END_DECLS
 
 #endif /* HB_DRAW_H */

--- a/test/api/test-draw.c
+++ b/test/api/test-draw.c
@@ -813,6 +813,16 @@ test_hb_draw_stroking (void)
   }
 }
 
+static void
+test_hb_draw_immutable (void)
+{
+  hb_draw_funcs_t *draw_funcs = hb_draw_funcs_create ();
+  g_assert (!hb_draw_funcs_is_immutable (draw_funcs));
+  hb_draw_funcs_make_immutable (draw_funcs);
+  g_assert (hb_draw_funcs_is_immutable (draw_funcs));
+  hb_draw_funcs_destroy (draw_funcs);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -822,12 +832,14 @@ main (int argc, char **argv)
   hb_draw_funcs_set_quadratic_to_func (funcs, (hb_draw_quadratic_to_func_t) quadratic_to);
   hb_draw_funcs_set_cubic_to_func (funcs, (hb_draw_cubic_to_func_t) cubic_to);
   hb_draw_funcs_set_close_path_func (funcs, (hb_draw_close_path_func_t) close_path);
+  hb_draw_funcs_make_immutable (funcs);
 
   funcs2 = hb_draw_funcs_create ();
   hb_draw_funcs_set_move_to_func (funcs2, (hb_draw_move_to_func_t) move_to);
   hb_draw_funcs_set_line_to_func (funcs2, (hb_draw_line_to_func_t) line_to);
   hb_draw_funcs_set_cubic_to_func (funcs2, (hb_draw_cubic_to_func_t) cubic_to);
   hb_draw_funcs_set_close_path_func (funcs2, (hb_draw_close_path_func_t) close_path);
+  hb_draw_funcs_make_immutable (funcs2);
 
   hb_test_init (&argc, &argv);
   hb_test_add (test_itoa);
@@ -840,6 +852,7 @@ main (int argc, char **argv)
   hb_test_add (test_hb_draw_font_kit_glyphs_tests);
   hb_test_add (test_hb_draw_font_kit_variations_tests);
   hb_test_add (test_hb_draw_stroking);
+  hb_test_add (test_hb_draw_immutable);
   unsigned result = hb_test_run ();
 
   hb_draw_funcs_destroy (funcs);


### PR DESCRIPTION
Auxiliary things

Other things to consider,
* parent parameter for create and inheritence, `hb_unicode_funcs_create (hb_unicode_funcs_t *parent);` has it but `hb_font_funcs_create (void)` don't so not sure if we need it also.
* `hb_draw_{move,line,quadratic,cubic}_to ()` and `hb_draw_close_path ()`, I think doing so implies `hb_draw_funcs_t` is useful for two ways callings but without having current points using untouched `hb_draw_funcs_t` object isn't that useful for cases line quadratic to cubic or, curve to lines translations, guess we need another abstraction, maybe called pen, to provide those.