### PR TITLE
[meson] Mark longer tests with slow

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -680,7 +680,7 @@ if get_option('tests').enabled()
     test(name, find_program(name + '.py'),
       env: env,
       depends: name == 'check-symbols' ? defs_list : [],
-      suite: ['src'],
+      suite: ['src'] + (name == 'check-static-inits' ? ['slow'] : []),
     )
   endforeach
 endif

--- a/test/fuzzing/meson.build
+++ b/test/fuzzing/meson.build
@@ -28,7 +28,7 @@ test('shape_fuzzer', find_program('run-shape-fuzzer-tests.py'),
   depends: [hb_shape_fuzzer_exe, libharfbuzz, libharfbuzz_subset],
   workdir: meson.current_build_dir() / '..' / '..',
   env: env,
-  suite: ['fuzzing'],
+  suite: ['fuzzing', 'slow'],
 )
 
 test('subset_fuzzer', find_program('run-subset-fuzzer-tests.py'),
@@ -40,7 +40,7 @@ test('subset_fuzzer', find_program('run-subset-fuzzer-tests.py'),
   timeout: 300,
   workdir: meson.current_build_dir() / '..' / '..',
   env: env,
-  suite: ['fuzzing'],
+  suite: ['fuzzing', 'slow'],
 )
 
 test('draw_fuzzer', find_program('run-draw-fuzzer-tests.py'),

--- a/test/subset/meson.build
+++ b/test/subset/meson.build
@@ -38,6 +38,6 @@ foreach t : tests
     # ideally better to break and let meson handles them in parallel
     timeout: 500,
     workdir: meson.current_build_dir() / '..' / '..',
-    suite: ['subset'],
+    suite: ['subset', 'slow'],
   )
 endforeach


### PR DESCRIPTION
So one can skip them easily by `meson test -Cbuild --no-suite slow`

This decreases my time to running the test suite to 6s.

```

Ok:                 304 
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            15  
Timeout:            0   

meson test -Cbuild --no-suite slow  26.65s user 12.29s system 586% cpu 6.635 total
```