### PR TITLE
meson: Export symbols for a DLL when not building statically

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -383,7 +383,7 @@ version = '0.' + '0'.join(meson.project_version().split('.')) + '.0'
 
 extra_hb_cpp_args = []
 if cpp.get_id() == 'msvc'
-  if get_option('default_library') == 'shared'
+  if get_option('default_library') != 'static'
     extra_hb_cpp_args += '-DHB_DLL_EXPORT'
   endif
   hb_so_version = ''


### PR DESCRIPTION
`default_library` might be 'both', in which case we will fail to link when building with MSVC.