### PR TITLE
benchmark against ttf-parser

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: sudo apt-get install pkg-config gcc ragel gcovr gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-setuptools ninja-build gobject-introspection libgirepository1.0-dev
+      run: sudo apt-get install pkg-config gcc ragel gcovr gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-setuptools ninja-build gobject-introspection libgirepository1.0-dev rustc
     - run: sudo pip3 install fonttools
     - run: sudo pip3 install git+https://github.com/mesonbuild/meson
     - name: run

--- a/perf/meson.build
+++ b/perf/meson.build
@@ -1,8 +1,20 @@
 google_benchmark = subproject('google-benchmark')
 google_benchmark_dep = google_benchmark.get_variable('google_benchmark_dep')
 
+ttf_parser_dep = dependency('', required: false)
+if add_languages('rust', required: false, native: true)
+  ttf_parser_dep = subproject('ttf-parser').get_variable('ttf_parser_dep')
+endif
+
 benchmark('perf', executable('perf', 'perf.cc',
-  dependencies : [google_benchmark_dep, freetype_dep],
+  dependencies: [
+    google_benchmark_dep, freetype_dep,
+
+    # the last two, thread and dl, aren't nice as ttf-parser isn't no_std yet
+    # https://github.com/RazrFalcon/ttf-parser/issues/29
+    ttf_parser_dep, thread_dep, cpp.find_library('dl'),
+  ],
+  cpp_args: ttf_parser_dep.found() ? ['-DHAVE_TTFPARSER'] : [],
   include_directories: [incconfig, incsrc],
   link_with: [libharfbuzz],
   install: false,

--- a/perf/perf-draw.hh
+++ b/perf/perf-draw.hh
@@ -5,6 +5,10 @@
 #include "hb-ft.h"
 #include FT_OUTLINE_H
 
+#ifdef HAVE_TTFPARSER
+#include "ttfparser.h"
+#endif
+
 #define HB_UNUSED __attribute__((unused))
 
 static void
@@ -41,8 +45,15 @@ static void
 _ft_cubic_to (const FT_Vector* control1 HB_UNUSED, const FT_Vector* control2 HB_UNUSED,
 	      const FT_Vector* to HB_UNUSED, void* user HB_UNUSED) {}
 
+#ifdef HAVE_TTFPARSER
+static void _tp_move_to (float x HB_UNUSED, float y HB_UNUSED, void *data HB_UNUSED) {}
+static void _tp_line_to (float x, float y, void *data) {}
+static void _tp_quad_to (float x1, float y1, float x, float y, void *data) {}
+static void _tp_curve_to (float x1, float y1, float x2, float y2, float x, float y, void *data) {}
+static void _tp_close_path (void *data) {}
+#endif
 
-static void draw (benchmark::State &state, const char *font_path, bool is_var, bool is_ft)
+static void draw (benchmark::State &state, const char *font_path, bool is_var, backend_t backend)
 {
   hb_font_t *font;
   unsigned num_glyphs;
@@ -56,14 +67,33 @@ static void draw (benchmark::State &state, const char *font_path, bool is_var, b
     hb_face_destroy (face);
   }
 
-  if (is_var)
+  if (backend == HARFBUZZ)
   {
-    hb_variation_t wght = {HB_TAG ('w','g','h','t'), 500};
-    hb_font_set_variations (font, &wght, 1);
-  }
+    if (is_var)
+    {
+      hb_variation_t wght = {HB_TAG ('w','g','h','t'), 500};
+      hb_font_set_variations (font, &wght, 1);
+    }
+    hb_draw_funcs_t *draw_funcs = hb_draw_funcs_create ();
+    hb_draw_funcs_set_move_to_func (draw_funcs, _hb_move_to);
+    hb_draw_funcs_set_line_to_func (draw_funcs, _hb_line_to);
+    hb_draw_funcs_set_quadratic_to_func (draw_funcs, _hb_quadratic_to);
+    hb_draw_funcs_set_cubic_to_func (draw_funcs, _hb_cubic_to);
+    hb_draw_funcs_set_close_path_func (draw_funcs, _hb_close_path);
 
-  if (is_ft)
+    for (auto _ : state)
+      for (unsigned gid = 0; gid < num_glyphs; ++gid)
+	hb_font_draw_glyph (font, gid, draw_funcs, nullptr);
+
+    hb_draw_funcs_destroy (draw_funcs);
+  }
+  else if (backend == FREETYPE)
   {
+    if (is_var)
+    {
+      hb_variation_t wght = {HB_TAG ('w','g','h','t'), 500};
+      hb_font_set_variations (font, &wght, 1);
+    }
     hb_ft_font_set_funcs (font);
     FT_Face ft_face = hb_ft_font_get_face (font);
     hb_ft_font_set_load_flags (font, FT_LOAD_NO_HINTING | FT_LOAD_NO_SCALE);
@@ -83,47 +113,65 @@ static void draw (benchmark::State &state, const char *font_path, bool is_var, b
 	FT_Outline_Decompose (&ft_face->glyph->outline, &draw_funcs, nullptr);
       }
   }
-  else
+  else if (backend == TTF_PARSER)
   {
-    hb_draw_funcs_t *draw_funcs = hb_draw_funcs_create ();
-    hb_draw_funcs_set_move_to_func (draw_funcs, _hb_move_to);
-    hb_draw_funcs_set_line_to_func (draw_funcs, _hb_line_to);
-    hb_draw_funcs_set_quadratic_to_func (draw_funcs, _hb_quadratic_to);
-    hb_draw_funcs_set_cubic_to_func (draw_funcs, _hb_cubic_to);
-    hb_draw_funcs_set_close_path_func (draw_funcs, _hb_close_path);
+#ifdef HAVE_TTFPARSER
+    ttfp_face *tp_font = (ttfp_face *) malloc (ttfp_face_size_of ());
+    hb_blob_t *blob = hb_face_reference_blob (hb_font_get_face (font));
+    assert (ttfp_face_init (hb_blob_get_data (blob, nullptr), hb_blob_get_length (blob), 0, tp_font));
+    if (is_var) ttfp_set_variation (tp_font, TTFP_TAG('w','g','h','t'), 500);
 
+    ttfp_outline_builder builder;
+    builder.move_to = _tp_move_to;
+    builder.line_to = _tp_line_to;
+    builder.quad_to = _tp_quad_to;
+    builder.curve_to = _tp_curve_to;
+    builder.close_path = _tp_close_path;
+
+    ttfp_rect bbox;
     for (auto _ : state)
       for (unsigned gid = 0; gid < num_glyphs; ++gid)
-	hb_font_draw_glyph (font, gid, draw_funcs, nullptr);
+	ttfp_outline_glyph (tp_font, builder, &builder, gid, &bbox);
 
-    hb_draw_funcs_destroy (draw_funcs);
+    hb_blob_destroy (blob);
+    free (tp_font);
+#endif
   }
+  else abort ();
 
   hb_font_destroy (font);
 }
 
 #define FONT_BASE_PATH "test/subset/data/fonts/"
 
-BENCHMARK_CAPTURE (draw, cff - ot - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, false);
-BENCHMARK_CAPTURE (draw, cff - ft - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, true);
+BENCHMARK_CAPTURE (draw, cff - ot - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (draw, cff - ft - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, FREETYPE);
+BENCHMARK_CAPTURE (draw, cff - tp - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, TTF_PARSER);
 
-BENCHMARK_CAPTURE (draw, cff2 - ot - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, false);
-BENCHMARK_CAPTURE (draw, cff2 - ft - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, true);
+BENCHMARK_CAPTURE (draw, cff2 - ot - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (draw, cff2 - ft - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, FREETYPE);
+BENCHMARK_CAPTURE (draw, cff2 - tp - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, TTF_PARSER);
 
-BENCHMARK_CAPTURE (draw, cff2/vf - ot - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, false);
-BENCHMARK_CAPTURE (draw, cff2/vf - ft - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, true);
+BENCHMARK_CAPTURE (draw, cff2/vf - ot - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, HARFBUZZ);
+BENCHMARK_CAPTURE (draw, cff2/vf - ft - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, FREETYPE);
+BENCHMARK_CAPTURE (draw, cff2/vf - tp - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, TTF_PARSER);
 
-BENCHMARK_CAPTURE (draw, glyf - ot - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, false);
-BENCHMARK_CAPTURE (draw, glyf - ft - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, true);
+BENCHMARK_CAPTURE (draw, glyf - ot - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (draw, glyf - ft - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, FREETYPE);
+BENCHMARK_CAPTURE (draw, glyf - tp - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, TTF_PARSER);
 
-BENCHMARK_CAPTURE (draw, glyf/vf - ot - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, false);
-BENCHMARK_CAPTURE (draw, glyf/vf - ft - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, true);
+BENCHMARK_CAPTURE (draw, glyf/vf - ot - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, HARFBUZZ);
+BENCHMARK_CAPTURE (draw, glyf/vf - ft - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, FREETYPE);
+BENCHMARK_CAPTURE (draw, glyf/vf - tp - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, TTF_PARSER);
 
-BENCHMARK_CAPTURE (draw, glyf - ot - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, false);
-BENCHMARK_CAPTURE (draw, glyf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, true);
+BENCHMARK_CAPTURE (draw, glyf - ot - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (draw, glyf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, FREETYPE);
+BENCHMARK_CAPTURE (draw, glyf - tp - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, TTF_PARSER);
 
-BENCHMARK_CAPTURE (draw, glyf/vf - ot - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, false);
-BENCHMARK_CAPTURE (draw, glyf/vf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, true);
+BENCHMARK_CAPTURE (draw, glyf/vf - ot - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, HARFBUZZ);
+BENCHMARK_CAPTURE (draw, glyf/vf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, FREETYPE);
+BENCHMARK_CAPTURE (draw, glyf/vf - tp - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, TTF_PARSER);
 
-BENCHMARK_CAPTURE (draw, glyf - ot - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, false);
-BENCHMARK_CAPTURE (draw, glyf - ft - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, true);
+BENCHMARK_CAPTURE (draw, glyf - ot - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (draw, glyf - ft - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, FREETYPE);
+BENCHMARK_CAPTURE (draw, glyf - tp - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, TTF_PARSER);

--- a/perf/perf-extents.hh
+++ b/perf/perf-extents.hh
@@ -4,7 +4,11 @@
 #include "hb-ft.h"
 #include "hb-ot.h"
 
-static void extents (benchmark::State &state, const char *font_path, bool is_var, bool is_ft)
+#ifdef HAVE_TTFPARSER
+#include "ttfparser.h"
+#endif
+
+static void extents (benchmark::State &state, const char *font_path, bool is_var, backend_t backend)
 {
   hb_font_t *font;
   unsigned num_glyphs;
@@ -24,42 +28,71 @@ static void extents (benchmark::State &state, const char *font_path, bool is_var
     hb_font_set_variations (font, &wght, 1);
   }
 
-  if (is_ft)
+  if (backend == HARFBUZZ || backend == FREETYPE)
   {
-    hb_ft_font_set_funcs (font);
-    hb_ft_font_set_load_flags (font, FT_LOAD_NO_HINTING | FT_LOAD_NO_SCALE);
-  }
+    if (backend == FREETYPE)
+    {
+      hb_ft_font_set_funcs (font);
+      hb_ft_font_set_load_flags (font, FT_LOAD_NO_HINTING | FT_LOAD_NO_SCALE);
+    }
 
-  hb_glyph_extents_t extents;
-  for (auto _ : state)
-    for (unsigned gid = 0; gid < num_glyphs; ++gid)
-      hb_font_get_glyph_extents (font, gid, &extents);
+    hb_glyph_extents_t extents;
+    for (auto _ : state)
+      for (unsigned gid = 0; gid < num_glyphs; ++gid)
+	hb_font_get_glyph_extents (font, gid, &extents);
+  }
+  else if (backend == TTF_PARSER)
+  {
+#ifdef HAVE_TTFPARSER
+    ttfp_face *tp_font = (ttfp_face *) malloc (ttfp_face_size_of ());
+    hb_blob_t *blob = hb_face_reference_blob (hb_font_get_face (font));
+    assert (ttfp_face_init (hb_blob_get_data (blob, nullptr), hb_blob_get_length (blob), 0, tp_font));
+    if (is_var) ttfp_set_variation (tp_font, TTFP_TAG('w','g','h','t'), 500);
+
+    ttfp_rect bbox;
+    for (auto _ : state)
+      for (unsigned gid = 0; gid < num_glyphs; ++gid)
+	ttfp_get_glyph_bbox(tp_font, gid, &bbox);
+
+    hb_blob_destroy (blob);
+    free (tp_font);
+#endif
+  }
 
   hb_font_destroy (font);
 }
 
 #define FONT_BASE_PATH "test/subset/data/fonts/"
 
-BENCHMARK_CAPTURE (extents, cff - ot - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, false);
-BENCHMARK_CAPTURE (extents, cff - ft - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, true);
+BENCHMARK_CAPTURE (extents, cff - ot - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (extents, cff - ft - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, FREETYPE);
+BENCHMARK_CAPTURE (extents, cff - tp - SourceSansPro, FONT_BASE_PATH "SourceSansPro-Regular.otf", false, TTF_PARSER);
 
-BENCHMARK_CAPTURE (extents, cff2 - ot - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, false);
-BENCHMARK_CAPTURE (extents, cff2 - ft - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, true);
+BENCHMARK_CAPTURE (extents, cff2 - ot - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (extents, cff2 - ft - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, FREETYPE);
+BENCHMARK_CAPTURE (extents, cff2 - tp - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", false, TTF_PARSER);
 
-BENCHMARK_CAPTURE (extents, cff2/vf - ot - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, false);
-BENCHMARK_CAPTURE (extents, cff2/vf - ft - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, true);
+BENCHMARK_CAPTURE (extents, cff2/vf - ot - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, HARFBUZZ);
+BENCHMARK_CAPTURE (extents, cff2/vf - ft - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, FREETYPE);
+BENCHMARK_CAPTURE (extents, cff2/vf - tp - AdobeVFPrototype, FONT_BASE_PATH "AdobeVFPrototype.otf", true, TTF_PARSER);
 
-BENCHMARK_CAPTURE (extents, glyf - ot - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, false);
-BENCHMARK_CAPTURE (extents, glyf - ft - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, true);
+BENCHMARK_CAPTURE (extents, glyf - ot - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (extents, glyf - ft - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, FREETYPE);
+BENCHMARK_CAPTURE (extents, glyf - tp - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", false, TTF_PARSER);
 
-BENCHMARK_CAPTURE (extents, glyf/vf - ot - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, false);
-BENCHMARK_CAPTURE (extents, glyf/vf - ft - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, true);
+BENCHMARK_CAPTURE (extents, glyf/vf - ot - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, HARFBUZZ);
+BENCHMARK_CAPTURE (extents, glyf/vf - ft - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, FREETYPE);
+BENCHMARK_CAPTURE (extents, glyf/vf - tp - SourceSerifVariable, FONT_BASE_PATH "SourceSerifVariable-Roman.ttf", true, TTF_PARSER);
 
-BENCHMARK_CAPTURE (extents, glyf - ot - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, false);
-BENCHMARK_CAPTURE (extents, glyf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, true);
+BENCHMARK_CAPTURE (extents, glyf - ot - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (extents, glyf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, FREETYPE);
+BENCHMARK_CAPTURE (extents, glyf - tp - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", false, TTF_PARSER);
 
-BENCHMARK_CAPTURE (extents, glyf/vf - ot - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, false);
-BENCHMARK_CAPTURE (extents, glyf/vf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, true);
+BENCHMARK_CAPTURE (extents, glyf/vf - ot - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, HARFBUZZ);
+BENCHMARK_CAPTURE (extents, glyf/vf - ft - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, FREETYPE);
+BENCHMARK_CAPTURE (extents, glyf/vf - tp - Comfortaa, FONT_BASE_PATH "Comfortaa-Regular-new.ttf", true, TTF_PARSER);
 
-BENCHMARK_CAPTURE (extents, glyf - ot - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, false);
-BENCHMARK_CAPTURE (extents, glyf - ft - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, true);
+BENCHMARK_CAPTURE (extents, glyf - ot - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, HARFBUZZ);
+BENCHMARK_CAPTURE (extents, glyf - ft - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, FREETYPE);
+BENCHMARK_CAPTURE (extents, glyf - tp - Roboto, FONT_BASE_PATH "Roboto-Regular.ttf", false, TTF_PARSER);
+

--- a/perf/perf.cc
+++ b/perf/perf.cc
@@ -6,6 +6,7 @@
 
 #include "perf-shaping.hh"
 #ifdef HAVE_FREETYPE
+enum backend_t { HARFBUZZ, FREETYPE, TTF_PARSER };
 #include "perf-extents.hh"
 #ifdef HB_EXPERIMENTAL_API
 #include "perf-draw.hh"

--- a/subprojects/ttf-parser.wrap
+++ b/subprojects/ttf-parser.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+directory=ttf-parser
+url=https://github.com/RazrFalcon/ttf-parser.git
+depth=1
+revision=master


### PR DESCRIPTION
```
# first install rustc from your package manager, if you have it from rustup or anything well that's even better
meson build -Dexperimental_api=true -Doptimization=2
ninja -Cbuild
build/perf/perf
```

ttf-parser's extents calculates costly for variable font's when there is no actual coordinates so needs some tweaks, https://github.com/RazrFalcon/ttf-parser/issues/28 and https://github.com/RazrFalcon/ttf-parser/issues/27 to become comparable, it is still comparable when coordinate are given (`/vf` cases) and specially in CFF/CFF2

rustybuzz is a gradual port of harfbuzz to rust https://github.com/RazrFalcon/rustybuzz that now doesn't have glyph related part of our font parsing logics still runs our test suite thanks to ttf-parser.

things can be improved on ot-draw if path command 'sanitization'  be removed.

picked up from https://circleci.com/gh/harfbuzz/harfbuzz/146188 "build/perf/perf && rm -rf build" section

```
---------------------------------------------------------------------------------------
Benchmark                                                Time           CPU Iterations
---------------------------------------------------------------------------------------
shape/fa-thelittleprince.txt - Amiri             122202682 ns  122183608 ns          5
shape/fa-thelittleprince.txt - NotoNastaliqUrdu  423983455 ns  423303848 ns          2
shape/fa-monologue.txt - Amiri                    20740165 ns   20382469 ns         34
shape/fa-monologue.txt - NotoNastaliqUrdu         74148273 ns   72333353 ns         10
shape/en-thelittleprince.txt - Roboto             64665055 ns   64377800 ns         10
shape/en-words.txt - Roboto                       75118780 ns   75024550 ns          8
extents/cff - ot - SourceSansPro                   5066222 ns    5064483 ns        134
extents/cff - ft - SourceSansPro                  11262572 ns   11232289 ns         66
extents/cff - tp - SourceSansPro                   2393903 ns    2393362 ns        292
extents/cff2 - ot - AdobeVFPrototype               5247237 ns    5206772 ns        132
extents/cff2 - ft - AdobeVFPrototype               3980850 ns    3979831 ns        179
extents/cff2 - tp - AdobeVFPrototype               2057811 ns    2057536 ns        346
extents/cff2/vf - ot - AdobeVFPrototype            5376816 ns    5299965 ns        100
extents/cff2/vf - ft - AdobeVFPrototype            4078521 ns    4074512 ns        172
extents/cff2/vf - tp - AdobeVFPrototype            2067422 ns    2041259 ns        350
extents/glyf - ot - SourceSerifVariable              50883 ns      50699 ns      12265
extents/glyf - ft - SourceSerifVariable            1663266 ns    1643066 ns        414
extents/glyf - tp - SourceSerifVariable            3873030 ns    3871871 ns        185
extents/glyf/vf - ot - SourceSerifVariable         6347738 ns    6312792 ns        108
extents/glyf/vf - ft - SourceSerifVariable         5716778 ns    5708774 ns        125
extents/glyf/vf - tp - SourceSerifVariable         6615693 ns    6532585 ns        122
extents/glyf - ot - Comfortaa                        33474 ns      33208 ns      21543
extents/glyf - ft - Comfortaa                       984342 ns     979308 ns        752
extents/glyf - tp - Comfortaa                      2399276 ns    2359676 ns        296
extents/glyf/vf - ot - Comfortaa                   3891430 ns    3889872 ns        177
extents/glyf/vf - ft - Comfortaa                   3316384 ns    3312605 ns        222
extents/glyf/vf - tp - Comfortaa                   4251239 ns    4243509 ns        164
extents/glyf - ot - Roboto                           45450 ns      45394 ns      15424
extents/glyf - ft - Roboto                         1166475 ns    1160516 ns        589
extents/glyf - tp - Roboto                           32090 ns      31966 ns      21862
draw/cff - ot - SourceSansPro                      6382060 ns    6381087 ns        103
draw/cff - ft - SourceSansPro                     11149430 ns   11136182 ns         61
draw/cff - tp - SourceSansPro                      2473528 ns    2458573 ns        288
draw/cff2 - ot - AdobeVFPrototype                  5159724 ns    5132608 ns        131
draw/cff2 - ft - AdobeVFPrototype                  3943370 ns    3920704 ns        180
draw/cff2 - tp - AdobeVFPrototype                  2059765 ns    2047303 ns        335
draw/cff2/vf - ot - AdobeVFPrototype               5527324 ns    5501692 ns        127
draw/cff2/vf - ft - AdobeVFPrototype               4111966 ns    4111240 ns        172
draw/cff2/vf - tp - AdobeVFPrototype               2077378 ns    2074750 ns        338
draw/glyf - ot - SourceSerifVariable               4443270 ns    4442628 ns        155
draw/glyf - ft - SourceSerifVariable               1629466 ns    1629228 ns        434
draw/glyf - tp - SourceSerifVariable               3906841 ns    3906258 ns        177
draw/glyf/vf - ot - SourceSerifVariable            8061347 ns    7959191 ns         84
draw/glyf/vf - ft - SourceSerifVariable            5451965 ns    5450260 ns        125
draw/glyf/vf - tp - SourceSerifVariable            6299210 ns    6265153 ns        105
draw/glyf - ot - Comfortaa                         2722454 ns    2722034 ns        257
draw/glyf - ft - Comfortaa                          977256 ns     960065 ns        719
draw/glyf - tp - Comfortaa                         2398904 ns    2396771 ns        278
draw/glyf/vf - ot - Comfortaa                      5024540 ns    5023935 ns        100
draw/glyf/vf - ft - Comfortaa                      3331846 ns    3290786 ns        207
draw/glyf/vf - tp - Comfortaa                      4346116 ns    4319098 ns        166
draw/glyf - ot - Roboto                            2602575 ns    2596758 ns        269
draw/glyf - ft - Roboto                            1144549 ns    1143878 ns        609
draw/glyf - tp - Roboto                            1243036 ns    1240433 ns        555
```