### PR TITLE
[meson] Add -Bsymbolic-functions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,10 @@ if cpp.get_id() == 'msvc'
   # noseh_link_args = ['/SAFESEH:NO']
 endif
 
+add_project_link_arguments(cpp.get_supported_link_arguments([
+  '-Bsymbolic-functions'
+]), language : 'c')
+
 add_project_arguments(cpp.get_supported_arguments([
   '-fno-rtti',
   '-fno-exceptions',


### PR DESCRIPTION
Originally done [here](https://github.com/harfbuzz/harfbuzz/commit/71cef14ac3de07e4fed0a2903b1f0f639406ec6c) and both our autotools and cmake port have it so guess now our meson port also should, let's see, found it while #2446.

`
[77/249] clang  -o src/libharfbuzz.so.0.20607.0 'src/25a6634@@harfbuzz@sha/hb-aat-layout.cc.o' ... 'src/25a6634@@harfbuzz@sha/hb-glib.cc.o' -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,--start-group -Wl,-soname,libharfbuzz.so.0 -Bsymbolic-functions -pthread -lm /usr/lib/libfreetype.so /usr/lib/libglib-2.0.so -Wl,--end-group
`

vs autotools',

`
/bin/sh ../libtool  --tag=CC   --mode=link clang  -g -O2  -Bsymbolic-functions -o libharfbuzz.la  -lm -version-info 20600:7:20600 -no-undefined   -rpath /usr/local/lib libharfbuzz_la-hb-aat-layout.lo ... libharfbuzz_la-hb-ft.lo                -lglib-2.0  -lfreetype         
`