### PR TITLE
added add_link_abs()

### DIFF
--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -362,25 +362,11 @@ struct OffsetTo : Offset<OffsetType, has_null>
     return ret;
   }
 
-  template <typename ...Ts>
   bool serialize_copy (hb_serialize_context_t *c,
 		       const OffsetTo& src,
 		       const void *src_base,
-		       const void *dst_base,
-		       Ts&&... ds)
-  {
-    *this = 0;
-    if (src.is_null ())
-      return false;
-
-    c->push ();
-
-    bool ret = c->copy (src_base+src, hb_forward<Ts> (ds)...);
-
-    c->add_link (*this, c->pop_pack (), dst_base);
-
-    return ret;
-  }
+		       const void *dst_base)
+  { return serialize_copy (c, src, src_base, dst_base, hb_serialize_context_t::Head); }
 
   bool sanitize_shallow (hb_sanitize_context_t *c, const void *base) const
   {

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -129,7 +129,7 @@ struct hb_serialize_context_t
 
   template <typename T1, typename T2>
   bool check_assign (T1 &v1, T2 &&v2)
-  { return check_equal ((hb_remove_reference<T2>) (v1 = v2), v2); }
+  { return check_equal (v1 = v2, v2); }
 
   template <typename T> bool propagate_error (T &&obj)
   { return check_success (!hb_deref (obj).in_error ()); }

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -324,7 +324,7 @@ struct hb_serialize_context_t
 	if (unlikely (!child)) { err_other_error(); return; }
 	unsigned offset;
 	switch ((whence_t)link.whence) {
-	case Head:     offset = child->head - parent->head; break;
+	case Head:     offset = (child->head - parent->head) - link.bias; break;
 	case Tail:     offset = child->head - parent->tail; break;
 	case Absolute: offset = (head - start) + (child->head - tail); break;
 	default: assert (0);

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -78,7 +78,7 @@ struct hb_serialize_context_t
       bool is_wide: 1;
       bool is_signed: 1;
       whence_t whence: 2;
-      unsigned position: 29;
+      unsigned position: 28;
       unsigned bias;
       objidx_t objidx;
     };
@@ -297,8 +297,13 @@ struct hb_serialize_context_t
     link.position = (const char *) &ofs - current->head;
     if (whence == Head)
     {
-      assert (current->head <= (const char *)base);
-      link.bias = (const char *) base - current->head;
+      if (base == nullptr)
+	link.bias = 0;
+      else
+      {
+	assert (current->head <= (const char *)base);
+	link.bias = (const char *) base - current->head;
+      }
     }
     else
       link.bias = 0;

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -77,7 +77,7 @@ struct hb_serialize_context_t
     {
       bool is_wide: 1;
       bool is_signed: 1;
-      whence_t whence: 2;
+      unsigned whence: 2;
       unsigned position: 28;
       unsigned bias;
       objidx_t objidx;
@@ -293,7 +293,7 @@ struct hb_serialize_context_t
 
     link.is_wide = sizeof (T) == 4;
     link.is_signed = hb_is_signed (hb_unwrap_type (T));
-    link.whence = whence;
+    link.whence = (unsigned)whence;
     link.position = (const char *) &ofs - current->head;
     if (whence == Head)
     {
@@ -323,7 +323,7 @@ struct hb_serialize_context_t
 	const object_t* child = packed[link.objidx];
 	if (unlikely (!child)) { err_other_error(); return; }
 	unsigned offset;
-	switch (link.whence) {
+	switch ((whence_t)link.whence) {
 	case Head:     offset = child->head - parent->head; break;
 	case Tail:     offset = child->head - parent->tail; break;
 	case Absolute: offset = (head - start) + (child->head - tail); break;

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -271,15 +271,15 @@ struct hb_serialize_context_t
   }
 
   enum base_mode_t {
-     HEAD,	/* Relative to the current object head (default). */
-     TAIL,	/* Relative to the current object tail. */
-     ABSOLUTE	/* Absolute: from the start of the serialize buffer. */
+     Head,	/* Relative to the current object head (default). */
+     Tail,	/* Relative to the current object tail. */
+     Absolute	/* Absolute: from the start of the serialize buffer. */
    };
 
   template <typename T>
   void add_link (T &ofs, objidx_t objidx,
 		 const void *base = nullptr,
-		 base_mode_t mode = HEAD)
+		 base_mode_t mode = Head)
   {
     static_assert (sizeof (T) == 2 || sizeof (T) == 4, "");
 
@@ -294,15 +294,15 @@ struct hb_serialize_context_t
 
     switch (mode)
     {
-    case HEAD:
+    case Head:
       dflt_base = current->head;
       link.is_absolute = false;
       break;
-    case TAIL:
+    case Tail:
       dflt_base = current->tail;
       link.is_absolute = false;
       break;
-    case ABSOLUTE:
+    case Absolute:
       dflt_base = start;
       link.is_absolute = true;
       break;


### PR DESCRIPTION
As described in issue #2156, I plan to use this new function `add_link_abs()` in hb-serialize.hh for setting up a sub-table link with an absolute offset (i.e., based on the very beginning of the table) for my work of modernizing CFF subsetter with _subset2 #1981.

`ofs` argument to `add_link_abs` may be a signed IntType or an unsigned IntType.
