### PR TITLE
Add "#include <climits>" to hb-meta.

### DIFF
--- a/src/hb-meta.hh
+++ b/src/hb-meta.hh
@@ -29,6 +29,7 @@
 
 #include "hb.hh"
 
+#include <climits>
 
 /*
  * C++ template meta-programming & fundamentals used with them.


### PR DESCRIPTION
This fixes compiling for the homebrew SDKs: Vita (vitasdk), Wii (devkitPPC), 3DS (devkitARM), Switch (devkitA64)

(they are all newlib based)