### PR TITLE
[meson] Don't allow introspection on static library

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -617,7 +617,17 @@ if have_gobject
   )
 
   gir = find_program('g-ir-scanner', required: get_option('introspection'))
-  build_gir = gir.found() and not meson.is_cross_build()
+  build_gir = gir.found()
+
+  build_gir = build_gir and not meson.is_cross_build()
+  if not build_gir and get_option('introspection').enabled()
+    error('Introspection support is requested but it isn\'t available in cross builds')
+  endif
+
+  build_gir = build_gir and get_option('default_library') != 'static'
+  if not build_gir and get_option('introspection').enabled()
+    error('Introspection support is requested but the default library option should be shared or both')
+  endif
 
   if build_gir
     conf.set('HAVE_INTROSPECTION', 1)


### PR DESCRIPTION
fixes #2564 

Why I care anyway? It reduces whole fuzzer build and run to `CXXFLAGS="-fsanitize=address,fuzzer-no-link" meson build --default-library=static -Dfuzzer_ldflags=-fsanitize=address,fuzzer && ninja -Cbuild && build/test/fuzzing/hb-shape-fuzzer` (no need to explicit disabling of introspection)