### PR TITLE
[draw] Add FreeType as a draw glyph backend

### DIFF
--- a/src/hb-draw.cc
+++ b/src/hb-draw.cc
@@ -24,13 +24,8 @@
 
 #include "hb.hh"
 
-#ifndef HB_NO_DRAW
-
 #include "hb-draw.hh"
 #include "hb-ot.h"
-#include "hb-ot-glyf-table.hh"
-#include "hb-ot-cff1-table.hh"
-#include "hb-ot-cff2-table.hh"
 
 /**
  * hb_draw_funcs_set_move_to_func:
@@ -224,36 +219,3 @@ hb_draw_funcs_is_immutable (hb_draw_funcs_t *funcs)
 {
   return hb_object_is_immutable (funcs);
 }
-
-/**
- * hb_font_draw_glyph:
- * @font: a font object
- * @glyph: a glyph id
- * @funcs: draw callbacks object
- * @user_data: parameter you like be passed to the callbacks when are called
- *
- * Draw a glyph.
- *
- * Returns: Whether the font had the glyph and the operation completed successfully.
- * Since: REPLACEME
- **/
-hb_bool_t
-hb_font_draw_glyph (hb_font_t *font, hb_codepoint_t glyph,
-		    const hb_draw_funcs_t *funcs,
-		    void *user_data)
-{
-  if (unlikely (funcs == &Null (hb_draw_funcs_t) ||
-		glyph >= font->face->get_num_glyphs ()))
-    return false;
-
-  draw_helper_t draw_helper (funcs, user_data);
-  if (font->face->table.glyf->get_path (font, glyph, draw_helper)) return true;
-#ifndef HB_NO_CFF
-  if (font->face->table.cff1->get_path (font, glyph, draw_helper)) return true;
-  if (font->face->table.cff2->get_path (font, glyph, draw_helper)) return true;
-#endif
-
-  return false;
-}
-
-#endif

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -472,6 +472,27 @@ hb_font_get_glyph_from_name_default (hb_font_t *font,
   return font->parent->get_glyph_from_name (name, len, glyph);
 }
 
