### PR TITLE
[meson] Add build configuration summary just like autotools

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -8,6 +8,8 @@ if not find_program('gtkdoc-scan', required: get_option('gtk_doc')).found()
   subdir_done()
 endif
 
+conf.set('HAVE_GTK_DOC', 1)
+
 gnome = import('gnome')
 
 docconf = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -347,3 +347,30 @@ if not get_option('gtk_doc').disabled()
 endif
 
 configure_file(output: 'config.h', configuration: conf)
+
+summary({'prefix': get_option('prefix'),
+         'bindir': get_option('bindir'),
+         'libdir': get_option('libdir'),
+         'includedir': get_option('includedir'),
+         'datadir': get_option('datadir'),
+        }, section: 'Directories')
+summary({'Builtin': true,
+         'Glib': conf.get('HAVE_GLIB', 0) == 1,
+         'ICU': conf.get('HAVE_ICU', 0) == 1,
+        }, bool_yn: true, section: 'Unicode callbacks (you want at least one)')
+summary({'FreeType': conf.get('HAVE_FREETYPE', 0) == 1,
+        }, bool_yn: true, section: 'Font callbacks (the more the merrier)')
+summary({'Cairo': conf.get('HAVE_CAIRO', 0) == 1,
+         'Fontconfig': conf.get('HAVE_FONTCONFIG', 0) == 1,
+        }, bool_yn: true, section: 'Tools used for command-line utilities')
+summary({'Graphite2': conf.get('HAVE_GRAPHITE2', 0) == 1,
+        }, bool_yn: true, section: 'Additional shapers (the more the merrier)')
+summary({'CoreText': conf.get('HAVE_CORETEXT', 0) == 1,
+         'DirectWrite': conf.get('HAVE_DIRECTWRITE', 0) == 1,
+         'GDI': conf.get('HAVE_GDI', 0) == 1,
+         'Uniscribe': conf.get('HAVE_UNISCRIBE', 0) == 1,
+        }, bool_yn: true, section: 'Platform shapers (not normally needed)')
+summary({'Documentation': conf.get('HAVE_GTK_DOC', 0) == 1,
+         'GObject bindings': conf.get('HAVE_GOBJECT', 0) == 1,
+         'Introspection': conf.get('HAVE_INTROSPECTION', 0) == 1,
+        }, bool_yn: true, section: 'Other features')

--- a/src/meson.build
+++ b/src/meson.build
@@ -650,6 +650,7 @@ if have_gobject
   build_gir = gir.found() and not meson.is_cross_build()
 
   if build_gir
+    conf.set('HAVE_INTROSPECTION', 1)
     hb_gen_files_gir = gnome.generate_gir(libharfbuzz, libharfbuzz_gobject,
       sources: [hb_headers, hb_sources, hb_gobject_headers, hb_gobject_sources, enum_h],
       namespace: 'HarfBuzz',


### PR DESCRIPTION
Fixes #2414

Looks like this, except YES and NO are colored with green and red also which looks nice!
```
harfbuzz 2.6.6

  Directories
              prefix: /usr/local
              bindir: bin
              libdir: lib
          includedir: include
             datadir: share

  Unicode callbacks (you want at least one)
             Builtin: YES
                Glib: YES
                 ICU: YES

  Font callbacks (the more the merrier)
            FreeType: YES

  Tools used for command-line utilities
               Cairo: YES
          Fontconfig: YES

  Additional shapers (the more the merrier)
           Graphite2: NO

  Platform shapers (not normally needed)
            CoreText: NO
         DirectWrite: NO
                 GDI: NO
           Uniscribe: NO

  Other features
       Documentation: YES
    GObject bindings: NO
       Introspection: NO
```