### PR TITLE
Meson test api c files build fix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -144,13 +144,14 @@ deps = []
 
 conf = configuration_data()
 incconfig = include_directories('.')
-cpp_args = ['-DHAVE_CONFIG_H']
+
+add_project_arguments('-DHAVE_CONFIG_H', language: ['c', 'cpp'])
 
 warn_cflags = [
   '-Wno-non-virtual-dtor',
 ]
 
-cpp_args += cpp.get_supported_arguments(warn_cflags)
+cpp_args = cpp.get_supported_arguments(warn_cflags)
 
 if m_dep.found()
   deps += [m_dep]

--- a/meson.build
+++ b/meson.build
@@ -34,13 +34,12 @@ if cpp.get_id() == 'msvc'
       '/wd4305', # truncating type conversion (e.g. double -> float)
       cpp.get_supported_arguments(['/utf-8']), # set the input encoding to utf-8
   ]
-  add_project_arguments(msvc_args, language : 'c')
-  add_project_arguments(msvc_args, language : 'cpp')
+  add_project_arguments(msvc_args, language : ['c', 'cpp'])
   # Disable SAFESEH with MSVC for libs that use external deps that are built with MinGW
   # noseh_link_args = ['/SAFESEH:NO']
 endif
 
-add_global_arguments(cpp.get_supported_arguments([
+add_project_arguments(cpp.get_supported_arguments([
   '-fno-rtti',
   '-fno-exceptions',
   '-fno-threadsafe-statics',
@@ -49,7 +48,7 @@ add_global_arguments(cpp.get_supported_arguments([
 
 if host_machine.cpu_family() == 'arm' and cpp.alignment('struct { char c; }') != 1
   if cpp.has_argument('-mstructure-size-boundary=8')
-    add_global_arguments('-mstructure-size-boundary=8', language : 'cpp')
+    add_project_arguments('-mstructure-size-boundary=8', language : 'cpp')
   endif
 endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -185,11 +185,6 @@ if conf.get('HAVE_GLIB', 0) == 1
   hb_headers += hb_glib_headers
 endif
 
-if conf.get('HAVE_ICU', 0) == 1
-  hb_sources += hb_icu_sources
-  hb_headers += hb_icu_headers
-endif
-
 if conf.get('HAVE_UNISCRIBE', 0) == 1
   hb_sources += ['hb-uniscribe.cc']
   hb_headers += ['hb-uniscribe.h']
@@ -208,6 +203,12 @@ endif
 if get_option('amalgam')
   # replace the array if is amalgam build
   hb_sources = ['harfbuzz.cc']
+endif
+
+# FIXME: move into harfbuzz-icu module
+if conf.get('HAVE_ICU', 0) == 1
+  hb_sources += hb_icu_sources
+  hb_headers += hb_icu_headers
 endif
 
 # harfbuzz

--- a/test/api/meson.build
+++ b/test/api/meson.build
@@ -45,10 +45,9 @@ if conf.get('HAVE_GLIB', 0) == 1
     opts = test_data.length() > 1 ? test_data[1] : {}
     extra_c_args = opts.get('c_args', [])
 
-
-
     test_name = fname.split('.')[0].underscorify()
     exe = executable(test_name, fname,
+      c_args: extra_c_args,
       cpp_args: cpp_args + extra_c_args,
       include_directories: [incconfig, incsrc],
       dependencies: deps,


### PR DESCRIPTION
commit 1322ebae33618c78f8e5779b05c17cdaca44c092:

```
[meson] use add_project_arguments() instead of add_global_arguments()
.. and simplify, can pass two languages in one go.

add_global_arguments() won't work if harfbuzz is used as a
meson subproject.
```

commit 7c24cc3f4e0c40d149479475c89c445993975629:

```
[meson] fix spurious warning when building test/api C sources
Fixes compiler warning

  test-unicode.c:589:1: warning: ‘test_unicode_properties_lenient’ defined but not used

which didn't happen with autotools.

Reason it does with meson is that the setup for C was slightly wrong.
We would only add -DHAVE_CONFIG_H to cpp_args which is only valid when
compiling C++ code, but not plain C code, and many of these tests were
plain C.

Instead pass -DHAVE_CONFIG_H via add_project_arguments() and make sure
to set both c_args and cpp_args when building test executables.

Fixes https://github.com/harfbuzz/harfbuzz/issues/2257
```
