### PR TITLE
Fix autotools's harfbuzz.cc build

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -277,8 +277,7 @@ $(srcdir)/%.hh: $(srcdir)/%.rl
 
 harfbuzz.cc: Makefile.sources
 	$(AM_V_GEN) \
-	$(srcdir)/gen-harfbuzzcc.py \
-		$(srcdir)/harfbuzz.cc \
+	$(srcdir)/gen-harfbuzzcc.py harfbuzz.cc \
 		$(HB_BASE_sources) \
 		$(HB_GLIB_sources) \
 		$(HB_FT_sources) \


### PR DESCRIPTION
How this works? gen-harfbuzzcc.py operates at its own source path (see its 7th line)
and that is reliable when used both on meson and autotools.

Just like 19ecabed, weirdly this didn't come up sooner, guess it has something
to do with timestamps. Fortunately whole harfbuzz.cc just doesn't matter for
packagers but we can tag a release only for this if needed.

Just received an email that a Linux user on Debian isn't able to compile harfbuzz for sometime and now that the release is happened that person decided to send a similar to this patch to me. Thanks for letting me know. We have OpenBSD ports https://twitter.com/OpenBSD_ports/status/1275389506120593408 and ArchLinux https://twitter.com/arch_update_bot/status/1275182798857310208 that were able to update their packages and our distcheck and our CI bot doing the same weren't able to catch this yet this is a very small fix packagers can hold the patch locally.

It is now in Fedora also https://github.com/harfbuzz/harfbuzz/issues/673#issuecomment-648323491 so this only makes issue for development clones not package building, it is unfortunate but fortunately isn't breaking issue.