### PR TITLE
[gintrospection] Fix g-ir-scanner syntax errors

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -189,7 +189,6 @@ HB_BASE_RAGEL_sources = \
 	$(NULL)
 
 HB_BASE_headers = \
-	hb-aat-layout.h \
 	hb-aat.h \
 	hb-blob.h \
 	hb-buffer.h \
@@ -207,7 +206,6 @@ HB_BASE_headers = \
 	hb-ot-meta.h \
 	hb-ot-metrics.h \
 	hb-ot-name.h \
-	hb-ot-shape.h \
 	hb-ot-var.h \
 	hb-ot.h \
 	hb-set.h \
@@ -216,6 +214,8 @@ HB_BASE_headers = \
 	hb-unicode.h \
 	hb-version.h \
 	hb.h \
+	hb-aat-layout.h \
+	hb-ot-shape.h \
 	$(NULL)
 
 # Optional Sources and Headers with external deps


### PR DESCRIPTION
... when compiling with --with-gobject=yes --enable-introspection=yes

The file list given to `g-ir-scanner` is somehow position dependent. See first post in issue #1912 for the error output.
The errors disappear if hb-aat-layout.h and hb-ot-shape.h slide down the list.
(Note that this was no fatal failure. Some warnings remain.)