### PR TITLE
minor: fix hb_ot_layout_get_ligature_carets

### DIFF
--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -369,7 +369,7 @@ hb_ot_layout_get_ligature_carets (hb_font_t      *font,
 				  unsigned int   *caret_count /* IN/OUT */,
 				  hb_position_t  *caret_array /* OUT */)
 {
-  unsigned int result_caret_count = 0;
+  unsigned int result_caret_count = caret_count ? *caret_count : 0;
   unsigned int result = font->face->table.GDEF->table->get_lig_carets (font, direction, glyph, start_offset, &result_caret_count, caret_array);
   if (result)
   {


### PR DESCRIPTION
Hi!
I'm finding it necessary to apply this patch in order to get anything back from `hb_ot_layout_get_ligature_carets`. I'm using `Libertinus Serif Display` (`Regular`). If I'm reading the code correctly, we need to pass in the original caret count this way.

Please let me know if there's anything else you need for this PR to be applied, or if I'm mistaken somehow and the original code is correct.

Thanks!