### PR TITLE
Remove concept of stable/unstable from build tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,16 +46,7 @@ AC_SUBST(HB_VERSION)
 # Libtool version
 m4_define([hb_version_int],
 	  m4_eval(hb_version_major*10000 + hb_version_minor*100 + hb_version_micro))
-m4_if(m4_eval(hb_version_minor % 2), [1],
-      dnl for unstable releases
-      [m4_define([hb_libtool_revision], 0)],
-      dnl for stable releases
-      [m4_define([hb_libtool_revision], hb_version_micro)])
-m4_define([hb_libtool_age],
-	  m4_eval(hb_version_int - hb_libtool_revision))
-m4_define([hb_libtool_current],
-	  m4_eval(hb_libtool_age))
-HB_LIBTOOL_VERSION_INFO=hb_libtool_current:hb_libtool_revision:hb_libtool_age
+HB_LIBTOOL_VERSION_INFO=hb_version_int:0:hb_version_int
 AC_SUBST(HB_LIBTOOL_VERSION_INFO)
 
 AC_ARG_WITH([libstdc++],

--- a/meson.build
+++ b/meson.build
@@ -12,14 +12,7 @@ hb_version_micro = hb_version_arr[2].to_int()
 
 # libtool versioning
 hb_version_int = hb_version_major*10000 + hb_version_minor*100 + hb_version_micro
-if hb_version_minor % 2 == 1
-  hb_libtool_revision = 0                # for unstable releases
-else
-  hb_libtool_revision = hb_version_micro # for stable releases
-endif
-hb_libtool_age = hb_version_int - hb_libtool_revision
-hb_libtool_current = hb_libtool_age
-hb_libtool_version_info = '@0@:@1@:@2@'.format(hb_libtool_current, hb_libtool_revision, hb_libtool_age)
+hb_libtool_version_info = '@0@:0:@0@'.format(hb_version_int)
 
 pkgmod = import('pkgconfig')
 cpp = meson.get_compiler('cpp')

--- a/src/meson.build
+++ b/src/meson.build
@@ -379,7 +379,7 @@ harfbuzz_def = custom_target('harfbuzz.def',
     output: 'harfbuzz.def')
 defs_list = [harfbuzz_def]
 
-version = '0.' + '0'.join(meson.project_version().split('.')) + '.0'
+version = '0.@0@.0'.format(hb_version_int)
 
 extra_hb_cpp_args = []
 if cpp.get_id() == 'msvc'


### PR DESCRIPTION
We never practiced the concept of stable and unstable releases, let's
remove the code and always use the stable scheme.

With this we will just always use stable scheme, nothing different from "stable" releases but we may need to tag 2.7.0 after this change to not have confused versioning.

About the meson `version =` part, there is no consistent state between the changes those this is in one commit.

using autotools and issuing 2.7.0, before this change,

`/bin/sh ../libtool  --tag=CC   --mode=link gcc  -g -O2  -Bsymbolic-functions -o libharfbuzz.la  -lm -version-info 20600:8:20600 -no-undefined   -rpath /usr/local/lib libharfbuzz_la-hb-aat-layout.lo ... libharfbuzz_la-hb-ft.lo -lglib-2.0  -lfreetype         `

After the change

`/bin/sh ../libtool  --tag=CC   --mode=link gcc  -g -O2  -Bsymbolic-functions -o libharfbuzz.la  -lm -version-info 20608:0:20608 -no-undefined   -rpath /usr/local/lib libharfbuzz_la-hb-aat-layout.lo ... libharfbuzz_la-hb-ft.lo                -lglib-2.0  -lfreetype         `

Of course is different but only for our "unstable" release, but what happens when we want build 2.7.8, before this change but building the version 2.7.8,

`/bin/sh ../libtool  --tag=CC   --mode=link gcc  -g -O2  -Bsymbolic-functions -o libharfbuzz.la  -lm -version-info 20708:0:20708 -no-undefined   -rpath /usr/local/lib libharfbuzz_la-hb-aat-layout.lo ... libharfbuzz_la-hb-ft.lo -lglib-2.0  -lfreetype `

After the change

`/bin/sh ../libtool  --tag=CC   --mode=link gcc  -g -O2  -Bsymbolic-functions -o libharfbuzz.la  -lm -version-info 20708:0:20708 -no-undefined   -rpath /usr/local/lib libharfbuzz_la-hb-aat-layout.lo ... libharfbuzz_la-hb-ft.lo                -lglib-2.0  -lfreetype`

No difference.