### PR TITLE
win32: Cleanup PARTITION handling

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -569,7 +569,7 @@ fail_without_close:
   wchar_t * wchar_file_name = (wchar_t *) malloc (sizeof (wchar_t) * size);
   if (unlikely (!wchar_file_name)) goto fail_without_close;
   mbstowcs (wchar_file_name, file_name, size);
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+#if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   {
     CREATEFILE2_EXTENDED_PARAMETERS ceparams = { 0 };
     ceparams.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
@@ -590,7 +590,7 @@ fail_without_close:
 
   if (unlikely (fd == INVALID_HANDLE_VALUE)) goto fail_without_close;
 
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+#if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   {
     LARGE_INTEGER length;
     GetFileSizeEx (fd, &length);
@@ -603,7 +603,7 @@ fail_without_close:
 #endif
   if (unlikely (!file->mapping)) goto fail;
 
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+#if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   file->contents = (char *) MapViewOfFileFromApp (file->mapping, FILE_MAP_READ, 0, 0);
 #else
   file->contents = (char *) MapViewOfFile (file->mapping, FILE_MAP_READ, 0, 0, 0);

--- a/src/hb-mutex.hh
+++ b/src/hb-mutex.hh
@@ -61,10 +61,9 @@ typedef pthread_mutex_t hb_mutex_impl_t;
 
 #elif !defined(HB_NO_MT) && defined(_WIN32)
 
-#include <windows.h>
 typedef CRITICAL_SECTION hb_mutex_impl_t;
 #define HB_MUTEX_IMPL_INIT	{0}
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+#if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #define hb_mutex_impl_init(M)	InitializeCriticalSectionEx (M, 0, 0)
 #else
 #define hb_mutex_impl_init(M)	InitializeCriticalSection (M)

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -189,10 +189,14 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
 #endif
-#include <windows.h>
 #else
 #include <intrin.h>
 #endif
+#endif
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winapifamily.h>
 #endif
 
 #define HB_PASTE1(a,b) a##b
@@ -336,7 +340,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #    undef _WIN32_WINNT
 #  endif
 #  ifndef _WIN32_WINNT
-#    if !defined(WINAPI_FAMILY) || !(WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+#    if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #      define _WIN32_WINNT 0x0600
 #    endif
 #  endif
@@ -357,7 +361,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #      define HB_NO_SETLOCALE
 #      define HB_NO_ERRNO
 #    endif
-#  elif defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+#  elif WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #    ifndef HB_NO_GETENV
 #      define HB_NO_GETENV
 #    endif


### PR DESCRIPTION
Use the WINAPI_PARTITION macro to filter desktop/app flavors.
We use a negated desktop check because the default (for mingw-w64 at
least) is to allow all API by combining desktop + app partitions.
This causes build failures if we were to filter using
WINAPI_PARTITION(WINAPI_FAMILY_APP) because it would always be true, but
those API also require Windows 8 or later, while we only require Vista

Fixes warnings like
../src/hb-blob.cc:572:47: warning: 'WINAPI_FAMILY_PC_APP' is not defined, evaluates to 0 [-Wundef]
 #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
                                              ^
../src/hb-blob.cc:572:86: warning: 'WINAPI_FAMILY_PHONE_APP' is not defined, evaluates to 0 [-Wundef]
 #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_PC_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)