### PR TITLE
[draw] Expose draw API

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -222,6 +222,26 @@ hb_directwrite_shape_experimental_width
 </SECTION>
 
 <SECTION>
+<FILE>hb-draw</FILE>
+hb_draw_funcs_t
+hb_draw_move_to_func_t
+hb_draw_line_to_func_t
+hb_draw_quadratic_to_func_t
+hb_draw_cubic_to_func_t
+hb_draw_close_path_func_t
+hb_draw_funcs_create
+hb_draw_funcs_destroy
+hb_draw_funcs_make_immutable
+hb_draw_funcs_is_immutable
+hb_draw_funcs_reference
+hb_draw_funcs_set_move_to_func
+hb_draw_funcs_set_line_to_func
+hb_draw_funcs_set_quadratic_to_func
+hb_draw_funcs_set_cubic_to_func
+hb_draw_funcs_set_close_path_func
+</SECTION>
+
+<SECTION>
 <FILE>hb-face</FILE>
 hb_face_count
 hb_face_t
@@ -256,6 +276,7 @@ hb_font_add_glyph_origin_for_direction
 hb_font_create
 hb_font_create_sub_font
 hb_font_destroy
+hb_font_draw_glyph
 hb_font_funcs_create
 hb_font_funcs_destroy
 hb_font_funcs_get_empty

