### PR TITLE
add "add_link()" with bias arg - take 2

### DIFF
--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -316,7 +316,6 @@ struct OffsetTo : Offset<OffsetType, has_null>
   bool serialize_subset (hb_subset_context_t *c,
 			 const OffsetTo& src,
 			 const void *src_base,
-			 const void *dst_base,
 			 Ts&&... ds)
   {
     *this = 0;
@@ -330,7 +329,7 @@ struct OffsetTo : Offset<OffsetType, has_null>
     bool ret = c->dispatch (src_base+src, hb_forward<Ts> (ds)...);
 
     if (ret || !has_null)
-      s->add_link (*this, s->pop_pack (), dst_base);
+      s->add_link (*this, s->pop_pack ());
     else
       s->pop_discard ();
 
@@ -345,7 +344,7 @@ struct OffsetTo : Offset<OffsetType, has_null>
   bool serialize_copy (hb_serialize_context_t *c,
 		       const OffsetTo& src,
 		       const void *src_base,
-		       const void *dst_base,
+		       unsigned dst_bias,
 		       hb_serialize_context_t::whence_t whence,
 		       Ts&&... ds)
   {
@@ -357,7 +356,7 @@ struct OffsetTo : Offset<OffsetType, has_null>
 
     bool ret = c->copy (src_base+src, hb_forward<Ts> (ds)...);
 
-    c->add_link (*this, c->pop_pack (), dst_base, whence);
+    c->add_link (*this, c->pop_pack (), whence, dst_bias);
 
     return ret;
   }
@@ -365,8 +364,8 @@ struct OffsetTo : Offset<OffsetType, has_null>
   bool serialize_copy (hb_serialize_context_t *c,
 		       const OffsetTo& src,
 		       const void *src_base,
-		       const void *dst_base)
-  { return serialize_copy (c, src, src_base, dst_base, hb_serialize_context_t::Head); }
+		       unsigned dst_bias = 0)
+  { return serialize_copy (c, src, src_base, dst_bias, hb_serialize_context_t::Head); }
 
   bool sanitize_shallow (hb_sanitize_context_t *c, const void *base) const
   {

--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -892,8 +892,7 @@ struct VariationSelectorRecord
         const hb_set_t *unicodes,
         const hb_set_t *glyphs,
         const hb_map_t *glyph_map,
-        const void *src_base,
-        const void *dst_base) const
+        const void *src_base) const
   {
     auto snap = c->snapshot ();
     auto *out = c->embed<VariationSelectorRecord> (*this);
@@ -985,7 +984,7 @@ struct CmapSubtableFormat14
     for (int i = src_tbl->record.len - 1; i >= 0; i--)
     {
       hb_pair_t<unsigned, unsigned> result =
-          src_tbl->record[i].copy (c, unicodes, glyphs, glyph_map, src_base, this);
+          src_tbl->record[i].copy (c, unicodes, glyphs, glyph_map, src_base);
       if (result.first || result.second)
         obj_indices.push (result);
     }
@@ -1026,8 +1025,8 @@ struct CmapSubtableFormat14
        * are for the variation record at record[j].
        */
       int j = obj_indices.length - 1 - i;
-      c->add_link (record[j].defaultUVS, obj_indices[i].first, this);
-      c->add_link (record[j].nonDefaultUVS, obj_indices[i].second, this);
+      c->add_link (record[j].defaultUVS, obj_indices[i].first);
+      c->add_link (record[j].nonDefaultUVS, obj_indices[i].second);
     }
   }
 
@@ -1170,7 +1169,6 @@ struct EncodingRecord
 			Iterator it,
 			unsigned format,
 			const void *src_base,
-			const void *dst_base,
 			const hb_subset_plan_t *plan,
 			/* INOUT */ unsigned *objidx) const
   {
@@ -1195,7 +1193,7 @@ struct EncodingRecord
       return_trace (nullptr);
     }
 
-    c->add_link (out->subtable, *objidx, dst_base);
+    c->add_link (out->subtable, *objidx);
     return_trace (out);
   }
 
@@ -1231,9 +1229,9 @@ struct cmap
 
       unsigned format = (src_base+_.subtable).u.format;
 
