### PR TITLE
[meson] Categorize tests using `suite: [...]`

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -492,7 +492,7 @@ if get_option('tests').enabled()
       cpp_args: cpp_args + ['-DMAIN', '-UNDEBUG'],
       dependencies: libharfbuzz_dep,
       install: false,
-    ))
+    ), suite: ['src'])
   endforeach
 endif
 
@@ -686,7 +686,11 @@ if get_option('tests').enabled()
   endif
 
   foreach name : dist_check_script
-    test(name, find_program(name + '.py'), env: env, depends: defs_list)
+    test(name, find_program(name + '.py'),
+      env: env,
+      depends: name == 'check-symbols' ? defs_list : [],
+      suite: ['src'],
+    )
   endforeach
 endif
 

--- a/test/api/meson.build
+++ b/test/api/meson.build
@@ -83,5 +83,5 @@ foreach source : tests
     dependencies: deps,
     link_with: link_withs,
     install: false,
-  ), env: env)
+  ), env: env, suite: ['api'] + (test_name.contains('-subset') ? ['subset'] : []))
 endforeach

--- a/test/fuzzing/meson.build
+++ b/test/fuzzing/meson.build
@@ -28,7 +28,9 @@ test('shape_fuzzer', find_program('run-shape-fuzzer-tests.py'),
   ],
   depends: [hb_shape_fuzzer_exe, libharfbuzz, libharfbuzz_subset],
   workdir: meson.current_build_dir() / '..' / '..',
-  env: env)
+  env: env,
+  suite: ['fuzzing'],
+)
 
 test('subset_fuzzer', find_program('run-subset-fuzzer-tests.py'),
   args: [
@@ -38,11 +40,15 @@ test('subset_fuzzer', find_program('run-subset-fuzzer-tests.py'),
   # ideally better to break and let meson handles them in parallel
   timeout: 300,
   workdir: meson.current_build_dir() / '..' / '..',
-  env: env)
+  env: env,
+  suite: ['fuzzing'],
+)
 
 test('draw_fuzzer', find_program('run-draw-fuzzer-tests.py'),
   args: [
     hb_draw_fuzzer_exe,
   ],
   workdir: meson.current_build_dir() / '..' / '..',
-  env: env)
+  env: env,
+  suite: ['fuzzing'],
+)

--- a/test/shaping/meson.build
+++ b/test/shaping/meson.build
@@ -280,6 +280,7 @@ foreach file_name : in_house_tests
       meson.current_source_dir() / 'data' / 'in-house' / 'tests' / file_name,
     ],
     workdir: meson.current_build_dir() / '..' / '..',
+    suite: ['shaping', 'in-house'],
   )
 endforeach
 
@@ -292,6 +293,7 @@ foreach file_name : aots_tests
       meson.current_source_dir() / 'data' / 'aots' / 'tests' / file_name,
     ],
     workdir: meson.current_build_dir() / '..' / '..',
+    suite: ['shaping', 'aots'],
   )
 endforeach
 
@@ -304,5 +306,6 @@ foreach file_name : text_rendering_tests
       meson.current_source_dir() / 'data' / 'text-rendering-tests' / 'tests' / file_name,
     ],
     workdir: meson.current_build_dir() / '..' / '..',
+    suite: ['shaping', 'text-rendering-tests'],
   )
 endforeach

--- a/test/subset/meson.build
+++ b/test/subset/meson.build
@@ -39,5 +39,6 @@ foreach t : tests
     # ideally better to break and let meson handles them in parallel
     timeout: 500,
     workdir: meson.current_build_dir() / '..' / '..',
+    suite: ['subset'],
   )
 endforeach


### PR DESCRIPTION
```
So one can run a category of interested tests like

  meson test -Cbuild --suite aots --suite src --print-errorlogs

Intead issuing particular tests which also is possible like

  meson test -Cbuild test-shape --print-errorlogs
```

Feel free to suggest more categories or anything!