### PR TITLE
[kern] Simplify hb_kern_machine_t

### DIFF
--- a/src/hb-kern.hh
+++ b/src/hb-kern.hh
@@ -52,8 +52,7 @@ struct hb_kern_machine_t
     OT::hb_ot_apply_context_t c (1, font, buffer);
     c.set_lookup_mask (kern_mask);
     c.set_lookup_props (OT::LookupFlag::IgnoreMarks);
-    OT::hb_ot_apply_context_t::skipping_iterator_t &skippy_iter = c.iter_input;
-    skippy_iter.init (&c);
+    auto &skippy_iter = c.iter_input;
 
     bool horizontal = HB_DIRECTION_IS_HORIZONTAL (buffer->props.direction);
     unsigned int count = buffer->len;


### PR DESCRIPTION
This commit removes some rudimentary code like `skippy_iter.init (&c);` which isn't needed since `set_lookup_mask` and `set_lookup_props` already called it.

Also, it uses an iterator directly, without a temporary reference.

Overall, this is just a simple refactoring.