### PR TITLE
meson: Use find_program instead of the python module

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ if host_machine.cpu_family() == 'arm' and cpp.alignment('struct { char c; }') !=
   endif
 endif
 
-python3 = import('python').find_installation('python3')
+python3 = find_program('python3')
 
 check_headers = [
   ['unistd.h'],


### PR DESCRIPTION
Using the python module introduces a dependency on python3-setuptools,
which may be uninstalled on some machines, especially buildbots.
find_programs will run less checks but all since all that's needed is a
python3 installation to run some scripts, that seems good enough