-      if (format == 4) c->copy (_, + it | hb_filter (unicodes_set, hb_first), 4u, src_base, this, plan, &format4objidx);
-      else if (format == 12) c->copy (_, + it | hb_filter (unicodes_set, hb_first), 12u, src_base, this, plan, &format12objidx);
-      else if (format == 14) c->copy (_, it, 14u, src_base, this, plan, &format14objidx);
+      if (format == 4) c->copy (_, + it | hb_filter (unicodes_set, hb_first), 4u, src_base, plan, &format4objidx);
+      else if (format == 12) c->copy (_, + it | hb_filter (unicodes_set, hb_first), 12u, src_base, plan, &format12objidx);
+      else if (format == 14) c->copy (_, it, 14u, src_base, plan, &format14objidx);
     }
 
     c->check_assign(this->encodingRecord.len, (c->length () - cmap::min_size)/EncodingRecord::static_size);

--- a/src/hb-ot-color-cbdt-table.hh
+++ b/src/hb-ot-color-cbdt-table.hh
@@ -584,7 +584,7 @@ struct IndexSubtableArray
     {
       IndexSubtableRecord* record = c->serializer->embed (records[i]);
       if (unlikely (!record)) return_trace (false);
-      c->serializer->add_link (record->offsetToSubtable, objidxs[records.length - 1 - i], dst);
+      c->serializer->add_link (record->offsetToSubtable, objidxs[records.length - 1 - i]);
     }
     return_trace (true);
   }
@@ -628,7 +628,7 @@ struct BitmapSizeTable
   }
 
   bool
-  subset (hb_subset_context_t *c, const void *src_base, const void *dst_base,
+  subset (hb_subset_context_t *c, const void *src_base,
 	  const char *cbdt, unsigned int cbdt_length,
 	  hb_vector_t<char> *cbdt_prime /* INOUT */) const
   {
@@ -648,7 +648,6 @@ struct BitmapSizeTable
     if (!out_table->indexSubtableArrayOffset.serialize_subset (c,
 							       indexSubtableArrayOffset,
 							       src_base,
-							       dst_base,
 							       &bitmap_size_context))
       return_trace (false);
     if (!bitmap_size_context.size ||
@@ -748,7 +747,7 @@ struct CBLC
     auto snap = c->serializer->snapshot ();
     auto cbdt_prime_len = cbdt_prime->length;
 
-    if (!table.subset (c, this, cblc_prime, cbdt, cbdt_length, cbdt_prime))
+    if (!table.subset (c, this, cbdt, cbdt_length, cbdt_prime))
     {
       cblc_prime->sizeTables.len--;
       c->serializer->revert (snap);

--- a/src/hb-ot-color-sbix-table.hh
+++ b/src/hb-ot-color-sbix-table.hh
@@ -340,7 +340,7 @@ struct sbix
   }
 
   bool
-  add_strike (hb_subset_context_t *c, const void *dst_base, unsigned i) const
+  add_strike (hb_subset_context_t *c, unsigned i) const
   {
     if (strikes[i].is_null () || c->source_blob->length < (unsigned) strikes[i])
       return false;
@@ -348,7 +348,7 @@ struct sbix
     return (this+strikes[i]).subset (c, c->source_blob->length - (unsigned) strikes[i]);
   }
 
-  bool serialize_strike_offsets (hb_subset_context_t *c, const void *dst_base) const
+  bool serialize_strike_offsets (hb_subset_context_t *c) const
   {
     TRACE_SERIALIZE (this);
 
@@ -365,7 +365,7 @@ struct sbix
       *o = 0;
       auto snap = c->serializer->snapshot ();
       c->serializer->push ();
-      bool ret = add_strike (c, dst_base, i);
+      bool ret = add_strike (c, i);
       if (!ret)
       {
 	c->serializer->pop_discard ();
@@ -379,7 +379,7 @@ struct sbix
       }
     }
     for (unsigned int i = 0; i < new_strikes.length; ++i)
-      c->serializer->add_link (*new_strikes[i], objidxs[new_strikes.length - 1 - i], dst_base);
+      c->serializer->add_link (*new_strikes[i], objidxs[new_strikes.length - 1 - i]);
 
     return_trace (true);
   }
@@ -393,7 +393,7 @@ struct sbix
     if (unlikely (!c->serializer->embed (this->version))) return_trace (false);
     if (unlikely (!c->serializer->embed (this->flags))) return_trace (false);
 
-    return_trace (serialize_strike_offsets (c, sbix_prime));
+    return_trace (serialize_strike_offsets (c));
   }
 
   protected:

--- a/src/hb-ot-layout-gdef-table.hh
+++ b/src/hb-ot-layout-gdef-table.hh
@@ -173,7 +173,7 @@ struct CaretValueFormat3
     auto *out = c->serializer->embed (this);
     if (unlikely (!out)) return_trace (false);
 
-    return_trace (out->deviceTable.serialize_copy (c->serializer, deviceTable, this, out));
+    return_trace (out->deviceTable.serialize_copy (c->serializer, deviceTable, this));
   }
 
   bool sanitize (hb_sanitize_context_t *c) const
