### PR TITLE
tests: fix subset/run-tests.py under Windows

### DIFF
--- a/test/subset/run-tests.py
+++ b/test/subset/run-tests.py
@@ -23,7 +23,8 @@ if not fonttools:
 
 def cmd(command):
 	p = subprocess.Popen (
-		command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+		universal_newlines=True)
 	(stdoutdata, stderrdata) = p.communicate ()
 	print (stderrdata, end="") # file=sys.stderr
 	return stdoutdata, p.returncode
@@ -91,7 +92,7 @@ def run_ttx (file):
 def strip_check_sum (ttx_string):
 	return re.sub ('checkSumAdjustment value=["]0x([0-9a-fA-F])+["]',
 		       'checkSumAdjustment value="0x00000000"',
-		       ttx_string.decode ("utf-8"), count=1)
+		       ttx_string, count=1)
 
 def has_ots ():
 	if not ots_sanitize:


### PR DESCRIPTION
It assumed that stdout of a subprocess in binary mode was using
utf-8 which isn't the case. Instead open stdout of the subprocess
in text mode and let Python handle the decoding.