### PR TITLE
Minor, fix -Wrange-loop-analysis warnings

### DIFF
--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -174,7 +174,7 @@ struct COLR
     baseGlyphsZ = COLR::min_size;
     layersZ = COLR::min_size + numBaseGlyphs * BaseGlyphRecord::min_size;
 
-    for (const hb_item_type<BaseIterator>& _ : + base_it.iter ())
+    for (const hb_item_type<BaseIterator> _ : + base_it.iter ())
     {
       auto* record = c->embed (_);
       if (unlikely (!record)) return_trace (false);

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -1717,7 +1717,7 @@ struct ClassDefFormat1
 
     startGlyph = glyph_min;
     if (unlikely (!classValue.serialize (c, glyph_count))) return_trace (false);
-    for (const hb_pair_t<hb_codepoint_t, unsigned>& gid_klass_pair : + it)
+    for (const hb_pair_t<hb_codepoint_t, unsigned> gid_klass_pair : + it)
     {
       unsigned idx = gid_klass_pair.first - glyph_min;
       classValue[idx] = gid_klass_pair.second;


### PR DESCRIPTION
Fixing these complains raised by newer versions of clang,

`./hb-ot-layout-common.hh:1720:53: error: loop variable 'gid_klass_pair' is always a copy because the range of type 'hb_map_iter_t<hb_sorted_array_t<OT::HBGlyphID>, (lambda at ./hb-ot-layout-common.hh:1672:29), hb_function_sortedness_t::RETAINS_SORTING, nullptr>' does not return a reference [-Werror,-Wrange-loop-analysis]
    for (const hb_pair_t<hb_codepoint_t, unsigned>& gid_klass_pair : + it)`

And

`./hb-ot-color-colr-table.hh:177:44: error: loop variable '_' is always a copy because the range of type 'hb_map_iter_t<hb_filter_iter_t<hb_map_iter_t<hb_range_iter_t<unsigned int, unsigned int>, (lambda at ./hb-ot-color-colr-table.hh:209:31), hb_function_sortedness_t::RETAINS_SORTING, nullptr>, (anonymous struct at ./hb-algs.hh:331:1) &, (anonymous struct at ./hb-algs.hh:51:1) &, nullptr>, (anonymous struct at ./hb-algs.hh:338:1) &, hb_function_sortedness_t::RETAINS_SORTING, nullptr>' does not return a reference [-Werror,-Wrange-loop-analysis]
    for (const hb_item_type<BaseIterator>& _ : + base_it.iter ())`

To fix clang-everything bot, https://circleci.com/gh/harfbuzz/harfbuzz/147349 which uses a brand new clang installation.



This is also one of the reasons I favor foreach over hb_apply where possible and that is better analysis by compiler, I remember had to fix one these on turning one of the dagger to foreach, not sure if you think this shows case shows a good complain however, to me the code should definitely match what really happens which I see this warning toward that. 