### PR TITLE
Merge max_subtables of sanitizer with its max_ops

### DIFF
--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -1098,8 +1098,8 @@ struct Lookup
     TRACE_SANITIZE (this);
     if (!(c->check_struct (this) && subTable.sanitize (c))) return_trace (false);
 
-    unsigned subtables = get_subtable_count ();
-    if (unlikely (!c->visit_subtables (subtables))) return_trace (false);
+    unsigned num_subtables = get_subtable_count ();
+    if (unlikely (((c->max_ops -= num_subtables) <= 0))) return_trace (false);
 
     if (lookupFlag & LookupFlag::UseMarkFilteringSet)
     {
@@ -1123,7 +1123,7 @@ struct Lookup
        * https://bugs.chromium.org/p/chromium/issues/detail?id=960331
        */
       unsigned int type = get_subtable<TSubTable> (0).u.extension.get_type ();
-      for (unsigned int i = 1; i < subtables; i++)
+      for (unsigned int i = 1; i < num_subtables; i++)
 	if (get_subtable<TSubTable> (i).u.extension.get_type () != type)
 	  return_trace (false);
     }

--- a/src/hb-sanitize.hh
+++ b/src/hb-sanitize.hh
@@ -113,9 +113,6 @@
 #ifndef HB_SANITIZE_MAX_OPS_MAX
 #define HB_SANITIZE_MAX_OPS_MAX 0x3FFFFFFF
 #endif
-#ifndef HB_SANITIZE_MAX_SUTABLES
-#define HB_SANITIZE_MAX_SUTABLES 0x4000
-#endif
 
 struct hb_sanitize_context_t :
        hb_dispatch_context_t<hb_sanitize_context_t, bool, HB_DEBUG_SANITIZE>
@@ -123,7 +120,7 @@ struct hb_sanitize_context_t :
   hb_sanitize_context_t () :
 	debug_depth (0),
 	start (nullptr), end (nullptr),
-	max_ops (0), max_subtables (0),
+	max_ops (0),
 	writable (false), edit_count (0),
 	blob (nullptr),
 	num_glyphs (65536),
@@ -136,12 +133,6 @@ struct hb_sanitize_context_t :
   static return_t default_return_value () { return true; }
   static return_t no_dispatch_return_value () { return false; }
   bool stop_sublookup_iteration (const return_t r) const { return !r; }
-
-  bool visit_subtables (unsigned count)
-  {
-    max_subtables += count;
-    return max_subtables < HB_SANITIZE_MAX_SUTABLES;
-  }
 
   private:
   template <typename T, typename ...Ts> auto
@@ -389,7 +380,7 @@ struct hb_sanitize_context_t :
 
   mutable unsigned int debug_depth;
   const char *start, *end;
-  mutable int max_ops, max_subtables;
+  mutable int max_ops;
   private:
   bool writable;
   unsigned int edit_count;


### PR DESCRIPTION
Most likely it is safe to consume from sanitizer's max_ops while reading from Lookup subtables, added on #2219 to fix #1647