### PR TITLE
When serializing cmap14 order the offsets from smallest to largest.

### DIFF
--- a/src/hb-array.hh
+++ b/src/hb-array.hh
@@ -171,6 +171,21 @@ struct hb_array_t : hb_iter_with_fallback_t<hb_array_t<Type>, Type&>
 
   unsigned int get_size () const { return length * this->get_item_size (); }
 
+  void reverse ()
+  {
+    int rhs = length - 1;
+    int lhs = 0;
+    while (rhs > lhs)
+    {
+      Type value_rhs = arrayZ[rhs];
+      Type value_lhs = arrayZ[lhs];
+      arrayZ[rhs] = value_lhs;
+      arrayZ[lhs] = value_rhs;
+      rhs--;
+      lhs++;
+    }
+  }
+
   hb_array_t sub_array (unsigned int start_offset = 0, unsigned int *seg_count = nullptr /* IN/OUT */) const
   {
     if (!start_offset && !seg_count)

--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -948,17 +948,19 @@ struct CmapSubtableFormat14
 
     auto src_tbl = reinterpret_cast<const CmapSubtableFormat14*> (src_base);
 
-    // Some versions of OTS require that offsets are in order. Due to the use
-    // of push()/pop_pack() serializing the variation records in order results
-    // in the offsets being in reverse order (first record has the largest
-    // offset). While this is perfectly valid, it will cause some versions of
-    // OTS to consider this table bad.
-    //
-    // So to prevent this issue we serialize the variation records in reverse
-    // order, so that the offsets are ordered from small to large. Since
-    // variation records are supposed to be in increasing order of varSelector
-    // we then have to reverse the order of the written variation selector
-    // records after everything is finalized.
+    /*
+     * Some versions of OTS require that offsets are in order. Due to the use
+     * of push()/pop_pack() serializing the variation records in order results
+     * in the offsets being in reverse order (first record has the largest
+     * offset). While this is perfectly valid, it will cause some versions of
+     * OTS to consider this table bad.
+     *
+     * So to prevent this issue we serialize the variation records in reverse
+     * order, so that the offsets are ordered from small to large. Since
+     * variation records are supposed to be in increasing order of varSelector
+     * we then have to reverse the order of the written variation selector
+     * records after everything is finalized.
+     */
     hb_vector_t<hb_pair_t<unsigned, unsigned>> obj_indices;
     for (int i = src_tbl->record.len - 1; i >= 0; i--)
     {
@@ -980,11 +982,11 @@ struct CmapSubtableFormat14
                      (c->length () - table_initpos - CmapSubtableFormat14::min_size) /
                      VariationSelectorRecord::static_size);
 
-    // Correct the incorrect write order by reversing the order of the variation
-    // records array.
+    /* Correct the incorrect write order by reversing the order of the variation
+       records array. */
     _reverse_variation_records ();
 
-    // Now that records are in the right order, we can set up the offsets.
+    /* Now that records are in the right order, we can set up the offsets. */
     _add_links_to_variation_records (c, obj_indices);
   }
 
@@ -1008,9 +1010,11 @@ struct CmapSubtableFormat14
   {
     for (unsigned i = 0; i < obj_indices.length; i++)
     {
-      // Since the record array has been reversed (see comments in copy())
-      // but obj_indices has not been, the indices at obj_indices[i]
-      // are for the variation record at record[j].
+      /*
+       * Since the record array has been reversed (see comments in copy())
+       * but obj_indices has not been, the indices at obj_indices[i]
+       * are for the variation record at record[j].
+       */
       int j = obj_indices.length - 1 - i;
       c->add_link (record[j].defaultUVS, obj_indices[i].first, this);
       c->add_link (record[j].nonDefaultUVS, obj_indices[i].second, this);

--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -850,6 +850,20 @@ struct VariationSelectorRecord
     return GLYPH_VARIANT_NOT_FOUND;
   }
 
+  VariationSelectorRecord(const VariationSelectorRecord& other)
+  {
+    *this = other;
+  }
+
+  void operator= (const VariationSelectorRecord& other)
+  {
+    varSelector = other.varSelector;
+    HBUINT32 offset = other.defaultUVS;
+    defaultUVS = offset;
+    offset = other.nonDefaultUVS;
+    nonDefaultUVS = offset;
+  }
+
   void collect_unicodes (hb_set_t *out, const void *base) const
   {
     (base+defaultUVS).collect_unicodes (out);
@@ -992,17 +1006,7 @@ struct CmapSubtableFormat14
 
   void _reverse_variation_records ()
   {
-    int rhs = record.len - 1;
-    int lhs = 0;
-    while (rhs > lhs)
-    {
-      int value_rhs = record[rhs].varSelector;
-      int value_lhs = record[lhs].varSelector;
-      record[rhs].varSelector = value_lhs;
-      record[lhs].varSelector = value_rhs;
-      rhs--;
-      lhs++;
-    }
+    record.as_array ().reverse ();
   }
 
   void _add_links_to_variation_records (hb_serialize_context_t *c,


### PR DESCRIPTION
Current versions of OTS fail fonts with cmap 14's who's last offset does not point to the a block at the end of the table.