### PR TITLE
autotools: Add fix_get_types.py to EXTRA_DIST

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,7 @@ check_PROGRAMS =
 
 EXTRA_DIST += harfbuzz.cc
 EXTRA_DIST += meson.build
+EXTRA_DIST += fix_get_types.py
 
 # Convenience targets:
 lib: $(BUILT_SOURCES) libharfbuzz.la


### PR DESCRIPTION
So it ends up in the release tarball and can be used in the meson build.

Fixes #2337