### PR TITLE
Increase the size of the serialization buffer

### DIFF
--- a/util/options.cc
+++ b/util/options.cc
@@ -917,7 +917,7 @@ format_options_t::serialize_glyphs (hb_buffer_t *buffer,
 
   while (start < num_glyphs)
   {
-    char buf[1024];
+    char buf[32768];
     unsigned int consumed;
     start += hb_buffer_serialize_glyphs (buffer, start, num_glyphs,
 					 buf, sizeof (buf), &consumed,


### PR DESCRIPTION
This is a workaround for #2371.