### PR TITLE
Move update unicode tables to its own make file

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -258,42 +258,9 @@ GENERATORS = \
 	$(NULL)
 EXTRA_DIST += $(GENERATORS)
 
-unicode-tables: \
-	arabic-table \
-	emoji-table \
-	indic-table \
-	tag-table \
-	ucd-table \
-	use-table \
-	vowel-constraints \
-	$(NULL)
-
-arabic-table: gen-arabic-table.py ArabicShaping.txt UnicodeData.txt Blocks.txt
-	$(AM_V_GEN) $(builddir)/$^ > $(srcdir)/hb-ot-shape-complex-arabic-table.hh \
-	|| ($(RM) $(srcdir)/hb-ot-shape-complex-arabic-table.hh; false)
-emoji-table: gen-emoji-table.py emoji-data.txt
-	$(AM_V_GEN) $(builddir)/$^ > $(srcdir)/hb-unicode-emoji-table.hh \
-	|| ($(RM) $(srcdir)/hb-unicode-emoji-table.hh; false)
-indic-table: gen-indic-table.py IndicSyllabicCategory.txt IndicPositionalCategory.txt Blocks.txt
-	$(AM_V_GEN) $(builddir)/$^ > $(srcdir)/hb-ot-shape-complex-indic-table.cc \
-	|| ($(RM) $(srcdir)/hb-ot-shape-complex-indic-table.cc; false)
-tag-table: gen-tag-table.py languagetags language-subtag-registry
-	$(AM_V_GEN) $(builddir)/$^ > $(srcdir)/hb-ot-tag-table.hh \
-	|| ($(RM) $(srcdir)/hb-ot-tag-table.hh; false)
-ucd-table: gen-ucd-table.py ucd.nounihan.grouped.zip hb-common.h
-	$(AM_V_GEN) $(builddir)/$^ > $(srcdir)/hb-ucd-table.hh \
-	|| ($(RM) $(srcdir)/hb-ucd-table.hh; false)
-use-table: gen-use-table.py IndicSyllabicCategory.txt IndicPositionalCategory.txt UnicodeData.txt Blocks.txt
-	$(AM_V_GEN) $(builddir)/$^ > $(srcdir)/hb-ot-shape-complex-use-table.cc \
-	|| ($(RM) $(srcdir)/hb-ot-shape-complex-use-table.cc; false)
-vowel-constraints: gen-vowel-constraints.py ms-use/IndicShapingInvalidCluster.txt Scripts.txt
-	$(AM_V_GEN) $(builddir)/$^ > $(srcdir)/hb-ot-shape-complex-vowel-constraints.cc \
-	|| ($(RM) $(srcdir)/hb-ot-shape-complex-vowel-constraints.cc; false)
-
-
 built-sources: $(BUILT_SOURCES)
 
-.PHONY: unicode-tables arabic-table indic-table tag-table use-table vowel-constraints emoji-table built-sources
+.PHONY: built-sources
 
 RAGEL_GENERATED = \
 	$(patsubst %,$(srcdir)/%,$(HB_BASE_RAGEL_GENERATED_sources)) \

--- a/src/update-unicode-tables.make
+++ b/src/update-unicode-tables.make
@@ -2,7 +2,7 @@
 
 all: packtab arabic-table emoji-table indic-table tag-table ucd-table use-table vowel-constraints
 
-.PHONY: all clean packtab arabic-table indic-table tag-table use-table vowel-constraints emoji-table
+.PHONY: all clean packtab arabic-table emoji-table indic-table tag-table ucd-table use-table vowel-constraints
 
 arabic-table: gen-arabic-table.py ArabicShaping.txt UnicodeData.txt Blocks.txt
 	./$^ > hb-ot-shape-complex-arabic-table.hh || (rm hb-ot-shape-complex-arabic-table.hh; false)

--- a/src/update-unicode-tables.make
+++ b/src/update-unicode-tables.make
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S make -f
 
-all: arabic-table emoji-table indic-table tag-table ucd-table use-table vowel-constraints
+all: packtab arabic-table emoji-table indic-table tag-table ucd-table use-table vowel-constraints
+
+.PHONY: all clean packtab arabic-table indic-table tag-table use-table vowel-constraints emoji-table
 
 arabic-table: gen-arabic-table.py ArabicShaping.txt UnicodeData.txt Blocks.txt
 	./$^ > hb-ot-shape-complex-arabic-table.hh || (rm hb-ot-shape-complex-arabic-table.hh; false)
@@ -18,42 +20,40 @@ vowel-constraints: gen-vowel-constraints.py ms-use/IndicShapingInvalidCluster.tx
 	./$^ > hb-ot-shape-complex-vowel-constraints.cc || (hb-ot-shape-complex-vowel-constraints.cc; false)
 
 packtab:
-	python -c "import packTab" 2>/dev/null || /usr/bin/env pip3 install git+https://github.com/harfbuzz/packtab
-
-.PHONY: packtab arabic-table indic-table tag-table use-table vowel-constraints emoji-table
+	/usr/bin/env python3 -c "import packTab" 2>/dev/null || /usr/bin/env pip3 install git+https://github.com/harfbuzz/packtab
 
 ArabicShaping.txt:
-	wget https://unicode.org/Public/UCD/latest/ucd/ArabicShaping.txt
+	curl -O https://unicode.org/Public/UCD/latest/ucd/ArabicShaping.txt
 
 UnicodeData.txt:
