### PR TITLE
meson: error out if introspection is enabled but gobject isn't

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -657,6 +657,10 @@ if have_gobject
 
   install_headers(hb_gobject_headers, subdir: meson.project_name())
 else
+  if get_option('introspection').enabled()
+    error('introspection requires gobject to be enabled')
+  endif
+
   libharfbuzz_gobject_dep = dependency('', required: false)
 endif
 


### PR DESCRIPTION
In case a user passed -Dintrospection=enabled the build would just ignore
it by default because gobject defaults to disabled and the introspection build
gets skipped.

Instead, if introspection is explicitly enabled but gobject is for some reason
missing error out.

Fixes #2404