### PR TITLE
meson: Make Requires in .pc files match autotools

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -501,6 +501,7 @@ pkgmod.generate(libharfbuzz,
 
 pkgmod.generate(libharfbuzz_subset,
   description: 'HarfBuzz font subsetter',
+  requires: ['harfbuzz'],
   subdirs: [meson.project_name()],
   version: meson.project_version(),
 )
@@ -531,6 +532,7 @@ if have_icu and not have_icu_builtin
 
   pkgmod.generate(libharfbuzz_icu,
     description: 'HarfBuzz text shaping library ICU integration',
+    requires: ['harfbuzz'],
     subdirs: [meson.project_name()],
     version: meson.project_version(),
   )
@@ -644,6 +646,7 @@ if have_gobject
 
   pkgmod.generate(libharfbuzz_gobject,
     description: 'HarfBuzz text shaping library GObject integration',
+    requires: ['harfbuzz', 'glib-2.0', 'gobject-2.0'],
     subdirs: [meson.project_name()],
     version: meson.project_version(),
   )

--- a/src/meson.build
+++ b/src/meson.build
@@ -501,7 +501,7 @@ pkgmod.generate(libharfbuzz,
 
 pkgmod.generate(libharfbuzz_subset,
   description: 'HarfBuzz font subsetter',
-  requires: ['harfbuzz'],
+  requires: ['harfbuzz = @0@'.format(meson.project_version())],
   subdirs: [meson.project_name()],
   version: meson.project_version(),
 )
@@ -532,7 +532,7 @@ if have_icu and not have_icu_builtin
 
   pkgmod.generate(libharfbuzz_icu,
     description: 'HarfBuzz text shaping library ICU integration',
-    requires: ['harfbuzz'],
+    requires: ['harfbuzz = @0@'.format(meson.project_version())],
     subdirs: [meson.project_name()],
     version: meson.project_version(),
   )
@@ -646,7 +646,7 @@ if have_gobject
 
   pkgmod.generate(libharfbuzz_gobject,
     description: 'HarfBuzz text shaping library GObject integration',
-    requires: ['harfbuzz', 'glib-2.0', 'gobject-2.0'],
+    requires: ['harfbuzz = @0@'.format(meson.project_version()), 'glib-2.0', 'gobject-2.0'],
     subdirs: [meson.project_name()],
     version: meson.project_version(),
   )


### PR DESCRIPTION
Libreoffice tries to use only `harfbuzz-icu.pc` and assumes this includes `-lharfbuzz`.