+static hb_bool_t
+hb_font_get_draw_glyph_nil (hb_font_t *font HB_UNUSED,
+			    void *font_data HB_UNUSED,
+			    hb_codepoint_t glyph HB_UNUSED,
+			    const hb_draw_funcs_t *funcs HB_UNUSED,
+			    void *call_user_data HB_UNUSED,
+			    void *user_data HB_UNUSED)
+{
+  return false;
+}
+static hb_bool_t
+hb_font_get_draw_glyph_default (hb_font_t *font,
+				void *font_data HB_UNUSED,
+				hb_codepoint_t glyph,
+				const hb_draw_funcs_t *funcs,
+				void *call_user_data,
+				void *user_data HB_UNUSED)
+{
+  return font->parent->draw_glyph (glyph, funcs, call_user_data);
+}
+
 DEFINE_NULL_INSTANCE (hb_font_funcs_t) =
 {
   HB_OBJECT_HEADER_STATIC,
@@ -1313,6 +1334,25 @@ hb_font_glyph_from_string (hb_font_t *font,
   return font->glyph_from_string (s, len, glyph);
 }
 
+/**
+ * hb_font_draw_glyph:
+ * @font: a font object
+ * @glyph: a glyph id
+ * @funcs: draw callbacks object
+ * @user_data: parameter you like be passed to the callbacks when are called
+ *
+ * Draw a glyph.
+ *
+ * Returns: Whether the font had the glyph and the operation completed successfully.
+ * Since: REPLACEME
+ **/
+hb_bool_t
+hb_font_draw_glyph (hb_font_t *font, hb_codepoint_t glyph,
+		    const hb_draw_funcs_t *funcs,
+		    void *user_data)
+{
+  return font->draw_glyph (glyph, funcs, user_data);
+}
 
 /*
  * hb_font_t

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -183,6 +183,9 @@ typedef hb_bool_t (*hb_font_get_glyph_from_name_func_t) (hb_font_t *font, void *
 							 hb_codepoint_t *glyph,
 							 void *user_data);
 
+typedef hb_bool_t (*hb_font_get_draw_glyph_func_t) (hb_font_t *font, void *font_data,
+						    hb_codepoint_t glyph, const hb_draw_funcs_t *funcs,
+						    void *call_user_data, void *user_data);
 
 /* func setters */
 
@@ -441,6 +444,22 @@ HB_EXTERN void
 hb_font_funcs_set_glyph_from_name_func (hb_font_funcs_t *ffuncs,
 					hb_font_get_glyph_from_name_func_t func,
 					void *user_data, hb_destroy_func_t destroy);
+
+/**
+ * hb_font_funcs_draw_glyph_func:
+ * @ffuncs: font functions.
+ * @func: (closure user_data) (destroy destroy) (scope notified):
+ * @user_data:
+ * @destroy:
+ *
+ *
+ *
+ * Since: REPLACEME
+ **/
+HB_EXTERN void
+hb_font_funcs_set_draw_glyph_func (hb_font_funcs_t *ffuncs,
+				   hb_font_get_draw_glyph_func_t func,
+				   void *user_data, hb_destroy_func_t destroy);
 
 /* func dispatch */
 

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -183,9 +183,9 @@ typedef hb_bool_t (*hb_font_get_glyph_from_name_func_t) (hb_font_t *font, void *
 							 hb_codepoint_t *glyph,
 							 void *user_data);
 
-typedef hb_bool_t (*hb_font_get_draw_glyph_func_t) (hb_font_t *font, void *font_data,
-						    hb_codepoint_t glyph, const hb_draw_funcs_t *funcs,
-						    void *call_user_data, void *user_data);
+typedef hb_bool_t (*hb_font_draw_glyph_func_t) (hb_font_t *font, void *font_data,
+						hb_codepoint_t glyph, const hb_draw_funcs_t *funcs,
+						void *call_user_data, void *user_data);
 
 /* func setters */
 
@@ -458,7 +458,7 @@ hb_font_funcs_set_glyph_from_name_func (hb_font_funcs_t *ffuncs,
  **/
 HB_EXTERN void
 hb_font_funcs_set_draw_glyph_func (hb_font_funcs_t *ffuncs,
-				   hb_font_get_draw_glyph_func_t func,
+				   hb_font_draw_glyph_func_t func,
 				   void *user_data, hb_destroy_func_t destroy);
 
 /* func dispatch */

--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -57,6 +57,7 @@
   HB_FONT_FUNC_IMPLEMENT (glyph_contour_point) \
   HB_FONT_FUNC_IMPLEMENT (glyph_name) \
   HB_FONT_FUNC_IMPLEMENT (glyph_from_name) \
+  HB_FONT_FUNC_IMPLEMENT (draw_glyph) \
   /* ^--- Add new callbacks here */
 
 struct hb_font_funcs_t
@@ -367,6 +368,14 @@ struct hb_font_t
 					 name, len,
 					 glyph,
 					 klass->user_data.glyph_from_name);
+  }
+
+  hb_bool_t draw_glyph (hb_codepoint_t glyph, const hb_draw_funcs_t *funcs,
+			void *call_user_data)
+  {
+
+    return klass->get.f.draw_glyph (this, user_data, glyph, funcs, call_user_data,
+				    klass->user_data.draw_glyph);
   }
 
 

--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -57,7 +57,6 @@
   HB_FONT_FUNC_IMPLEMENT (glyph_contour_point) \
   HB_FONT_FUNC_IMPLEMENT (glyph_name) \
   HB_FONT_FUNC_IMPLEMENT (glyph_from_name) \
-  HB_FONT_FUNC_IMPLEMENT (draw_glyph) \
   /* ^--- Add new callbacks here */
 
 struct hb_font_funcs_t
