### PR TITLE
[meson] Add needed compiler flags

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,19 @@ if cpp.get_id() == 'msvc'
   # noseh_link_args = ['/SAFESEH:NO']
 endif
 
+add_global_arguments(cpp.get_supported_arguments([
+  '-fno-rtti',
+  '-fno-exceptions',
+  '-fno-threadsafe-statics',
+  '-fvisibility-inlines-hidden', # maybe shouldn't be applied for mingw
+]), language : 'cpp')
+
+if host_machine.cpu_family() == 'arm' and cpp.alignment('struct { char c; }') != 1
+  if cpp.has_argument('-mstructure-size-boundary=8')
+    add_global_arguments('-mstructure-size-boundary=8', language : 'cpp')
+  endif
+endif
+
 python3 = import('python').find_installation('python3')
 
 check_headers = [


### PR DESCRIPTION
Are based on https://github.com/harfbuzz/harfbuzz/blob/2.6.4/configure.ac#L86

@tp-m Can you help on the comments on the patch and review please?

@khaledhosny @behdad just have merged meson port https://github.com/harfbuzz/harfbuzz/pull/1437/files and applied 1c3f80ba136bffec00343bae87269bbc9c33ecde c494d7abcd626c274477319859b9bcb873aca388 on top, let's reach to some acceptable level at least to remove CMake port before the release, please have a look at the changes and give me and @tp-m your feedbacks, thanks!