### PR TITLE
Add dedicated shaping and extents performance measurement tools

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,32 @@
+Benchmarking
+============
+
+Build the project like,
+
+```
+meson build -Dbenchmark=true -Dexperimental_api=true -Doptimization=2
+ninja -Cbuild
+```
+
+Now you have different options,
+
+* Run all the benchmarks,
+
+```
+ninja -Cbuild && build/perf/perf
+```
+
+* Run shaping perf tool with a specific font and text,
+
+```
+ninja -Cbuild && build/perf/perf-shaping-bench perf/fonts/Amiri-Regular.ttf perf/texts/fa-thelittleprince.txt
+```
+
+* Run extents perf tool with a specific font,
+
+```
+ninja -Cbuild && build/perf/perf-extents-bench test/api/fonts/Estedad-VF.ttf
+```
+
+Other than Google Benchmark based benchmarks there is also `run.sh` which builds `hb-shape` itself
+and runs the `perf` tool afterward usually provided by your package manager.

--- a/perf/meson.build
+++ b/perf/meson.build
@@ -7,3 +7,17 @@ benchmark('perf', executable('perf', 'perf.cc',
   link_with: [libharfbuzz],
   install: false,
 ), workdir: meson.current_source_dir() / '..', timeout: 100)
+
+executable('perf-shaping-bench', 'perf-shaping-bench.cc',
+  dependencies : [google_benchmark_dep],
+  include_directories: [incconfig, incsrc],
+  link_with: [libharfbuzz],
+  install: false,
+)
+
+executable('perf-extents-bench', 'perf-extents-bench.cc',
+  dependencies : [google_benchmark_dep, freetype_dep],
+  include_directories: [incconfig, incsrc],
+  link_with: [libharfbuzz],
+  install: false,
+)

--- a/perf/perf-extents-bench.cc
+++ b/perf/perf-extents-bench.cc
@@ -1,0 +1,39 @@
+#define PERF_BENCH
+#include "perf-extents.hh"
+
+#include <stdlib.h>
+
+const char *font_path = "test/api/fonts/Estedad-VF.ttf";
+bool skip_var = false;
+
+static void extents_bench (benchmark::State &state, bool is_var, bool is_ft)
+{
+  if (is_var && skip_var) return;
+  extents (state, font_path, is_var, is_ft);
+}
+BENCHMARK_CAPTURE (extents_bench, ot, false, false);
+BENCHMARK_CAPTURE (extents_bench, ft, false, true);
+BENCHMARK_CAPTURE (extents_bench, ot/var, true, false);
+BENCHMARK_CAPTURE (extents_bench, ft/var, true, true);
+
+int main(int argc, char** argv)
+{
+  if (argc > 1 && argv[1][0] != '-') { font_path = argv[1]; ++argv; --argc; }
+
+  {
+    hb_blob_t *blob = hb_blob_create_from_file (font_path);
+    hb_face_t *face = hb_face_create (blob, 0);
+    hb_blob_destroy (blob);
+    if (!hb_ot_var_get_axis_count (face))
+    {
+      printf ("\n** Runs with variation will be skipped for this non-var font **\n\n");
+      skip_var = true;
+    }
+    hb_face_destroy (face);
+  }
+
+
+  ::benchmark::Initialize(&argc, argv);
+  if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
+  ::benchmark::RunSpecifiedBenchmarks();
+}

--- a/perf/perf-extents.hh
+++ b/perf/perf-extents.hh
@@ -40,6 +40,7 @@ static void extents (benchmark::State &state, const char *font_path, bool is_var
 
 #define FONT_BASE_PATH "test/subset/data/fonts/"
 
+#ifndef PERF_BENCH
 BENCHMARK_CAPTURE (extents, cff - ot - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, false);
 BENCHMARK_CAPTURE (extents, cff - ft - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, true);
 
@@ -63,3 +64,4 @@ BENCHMARK_CAPTURE (extents, glyf/vf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-
 
 BENCHMARK_CAPTURE (extents, glyf - ot - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, false);
 BENCHMARK_CAPTURE (extents, glyf - ft - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, true);
+#endif

--- a/perf/perf-shaping-bench.cc
+++ b/perf/perf-shaping-bench.cc
@@ -1,0 +1,24 @@
+#define PERF_BENCH
+#include "perf-shaping.hh"
+
+#include <stdlib.h>
+
+const char *font_path = "perf/fonts/Amiri-Regular.ttf";
+const char *text_path = "perf/texts/fa-thelittleprince.txt";
+
+static void shape_bench (benchmark::State &state)
+{
+  shape (state, text_path, HB_DIRECTION_INVALID, HB_SCRIPT_INVALID, font_path);
+}
+
+BENCHMARK (shape_bench);
+
+int main(int argc, char** argv)
+{
+  if (argc > 1 && argv[1][0] != '-') { font_path = argv[1]; ++argv; --argc; }
+  if (argc > 1 && argv[1][0] != '-') { text_path = argv[1]; ++argv; --argc; }
+
+  ::benchmark::Initialize(&argc, argv);
+  if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
+  ::benchmark::RunSpecifiedBenchmarks();
+}

--- a/perf/perf-shaping.hh
+++ b/perf/perf-shaping.hh
@@ -27,6 +27,8 @@ static void shape (benchmark::State &state, const char *text_path,
     hb_buffer_add_utf8 (buf, text, text_length, 0, -1);
     hb_buffer_set_direction (buf, direction);
     hb_buffer_set_script (buf, script);
+    if (direction == HB_DIRECTION_INVALID && script == HB_SCRIPT_INVALID)
+      hb_buffer_guess_segment_properties (buf);
     hb_shape (font, buf, nullptr, 0);
     hb_buffer_clear_contents (buf);
   }
@@ -36,6 +38,7 @@ static void shape (benchmark::State &state, const char *text_path,
   hb_font_destroy (font);
 }
 
+#ifndef PERF_BENCH
 BENCHMARK_CAPTURE (shape, fa-thelittleprince.txt - Amiri,
 		   "perf/texts/fa-thelittleprince.txt",
 		   HB_DIRECTION_RTL, HB_SCRIPT_ARABIC,
@@ -63,3 +66,4 @@ BENCHMARK_CAPTURE (shape, en-words.txt - Roboto,
 		   "perf/texts/en-words.txt",
 		   HB_DIRECTION_LTR, HB_SCRIPT_LATIN,
 		   "perf/fonts/Roboto-Regular.ttf");
+#endif


### PR DESCRIPTION
Build the project like,

```
meson build -Dbenchmark=true -Dexperimental_api=true -Doptimization=2
ninja -Cbuild
```

Now you have different options,

* Run all the benchmarks,

```
ninja -Cbuild && build/perf/perf
```

* Run shaping perf tool with a specific font and text,

```
ninja -Cbuild && build/perf/perf-shaping-bench perf/fonts/Amiri-Regular.ttf perf/texts/fa-thelittleprince.txt
```

* Run extents perf tool with a specific font,

```
ninja -Cbuild && build/perf/perf-extents-bench test/api/fonts/Estedad-VF.ttf
```

Other than Google Benchmark based benchmarks there is also `run.sh` which builds `hb-shape` itself
and runs the `perf` tool afterward usually provided by your package manager.
