### PR TITLE
[meson] Only pass required dependencies to everything

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -144,8 +144,6 @@ else
   cairo_ft_dep = dependency('', required: false)
 endif
 
-deps = []
-
 conf = configuration_data()
 incconfig = include_directories('.')
 
@@ -157,33 +155,24 @@ warn_cflags = [
 
 cpp_args = cpp.get_supported_arguments(warn_cflags)
 
-if m_dep.found()
-  deps += [m_dep]
-endif
-
 if glib_dep.found()
   conf.set('HAVE_GLIB', 1)
-  deps += [glib_dep]
 endif
 
 if gobject_dep.found()
   conf.set('HAVE_GOBJECT', 1)
-  deps += [gobject_dep]
 endif
 
 if cairo_dep.found()
   conf.set('HAVE_CAIRO', 1)
-  deps += [cairo_dep]
 endif
 
 if cairo_ft_dep.found()
   conf.set('HAVE_CAIRO_FT', 1)
-  deps += [cairo_ft_dep]
 endif
 
 if graphite2_dep.found()
   conf.set('HAVE_GRAPHITE2', 1)
-  deps += [graphite2_dep]
 endif
 
 if icu_dep.found()
@@ -200,7 +189,6 @@ endif
 
 if freetype_dep.found()
   conf.set('HAVE_FREETYPE', 1)
-  deps += [freetype_dep]
   check_freetype_funcs = [
     ['FT_Get_Var_Blend_Coordinates', {'deps': freetype_dep}],
     ['FT_Set_Var_Blend_Coordinates', {'deps': freetype_dep}],
@@ -219,15 +207,15 @@ endif
 
 if fontconfig_dep.found()
   conf.set('HAVE_FONTCONFIG', 1)
-  deps += [fontconfig_dep]
 endif
 
+gdi_uniscribe_deps = []
 # GDI (uniscribe) (windows)
 if host_machine.system() == 'windows' and not get_option('gdi').disabled()
   # TODO: make nicer once we have https://github.com/mesonbuild/meson/issues/3940
   if cpp.has_header('usp10.h') and cpp.has_header('windows.h')
     foreach usplib : ['usp10', 'gdi32', 'rpcrt4']
-      deps += [cpp.find_library(usplib, required: true)]
+      gdi_uniscribe_deps += cpp.find_library(usplib, required: true)
     endforeach
     conf.set('HAVE_UNISCRIBE', 1)
     conf.set('HAVE_GDI', 1)
@@ -237,9 +225,10 @@ if host_machine.system() == 'windows' and not get_option('gdi').disabled()
 endif
 
 # DirectWrite (windows)
+directwrite_dep = dependency('', required: false)
 if host_machine.system() == 'windows' and not get_option('directwrite').disabled()
   if cpp.has_header('dwrite_1.h')
-    deps += [cpp.find_library('dwrite', required: true)]
+    directwrite_dep = cpp.find_library('dwrite', required: true)
     conf.set('HAVE_DIRECTWRITE', 1)
   elif get_option('directwrite').enabled()
     error('DirectWrite was enabled explicitly, but required header is missing.')
@@ -247,10 +236,11 @@ if host_machine.system() == 'windows' and not get_option('directwrite').disabled
 endif
 
 # CoreText (macOS) - FIXME: untested
+coretext_deps = []
 if host_machine.system() == 'darwin' and not get_option('coretext').disabled()
   app_services_dep = dependency('appleframeworks', modules : ['ApplicationServices'], required: false)
   if cpp.has_type('CTFontRef', prefix: '#include <ApplicationServices/ApplicationServices.h>', dependencies: app_services_dep)
-    deps += [app_services_dep]
+    coretext_deps += [app_services_dep]
     conf.set('HAVE_CORETEXT', 1)
   # On iOS CoreText and CoreGraphics are stand-alone frameworks
   # Check for a different symbol to avoid getting cached result
@@ -259,7 +249,7 @@ if host_machine.system() == 'darwin' and not get_option('coretext').disabled()
     coregraphics_dep = dependency('appleframeworks', modules : ['CoreGraphics'], required: false)
     corefoundation_dep = dependency('appleframeworks', modules : ['CoreFoundation'], required: false)
     if cpp.has_type('CTRunRef', prefix: '#include <CoreText/CoreText.h>', dependencies: [coretext_dep, coregraphics_dep, corefoundation_dep])
-      deps += [coretext_dep, coregraphics_dep, corefoundation_dep]
+      coretext_deps += [coretext_dep, coregraphics_dep, corefoundation_dep]
       conf.set('HAVE_CORETEXT', 1)
     elif get_option('coretext').enabled()
       error('CoreText was enabled explicitly, but required headers or frameworks are missing.')
@@ -268,12 +258,12 @@ if host_machine.system() == 'darwin' and not get_option('coretext').disabled()
 endif
 
 # threads
+thread_dep = dependency('', required: false)
 if host_machine.system() != 'windows'
   thread_dep = dependency('threads', required: false)
 
   if thread_dep.found()
     conf.set('HAVE_PTHREAD', 1)
-    deps += [thread_dep]
   else
     check_headers += ['sched.h']
     check_funcs += ['sched_yield', {'link_with': 'rt'}]
@@ -293,6 +283,7 @@ foreach check : check_headers
   endif
 endforeach
 
+harfbuzz_extra_deps = []
 foreach check : check_funcs
   name = check[0]
   opts = check.get(1, {})
@@ -323,7 +314,7 @@ foreach check : check_funcs
   endif
 
   if found
-    deps += extra_deps
+    harfbuzz_extra_deps += extra_deps
     conf.set('HAVE_@0@'.format(name.to_upper()), 1)
   endif
 endforeach

--- a/src/meson.build
+++ b/src/meson.build
@@ -311,24 +311,30 @@ incsrc = include_directories('.')
 hb_sources = hb_base_sources + hb_base_ragel_generated_sources
 hb_headers = hb_base_headers
 
+harfbuzz_deps = [thread_dep, m_dep] + harfbuzz_extra_deps
+
 if conf.get('HAVE_FREETYPE', 0) == 1
   hb_sources += hb_ft_sources
   hb_headers += hb_ft_headers
+  harfbuzz_deps += [freetype_dep]
 endif
 
 if conf.get('HAVE_GDI', 0) == 1
   hb_sources += hb_gdi_sources
   hb_headers += hb_gdi_headers
+  harfbuzz_deps += gdi_uniscribe_deps
 endif
 
 if conf.get('HAVE_GRAPHITE2', 0) == 1
   hb_sources += hb_graphite2_sources
   hb_headers += hb_graphite2_headers
+  harfbuzz_deps += [graphite2_dep]
 endif
 
 if conf.get('HAVE_GLIB', 0) == 1
   hb_sources += hb_glib_sources
   hb_headers += hb_glib_headers
+  harfbuzz_deps += [glib_dep]
 endif
 
 if conf.get('HAVE_UNISCRIBE', 0) == 1
@@ -339,11 +345,13 @@ endif
 if conf.get('HAVE_DIRECTWRITE', 0) == 1
   hb_sources += hb_directwrite_sources
   hb_headers += hb_directwrite_headers
+  harfbuzz_deps += directwrite_dep
 endif
 
 if conf.get('HAVE_CORETEXT', 0) == 1
   hb_sources += hb_coretext_sources
   hb_headers += hb_coretext_headers
+  harfbuzz_deps += coretext_deps
 endif
 
 have_icu = conf.get('HAVE_ICU', 0) == 1
@@ -352,7 +360,7 @@ have_icu_builtin = conf.get('HAVE_ICU_BUILTIN', 0) == 1
 if have_icu and have_icu_builtin
   hb_sources += hb_icu_sources
   hb_headers += hb_icu_headers
-  deps += [icu_dep]
+  harfbuzz_deps += [icu_dep]
 endif
 
 if get_option('with_libstdcxx')
@@ -390,7 +398,7 @@ endif
 
 libharfbuzz = library('harfbuzz', hb_sources,
   include_directories: incconfig,
-  dependencies: deps,
+  dependencies: harfbuzz_deps,
   cpp_args: cpp_args + extra_hb_cpp_args,
   soversion: hb_so_version,
   version: version,
@@ -401,7 +409,7 @@ libharfbuzz = library('harfbuzz', hb_sources,
 libharfbuzz_dep = declare_dependency(
   link_with: libharfbuzz,
   include_directories: incsrc,
-  dependencies: deps)
+  dependencies: harfbuzz_deps)
 
 # harfbuzz-subset
 harfbuzz_subset_def = custom_target('harfbuzz-subset.def',
@@ -412,7 +420,7 @@ defs_list += [harfbuzz_subset_def]
 
 libharfbuzz_subset = library('harfbuzz-subset', hb_subset_sources,
   include_directories: incconfig,
-  dependencies: deps,
+  dependencies: [m_dep],
   link_with: [libharfbuzz],
   cpp_args: cpp_args + extra_hb_cpp_args,
   soversion: hb_so_version,
@@ -424,7 +432,7 @@ libharfbuzz_subset = library('harfbuzz-subset', hb_subset_sources,
 libharfbuzz_subset_dep = declare_dependency(
   link_with: libharfbuzz_subset,
   include_directories: incsrc,
-  dependencies: deps)
+  dependencies: [m_dep])
 
 if get_option('tests').enabled()
   # TODO: MSVC gives the following,
@@ -524,7 +532,7 @@ if have_icu and not have_icu_builtin
   libharfbuzz_icu_dep = declare_dependency(
     link_with: libharfbuzz_icu,
     include_directories: incsrc,
-    dependencies: deps)
+    dependencies: icu_dep)
 
   pkgmod.generate(libharfbuzz_icu,
     description: 'HarfBuzz text shaping library ICU integration',
@@ -596,7 +604,7 @@ if have_gobject
 
   libharfbuzz_gobject = library('harfbuzz-gobject', [hb_gobject_sources, enum_c, enum_h],
     include_directories: incconfig,
-    dependencies: deps,
+    dependencies: [glib_dep, gobject_dep],
     link_with: [libharfbuzz],
     cpp_args: cpp_args + extra_hb_cpp_args,
     soversion: hb_so_version,
@@ -637,7 +645,7 @@ if have_gobject
     link_with: libharfbuzz_gobject,
     include_directories: incsrc,
     sources: build_gir ? hb_gen_files_gir : hb_gobject_sources,
-    dependencies: deps)
+    dependencies: [glib_dep, gobject_dep])
 
   pkgmod.generate(libharfbuzz_gobject,
     description: 'HarfBuzz text shaping library GObject integration',

--- a/test/api/meson.build
+++ b/test/api/meson.build
@@ -80,7 +80,7 @@ foreach source : tests
 
   test(test_name, executable(test_name, source,
     include_directories: [incconfig, incsrc],
-    dependencies: deps,
+    dependencies: [glib_dep, freetype_dep, thread_dep],
     link_with: link_withs,
     install: false,
   ), env: env, suite: ['api'] + (test_name.contains('-subset') ? ['subset'] : []))

--- a/test/fuzzing/meson.build
+++ b/test/fuzzing/meson.build
@@ -11,7 +11,6 @@ foreach file_name : tests
   exe = executable(test_name, [file_name, 'main.cc'],
     cpp_args: cpp_args,
     include_directories: [incconfig, incsrc],
-    dependencies: deps,
     link_with: [libharfbuzz, libharfbuzz_subset],
     install: false,
   )

--- a/util/meson.build
+++ b/util/meson.build
@@ -23,13 +23,15 @@ hb_subset_cli_sources = [
   'options-subset.cc',
 ]
 
+util_deps = [freetype_dep, cairo_dep, cairo_ft_dep, glib_dep]
+
 if conf.get('HAVE_GLIB', 0) == 1
   if conf.get('HAVE_FREETYPE', 0) == 1 and conf.get('HAVE_CAIRO_FT', 0) == 1
 
     hb_view = executable('hb-view', hb_view_sources,
       cpp_args: cpp_args,
       include_directories: [incconfig, incsrc],
-      dependencies: deps,
+      dependencies: util_deps,
       link_with: [libharfbuzz],
       install: true,
     )
@@ -38,7 +40,7 @@ if conf.get('HAVE_GLIB', 0) == 1
   hb_shape = executable('hb-shape', hb_shape_sources,
     cpp_args: cpp_args,
     include_directories: [incconfig, incsrc],
-    dependencies: deps,
+    dependencies: util_deps,
     link_with: [libharfbuzz],
     install: true,
   )
@@ -46,7 +48,7 @@ if conf.get('HAVE_GLIB', 0) == 1
   hb_subset = executable('hb-subset', hb_subset_cli_sources,
     cpp_args: cpp_args,
     include_directories: [incconfig, incsrc],
-    dependencies: deps,
+    dependencies: util_deps,
     link_with: [libharfbuzz, libharfbuzz_subset],
     install: true,
   )
@@ -54,7 +56,7 @@ if conf.get('HAVE_GLIB', 0) == 1
   hb_ot_shape_closure = executable('hb-ot-shape-closure', hb_ot_shape_closure_sources,
     cpp_args: cpp_args,
     include_directories: [incconfig, incsrc],
-    dependencies: deps,
+    dependencies: util_deps,
     link_with: [libharfbuzz],
     install: true,
   )


### PR DESCRIPTION
Instead of passing dependencies as required we used one giant shared
dependency list containing all dependencies for every library/executable.
While this kinda works, the specified deps are also used for generating
the pkg-config files and this leads to lots of Requires.private and Libs.private
entries which aren't really needed.

This removes the "deps" array and replaces it with a few smaller ones and
makes sure the public libraries only get passed the dependencies actually
needed.

Fixes #2441