### PR TITLE
[subset] Add source_blob as a hb_subset_context_t field

### DIFF
--- a/src/hb-ot-color-sbix-table.hh
+++ b/src/hb-ot-color-sbix-table.hh
@@ -339,20 +339,16 @@ struct sbix
 			  strikes.sanitize (c, this)));
   }
 
-  bool add_strike (hb_subset_context_t *c,
-		   const void *dst_base,
-		   unsigned int i,
-		   unsigned int sbix_len) const {
-    if (strikes[i].is_null () ||
-	sbix_len < (unsigned int) strikes[i])
+  bool
+  add_strike (hb_subset_context_t *c, const void *dst_base, unsigned i) const
+  {
+    if (strikes[i].is_null () || c->source_blob->length < (unsigned) strikes[i])
       return false;
 
-    return (this+strikes[i]).subset (c, sbix_len - (unsigned int) strikes[i]);
+    return (this+strikes[i]).subset (c, c->source_blob->length - (unsigned) strikes[i]);
   }
 
-  bool serialize_strike_offsets (hb_subset_context_t *c,
-				 const void *dst_base,
-				 unsigned int sbix_len) const
+  bool serialize_strike_offsets (hb_subset_context_t *c, const void *dst_base) const
   {
     TRACE_SERIALIZE (this);
 
@@ -369,7 +365,7 @@ struct sbix
       *o = 0;
       auto snap = c->serializer->snapshot ();
       c->serializer->push ();
-      bool ret = add_strike (c, dst_base, i, sbix_len);
+      bool ret = add_strike (c, dst_base, i);
       if (!ret)
       {
 	c->serializer->pop_discard ();
@@ -396,11 +392,8 @@ struct sbix
     if (unlikely (!sbix_prime)) return_trace (false);
     if (unlikely (!c->serializer->embed (this->version))) return_trace (false);
     if (unlikely (!c->serializer->embed (this->flags))) return_trace (false);
-    hb_blob_ptr_t<sbix> table = hb_sanitize_context_t ().reference_table<sbix> (c->plan->source);
-    const unsigned int sbix_len = table.get_blob ()->length;
-    table.destroy ();
 
-    return_trace (serialize_strike_offsets (c, sbix_prime, sbix_len));
+    return_trace (serialize_strike_offsets (c, sbix_prime));
   }
 
   protected:

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -89,7 +89,7 @@ _subset (hb_subset_plan_t *plan)
   retry:
     hb_serialize_context_t serializer ((void *) buf, buf_size);
     serializer.start_serialize<TableType> ();
-    hb_subset_context_t c (plan, &serializer);
+    hb_subset_context_t c (source_blob, plan, &serializer);
     bool needed = table->subset (&c);
     if (serializer.ran_out_of_room)
     {

--- a/src/hb-subset.hh
+++ b/src/hb-subset.hh
@@ -54,12 +54,15 @@ struct hb_subset_context_t :
   dispatch (const T &obj, Ts&&... ds) HB_AUTO_RETURN
   ( _dispatch (obj, hb_prioritize, hb_forward<Ts> (ds)...) )
 
+  hb_blob_t *source_blob;
   hb_subset_plan_t *plan;
   hb_serialize_context_t *serializer;
   unsigned int debug_depth;
 
-  hb_subset_context_t (hb_subset_plan_t *plan_,
+  hb_subset_context_t (hb_blob_t *source_blob_,
+		       hb_subset_plan_t *plan_,
 		       hb_serialize_context_t *serializer_) :
+		        source_blob (source_blob_),
 			plan (plan_),
 			serializer (serializer_),
 			debug_depth (0) {}


### PR DESCRIPTION
So no more double sanitizing source table.

Maybe there was a reason that this was left out in the original design, let's find out.