### PR TITLE
[meson] Generate harfbuzz.cc, hb-version.h and ragel artifacts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,12 +98,7 @@ BUILT_SOURCES += \
 	hb-version.h
 
 $(srcdir)/hb-version.h: hb-version.h.in $(top_srcdir)/configure.ac
-	$(AM_V_GEN) $(SED) \
-		-e 's/[@]HB_VERSION_MAJOR@/$(HB_VERSION_MAJOR)/' \
-		-e 's/[@]HB_VERSION_MINOR@/$(HB_VERSION_MINOR)/' \
-		-e 's/[@]HB_VERSION_MICRO@/$(HB_VERSION_MICRO)/' \
-		-e 's/[@]HB_VERSION@/$(HB_VERSION)/' \
-		"$<" > "$@" || ($(RM) "$@"; false)
+	$(AM_V_GEN) $(srcdir)/gen-hb-version.py $(HB_VERSION) "$<" "$@"
 
 # Put the library together
 
@@ -251,8 +246,11 @@ GENERATORS = \
 	gen-arabic-table.py \
 	gen-def.py \
 	gen-emoji-table.py \
+	gen-harfbuzzcc.py \
+	gen-hb-version.py \
 	gen-indic-table.py \
 	gen-os2-unicode-ranges.py \
+	gen-ragel-artifacts.py \
 	gen-tag-table.py \
 	gen-ucd-table.py \
 	gen-use-table.py \
@@ -312,7 +310,8 @@ $(srcdir)/%.hh: $(srcdir)/%.rl
 
 harfbuzz.cc: Makefile.sources
 	$(AM_V_GEN) \
-	for f in \
+	$(srcdir)/gen-harfbuzzcc.py \
+		$(srcdir)/harfbuzz.cc \
 		$(HB_BASE_sources) \
 		$(HB_GLIB_sources) \
 		$(HB_FT_sources) \
@@ -320,10 +319,7 @@ harfbuzz.cc: Makefile.sources
 		$(HB_UNISCRIBE_sources) \
 		$(HB_GDI_sources) \
 		$(HB_DIRECTWRITE_sources) \
-		$(HB_CORETEXT_sources) \
-		; do echo '#include "'$$f'"'; done | \
-	grep '[.]cc"' > $(srcdir)/harfbuzz.cc \
-	|| ($(RM) $(srcdir)/harfbuzz.cc; false)
+		$(HB_CORETEXT_sources)
 BUILT_SOURCES += harfbuzz.cc
 
 noinst_PROGRAMS = \

--- a/src/gen-harfbuzzcc.py
+++ b/src/gen-harfbuzzcc.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import io, os, re, sys
+
+if len (sys.argv) < 3:
+	sys.exit("usage: gen-harfbuzzcc.py harfbuzz.def hb-blob.cc hb-buffer.cc ...")
+
+output_file = sys.argv[1]
+source_paths = sys.argv[2:]
+
+with open (output_file, "wb") as f:
+	f.write ("".join ('#include "{}"\n'.format (x)
+					  for x in source_paths
+					  if x.endswith (".cc")).encode ())

--- a/src/gen-hb-version.py
+++ b/src/gen-hb-version.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import io, os, re, sys
+
+if len (sys.argv) < 4:
+	sys.exit("usage: gen-hb-version.py 1.0.0 hb-version.h.in hb-version.h")
+
+version = sys.argv[1]
+major, minor, micro = version.split (".")
+input = sys.argv[2]
+output = sys.argv[3]
+
+with open (output, "wb") as output_file, open (input, "r") as input_file:
+	output_file.write (input_file.read ()
+		.replace ("@HB_VERSION_MAJOR@", major)
+		.replace ("@HB_VERSION_MINOR@", minor)
+		.replace ("@HB_VERSION_MICRO@", micro)
+		.replace ("@HB_VERSION@", version)
+		.encode ())

--- a/src/gen-ragel-artifacts.py
+++ b/src/gen-ragel-artifacts.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import io, os, re, sys, subprocess, shutil
+
+if len (sys.argv) < 3:
+	ragel_sources = [x for x in os.listdir ('.') if x.endswith ('.rl')]
+else:
+	os.chdir(sys.argv[1])
+	ragel_sources = sys.argv[2:]
+
+ragel = shutil.which ('ragel')
+
+if not ragel:
+	print ('You have to install ragel if you are going to develop HarfBuzz itself')
+	exit (1)
+
+if not len (ragel_sources):
+	exit (77)
+
+for rl in ragel_sources:
+	hh = rl.replace ('.rl', '.hh')
+	subprocess.Popen ([ragel, '-e', '-F1', '-o', hh, rl]).wait ()

--- a/src/meson.build
+++ b/src/meson.build
@@ -280,6 +280,36 @@ hb_gobject_headers = [
   'hb-gobject-structs.h',
 ]
 
+custom_target('hb-version.h',
+  build_by_default: true,
+  input: 'hb-version.h.in',
+  output: 'hb-version.h',
+  command: [find_program('gen-hb-version.py'), meson.project_version(),
+            '@INPUT@', join_paths(meson.current_source_dir(), 'hb-version.h')])
+
+ragel = find_program('ragel', required: false)
+if not ragel.found()
+  message('You have to install ragel if you are going to develop HarfBuzz itself')
+else
+  foreach rl : hb_base_ragel_sources
+    hh = rl.split('.rl')[0] + '.hh'
+    custom_target(hh,
+      build_by_default: true,
+      depfile: rl,
+      output: hh,
+      command: [find_program('gen-ragel-artifacts.py'), meson.current_source_dir(), rl])
+  endforeach
+endif
+
+custom_target('harfbuzz.cc',
+  build_by_default: true,
+  output: 'harfbuzz.cc',
+  command: [find_program('gen-harfbuzzcc.py'),
+            join_paths(meson.source_root(), '@OUTPUT@')] +
+            hb_base_sources + hb_glib_sources + hb_ft_sources +
+            hb_graphite2_sources + hb_uniscribe_sources + hb_gdi_sources +
+            hb_directwrite_sources + hb_coretext_sources)
+
 incsrc = include_directories('.')
 
 hb_sources = hb_base_sources + hb_base_ragel_generated_sources


### PR DESCRIPTION
Fixes #2245 and #2242 however has one big issue, it generates ragel artifacts each time not only when the dependent file is updated, same as harfbuzz.cc, ideally harfbuzz.cc should be generated whenever `meson.build` itself is changed and ragel artifacts only when `.rl` files are changed which not considering that causes rest of the project in need for rebuild as timestamp updates.

This is considered the official way to define command targets https://mesonbuild.com/Run-targets.html what we need is basically always running them when some of the files are updated, like what make offers.