### PR TITLE
[tests] Use shared --batch process

### DIFF
--- a/test/shaping/meson.build
+++ b/test/shaping/meson.build
@@ -5,6 +5,11 @@ subdir('data/text-rendering-tests') # text_rendering_tests
 
 shaping_run_tests_py = find_program('run-tests.py')
 
+env = environment()
+if conf.get('HAVE_FREETYPE', 0) == 0
+  env.set('no_ft_funcs', '1')
+endif
+
 foreach file_name : in_house_tests
   test_name = file_name.split('.')[0].underscorify()
 
@@ -13,6 +18,7 @@ foreach file_name : in_house_tests
       hb_shape,
       meson.current_source_dir() / 'data' / 'in-house' / 'tests' / file_name,
     ],
+    env: env,
     workdir: meson.current_build_dir() / '..' / '..',
     suite: ['shaping', 'in-house'],
   )
@@ -26,6 +32,7 @@ foreach file_name : aots_tests
       hb_shape,
       meson.current_source_dir() / 'data' / 'aots' / 'tests' / file_name,
     ],
+    env: env,
     workdir: meson.current_build_dir() / '..' / '..',
     suite: ['shaping', 'aots'],
   )
@@ -39,6 +46,7 @@ foreach file_name : text_rendering_tests
       hb_shape,
       meson.current_source_dir() / 'data' / 'text-rendering-tests' / 'tests' / file_name,
     ],
+    env: env,
     workdir: meson.current_build_dir() / '..' / '..',
     suite: ['shaping', 'text-rendering-tests'],
   )


### PR DESCRIPTION
Reverts da95a8c and use another approach for no-ft compiles

Before the change,
`meson test -Cbuild --no-suite slow  31.22s user 15.25s system 569% cpu 8.157 total`

After the change,
`meson test -Cbuild --no-suite slow  25.07s user 7.21s system 503% cpu 6.406 total`

With 1.5s difference however I was thinking also dropping whole --batch support to avoid the need for #2313 or maybe not, we can discuss that also.