--- a/src/gen-def.py
+++ b/src/gen-def.py
@@ -17,24 +17,7 @@ symbols = sorted (re.findall (r"^hb_\w+(?= \()", "\n".join (headers_content), re
 if '--experimental-api' not in sys.argv:
 	# Move these to harfbuzz-sections.txt when got stable
 	experimental_symbols = \
-"""hb_font_draw_glyph
-hb_draw_funcs_t
-hb_draw_close_path_func_t
-hb_draw_cubic_to_func_t
-hb_draw_line_to_func_t
-hb_draw_move_to_func_t
-hb_draw_quadratic_to_func_t
-hb_draw_funcs_create
-hb_draw_funcs_destroy
-hb_draw_funcs_is_immutable
-hb_draw_funcs_make_immutable
-hb_draw_funcs_reference
-hb_draw_funcs_set_close_path_func
-hb_draw_funcs_set_cubic_to_func
-hb_draw_funcs_set_line_to_func
-hb_draw_funcs_set_move_to_func
-hb_draw_funcs_set_quadratic_to_func
-hb_font_get_var_coords_design
+"""hb_font_get_var_coords_design
 hb_ot_layout_closure_lookups
 hb_ot_layout_closure_features""".splitlines ()
 	symbols = [x for x in symbols if x not in experimental_symbols]

--- a/src/hb-draw.cc
+++ b/src/hb-draw.cc
@@ -25,7 +25,6 @@
 #include "hb.hh"
 
 #ifndef HB_NO_DRAW
-#ifdef HB_EXPERIMENTAL_API
 
 #include "hb-draw.hh"
 #include "hb-ot.h"
@@ -40,7 +39,7 @@
  *
  * Sets move-to callback to the draw functions object.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 void
 hb_draw_funcs_set_move_to_func (hb_draw_funcs_t        *funcs,
@@ -57,7 +56,7 @@ hb_draw_funcs_set_move_to_func (hb_draw_funcs_t        *funcs,
  *
  * Sets line-to callback to the draw functions object.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 void
 hb_draw_funcs_set_line_to_func (hb_draw_funcs_t        *funcs,
@@ -74,7 +73,7 @@ hb_draw_funcs_set_line_to_func (hb_draw_funcs_t        *funcs,
  *
  * Sets quadratic-to callback to the draw functions object.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 void
 hb_draw_funcs_set_quadratic_to_func (hb_draw_funcs_t             *funcs,
@@ -92,7 +91,7 @@ hb_draw_funcs_set_quadratic_to_func (hb_draw_funcs_t             *funcs,
  *
  * Sets cubic-to callback to the draw functions object.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 void
 hb_draw_funcs_set_cubic_to_func (hb_draw_funcs_t         *funcs,
@@ -109,7 +108,7 @@ hb_draw_funcs_set_cubic_to_func (hb_draw_funcs_t         *funcs,
  *
  * Sets close-path callback to the draw functions object.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 void
 hb_draw_funcs_set_close_path_func (hb_draw_funcs_t           *funcs,
@@ -144,7 +143,7 @@ _close_path_nil (void *user_data HB_UNUSED) {}
  *
  * Creates a new draw callbacks object.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 hb_draw_funcs_t *
 hb_draw_funcs_create ()
@@ -169,7 +168,7 @@ hb_draw_funcs_create ()
  * Add to callbacks object refcount.
  *
  * Returns: The same object.
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 hb_draw_funcs_t *
 hb_draw_funcs_reference (hb_draw_funcs_t *funcs)
@@ -184,7 +183,7 @@ hb_draw_funcs_reference (hb_draw_funcs_t *funcs)
  * Decreases refcount of callbacks object and deletes the object if it reaches
  * to zero.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 void
 hb_draw_funcs_destroy (hb_draw_funcs_t *funcs)
@@ -200,7 +199,7 @@ hb_draw_funcs_destroy (hb_draw_funcs_t *funcs)
  *
  * Makes funcs object immutable.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 void
 hb_draw_funcs_make_immutable (hb_draw_funcs_t *funcs)
@@ -218,7 +217,7 @@ hb_draw_funcs_make_immutable (hb_draw_funcs_t *funcs)
  * Checks whether funcs is immutable.
  *
  * Returns: If is immutable.
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 hb_bool_t
 hb_draw_funcs_is_immutable (hb_draw_funcs_t *funcs)
@@ -236,7 +235,7 @@ hb_draw_funcs_is_immutable (hb_draw_funcs_t *funcs)
  * Draw a glyph.
  *
  * Returns: Whether the font had the glyph and the operation completed successfully.
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 hb_bool_t
 hb_font_draw_glyph (hb_font_t *font, hb_codepoint_t glyph,
@@ -257,5 +256,4 @@ hb_font_draw_glyph (hb_font_t *font, hb_codepoint_t glyph,
   return false;
 }
 
-#endif
 #endif

--- a/src/hb-draw.h
+++ b/src/hb-draw.h
@@ -33,7 +33,6 @@
 
 HB_BEGIN_DECLS
 
-#ifdef HB_EXPERIMENTAL_API
 typedef void (*hb_draw_move_to_func_t) (hb_position_t to_x, hb_position_t to_y, void *user_data);
 typedef void (*hb_draw_line_to_func_t) (hb_position_t to_x, hb_position_t to_y, void *user_data);
 typedef void (*hb_draw_quadratic_to_func_t) (hb_position_t control_x, hb_position_t control_y,
@@ -53,7 +52,7 @@ typedef void (*hb_draw_close_path_func_t) (void *user_data);
  * _move_to, _line_to and _cubic_to calls are nessecary to be defined but we
  * translate _quadratic_to calls to _cubic_to if the callback isn't defined.
  *
- * Since: EXPERIMENTAL
+ * Since: REPLACEME
  **/
 typedef struct hb_draw_funcs_t hb_draw_funcs_t;
 
@@ -91,7 +90,6 @@ hb_draw_funcs_make_immutable (hb_draw_funcs_t *funcs);
 
 HB_EXTERN hb_bool_t
 hb_draw_funcs_is_immutable (hb_draw_funcs_t *funcs);
-#endif
 
 HB_END_DECLS
 

--- a/src/hb-draw.hh
+++ b/src/hb-draw.hh
@@ -27,7 +27,6 @@
 
 #include "hb.hh"
 
-#ifdef HB_EXPERIMENTAL_API
 struct hb_draw_funcs_t
 {
   hb_object_header_t header;
@@ -134,6 +133,5 @@ struct draw_helper_t
   const hb_draw_funcs_t *funcs;
   void *user_data;
 };
-#endif
 
 #endif /* HB_DRAW_HH */

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -724,11 +724,9 @@ HB_EXTERN void
 hb_font_set_var_named_instance (hb_font_t *font,
 				unsigned instance_index);
 
-#ifdef HB_EXPERIMENTAL_API
 HB_EXTERN hb_bool_t
 hb_font_draw_glyph (hb_font_t *font, hb_codepoint_t glyph,
 		    const hb_draw_funcs_t *funcs, void *user_data);
-#endif
 
 HB_END_DECLS
 

--- a/src/hb-ot-cff1-table.cc
+++ b/src/hb-ot-cff1-table.cc
@@ -442,7 +442,6 @@ bool OT::cff1::accelerator_t::get_extents (hb_font_t *font, hb_codepoint_t glyph
   return true;
 }
 
-#ifdef HB_EXPERIMENTAL_API
 struct cff1_path_param_t
 {
   cff1_path_param_t (const OT::cff1::accelerator_t *cff_, hb_font_t *font_,
@@ -564,7 +563,6 @@ bool OT::cff1::accelerator_t::get_path (hb_font_t *font, hb_codepoint_t glyph, d
 
   return _get_path (this, font, glyph, draw_helper);
 }
-#endif
 
 struct get_seac_param_t
 {

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -1346,9 +1346,7 @@ struct cff1
 
     HB_INTERNAL bool get_extents (hb_font_t *font, hb_codepoint_t glyph, hb_glyph_extents_t *extents) const;
     HB_INTERNAL bool get_seac_components (hb_codepoint_t glyph, hb_codepoint_t *base, hb_codepoint_t *accent) const;
-#ifdef HB_EXPERIMENTAL_API
     HB_INTERNAL bool get_path (hb_font_t *font, hb_codepoint_t glyph, draw_helper_t &draw_helper) const;
-#endif
 
     private:
     struct gname_t

--- a/src/hb-ot-cff2-table.cc
+++ b/src/hb-ot-cff2-table.cc
@@ -143,7 +143,6 @@ bool OT::cff2::accelerator_t::get_extents (hb_font_t *font,
   return true;
 }
 
-#ifdef HB_EXPERIMENTAL_API
 struct cff2_path_param_t
 {
   cff2_path_param_t (hb_font_t *font_, draw_helper_t &draw_helper_)
@@ -210,6 +209,5 @@ bool OT::cff2::accelerator_t::get_path (hb_font_t *font, hb_codepoint_t glyph, d
   if (unlikely (!interp.interpret (param))) return false;
   return true;
 }
-#endif
 
 #endif

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -506,9 +506,7 @@ struct cff2
     HB_INTERNAL bool get_extents (hb_font_t *font,
 				  hb_codepoint_t glyph,
 				  hb_glyph_extents_t *extents) const;
-#ifdef HB_EXPERIMENTAL_API
     HB_INTERNAL bool get_path (hb_font_t *font, hb_codepoint_t glyph, draw_helper_t &draw_helper) const;
-#endif
   };
 
   typedef accelerator_templ_t<cff2_private_dict_opset_subset_t, cff2_private_dict_values_subset_t> accelerator_subset_t;

--- a/src/hb-ot-glyf-table.hh
+++ b/src/hb-ot-glyf-table.hh
@@ -1030,7 +1030,6 @@ struct glyf
 	add_gid_and_children (item.glyphIndex, gids_to_retain, depth);
     }
 
-#ifdef HB_EXPERIMENTAL_API
     struct path_builder_t
     {
       hb_font_t *font;
@@ -1149,7 +1148,6 @@ struct glyf
     bool
     get_path (hb_font_t *font, hb_codepoint_t gid, draw_helper_t &draw_helper) const
     { return get_points (font, gid, path_builder_t (font, draw_helper)); }
-#endif
 
     private:
     bool short_offset;

--- a/src/main.cc
+++ b/src/main.cc
@@ -41,7 +41,7 @@
 #define hb_blob_create_from_file(x)  hb_blob_get_empty ()
 #endif
 
-#if !defined(HB_NO_COLOR) && !defined(HB_NO_DRAW) && defined(HB_EXPERIMENTAL_API)
+#if !defined(HB_NO_COLOR) && !defined(HB_NO_DRAW)
 static void
 svg_dump (hb_face_t *face, unsigned face_index)
 {
@@ -510,7 +510,7 @@ main (int argc, char **argv)
 #ifndef MAIN_CC_NO_PRIVATE_API
   print_layout_info_using_private_api (blob);
 #endif
-#if !defined(HB_NO_COLOR) && !defined(HB_NO_DRAW) && defined(HB_EXPERIMENTAL_API)
+#if !defined(HB_NO_COLOR) && !defined(HB_NO_DRAW)
   dump_glyphs (blob, argv[1]);
 #endif
   hb_blob_destroy (blob);

--- a/test/api/test-draw.c
+++ b/test/api/test-draw.c
@@ -26,7 +26,7 @@
 
 #include <hb.h>
 
-#ifdef HB_EXPERIMENTAL_API
+#ifndef HB_NO_DRAW
 typedef struct user_data_t
 {
   char *str;

--- a/test/fuzzing/hb-draw-fuzzer.cc
+++ b/test/fuzzing/hb-draw-fuzzer.cc
@@ -5,7 +5,6 @@
 
 #include "hb-fuzzer.hh"
 
-#ifdef HB_EXPERIMENTAL_API
 struct _user_data_t
 {
   bool is_open;
@@ -75,7 +74,6 @@ _close_path (void *user_data_)
   assert (user_data->path_start_x == user_data->path_last_x &&
 	  user_data->path_start_y == user_data->path_last_y);
 }
-#endif
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
@@ -97,7 +95,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   unsigned glyph_count = hb_face_get_glyph_count (face);
   glyph_count = glyph_count > 16 ? 16 : glyph_count;
 
-#ifdef HB_EXPERIMENTAL_API
   _user_data_t user_data = {false, 0, 0, 0, 0, 0};
 
   hb_draw_funcs_t *funcs = hb_draw_funcs_create ();
@@ -106,14 +103,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   hb_draw_funcs_set_quadratic_to_func (funcs, (hb_draw_quadratic_to_func_t) _quadratic_to);
   hb_draw_funcs_set_cubic_to_func (funcs, (hb_draw_cubic_to_func_t) _cubic_to);
   hb_draw_funcs_set_close_path_func (funcs, (hb_draw_close_path_func_t) _close_path);
-#endif
   volatile unsigned counter = !glyph_count;
   for (unsigned gid = 0; gid < glyph_count; ++gid)
   {
-#ifdef HB_EXPERIMENTAL_API
     hb_font_draw_glyph (font, gid, funcs, &user_data);
     assert (!user_data.is_open);
-#endif
 
     /* Glyph extents also may practices the similar path, call it now that is related */
     hb_glyph_extents_t extents;
@@ -123,9 +117,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (!counter) counter += 1;
   }
   assert (counter);
-#ifdef HB_EXPERIMENTAL_API
   hb_draw_funcs_destroy (funcs);
-#endif
 
   hb_font_destroy (font);
   hb_face_destroy (face);


### PR DESCRIPTION
Lets draw the attentions to it and get it reviewed, and maybe maybe have it for the next release, I feel missing this everytime I want to use the functionality somewhere else, e.g. glyphy. And I know @Harachie (per [this](https://github.com/harfbuzz/harfbuzz/issues/2145#issuecomment-598696472)) and @khaledhosny are using it already and guess they can give feedbacks also if any. Possibly fontgoggles https://github.com/justvanrossum/fontgoggles/issues/73 and many more projects also can use it.

Overview of other related files and patches on the repo:
* #2145 giving ideas and request for feedback, but as it got lengthy so [Godwin's law](https://en.wikipedia.org/wiki/Godwin%27s_law) is applied apparently.
* #2185 proxy draw API to freetype using font funcs mechanism, main issue is the naming as current font funcs naming requires having `_get_` in callbacks names, like `hb_font_get_draw_glyph_func_t`, but `_get_` doesn't mean much in the current API, so https://github.com/harfbuzz/harfbuzz/pull/2185/commits/d93b115abb02c716303b5ffc9ebd26e6019d154a applied which disturbs some of the macros, can be deferred I believe or maybe not.
* #2183 just a similar attempt to the previous one but without using font-funcs mechanism.
* #2170 "Main idea here is to implement some operators for draw to see if we are happy enough with our abstractions."