@@ -68,12 +67,14 @@ struct hb_font_funcs_t
 #define HB_FONT_FUNC_IMPLEMENT(name) void *name;
     HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
 #undef HB_FONT_FUNC_IMPLEMENT
+    void *draw_glyph;
   } user_data;
 
   struct {
 #define HB_FONT_FUNC_IMPLEMENT(name) hb_destroy_func_t name;
     HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
 #undef HB_FONT_FUNC_IMPLEMENT
+    hb_destroy_func_t draw_glyph;
   } destroy;
 
   /* Don't access these directly.  Call font->get_*() instead. */
@@ -82,11 +83,13 @@ struct hb_font_funcs_t
 #define HB_FONT_FUNC_IMPLEMENT(name) hb_font_get_##name##_func_t name;
       HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
 #undef HB_FONT_FUNC_IMPLEMENT
+      hb_font_draw_glyph_func_t draw_glyph;
     } f;
     void (*array[0
 #define HB_FONT_FUNC_IMPLEMENT(name) +1
       HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
 #undef HB_FONT_FUNC_IMPLEMENT
+	+1 /* for draw_glyph */
 		]) ();
   } get;
 };
@@ -195,6 +198,22 @@ struct hb_font_t
   }
   HB_FONT_FUNCS_IMPLEMENT_CALLBACKS
 #undef HB_FONT_FUNC_IMPLEMENT
