### PR TITLE
[var] Fix hb_ot_var_get_axis_infos's offset semantic

### DIFF
--- a/src/hb-ot-var-fvar-table.hh
+++ b/src/hb-ot-var-fvar-table.hh
@@ -150,17 +150,8 @@ struct fvar
   {
     if (axes_count)
     {
-      /* TODO Rewrite as hb_array_t<>::sub-array() */
-      unsigned int count = axisCount;
-      start_offset = hb_min (start_offset, count);
-
-      count -= start_offset;
-      axes_array += start_offset;
-
-      count = hb_min (count, *axes_count);
-      *axes_count = count;
-
-      for (unsigned int i = 0; i < count; i++)
+      hb_array_t<const AxisRecord> arr = hb_array (&(this+firstAxis), axisCount).sub_array (start_offset, axes_count);
+      for (unsigned i = 0; i < arr.length; ++i)
 	get_axis_deprecated (start_offset + i, axes_array + i);
     }
     return axisCount;
@@ -173,17 +164,8 @@ struct fvar
   {
     if (axes_count)
     {
-      /* TODO Rewrite as hb_array_t<>::sub-array() */
-      unsigned int count = axisCount;
-      start_offset = hb_min (start_offset, count);
-
-      count -= start_offset;
-      axes_array += start_offset;
-
-      count = hb_min (count, *axes_count);
-      *axes_count = count;
-
-      for (unsigned int i = 0; i < count; i++)
+      hb_array_t<const AxisRecord> arr = hb_array (&(this+firstAxis), axisCount).sub_array (start_offset, axes_count);
+      for (unsigned i = 0; i < arr.length; ++i)
 	get_axis_info (start_offset + i, axes_array + i);
     }
     return axisCount;

--- a/test/api/test-var-coords.c
+++ b/test/api/test-var-coords.c
@@ -67,10 +67,35 @@ test_get_var_coords (void)
   hb_face_destroy (face);
 }
 
+static void
+test_get_var_get_axis_infos (void)
+{
+  hb_face_t *face = hb_test_open_font_file ("fonts/Estedad-VF.ttf");
+
+  g_assert_cmpint (hb_ot_var_get_axis_count (face), ==, 2);
+
+  hb_ot_var_axis_info_t info;
+  unsigned c = 1;
+
+  g_assert_cmpint (hb_ot_var_get_axis_infos (face, 0, &c, &info), ==, 2);
+  g_assert (info.tag == HB_TAG ('w','g','h','t'));
+  g_assert_cmpint (c, ==, 1);
+
+  hb_ot_var_get_axis_infos (face, 1, &c, &info);
+  g_assert (info.tag == HB_TAG ('w','d','t','h'));
+  g_assert_cmpint (c, ==, 1);
+
+  hb_ot_var_get_axis_infos (face, 2, &c, &info);
+  g_assert_cmpint (c, ==, 0);
+
+  hb_face_destroy (face);
+}
+
 int
 main (int argc, char **argv)
 {
   hb_test_init (&argc, &argv);
   hb_test_add (test_get_var_coords);
+  hb_test_add (test_get_var_get_axis_infos);
   return hb_test_run ();
 }


### PR DESCRIPTION
The API was adding offset to input's infos buffer index also which is
unusual between our APIs and wrong.