### PR TITLE
Set sequence number when adding feature to aat map builder

### DIFF
--- a/src/hb-aat-map.cc
+++ b/src/hb-aat-map.cc
@@ -43,6 +43,7 @@ void hb_aat_map_builder_t::add_feature (hb_tag_t tag,
     feature_info_t *info = features.push();
     info->type = HB_AAT_LAYOUT_FEATURE_TYPE_CHARACTER_ALTERNATIVES;
     info->setting = (hb_aat_layout_feature_selector_t) value;
+    info->seq = features.length;
     return;
   }
 
@@ -52,6 +53,7 @@ void hb_aat_map_builder_t::add_feature (hb_tag_t tag,
   feature_info_t *info = features.push();
   info->type = mapping->aatFeatureType;
   info->setting = value ? mapping->selectorToEnable : mapping->selectorToDisable;
+  info->seq = features.length;
 }
 
 void


### PR DESCRIPTION
To properly support stable sort in compile() method.

Fixes #2288.