### PR TITLE
[meson] Run check-symbols.sh and check-static-inits.sh correctly

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -444,6 +444,7 @@ endif
 
 TESTS_ENVIRONMENT = \
 	srcdir="$(srcdir)" \
+	builddir="$(builddir)" \
 	MAKE="$(MAKE) $(AM_MAKEFLAGS)" \
 	HBSOURCES="$(HBSOURCES)" \
 	HBHEADERS="$(HBHEADERS)" \

--- a/src/check-libstdc++.sh
+++ b/src/check-libstdc++.sh
@@ -22,8 +22,7 @@ fi
 
 tested=false
 # harfbuzz-icu links to libstdc++ because icu does.
-# harfbuzz-subset uses libstdc++.
-for soname in harfbuzz harfbuzz-gobject; do
+for soname in harfbuzz harfbuzz-subset harfbuzz-gobject; do
 	for suffix in so dylib; do
 		so=$libs/lib$soname.$suffix
 		if ! test -f "$so"; then continue; fi

--- a/src/check-static-inits.sh
+++ b/src/check-static-inits.sh
@@ -4,7 +4,7 @@ LC_ALL=C
 export LC_ALL
 
 test -z "$srcdir" && srcdir=.
-test -z "$libs" && libs=.libs
+test -z "$builddir" && builddir=.
 stat=0
 
 if which objdump 2>/dev/null >/dev/null; then
@@ -14,11 +14,13 @@ else
 	exit 77
 fi
 
