### PR TITLE
[kern] Test format 3.

### DIFF
--- a/test/shaping/data/in-house/tests/macos.tests
+++ b/test/shaping/data/in-house/tests/macos.tests
@@ -123,3 +123,4 @@
 /System/Library/Fonts/Supplemental/Apple Chancery.ttf@4ec49cba0d4e68d025ada0498c4df1b2f9fd57ac:--font-funcs ot --features liga=0,sups=0,tnum=0:U+0066,U+0069,U+0072,U+0073,U+0074:[f=0+639|i=1+606|r=2+853|s=3+728|t=4+725]
 /System/Library/Fonts/Supplemental/Apple Chancery.ttf@4ec49cba0d4e68d025ada0498c4df1b2f9fd57ac:--font-funcs ot --features smcp=1:U+0066,U+0069,U+0072,U+0073,U+0074:[F.small=0+903|I.small=1+634|R.small=2+1113|S.small=3+911|T.small=4+1075]
 /System/Library/Fonts/Supplemental/Apple Chancery.ttf@4ec49cba0d4e68d025ada0498c4df1b2f9fd57ac:--font-funcs ot --features liga=0,dlig=1:U+0066,U+0069,U+0072,U+0073,U+0074:[f=0+639|i=1+606|r=2+853|s_t=3+1438]
+/System/Library/Fonts/Supplemental/Skia.ttf@caee56fc4085009c1a29a863500908050ea6248f:--font-funcs ot:U+0041,U+0056:[A=0+1345|V=1@-12,0+1346]


### PR DESCRIPTION
Looks like there are not format 3 tests yet. And since the only font I know that uses it is Skia - I've added a new test to `macos.tests`.