### PR TITLE
[meson] Add git log of last commit to .tarball-revision while dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ EXTRA_DIST = \
 	subprojects/zlib.wrap \
 	meson-cc-tests/intel-atomic-primitives-test.c \
 	meson-cc-tests/solaris-atomic-operations.c \
+	write-tarball-revision.py \
 	$(NULL)
 
 MAINTAINERCLEANFILES = \

--- a/meson.build
+++ b/meson.build
@@ -356,6 +356,8 @@ if not get_option('gtk_doc').disabled()
   subdir('docs')
 endif
 
+meson.add_dist_script('write-tarball-revision.py')
+
 configure_file(output: 'config.h', configuration: conf)
 
 summary({'prefix': get_option('prefix'),

--- a/write-tarball-revision.py
+++ b/write-tarball-revision.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import os, subprocess
+from pathlib import Path
+
+outfile = Path(
+    os.getenv('MESON_DIST_ROOT')
+    or os.getenv('MESON_SOURCE_ROOT')
+    or Path(__file__).parent
+) / '.tarball-revision'
+
+with open(outfile, 'wb') as f:
+	f.write(subprocess.check_output(['git', 'log', '--no-color', '--no-decorate', 'HEAD~..HEAD']))


### PR DESCRIPTION
Fixes #2472

Am open about the naming and so, inspired by https://github.com/GNOME/phodav/blob/7dc0ab1/meson.build#L12 and learned things from https://github.com/freedesktop/xdg-desktop-file-utils/blob/46d5759/changelog.py