### PR TITLE
Minor, disable strict-aliasing warning in set fuzzer

### DIFF
--- a/test/fuzzing/hb-set-fuzzer.cc
+++ b/test/fuzzing/hb-set-fuzzer.cc
@@ -35,7 +35,10 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   if (size < sizeof (instructions_t))
     return 0;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
   const instructions_t &instructions = reinterpret_cast<const instructions_t &> (data);
+#pragma GCC diagnostic pop
   data += sizeof (instructions_t);
   size -= sizeof (instructions_t);
 


### PR DESCRIPTION
../test/fuzzing/hb-set-fuzzer.cc: In function ‘int LLVMFuzzerTestOneInput(const uint8_t*, size_t)’:
../test/fuzzing/hb-set-fuzzer.cc:38:82: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   38 |   const instructions_t &instructions = reinterpret_cast<const instructions_t &> (data);
      |

And it is already disabled at project level so let's disable it here also.