### PR TITLE
meson: install gobject/icu headers if they are enabled

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -627,4 +627,4 @@ else
   libharfbuzz_gobject_dep = dependency('', required: false)
 endif
 
-install_headers(hb_headers + hb_gobject_headers + hb_subset_headers, subdir: meson.project_name())
+install_headers(hb_headers + hb_gobject_headers + hb_subset_headers + hb_icu_headers, subdir: meson.project_name())

--- a/src/meson.build
+++ b/src/meson.build
@@ -515,6 +515,8 @@ if have_icu and not have_icu_builtin
     subdirs: [meson.project_name()],
     version: meson.project_version(),
   )
+
+  install_headers(hb_icu_headers, subdir: meson.project_name())
 else
   libharfbuzz_icu_dep = dependency('', required: false)
 endif
@@ -623,8 +625,10 @@ if have_gobject
     subdirs: [meson.project_name()],
     version: meson.project_version(),
   )
+
+  install_headers(hb_gobject_headers, subdir: meson.project_name())
 else
   libharfbuzz_gobject_dep = dependency('', required: false)
 endif
 
-install_headers(hb_headers + hb_gobject_headers + hb_subset_headers + hb_icu_headers, subdir: meson.project_name())
+install_headers(hb_headers + hb_subset_headers, subdir: meson.project_name())


### PR DESCRIPTION
The first commit fixes that hb-icu.h was missing, the second skips the header install in case gobject/icu are disabled.