-	wget https://unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
+	curl -O https://unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
 
 Blocks.txt:
-	wget https://unicode.org/Public/UCD/latest/ucd/Blocks.txt
+	curl -O https://unicode.org/Public/UCD/latest/ucd/Blocks.txt
 
 emoji-data.txt:
-	wget https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-data.txt
+	curl -O https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-data.txt
 
 IndicSyllabicCategory.txt:
-	wget https://unicode.org/Public/UCD/latest/ucd/IndicSyllabicCategory.txt
+	curl -O https://unicode.org/Public/UCD/latest/ucd/IndicSyllabicCategory.txt
 
 IndicPositionalCategory.txt:
-	wget https://unicode.org/Public/UCD/latest/ucd/IndicPositionalCategory.txt
+	curl -O https://unicode.org/Public/UCD/latest/ucd/IndicPositionalCategory.txt
 
 languagetags:
-	wget https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags
+	curl -O https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags
 
 language-subtag-registry:
-	wget https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+	curl -O https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
 
 ucd.nounihan.grouped.zip:
-	wget https://unicode.org/Public/UCD/latest/ucdxml/ucd.nounihan.grouped.zip
+	curl -O https://unicode.org/Public/UCD/latest/ucdxml/ucd.nounihan.grouped.zip
 
 Scripts.txt:
-	wget https://unicode.org/Public/UCD/latest/ucd/Scripts.txt
+	curl -O https://unicode.org/Public/UCD/latest/ucd/Scripts.txt
 
 clean:
-	rm -f \
+	$(RM) \
 		ArabicShaping.txt UnicodeData.txt Blocks.txt emoji-data.txt \
 		IndicSyllabicCategory.txt IndicPositionalCategory.txt \
 		languagetags language-subtag-registry ucd.nounihan.grouped.zip Scripts.txt

--- a/src/update-unicode-tables.make
+++ b/src/update-unicode-tables.make
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S make -f
+
+all: arabic-table emoji-table indic-table tag-table ucd-table use-table vowel-constraints
+
+arabic-table: gen-arabic-table.py ArabicShaping.txt UnicodeData.txt Blocks.txt
+	./$^ > hb-ot-shape-complex-arabic-table.hh || (rm hb-ot-shape-complex-arabic-table.hh; false)
+emoji-table: gen-emoji-table.py emoji-data.txt
+	./$^ > hb-unicode-emoji-table.hh || (rm hb-unicode-emoji-table.hh; false)
+indic-table: gen-indic-table.py IndicSyllabicCategory.txt IndicPositionalCategory.txt Blocks.txt
+	./$^ > hb-ot-shape-complex-indic-table.cc || (rm hb-ot-shape-complex-indic-table.cc; false)
+tag-table: gen-tag-table.py languagetags language-subtag-registry
+	./$^ > hb-ot-tag-table.hh || (rm hb-ot-tag-table.hh; false)
+ucd-table: gen-ucd-table.py ucd.nounihan.grouped.zip hb-common.h
+	./$^ > hb-ucd-table.hh || (rm hb-ucd-table.hh; false)
+use-table: gen-use-table.py IndicSyllabicCategory.txt IndicPositionalCategory.txt UnicodeData.txt Blocks.txt
+	./$^ > hb-ot-shape-complex-use-table.cc || (rm hb-ot-shape-complex-use-table.cc; false)
+vowel-constraints: gen-vowel-constraints.py ms-use/IndicShapingInvalidCluster.txt Scripts.txt
+	./$^ > hb-ot-shape-complex-vowel-constraints.cc || (hb-ot-shape-complex-vowel-constraints.cc; false)
+
+packtab:
+	python -c "import packTab" 2>/dev/null || /usr/bin/env pip3 install git+https://github.com/harfbuzz/packtab
+
+.PHONY: packtab arabic-table indic-table tag-table use-table vowel-constraints emoji-table
+
+ArabicShaping.txt:
+	wget https://unicode.org/Public/UCD/latest/ucd/ArabicShaping.txt
+
+UnicodeData.txt:
+	wget https://unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
+
+Blocks.txt:
+	wget https://unicode.org/Public/UCD/latest/ucd/Blocks.txt
+
+emoji-data.txt:
+	wget https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-data.txt
+
+IndicSyllabicCategory.txt:
+	wget https://unicode.org/Public/UCD/latest/ucd/IndicSyllabicCategory.txt
+
+IndicPositionalCategory.txt:
+	wget https://unicode.org/Public/UCD/latest/ucd/IndicPositionalCategory.txt
+
+languagetags:
+	wget https://docs.microsoft.com/en-us/typography/opentype/spec/languagetags
+
+language-subtag-registry:
+	wget https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+
+ucd.nounihan.grouped.zip:
+	wget https://unicode.org/Public/UCD/latest/ucdxml/ucd.nounihan.grouped.zip
+
+Scripts.txt:
+	wget https://unicode.org/Public/UCD/latest/ucd/Scripts.txt
+
+clean:
+	rm -f \
+		ArabicShaping.txt UnicodeData.txt Blocks.txt emoji-data.txt \
+		IndicSyllabicCategory.txt IndicPositionalCategory.txt \
+		languagetags language-subtag-registry ucd.nounihan.grouped.zip Scripts.txt


### PR DESCRIPTION
Also downloads things needed for its job

#2436 related

Needs to be ran in `src/` using `./update-unicode-tables.make`, or in project's root using `make -C src -f update-unicode-tables.make`