### PR TITLE
[ft] Handle nullptr when destroying freetype font

### DIFF
--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -120,6 +120,9 @@ _hb_ft_font_destroy (void *data)
 {
   hb_ft_font_t *ft_font = (hb_ft_font_t *) data;
 
+  if (unlikely (!ft_font))
+    return;
+
   ft_font->advance_cache.fini ();
 
   if (ft_font->unref)


### PR DESCRIPTION
Fixes #2493