### PR TITLE
Improve Meson build support for Visual Studio

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -181,7 +181,7 @@ if fontconfig_dep.found()
   deps += [fontconfig_dep]
 endif
 
-# uniscribe (windows) - FIXME: untested
+# uniscribe (windows)
 if host_machine.system() == 'windows' and not get_option('uniscribe').disabled()
   # TODO: make nicer once we have https://github.com/mesonbuild/meson/issues/3940
   if cpp.has_header('usp10.h') and cpp.has_header('windows.h')
@@ -194,9 +194,9 @@ if host_machine.system() == 'windows' and not get_option('uniscribe').disabled()
   endif
 endif
 
-# DirectWrite (windows) - FIXME: untested
+# DirectWrite (windows)
 if host_machine.system() == 'windows' and not get_option('directwrite').disabled()
-  if cpp.has_header('dwrite.h')
+  if cpp.has_header('dwrite_1.h')
     deps += [cpp.find_library('dwrite', required: true)]
     conf.set('HAVE_DIRECTWRITE', 1)
   elif get_option('directwrite').enabled()

--- a/meson.build
+++ b/meson.build
@@ -90,8 +90,7 @@ glib_dep = dependency('glib-2.0', required: get_option('glib'),
                       fallback: ['glib', 'libglib_dep'])
 gobject_dep = dependency('gobject-2.0', required: get_option('gobject'),
                          fallback: ['glib', 'libgobject_dep'])
-cairo_dep = dependency('cairo', required: get_option('cairo'),
-                       fallback: ['cairo', 'libcairo_dep'])
+cairo_dep = dependency('cairo', required: false)
 fontconfig_dep = dependency('fontconfig', required: get_option('fontconfig'),
                             fallback: ['fontconfig', 'fontconfig_dep'])
 graphite2_dep = dependency('graphite2', required: get_option('graphite'))
@@ -117,12 +116,25 @@ if not icu_dep.found() and cpp.get_id() == 'msvc'
   endif
 endif
 
+if not cairo_dep.found() and cpp.get_id() == 'msvc'
+  if cpp.has_header('cairo.h')
+    cairo_dep = cpp.find_library('cairo')
+  endif
+endif
+
+if not cairo_dep.found() and get_option('cairo').enabled()
+  cairo_dep = dependency('cairo', fallback: ['cairo', 'libcairo_dep'])
+endif
+
 # Ensure that cairo-ft is fetched from the same library as cairo itself
 if cairo_dep.found()
   if cairo_dep.type_name() == 'pkgconfig'
     cairo_ft_dep = dependency('cairo-ft', required: get_option('cairo'))
   else
-    cairo_ft_dep = cairo_dep
+    if cpp.has_header('cairo-ft.h') and \
+       cpp.has_function('cairo_ft_font_face_create_for_ft_face', dependencies: cairo_dep)
+      cairo_ft_dep = cairo_dep
+    endif
   endif
 else
   # Not-found dependency

--- a/meson.build
+++ b/meson.build
@@ -212,16 +212,17 @@ if fontconfig_dep.found()
   deps += [fontconfig_dep]
 endif
 
-# uniscribe (windows)
-if host_machine.system() == 'windows' and not get_option('uniscribe').disabled()
+# GDI (uniscribe) (windows)
+if host_machine.system() == 'windows' and not get_option('gdi').disabled()
   # TODO: make nicer once we have https://github.com/mesonbuild/meson/issues/3940
   if cpp.has_header('usp10.h') and cpp.has_header('windows.h')
     foreach usplib : ['usp10', 'gdi32', 'rpcrt4']
       deps += [cpp.find_library(usplib, required: true)]
     endforeach
     conf.set('HAVE_UNISCRIBE', 1)
-  elif get_option('uniscribe').enabled()
-    error('uniscribe was enabled explicitly, but some required headers are missing.')
+    conf.set('HAVE_GDI', 1)
+  elif get_option('gdi').enabled()
+    error('gdi was enabled explicitly, but some required headers are missing.')
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -74,8 +74,18 @@ check_funcs = [
   ['roundf'],
 ]
 
