### PR TITLE
[meson] Make gobject and introspection features automatic

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,7 @@
 # HarfBuzz feature options
 option('glib', type: 'feature', value: 'auto',
   description: 'Enable GLib unicode functions')
-option('gobject', type: 'feature', value: 'disabled',
+option('gobject', type: 'feature', value: 'auto',
   description: 'Enable GObject bindings')
 option('cairo', type: 'feature', value: 'auto',
   description: 'Use Cairo graphics library')
@@ -23,7 +23,7 @@ option('coretext', type: 'feature', value: 'disabled',
 # Common feature options
 option('tests', type : 'feature', value : 'enabled', yield : true,
   description: 'Enable or disable unit tests')
-option('introspection', type : 'feature', value : 'disabled', yield : true,
+option('introspection', type : 'feature', value : 'auto', yield : true,
   description : 'Generate gobject-introspection bindings (.gir/.typelib files)')
 option('gtk_doc',  type : 'feature', value : 'auto', yield : true,
   description : 'Generate documentation with gtk-doc')


### PR DESCRIPTION
Meson doesn't have DISTCHECK_CONFIGURE_FLAGS like concept IIUC
and enabling these is the main thing we are doing with
distcheck flags anyway so lets turn these to auto.

#2436 related