### PR TITLE
meson: build a separate library for harfbuzz-icu

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,8 +95,12 @@ cairo_dep = dependency('cairo', required: false)
 fontconfig_dep = dependency('fontconfig', required: get_option('fontconfig'),
                             fallback: ['fontconfig', 'fontconfig_dep'])
 graphite2_dep = dependency('graphite2', required: get_option('graphite'))
-icu_dep = dependency('icu-uc', required: get_option('icu').enabled() and cpp.get_id() != 'msvc')
+icu_dep = dependency('icu-uc', required: false)
 m_dep = cpp.find_library('m', required: false)
+
+if not icu_dep.found() and get_option('icu').enabled()
+  icu_dep = dependency('icu-uc', required: cpp.get_id() != 'msvc')
+endif
 
 if not icu_dep.found() and cpp.get_id() == 'msvc'
   if cpp.has_header('unicode/uchar.h') and \
@@ -187,7 +191,6 @@ endif
 if icu_dep.found()
   conf.set('HAVE_ICU', 1)
   conf.set('HAVE_ICU_BUILTIN', 1)
-  deps += [icu_dep]
 endif
 
 if freetype_dep.found()

--- a/src/meson.build
+++ b/src/meson.build
@@ -325,12 +325,6 @@ if get_option('amalgam')
   hb_sources = ['harfbuzz.cc']
 endif
 
-# FIXME: move into harfbuzz-icu module
-if conf.get('HAVE_ICU', 0) == 1
-  hb_sources += hb_icu_sources
-  hb_headers += hb_icu_headers
-endif
-
 # harfbuzz
 gen_def = find_program('gen-def.py')
 harfbuzz_def = custom_target('harfbuzz.def',
@@ -490,6 +484,33 @@ pkgmod.generate(libharfbuzz_subset,
   subdirs: [meson.project_name()],
   version: meson.project_version(),
 )
+
+have_icu = conf.get('HAVE_ICU', 0) == 1
+
+if have_icu
+  libharfbuzz_icu = library('harfbuzz-icu', [hb_icu_sources, hb_icu_headers],
+    include_directories: incconfig,
+    dependencies: icu_dep,
+    link_with: [libharfbuzz],
+    cpp_args: cpp_args + extra_hb_cpp_args,
+    soversion: hb_so_version,
+    version: version,
+    install: true,
+    name_prefix: hb_lib_prefix)
+
+  libharfbuzz_icu_dep = declare_dependency(
+    link_with: libharfbuzz_icu,
+    include_directories: incsrc,
+    dependencies: deps)
+
+  pkgmod.generate(libharfbuzz_icu,
+    description: 'HarfBuzz text shaping library ICU integration',
+    subdirs: [meson.project_name()],
+    version: meson.project_version(),
+  )
+else
+  libharfbuzz_icu_dep = dependency('', required: false)
+endif
 
 have_gobject = conf.get('HAVE_GOBJECT', 0) == 1
 

--- a/test/api/meson.build
+++ b/test/api/meson.build
@@ -24,7 +24,6 @@ if conf.get('HAVE_GLIB', 0) == 1
     'test-ot-metrics-tt-var.c',
     'test-set.c',
     'test-shape.c',
-    'test-unicode.c',
     'test-var-coords.c',
     'test-version.c',
   ]
@@ -50,6 +49,11 @@ if conf.get('HAVE_GLIB', 0) == 1
     'test-subset-colr.c',
     'test-subset-cbdt.c',
   ]
+
+  icu_tests = []
+  if conf.get('HAVE_ICU', 0) == 1
+    icu_tests += 'test-unicode.c'
+  endif
 
   if conf.get('HAVE_FREETYPE', 0) == 1
     tests += 'test-ot-math.c'
@@ -83,6 +87,16 @@ if conf.get('HAVE_GLIB', 0) == 1
       include_directories: [incconfig, incsrc],
       dependencies: deps,
       link_with: [libharfbuzz, libharfbuzz_subset],
+      install: false,
+    ), env: env)
+  endforeach
+
+  foreach source : icu_tests
+    test_name = source.split('.')[0]
+    test(test_name, executable(test_name, source,
+      include_directories: [incconfig, incsrc],
+      dependencies: deps,
+      link_with: [libharfbuzz, libharfbuzz_icu],
       install: false,
     ), env: env)
   endforeach


### PR DESCRIPTION
This adds a seperate library like with autotools.

This also fixes the ico feature option which was just set to required:false
when disabled instead of really disabling it.
Disabling is still broken with msvc because it then tries to find the library
another way, but that's broken for all other deps as well so I left it as is.

For tests only test-unicode.c is using icu specific functions so split it out
into its own category which depends on harfbuzz-icu.

Fixes #2338