### PR TITLE
add "add_link()" with bias arg

### DIFF
--- a/src/hb-ot-cff-common.hh
+++ b/src/hb-ot-cff-common.hh
@@ -415,7 +415,7 @@ struct Dict : UnsizedByteStr
   {
     T &ofs = *(T *) (c->head + OpCode_Size (int_op));
     if (unlikely (!serialize_int_op<T> (c, op, 0, int_op))) return false;
-    c->add_link (ofs, link, nullptr, whence);
+    c->add_link (ofs, link, whence);
     return true;
   }
   


### PR DESCRIPTION
Addresses issue #2227: revisit hb_serialize_context_t::add_link() base arg

Added a prototype of hb_serialize_context_t::add_link() taking `bias` argument (defaulting to 0) which may be specified for all whence_t enum constants `Tail`, `Absolute`, in addition to `Head`. The existing add_link() with base arg calls into this with `bias = base - c->current->head` if base is non-null.