### PR TITLE
rewrite of CFF/CFF2 subsetter with _subset2

### DIFF
--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -1376,20 +1376,16 @@ struct cff1
 
   struct accelerator_subset_t : accelerator_templ_t<cff1_private_dict_opset_subset, cff1_private_dict_values_subset_t> {};
 
-  bool subset (hb_subset_plan_t *plan) const
+  bool subset (hb_subset_context_t *c) const
   {
-    hb_blob_t *cff_prime = nullptr;
-
     bool success = true;
-    if (hb_subset_cff1 (plan, &cff_prime)) {
-      success = success && plan->add_table (HB_OT_TAG_cff1, cff_prime);
-      hb_blob_t *head_blob = hb_sanitize_context_t().reference_table<head> (plan->source);
-      success = success && head_blob && plan->add_table (HB_OT_TAG_head, head_blob);
+    if (hb_subset_cff1 (c)) {
+      hb_blob_t *head_blob = hb_sanitize_context_t().reference_table<head> (c->plan->source);
+      success = success && head_blob && c->plan->add_table (HB_OT_TAG_head, head_blob);
       hb_blob_destroy (head_blob);
     } else {
       success = false;
     }
-    hb_blob_destroy (cff_prime);
 
     return success;
   }

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -539,20 +539,16 @@ struct cff2
 
   typedef accelerator_templ_t<cff2_private_dict_opset_subset_t, cff2_private_dict_values_subset_t> accelerator_subset_t;
 
-  bool subset (hb_subset_plan_t *plan) const
+  bool subset (hb_subset_context_t *c) const
   {
-    hb_blob_t *cff2_prime = nullptr;
-
     bool success = true;
-    if (hb_subset_cff2 (plan, &cff2_prime)) {
-      success = success && plan->add_table (HB_OT_TAG_cff2, cff2_prime);
-      hb_blob_t *head_blob = hb_sanitize_context_t().reference_table<head> (plan->source);
-      success = success && head_blob && plan->add_table (HB_OT_TAG_head, head_blob);
+    if (hb_subset_cff2 (c)) {
+      hb_blob_t *head_blob = hb_sanitize_context_t().reference_table<head> (c->plan->source);
+      success = success && head_blob && c->plan->add_table (HB_OT_TAG_head, head_blob);
       hb_blob_destroy (head_blob);
     } else {
       success = false;
     }
-    hb_blob_destroy (cff2_prime);
 
     return success;
   }

--- a/src/hb-subset-cff1.hh
+++ b/src/hb-subset-cff1.hh
@@ -32,7 +32,6 @@
 #include "hb-subset-plan.hh"
 
 HB_INTERNAL bool
-hb_subset_cff1 (hb_subset_plan_t *plan,
-	       hb_blob_t	**cff_prime /* OUT */);
+hb_subset_cff1 (hb_subset_context_t *c);
 
 #endif /* HB_SUBSET_CFF1_HH */

--- a/src/hb-subset-cff2.hh
+++ b/src/hb-subset-cff2.hh
@@ -32,7 +32,6 @@
 #include "hb-subset-plan.hh"
 
 HB_INTERNAL bool
-hb_subset_cff2 (hb_subset_plan_t *plan,
-	       hb_blob_t       **cff2_prime /* OUT */);
+hb_subset_cff2 (hb_subset_context_t *c);
 
 #endif /* HB_SUBSET_CFF2_HH */

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -210,10 +210,10 @@ _subset_table (hb_subset_plan_t *plan,
 
 #ifndef HB_NO_SUBSET_CFF
     case HB_OT_TAG_cff1:
-      result = _subset<const OT::cff1> (plan);
+      result = _subset2<const OT::cff1> (plan);
       break;
     case HB_OT_TAG_cff2:
-      result = _subset<const OT::cff2> (plan);
+      result = _subset2<const OT::cff2> (plan);
       break;
     case HB_OT_TAG_VORG:
       result = _subset2<const OT::VORG> (plan);


### PR DESCRIPTION
Issue #1981: Quick rewrite of CFF & CFF2 table subsetter using _subset2 in place of _subset.
More changes to follow.
