### PR TITLE
[hb-view] add --line-height option; fixes #2402

### DIFF
--- a/util/options.cc
+++ b/util/options.cc
@@ -399,6 +399,7 @@ view_options_t::add_options (option_parser_t *parser)
     {"background",	0, 0, G_OPTION_ARG_STRING,	&this->back,			"Set background color (default: " DEFAULT_BACK ")",	"rrggbb/rrggbbaa"},
     {"foreground",	0, 0, G_OPTION_ARG_STRING,	&this->fore,			"Set foreground color (default: " DEFAULT_FORE ")",	"rrggbb/rrggbbaa"},
     {"line-space",	0, 0, G_OPTION_ARG_DOUBLE,	&this->line_space,		"Set space between lines (default: 0)",			"units"},
+    {"line-height",  0, 0, G_OPTION_ARG_DOUBLE,  &this->line_height,    "Set the line height (default: font height)",     "units"},
     {"margin",		0, 0, G_OPTION_ARG_CALLBACK,	(gpointer) &parse_margin,	"Margin around output (default: " G_STRINGIFY(DEFAULT_MARGIN) ")","one to four numbers"},
     {nullptr}
   };

--- a/util/options.hh
+++ b/util/options.hh
@@ -125,6 +125,7 @@ struct view_options_t : option_group_t
     fore = nullptr;
     back = nullptr;
     line_space = 0;
+    line_height = 0;
     margin.t = margin.r = margin.b = margin.l = DEFAULT_MARGIN;
 
     add_options (parser);
@@ -141,6 +142,7 @@ struct view_options_t : option_group_t
   char *fore;
   char *back;
   double line_space;
+  double line_height;
   struct margin_t {
     double t, r, b, l;
   } margin;


### PR DESCRIPTION
As discussed in #2402, added the `--line-height` option to `hb-view`. 

Please note that:

* It's my first time in 15 years writing C++
* I couldn't wrap my head around all the possible combinations between direction and positive/negative font_size_x / font_size_y, but the combinations I tested seem to work as expected