### PR TITLE
[fuzzer] Make some use for test_font API calls

### DIFF
--- a/test/api/test-ot-face.c
+++ b/test/api/test-ot-face.c
@@ -101,6 +101,23 @@ test_font (hb_font_t *font, hb_codepoint_t cp)
 
   hb_ot_layout_get_ligature_carets (font, HB_DIRECTION_LTR, cp, 0, NULL, NULL);
 
+  {
+    unsigned temp = 0, temp2;
+    hb_ot_name_id_t name;
+    hb_ot_layout_get_size_params (face, &temp, &temp, &name, &temp, &temp);
+    hb_tag_t cv01 = HB_TAG ('c','v','0','1');
+    unsigned feature_index = 0;
+    hb_ot_layout_language_find_feature (face, HB_OT_TAG_GSUB, 0,
+					HB_OT_LAYOUT_DEFAULT_LANGUAGE_INDEX,
+					cv01, &feature_index);
+    hb_ot_layout_feature_get_name_ids (face, HB_OT_TAG_GSUB, feature_index,
+				       &name, &name, &name, &temp, &name);
+    temp = 1;
+    hb_ot_layout_feature_get_characters (face, HB_OT_TAG_GSUB, feature_index, 0, &temp, &g);
+    temp = 1;
+    hb_ot_layout_language_get_feature_indexes (face, HB_OT_TAG_GSUB, 0, 0, 0, &temp, &temp2);
+  }
+
   hb_ot_math_has_data (face);
   hb_ot_math_get_constant (font, HB_OT_MATH_CONSTANT_MATH_LEADING);
   hb_ot_math_get_glyph_italics_correction (font, cp);

--- a/test/fuzzing/hb-shape-fuzzer.cc
+++ b/test/fuzzing/hb-shape-fuzzer.cc
@@ -42,16 +42,16 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   if (size < len)
     len = size;
   if (len)
-    memcpy(text32, data + size - len, len);
+    memcpy (text32, data + size - len, len);
+
+  /* Misc calls on font. */
+  text32[10] = test_font (font, text32[15]) % 256;
 
   hb_buffer_t *buffer = hb_buffer_create ();
   hb_buffer_add_utf32 (buffer, text32, sizeof (text32) / sizeof (text32[0]), 0, -1);
   hb_buffer_guess_segment_properties (buffer);
   hb_shape (font, buffer, nullptr, 0);
   hb_buffer_destroy (buffer);
-
-  /* Misc calls on font. */
-  test_font (font, text32[15]);
 
   hb_font_destroy (font);
   hb_face_destroy (face);


### PR DESCRIPTION
Making some use for result of some of the test_font calls to make sure compilers in fuzzers aren't just optimizing the calls or their results.

This is due to my personal experience that sanitizers won't flag any issue unless they see some side effect having operation is happened and just moving of a memory doesn't convince them that something wrong has happened.