### PR TITLE
Use float in avar calculation instead ints and checking their overflows

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -645,18 +645,6 @@ hb_unsigned_mul_overflows (unsigned int count, unsigned int size)
   return (size > 0) && (count >= ((unsigned int) -1) / size);
 }
 
-static inline bool
-hb_int_mul_overflows (int x, int y, int &result)
-{
-#if __has_builtin(__builtin_mul_overflow)
-  return __builtin_mul_overflow (x, y, &result);
-#else
-  int64_t sink = (int64_t) x * y;
-  result = sink;
-  return result != sink;
-#endif
-}
-
 
 /*
  * Sort and search.

--- a/src/hb-ot-var-avar-table.hh
+++ b/src/hb-ot-var-avar-table.hh
@@ -89,14 +89,9 @@ struct SegmentMaps : ArrayOf<AxisValueMap>
     if (unlikely (arrayZ[i-1].fromCoord == arrayZ[i].fromCoord))
       return arrayZ[i-1].toCoord;
 
-    int factor;
-    if (unlikely (hb_int_mul_overflows (arrayZ[i].toCoord - arrayZ[i-1].toCoord,
-					value - arrayZ[i-1].fromCoord,
-					factor)))
-      return arrayZ[i-1].toCoord;
-
     int denom = arrayZ[i].fromCoord - arrayZ[i-1].fromCoord;
-    return arrayZ[i-1].toCoord + (factor + denom/2) / denom;
+    return roundf (arrayZ[i-1].toCoord + ((float) (arrayZ[i].toCoord - arrayZ[i-1].toCoord) *
+					  (value - arrayZ[i-1].fromCoord)) / denom);
 #undef toCoord
 #undef fromCoord
   }

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -219,10 +219,6 @@ extern "C" void  hb_free_impl(void *ptr);
  * Compiler attributes
  */
 
-#ifndef __has_builtin
-# define __has_builtin(x) 0
-#endif
-
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__OPTIMIZE__)
 #define likely(expr) (__builtin_expect (!!(expr), 1))
 #define unlikely(expr) (__builtin_expect (!!(expr), 0))


### PR DESCRIPTION
<s>The problem is in `test-var-coords.c`, the conversion error with it should be turned from 0.5 > to 0.8 > to allow tests be passed.</s> fixed by the comment below