@@ -272,7 +272,7 @@ struct LigGlyph
     if (unlikely (!c->serializer->extend_min (out))) return_trace (false);
 
     + hb_iter (carets)
-    | hb_apply (subset_offset_array (c, out->carets, this, out))
+    | hb_apply (subset_offset_array (c, out->carets, this))
     ;
 
     return_trace (bool (out->carets));
@@ -326,7 +326,7 @@ struct LigCaretList
     hb_sorted_vector_t<hb_codepoint_t> new_coverage;
     + hb_zip (this+coverage, ligGlyph)
     | hb_filter (glyphset, hb_first)
-    | hb_filter (subset_offset_array (c, out->ligGlyph, this, out), hb_second)
+    | hb_filter (subset_offset_array (c, out->ligGlyph, this), hb_second)
     | hb_map (hb_first)
     | hb_map (glyph_map)
     | hb_sink (new_coverage)
@@ -381,7 +381,7 @@ struct MarkGlyphSetsFormat1
       //See issue: https://github.com/khaledhosny/ots/issues/172
       c->serializer->push ();
       c->dispatch (this+offset);
-      c->serializer->add_link (*o, c->serializer->pop_pack (), out);
+      c->serializer->add_link (*o, c->serializer->pop_pack ());
     }
 
     return_trace (ret && out->coverage.len);
@@ -550,20 +550,20 @@ struct GDEF
     auto *out = c->serializer->embed (*this);
     if (unlikely (!out)) return_trace (false);
 
-    out->glyphClassDef.serialize_subset (c, glyphClassDef, this, out);
-    out->attachList = 0;//TODO(subset) serialize_subset (c, attachList, this, out);
-    out->ligCaretList.serialize_subset (c, ligCaretList, this, out);
-    out->markAttachClassDef.serialize_subset (c, markAttachClassDef, this, out);
+    out->glyphClassDef.serialize_subset (c, glyphClassDef, this);
+    out->attachList = 0;//TODO(subset) serialize_subset (c, attachList, this);
+    out->ligCaretList.serialize_subset (c, ligCaretList, this);
+    out->markAttachClassDef.serialize_subset (c, markAttachClassDef, this);
 
     if (version.to_int () >= 0x00010002u)
     {
-      if (!out->markGlyphSetsDef.serialize_subset (c, markGlyphSetsDef, this, out) &&
+      if (!out->markGlyphSetsDef.serialize_subset (c, markGlyphSetsDef, this) &&
           version.to_int () == 0x00010002u)
         out->version.minor = 0;
     }
 
     if (version.to_int () >= 0x00010003u)
-      out->varStore = 0;// TODO(subset) serialize_subset (c, varStore, this, out);
+      out->varStore = 0;// TODO(subset) serialize_subset (c, varStore, this);
 
     return_trace (true);
   }

--- a/src/hb-ot-layout-gsub-table.hh
+++ b/src/hb-ot-layout-gsub-table.hh
@@ -457,7 +457,7 @@ struct MultipleSubstFormat1
     hb_sorted_vector_t<hb_codepoint_t> new_coverage;
     + hb_zip (this+coverage, sequence)
     | hb_filter (glyphset, hb_first)
