### PR TITLE
FIX: -Werror,-Wextra-semi-stmt in Clang9

### DIFF
--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -660,7 +660,7 @@ _hb_coretext_shape (hb_shape_plan_t    *shape_plan,
     scratch_size -= _consumed; \
   } while (0)
 
-  ALLOCATE_ARRAY (UniChar, pchars, buffer->len * 2, /*nothing*/);
+  ALLOCATE_ARRAY (UniChar, pchars, buffer->len * 2, ((void)nullptr) /*nothing*/);
   unsigned int chars_len = 0;
   for (unsigned int i = 0; i < buffer->len; i++) {
     hb_codepoint_t c = buffer->info[i].codepoint;
@@ -674,7 +674,7 @@ _hb_coretext_shape (hb_shape_plan_t    *shape_plan,
     }
   }
 
-  ALLOCATE_ARRAY (unsigned int, log_clusters, chars_len, /*nothing*/);
+  ALLOCATE_ARRAY (unsigned int, log_clusters, chars_len, ((void)nullptr) /*nothing*/);
   chars_len = 0;
   for (unsigned int i = 0; i < buffer->len; i++)
   {


### PR DESCRIPTION
This works around a build issue I recent ran into when building harfbuzz via its conan recipe on bincrafters with Clang 9.0.1:

```
In file included from /Users/rmeusel/.conan/data/harfbuzz/2.6.4/bincrafters/stable/build/e904e11fef36cfcfed90909784b525499cdc3731/source_subfolder/src/harfbuzz.cc:53:
/Users/rmeusel/.conan/data/harfbuzz/2.6.4/bincrafters/stable/build/e904e11fef36cfcfed90909784b525499cdc3731/source_subfolder/src/hb-coretext.cc:608:200: error: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Werror,-Wextra-semi-stmt]
  UniChar *pchars = (UniChar *) scratch; do { unsigned int _consumed = DIV_CEIL ((buffer->len * 2) * sizeof (UniChar), sizeof (*scratch)); if ((__builtin_expect (!!(_consumed > scratch_size), 0))) { ; ((void)0); } scratch += _consumed; scratch_size -= _consumed; } while (0);
                                                                                                                                                                                                       ^~
/Users/rmeusel/.conan/data/harfbuzz/2.6.4/bincrafters/stable/build/e904e11fef36cfcfed90909784b525499cdc3731/source_subfolder/src/hb-coretext.cc:622:215: error: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Werror,-Wextra-semi-stmt]
  unsigned int *log_clusters = (unsigned int *) scratch; do { unsigned int _consumed = DIV_CEIL ((chars_len) * sizeof (unsigned int), sizeof (*scratch)); if ((__builtin_expect (!!(_consumed > scratch_size), 0))) { ; ((void)0); } scratch += _consumed; scratch_size -= _consumed; } while (0);
                                                                                                                                                                                                                      ^~
228 warnings and 2 errors generated.
```

In the resolution of the `ALLOCATE_ARRAY` an empty statement is generated (similar to [this previous pull request](https://github.com/harfbuzz/harfbuzz/pull/1783)) resulting in a build failure.