+
+
+  bool
+  has_draw_glyph_func ()
+  {
+    hb_font_funcs_t *funcs = this->klass;
+    unsigned int i = offsetof (hb_font_funcs_t::get_t::get_funcs_t, draw_glyph) / sizeof (funcs->get.array[0]);
+    return has_func (i);
+  }
+  bool
+  has_draw_glyph_func_set ()
+  {
+    hb_font_funcs_t *funcs = this->klass;
+    unsigned int i = offsetof (hb_font_funcs_t::get_t::get_funcs_t, draw_glyph) / sizeof (funcs->get.array[0]);
+    return has_func_set (i);
+  }
 
   hb_bool_t get_font_h_extents (hb_font_extents_t *extents)
   {

--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -33,6 +33,7 @@
 
 #include "hb-ft.h"
 
+#include "hb-draw.hh"
 #include "hb-font.hh"
 #include "hb-machinery.hh"
 #include "hb-cache.hh"
@@ -528,6 +529,92 @@ hb_ft_get_glyph_from_name (hb_font_t *font HB_UNUSED,
   return *glyph != 0;
 }
 
+struct _ft_draw_user_data
+{
+  const hb_draw_funcs_t *funcs;
+  void *user_data;
+  bool is_open;
+};
+
+static int
+_ft_move_to (const FT_Vector *to, _ft_draw_user_data *user_data)
+{
+  if (user_data->is_open) user_data->funcs->close_path (user_data->user_data);
+  user_data->funcs->move_to (round (to->x), round (to->y), user_data->user_data);
+  return FT_Err_Ok;
+}
+
+static int
+_ft_line_to (const FT_Vector *to, _ft_draw_user_data *user_data)
+{
+  user_data->is_open = true;
+  user_data->funcs->line_to (round (to->x), round (to->y), user_data->user_data);
+  return FT_Err_Ok;
+}
+
+static int
+_ft_conic_to (const FT_Vector *control, const FT_Vector *to, _ft_draw_user_data *user_data)
+{
+  user_data->is_open = true;
+  user_data->funcs->quadratic_to (round (control->x), round (control->y),
+				  round (to->x), round (to->y), user_data->user_data);
+  return FT_Err_Ok;
+}
+
+static int
+_ft_cubic_to (const FT_Vector *control1, const FT_Vector *control2, const FT_Vector *to, _ft_draw_user_data *user_data)
+{
+  user_data->is_open = true;
+  user_data->funcs->cubic_to (round (control1->x), round (control1->y),
+			      round (control2->x), round (control2->y),
+			      round (to->x), round (to->y),
+			      user_data->user_data);
+  return FT_Err_Ok;
+}
+
+static hb_bool_t
+hb_ft_draw_glyph (hb_font_t *font HB_UNUSED,
+		  void *font_data,
+		  hb_codepoint_t glyph,
+		  const hb_draw_funcs_t *funcs,
+		  void *call_user_data,
+		  void *user_data HB_UNUSED)
+{
+  const hb_ft_font_t *ft_font = (const hb_ft_font_t *) font_data;
+  hb_lock_t lock (ft_font->lock);
+
+  if (unlikely (FT_Load_Glyph (ft_font->ft_face, glyph,
+			       FT_LOAD_NO_BITMAP | ft_font->load_flags)))
+    return false;
+
+  if (ft_font->ft_face->glyph->format != FT_GLYPH_FORMAT_OUTLINE)
+    return false;
+
+  const FT_Outline_Funcs outline_funcs = {
+    (FT_Outline_MoveToFunc) _ft_move_to,
+    (FT_Outline_LineToFunc) _ft_line_to,
+    (FT_Outline_ConicToFunc) _ft_conic_to,
+    (FT_Outline_CubicToFunc) _ft_cubic_to,
+    0, /* shift */
+    0, /* delta */
+  };
+
+  _ft_draw_user_data ft_user_data = {
+    funcs,
+    call_user_data,
+    false
+  };
+
+  if (unlikely (FT_Outline_Decompose (&ft_font->ft_face->glyph->outline,
+				      &outline_funcs, &ft_user_data)))
+    return false;
+
+  if (ft_user_data.is_open)
+    funcs->close_path (call_user_data);
+
+  return true;
+}
+
 static hb_bool_t
 hb_ft_get_font_h_extents (hb_font_t *font HB_UNUSED,
 			  void *font_data,
@@ -576,6 +663,7 @@ static struct hb_ft_font_funcs_lazy_loader_t : hb_font_funcs_lazy_loader_t<hb_ft
     hb_font_funcs_set_glyph_contour_point_func (funcs, hb_ft_get_glyph_contour_point, nullptr, nullptr);
     hb_font_funcs_set_glyph_name_func (funcs, hb_ft_get_glyph_name, nullptr, nullptr);
     hb_font_funcs_set_glyph_from_name_func (funcs, hb_ft_get_glyph_from_name, nullptr, nullptr);
+    hb_font_funcs_set_draw_glyph_func (funcs, hb_ft_draw_glyph, nullptr, nullptr);
 
     hb_font_funcs_make_immutable (funcs);
 

--- a/src/hb-ft.h
+++ b/src/hb-ft.h
@@ -33,6 +33,7 @@
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
+#include FT_OUTLINE_H
 
 HB_BEGIN_DECLS
 

--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -243,7 +243,7 @@ hb_ot_draw_glyph (hb_font_t *font, void *font_data HB_UNUSED,
 		glyph >= font->face->get_num_glyphs ()))
     return false;
 
-  draw_helper_t draw_helper (funcs, user_data);
+  draw_helper_t draw_helper (funcs, call_user_data);
   if (font->face->table.glyf->get_path (font, glyph, draw_helper)) return true;
 #ifndef HB_NO_CFF
   if (font->face->table.cff1->get_path (font, glyph, draw_helper)) return true;

--- a/test/api/Makefile.am
+++ b/test/api/Makefile.am
@@ -34,7 +34,6 @@ TEST_PROGS = \
 	test-buffer \
 	test-collect-unicodes \
 	test-common \
-	test-draw \
 	test-font \
 	test-map \
 	test-object \
@@ -65,6 +64,13 @@ TEST_PROGS = \
 	test-version \
 	test-subset-nameids \
 	$(NULL)
+
+TEST_PROGS += test-draw
+test_draw_SOURCES = test-draw.c
+if HAVE_FREETYPE
+test_draw_CFLAGS = $(CFLAGS) $(FREETYPE_CFLAGS)
+test_draw_LDADD = $(LDADD) $(FREETYPE_LIBS)
+endif
 
 test_subset_LDADD = $(LDADD) $(top_builddir)/src/libharfbuzz-subset.la
 test_subset_cmap_LDADD = $(LDADD) $(top_builddir)/src/libharfbuzz-subset.la

--- a/test/api/test-draw.c
+++ b/test/api/test-draw.c
@@ -25,6 +25,9 @@
 #include "hb-test.h"
 
 #include <hb.h>
+#ifdef HAVE_FREETYPE
+#include <hb-ft.h>
+#endif
 
 typedef struct user_data_t
 {
@@ -898,6 +901,44 @@ test_hb_draw_immutable (void)
   hb_draw_funcs_destroy (draw_funcs);
 }
 
+#ifdef HAVE_FREETYPE
+static void
+test_hb_draw_freetype (void)
+{
+  char str[2048];
+  user_data_t user_data = {
+    .str = str,
+    .size = sizeof (str)
+  };
+  {
+    hb_face_t *face = hb_test_open_font_file ("fonts/Stroking.ttf");
+    hb_font_t *font = hb_font_create (face);
+    hb_ft_font_set_funcs (font);
+    hb_face_destroy (face);
+
+    user_data.consumed = 0;
+    g_assert (hb_font_draw_glyph (font, 6, funcs, &user_data));
+    char expected[] = "M1626,1522Q1626,1522 1626,1522Q1626,1522 1626,1522Z"
+		      "M530,1984Q436,1764 436,1522Q436,1280 530,1059Q625,839 784,680"
+		      "Q943,521 1163,426Q1384,332 1626,332Q1868,332 2088,426"
+		      "Q2309,521 2468,680Q2627,839 2721,1059Q2816,1280 2816,1522"
+		      "Q2816,1764 2721,1984Q2627,2205 2468,2364Q2309,2523 2088,2617"
+		      "Q1868,2712 1626,2712Q1384,2712 1163,2617Q943,2523 784,2364"
+		      "Q625,2205 530,1984ZM305,1164Q256,1342 256,1528Q256,1714 305,1891"
+		      "Q355,2069 443,2219Q531,2370 657,2496Q784,2623 934,2711"
+		      "Q1085,2799 1262,2848Q1440,2898 1626,2898Q1812,2898 1989,2848"
+		      "Q2167,2799 2317,2711Q2468,2623 2594,2496Q2721,2370 2809,2219"
+		      "Q2897,2069 2946,1891Q2996,1714 2996,1528Q2996,1342 2946,1164"
+		      "Q2897,987 2809,836Q2721,686 2594,559Q2468,433 2317,345"
+		      "Q2167,257 1989,207Q1812,158 1626,158Q1440,158 1262,207"
+		      "Q1085,257 934,345Q784,433 657,559Q531,686 443,836Q355,987 305,1164Z";
+    g_assert_cmpmem (str, user_data.consumed, expected, sizeof (expected) - 1);
+
+    hb_font_destroy (font);
+  }
+}
+#endif
+
 int
 main (int argc, char **argv)
 {
@@ -929,6 +970,9 @@ main (int argc, char **argv)
   hb_test_add (test_hb_draw_estedad_vf);
   hb_test_add (test_hb_draw_stroking);
   hb_test_add (test_hb_draw_immutable);
+#ifdef HAVE_FREETYPE
+  hb_test_add (test_hb_draw_freetype);
+#endif
   unsigned result = hb_test_run ();
 
   hb_draw_funcs_destroy (funcs);


### PR DESCRIPTION
#2183 spin off (that can be reconsidered after this), its naming doesn't make it useful for HB_FONT_FUNCS_IMPLEMENT_CALLBACKS however as it isn't a getter unlike the others and the fact we should carry two user_data, one for the specific draw call and as font funcs makes it a bit pain. One of my concern about the API is the decision of keeping or merging user_data of a specific draw call with the draw funcs which the situation here makes me a bit more undecided. WDYT