-freetype_dep = dependency('freetype2', required: get_option('freetype'),
-                          fallback: ['freetype2', 'freetype_dep'])
+freetype_dep = dependency('freetype2', required: false)
+
+if not freetype_dep.found() and cpp.get_id() == 'msvc'
+  if cpp.has_header('ft2build.h')
+    freetype_dep = cpp.find_library('freetype', required: false)
+  endif
+endif
+
+if not freetype_dep.found() and get_option('freetype').enabled()
+  freetype_dep = dependency('freetype2', fallback: ['freetype2', 'freetype_dep'])
+endif
+
 glib_dep = dependency('glib-2.0', required: get_option('glib'),
                       fallback: ['glib', 'libglib_dep'])
 gobject_dep = dependency('gobject-2.0', required: get_option('gobject'),

--- a/meson.build
+++ b/meson.build
@@ -95,8 +95,27 @@ cairo_dep = dependency('cairo', required: get_option('cairo'),
 fontconfig_dep = dependency('fontconfig', required: get_option('fontconfig'),
                             fallback: ['fontconfig', 'fontconfig_dep'])
 graphite2_dep = dependency('graphite2', required: get_option('graphite'))
-icu_dep = dependency('icu-uc', required: get_option('icu'))
+icu_dep = dependency('icu-uc', required: get_option('icu').enabled() and cpp.get_id() != 'msvc')
 m_dep = cpp.find_library('m', required: false)
+
+if not icu_dep.found() and cpp.get_id() == 'msvc'
+  if cpp.has_header('unicode/uchar.h') and \
+     cpp.has_header('unicode/unorm2.h') and \
+     cpp.has_header('unicode/ustring.h') and \
+     cpp.has_header('unicode/utf16.h') and \
+     cpp.has_header('unicode/uversion.h') and \
+     cpp.has_header('unicode/uscript.h')
+    if get_option('buildtype') == 'debug'
+      icu_dep = cpp.find_library('icuucd', required: get_option('icu'))
+    else
+      icu_dep = cpp.find_library('icuuc', required: get_option('icu'))
+    endif
+  else
+    if get_option('icu').enabled()
+      error('ICU headers and libraries must be present to build ICU support')
+    endif
+  endif
+endif
 
 # Ensure that cairo-ft is fetched from the same library as cairo itself
 if cairo_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,6 @@ if cpp.get_id() == 'msvc'
       '/wd4244', # lossy type conversion (e.g. double -> int)
       '/wd4305', # truncating type conversion (e.g. double -> float)
       cpp.get_supported_arguments(['/utf-8']), # set the input encoding to utf-8
-      '-DHB_DLL_EXPORT', # FIXME: shouldn't this be set only on the lib targets?
   ]
   add_project_arguments(msvc_args, language : 'c')
   add_project_arguments(msvc_args, language : 'cpp')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,8 +13,8 @@ option('graphite', type: 'feature', value: 'disabled',
   description: 'Enable Graphite2 complementary shaper')
 option('freetype', type: 'feature', value: 'auto',
   description: 'Enable freetype interop helpers')
-option('uniscribe', type: 'feature', value: 'disabled',
-  description: 'Enable Uniscribe shaper backend (Windows only)')
+option('gdi', type: 'feature', value: 'disabled',
+  description: 'Enable GDI helpers and Uniscribe shaper backend (Windows only)')
 option('directwrite', type: 'feature', value: 'disabled',
   description: 'Enable DirectWrite shaper backend on Windows (experimental)')
 option('coretext', type: 'feature', value: 'disabled',

--- a/src/hb-gobject-enums.cc.tmpl
+++ b/src/hb-gobject-enums.cc.tmpl
@@ -1,6 +1,6 @@
 /*** BEGIN file-header ***/
 /*
- * Copyright © 2011  Google, Inc.
+ * Copyright (C) 2011  Google, Inc.
  *
  *  This is part of HarfBuzz, a text shaping library.
  *

--- a/src/hb-gobject-enums.h.tmpl
+++ b/src/hb-gobject-enums.h.tmpl
@@ -1,6 +1,6 @@
 /*** BEGIN file-header ***/
 /*
- * Copyright © 2013  Google, Inc.
+ * Copyright (C) 2013  Google, Inc.
  *
  *  This is part of HarfBuzz, a text shaping library.
  *

--- a/src/hb-gobject-structs.h
+++ b/src/hb-gobject-structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2011  Google, Inc.
+ * Copyright (C) 2011  Google, Inc.
  *
  *  This is part of HarfBuzz, a text shaping library.
  *

--- a/src/hb-gobject.h
+++ b/src/hb-gobject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2011  Google, Inc.
+ * Copyright (C) 2011  Google, Inc.
  *
  *  This is part of HarfBuzz, a text shaping library.
  *

--- a/src/meson.build
+++ b/src/meson.build
@@ -215,19 +215,25 @@ harfbuzz_def = custom_target('harfbuzz.def',
 version = '0.' + '0'.join(meson.project_version().split('.')) + '.0'
 
 extra_hb_cpp_args = []
-if get_option('default_library') == 'shared' and cpp.get_id() == 'msvc'
-  extra_hb_cpp_args += '-DHB_DLL_EXPORT'
+if cpp.get_id() == 'msvc'
+  if get_option('default_library') == 'shared'
+    extra_hb_cpp_args += '-DHB_DLL_EXPORT'
+  endif
+  hb_so_version = ''
+  hb_lib_prefix = ''
+else
+  hb_so_version = '0'
+  hb_lib_prefix = 'lib'
 endif
 
 libharfbuzz = library('harfbuzz', hb_sources,
   include_directories: [incconfig, incucdn],
   dependencies: deps,
   cpp_args: cpp_args + extra_hb_cpp_args,
-  vs_module_defs: harfbuzz_def,
-  soversion: '0',
+  soversion: hb_so_version,
   version: version,
   install: true,
-  name_prefix: 'lib')
+  name_prefix: hb_lib_prefix)
 
 libharfbuzz_dep = declare_dependency(
   link_with: libharfbuzz,
@@ -244,11 +250,10 @@ libharfbuzz_subset = library('harfbuzz-subset', hb_subset_sources,
   include_directories: incconfig,
   link_with: [libharfbuzz],
   cpp_args: cpp_args + extra_hb_cpp_args,
-  vs_module_defs: harfbuzz_subset_def,
-  soversion: '0',
+  soversion: hb_so_version,
   version: version,
   install: true,
-  name_prefix: 'lib')
+  name_prefix: hb_lib_prefix)
 
 libharfbuzz_subset_dep = declare_dependency(
   link_with: libharfbuzz_subset,
@@ -328,11 +333,10 @@ if have_gobject
     dependencies: deps,
     link_with: [libharfbuzz],
     cpp_args: cpp_args + extra_hb_cpp_args,
-    vs_module_defs: harfbuzz_gobject_def,
-    soversion: '0',
+    soversion: hb_so_version,
     version: version,
     install: true,
-    name_prefix: 'lib')
+    name_prefix: hb_lib_prefix)
 
   gir = find_program('g-ir-scanner', required: get_option('introspection'))
   build_gir = gir.found() and not meson.is_cross_build()

--- a/src/meson.build
+++ b/src/meson.build
@@ -214,10 +214,15 @@ harfbuzz_def = custom_target('harfbuzz.def',
 
 version = '0.' + '0'.join(meson.project_version().split('.')) + '.0'
 
+extra_hb_cpp_args = []
+if get_option('default_library') == 'shared' and cpp.get_id() == 'msvc'
+  extra_hb_cpp_args += '-DHB_DLL_EXPORT'
+endif
+
 libharfbuzz = library('harfbuzz', hb_sources,
   include_directories: [incconfig, incucdn],
   dependencies: deps,
-  cpp_args: cpp_args,
+  cpp_args: cpp_args + extra_hb_cpp_args,
   vs_module_defs: harfbuzz_def,
   soversion: '0',
   version: version,
@@ -238,7 +243,7 @@ harfbuzz_subset_def = custom_target('harfbuzz-subset.def',
 libharfbuzz_subset = library('harfbuzz-subset', hb_subset_sources,
   include_directories: incconfig,
   link_with: [libharfbuzz],
-  cpp_args: cpp_args,
+  cpp_args: cpp_args + extra_hb_cpp_args,
   vs_module_defs: harfbuzz_subset_def,
   soversion: '0',
   version: version,
@@ -322,7 +327,7 @@ if have_gobject
     include_directories: incconfig,
     dependencies: deps,
     link_with: [libharfbuzz],
-    cpp_args: cpp_args,
+    cpp_args: cpp_args + extra_hb_cpp_args,
     vs_module_defs: harfbuzz_gobject_def,
     soversion: '0',
     version: version,

--- a/src/meson.build
+++ b/src/meson.build
@@ -170,6 +170,11 @@ if conf.get('HAVE_FREETYPE', 0) == 1
   hb_headers += hb_ft_headers
 endif
 
+if conf.get('HAVE_GDI', 0) == 1
+  hb_sources += ['hb-gdi.cc']
+  hb_headers += ['hb-gdi.h']
+endif
+
 if conf.get('HAVE_GRAPHITE2', 0) == 1
   hb_sources += hb_graphite2_sources
   hb_headers += hb_graphite2_headers

--- a/src/meson.build
+++ b/src/meson.build
@@ -360,7 +360,7 @@ if have_gobject
   libharfbuzz_gobject_dep = declare_dependency(
     link_with: libharfbuzz_gobject,
     include_directories: incsrc,
-    sources: hb_gen_files_gir,
+    sources: build_gir ? hb_gen_files_gir : hb_gobject_sources,
     dependencies: deps)
 
   pkgmod.generate(libharfbuzz_gobject,

--- a/test/shaping/run-tests.py
+++ b/test/shaping/run-tests.py
@@ -2,11 +2,6 @@
 
 import sys, os, subprocess, hashlib, tempfile, shutil
 
-def cmd(command):
-	global process
-	process.stdin.write ((' '.join (command) + '\n').encode ("utf-8"))
-	process.stdin.flush ()
-	return process.stdout.readline().decode ("utf-8").strip ()
 
 args = sys.argv[1:]
 
@@ -20,10 +15,21 @@ if not args or args[0].find('hb-shape') == -1 or not os.path.exists (args[0]):
 	sys.exit (1)
 hb_shape, args = args[0], args[1:]
 
-process = subprocess.Popen ([hb_shape, '--batch'],
+def cmd(command):
+	process = subprocess.Popen ([hb_shape, '--batch'],
 			    stdin=subprocess.PIPE,
 			    stdout=subprocess.PIPE,
-			    stderr=sys.stdout)
+			    stderr=subprocess.PIPE)
+	process.stdin.write ((' '.join (command) + '\n').encode ("utf-8"))
+	process.stdin.flush ()
+	ret_stdout = None
+	ret_stderr = None
+	ret_stdout, ret_stderr = process.communicate ()
+	if ret_stdout is not None:
+		ret_stdout = ret_stdout.decode ("utf-8").strip ()
+	if ret_stderr is not None:
+		ret_stderr = ret_stderr.decode ("utf-8").strip ()
+	return (ret_stdout, ret_stderr)
 
 passes = 0
 fails = 0
@@ -102,23 +108,31 @@ for filename in args:
 			fontfile] + extra_options + ["--unicodes",
 			unicodes] + (options.split (' ') if options else []))
 
+		if glyphs1[1] is not None or glyphs1[1] != '':
+			check_string = hb_shape[hb_shape.find(os.path.sep) + 1:] + \
+			               ': Unknown font function implementation `ft\''
+			if glyphs1[1].startswith(check_string):
+				skips += 1
+				print ("Skipping test due to lack of FreeType support")
+				continue
+
 		glyphs2 = cmd ([hb_shape, "--font-funcs=ot",
 			fontfile] + extra_options + ["--unicodes",
 			unicodes] + (options.split (' ') if options else []))
 
-		if glyphs1 != glyphs2 and glyphs_expected != '*':
-			print ("FT funcs: " + glyphs1) # file=sys.stderr
-			print ("OT funcs: " + glyphs2) # file=sys.stderr
+		if glyphs1[0] != glyphs2[0] and glyphs_expected != '*':
+			print ("FT funcs: " + glyphs1[0]) # file=sys.stderr
+			print ("OT funcs: " + glyphs2[0]) # file=sys.stderr
 			fails += 1
 		else:
 			passes += 1
 
 		if reference:
-			print (":".join ([fontfile, options, unicodes, glyphs1]))
+			print (":".join ([fontfile, options, unicodes, glyphs1[0]]))
 			continue
 
-		if glyphs1.strip() != glyphs_expected and glyphs_expected != '*':
-			print ("Actual:   " + glyphs1) # file=sys.stderr
+		if glyphs1[0].strip() != glyphs_expected and glyphs_expected != '*':
+			print ("Actual:   " + glyphs1[0]) # file=sys.stderr
 			print ("Expected: " + glyphs_expected) # file=sys.stderr
 			fails += 1
 		else:


### PR DESCRIPTION
Hi,

This attempts to improve build support with Visual Studio for Meson builds, by:

*  Only applying ```-DHB_DLL_EXPORT``` for the library builds, when built as a shared library
*  Skip tests that involve FreeType, if FreeType support is not enabled
*  Enable finding ICU, Cairo and FreeType manually via looking for headers and .lib's,  GObject/GLib and Graphite2 provide pkg-config files with their build systems for Visual Studio builds, so we could leave these alone.
*  Gave DirectWrite and Uniscribe build support their greenlight, with a minor update
*  Cleaned up DLL builds a bit, since HB_DLL_EXPORT would make the vs_module_defs obsolete as it activates macros to do __declspec(dllexport).  The .def files may still be useful in other situations (MinGW builds?), but that would be outside the scope of this PR.

Few catches:
*  All the tests are either passing or skipped, except for the macos test.  I was getting a Python error, as follows:
'''
Traceback (most recent call last):
  File "c:\gnome.build\hb\..\..\Users\fanc999\harfbuzz\test\shaping\run-tests.py", line 53, in <module>
    for line in f:
  File "c:\python37\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 6498: character maps to <undefined>
'''

*  Introspection builds don't work, I was getting: ```error parsing file src/HarfBuzz-0.0.gir: Line 19, character 56: The attribute 'name' on the element 'type' must be specified```.  I didn't touch any of the introspection stuff, so I am out of ideas for this for now.

With blessings, thank you!

Fixes #2251