-OBJS=$libs/*.o
+OBJS=$(find $builddir/ -name '*.o')
 if test "x`echo $OBJS`" = "x$OBJS" 2>/dev/null >/dev/null; then
 	echo "check-static-inits.sh: object files not found; skipping test"
 	exit 77
 fi
+
+tested=false
 
 echo "Checking that no object file has static initializers"
 for obj in $OBJS; do
@@ -26,6 +28,7 @@ for obj in $OBJS; do
 		echo "Ouch, $obj has static initializers/finalizers"
 		stat=1
 	fi
+	tested=true
 done
 
 echo "Checking that no object file has lazy static C++ constructors/destructors or other such stuff"
@@ -35,6 +38,12 @@ for obj in $OBJS; do
 		echo "Ouch, $obj has lazy static C++ constructors/destructors or other such stuff"
 		stat=1
 	fi
+	tested=true
 done
+
+if ! $tested; then
+	echo "check-static-inits.sh: no objects found; skipping test"
+	exit 77
+fi
 
 exit $stat

--- a/src/check-symbols.sh
+++ b/src/check-symbols.sh
@@ -4,6 +4,7 @@ LC_ALL=C
 export LC_ALL
 
 test -z "$srcdir" && srcdir=.
+test -z "$builddir" && builddir=.
 test -z "$libs" && libs=.libs
 stat=0
 
@@ -36,7 +37,7 @@ for soname in harfbuzz harfbuzz-subset harfbuzz-icu harfbuzz-gobject; do
 			stat=1
 		fi
 
-		def=$soname.def
+		def=$builddir/$soname.def
 		if ! test -f "$def"; then
 			echo "'$def' not found; skipping"
 		else
@@ -47,9 +48,9 @@ for soname in harfbuzz harfbuzz-subset harfbuzz-icu harfbuzz-gobject; do
 				# cheat: copy the last line from the def file!
 				tail -n1 "$def"
 			} | c++filt | diff "$def" - >&2 || stat=1
-		fi
 
-		tested=true
+			tested=true
+		fi
 	done
 done
 if ! $tested; then

--- a/src/meson.build
+++ b/src/meson.build
@@ -366,6 +366,26 @@ libharfbuzz_dep = declare_dependency(
   include_directories: incsrc,
   dependencies: deps)
 
+# harfbuzz-subset
+harfbuzz_subset_def = custom_target('harfbuzz-subset.def',
+    command: [gen_def, '@OUTPUT@', '@INPUT@'],
+    input: hb_subset_headers,
+    output: 'harfbuzz-subset.def')
+
+libharfbuzz_subset = library('harfbuzz-subset', hb_subset_sources,
+  include_directories: incconfig,
+  link_with: [libharfbuzz],
+  cpp_args: cpp_args + extra_hb_cpp_args,
+  soversion: hb_so_version,
+  version: version,
+  install: true,
+  name_prefix: hb_lib_prefix)
+
+libharfbuzz_subset_dep = declare_dependency(
+  link_with: libharfbuzz_subset,
+  include_directories: incsrc,
+  dependencies: deps)
+
 # TODO: MSVC gives the following,
 # error LNK2019: unresolved external symbol "unsigned __int64 const * const _hb_NullPool"
 if cpp.get_id() != 'msvc'
@@ -434,45 +454,30 @@ if host_machine.system() != 'windows' and not meson.is_cross_build()
     'check-c-linkage-decls.sh',
     'check-externs.sh',
     'check-header-guards.sh',
-    'check-static-inits.sh', # fails with "check-static-inits.sh: object files not found; skipping test"
-    'check-symbols.sh', # fails with "'harfbuzz.def' not found; skipping"
+    'check-static-inits.sh',
   ]
   if not get_option('amalgam')
-    dist_check_script += ['check-includes.sh']
+    dist_check_script += 'check-includes.sh'
   endif
   if false # !WITH_LIBSTDCXX
-    dist_check_script += 'check-libstdc++.sh' # we don't have chosen_linker logic here yet
+    dist_check_script += 'check-libstdc++.sh' # See https://github.com/harfbuzz/harfbuzz/issues/2276
   endif
 
+  env = environment()
+  env.set('srcdir', meson.current_source_dir())
+  env.set('builddir', meson.current_build_dir())
+  env.set('libs', meson.current_build_dir()) # TODO: Merge this with builddir after autotools removal
+  env.set('HBSOURCES', ' '.join(hb_sources))
+  env.set('HBHEADERS', ' '.join(hb_headers))
+
   foreach name : dist_check_script
-    env = environment()
-    env.set('srcdir', meson.current_source_dir())
-    env.set('libs', meson.current_build_dir())
-    env.set('HBSOURCES', ' '.join(hb_sources))
-    env.set('HBHEADERS', ' '.join(hb_headers))
     test(name, find_program(name), env: env)
   endforeach
+
+  test('check-symbols.sh', find_program('check-symbols.sh'),
+    depends: [harfbuzz_def, harfbuzz_subset_def], # TODO: harfbuzz_icu_def and harfbuzz_gobject_def also
+    env: env)
 endif
-
-# harfbuzz-subset
-harfbuzz_subset_def = custom_target('harfbuzz-subset.def',
-    command: [gen_def, '@OUTPUT@', '@INPUT@'],
-    input: hb_subset_headers,
-    output: 'harfbuzz-subset.def')
-
-libharfbuzz_subset = library('harfbuzz-subset', hb_subset_sources,
-  include_directories: incconfig,
-  link_with: [libharfbuzz],
-  cpp_args: cpp_args + extra_hb_cpp_args,
-  soversion: hb_so_version,
-  version: version,
-  install: true,
-  name_prefix: hb_lib_prefix)
-
-libharfbuzz_subset_dep = declare_dependency(
-  link_with: libharfbuzz_subset,
-  include_directories: incsrc,
-  dependencies: deps)
 
 pkgmod.generate(libharfbuzz,
   description: 'HarfBuzz text shaping library',


### PR DESCRIPTION
* Search src/ build directory for objects in check-static-inits.sh
* Find .def files in src/ build directory in src/check-symbols.sh
* Pass builddir also in autotools also, we may just remove libs passing after autotools removal
* Move harfbuzz_subset_def target definition so can be referenced as a check-static-inits.sh dependency