-    | hb_filter (subset_offset_array (c, out->sequence, this, out), hb_second)
+    | hb_filter (subset_offset_array (c, out->sequence, this), hb_second)
     | hb_map (hb_first)
     | hb_map (glyph_map)
     | hb_sink (new_coverage)
@@ -670,7 +670,7 @@ struct AlternateSubstFormat1
     hb_sorted_vector_t<hb_codepoint_t> new_coverage;
     + hb_zip (this+coverage, alternateSet)
     | hb_filter (glyphset, hb_first)
-    | hb_filter (subset_offset_array (c, out->alternateSet, this, out), hb_second)
+    | hb_filter (subset_offset_array (c, out->alternateSet, this), hb_second)
     | hb_map (hb_first)
     | hb_map (glyph_map)
     | hb_sink (new_coverage)
@@ -930,7 +930,7 @@ struct LigatureSet
     if (unlikely (!c->serializer->extend_min (out))) return_trace (false);
 
     + hb_iter (ligature)
-    | hb_filter (subset_offset_array (c, out->ligature, this, out))
+    | hb_filter (subset_offset_array (c, out->ligature, this))
     | hb_drain
     ;
     return_trace (bool (out->ligature));
@@ -1046,7 +1046,7 @@ struct LigatureSubstFormat1
     hb_sorted_vector_t<hb_codepoint_t> new_coverage;
     + hb_zip (this+coverage, ligatureSet)
     | hb_filter (glyphset, hb_first)
-    | hb_filter (subset_offset_array (c, out->ligatureSet, this, out), hb_second)
+    | hb_filter (subset_offset_array (c, out->ligatureSet, this), hb_second)
     | hb_map (hb_first)
     | hb_map (glyph_map)
     | hb_sink (new_coverage)

--- a/src/hb-ot-name-table.hh
+++ b/src/hb-ot-name-table.hh
@@ -103,7 +103,7 @@ struct NameRecord
     TRACE_SERIALIZE (this);
     auto *out = c->embed (this);
     if (unlikely (!out)) return_trace (nullptr);
-    out->offset.serialize_copy (c, offset, src_base, nullptr, hb_serialize_context_t::Tail, length);
+    out->offset.serialize_copy (c, offset, src_base, 0, hb_serialize_context_t::Tail, length);
     return_trace (out);
   }
 

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -278,7 +278,7 @@ struct hb_serialize_context_t
 
   template <typename T>
   void add_link (T &ofs, objidx_t objidx,
-		 whence_t whence,
+		 whence_t whence = Head,
 		 unsigned bias = 0)
   {
     static_assert (sizeof (T) == 2 || sizeof (T) == 4, "");
@@ -299,11 +299,13 @@ struct hb_serialize_context_t
     link.objidx = objidx;
   }
 
-  template <typename T>
-  void add_link (T &ofs, objidx_t objidx,
-		 const void *base = nullptr,
-		 whence_t whence = Head)
-  { add_link (ofs, objidx, whence, to_bias (base)); }
+  unsigned to_bias (const void *base) const
+  {
+    if (!base) return 0;
+    assert (current);
+    assert (current->head <= (const char *) base);
+    return (const char *) base - current->head;
+  }
 
   void resolve_links ()
   {
@@ -487,14 +489,6 @@ struct hb_serialize_context_t
     auto &off = * ((BEInt<T, sizeof (T)> *) (parent->head + link.position));
     assert (0 == off);
     check_assign (off, offset);
-  }
-
-  unsigned to_bias (const void *base) const
-  {
-    if (!base) return 0;
-    assert (current);
-    assert (current->head <= (const char *) base);
-    return (const char *) base - current->head;
   }
 
   public: /* TODO Make private. */


### PR DESCRIPTION
On top of PR#2232 for fixes #2227 , removed “base” arg to `add_link()` when it is actually `current->head` from cmap, gdef, gpos, gsub, cbdt, sbix subsetters.

Two places where non-head base is used, `AnchorMatrix::serialize()` and `MarkArray::serialize()` in hb-ot-layout-gpos-table.hh, convert base pointer to bias by calling `to_bias()`, then calls add_link() which takes bias replacing base. 

add_link() taking base is removed. 
