### PR TITLE
meson: build documentation with gtk-doc

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -107,7 +107,7 @@ include $(top_srcdir)/gtk-doc.make
 
 # Other files to distribute
 # e.g. EXTRA_DIST += version.xml.in
-EXTRA_DIST += version.xml.in
+EXTRA_DIST += version.xml.in meson.build
 
 # Files not to distribute
 # for --rebuild-types in $(SCAN_OPTIONS), e.g. $(DOC_MODULE).types

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,0 +1,67 @@
+if build_machine.system() == 'windows'
+  message('Skipping gtk-doc while building on Windows')
+  subdir_done()
+endif
+
+if not find_program('gtkdoc-scan', required: get_option('gtk_doc')).found()
+  message('Not building documentation as gtk-doc was not found')
+  subdir_done()
+endif
+
+gnome = import('gnome')
+
+docconf = configuration_data()
+docconf.set('HB_VERSION', meson.project_version())
+
+version_xml = configure_file(input: 'version.xml.in',
+  output: 'version.xml',
+  configuration: docconf)
+
+content_files = [
+  'usermanual-what-is-harfbuzz.xml',
+  'usermanual-install-harfbuzz.xml',
+  'usermanual-getting-started.xml',
+  'usermanual-glyph-information.xml',
+  'usermanual-shaping-concepts.xml',
+  'usermanual-object-model.xml',
+  'usermanual-buffers-language-script-and-direction.xml',
+  'usermanual-fonts-and-faces.xml',
+  'usermanual-opentype-features.xml',
+  'usermanual-clusters.xml',
+  'usermanual-utilities.xml',
+  'usermanual-integration.xml',
+  version_xml,
+]
+
+html_images = [
+  'HarfBuzz.png',
+  'HarfBuzz.svg',
+]
+
+ignore_headers = []
+if have_gobject
+  ignore_headers += [
+    'hb-gobject.h',
+    'hb-gobject-enums.h',
+    'hb-gobject-enums-tmp.h',
+    'hb-gobject-structs.h',
+  ]
+endif
+
+gnome.gtkdoc('harfbuzz',
+  main_sgml: 'harfbuzz-docs.xml',
+  src_dir: [join_paths(meson.current_source_dir(), '..'),
+            join_paths(meson.current_build_dir(), '..'),
+           ],
+  scan_args: ['--deprecated-guards=HB_DISABLE_DEPRECATED',
+              '--ignore-decorators=HB_EXTERN',
+             ],
+  mkdb_args: ['--source-suffixes=h,cc',
+              '--xml-mode',
+              '--output-format=xml',
+             ],
+  content_files: content_files,
+  html_assets: html_images,
+  ignore_headers: ignore_headers,
+  dependencies: [libharfbuzz_dep, libharfbuzz_gobject_dep],
+  install: true)

--- a/meson.build
+++ b/meson.build
@@ -342,4 +342,8 @@ if not get_option('tests').disabled()
   subdir('test')
 endif
 
+if not get_option('gtk_doc').disabled()
+  subdir('docs')
+endif
+
 configure_file(output: 'config.h', configuration: conf)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,6 +25,8 @@ option('tests', type : 'feature', value : 'enabled', yield : true,
   description: 'Enable or disable unit tests')
 option('introspection', type : 'feature', value : 'disabled', yield : true,
   description : 'Generate gobject-introspection bindings (.gir/.typelib files)')
+option('gtk_doc',  type : 'feature', value : 'auto', yield : true,
+  description : 'Generate documentation with gtk-doc')
 
 option('icu-builtin', type: 'boolean', value: false,
   description: 'Don\'t separate ICU support as harfbuzz-icu module')


### PR DESCRIPTION
Fixes https://github.com/harfbuzz/harfbuzz/issues/2409
---

Does something, only lightly tested.

Note that gtk-doc docs are not built by default, only on install. Build `harfbuzz-doc` target explicitly to force a gtk-doc docs build.