### PR TITLE
[subset] Avoid linking to libstdc++ in libharfbuzz-subset.so

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -149,6 +149,7 @@ cmake_DATA = harfbuzz-config.cmake
 EXTRA_DIST += hb-version.h.in harfbuzz.pc.in harfbuzz-config.cmake.in
 
 lib_LTLIBRARIES += libharfbuzz-subset.la
+libharfbuzz_subset_la_LINK = $(chosen_linker) $(libharfbuzz_subset_la_LDFLAGS)
 libharfbuzz_subset_la_SOURCES = $(HB_SUBSET_sources)
 libharfbuzz_subset_la_CPPFLAGS = $(HBCFLAGS) $(CODE_COVERAGE_CFLAGS)
 libharfbuzz_subset_la_LDFLAGS = $(base_link_flags) $(export_symbols_subset) $(CODE_COVERAGE_LDFLAGS)


### PR DESCRIPTION
Just like other targets (except harfbuzz-icu) avoid linking to libstdc++