### PR TITLE
CI: Port MSYS2 jobs from appveyor to github actions

### DIFF
--- a/.github/workflows/msys2-ci.yml
+++ b/.github/workflows/msys2-ci.yml
@@ -1,0 +1,66 @@
+name: msys2
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  msys2:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        include:
+          - MSYSTEM: MINGW32
+            MSYS2_ARCH: i686
+          - MSYSTEM: MINGW64
+            MSYS2_ARCH: x86_64
+    name: ${{ matrix.MSYSTEM }}
+
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v1
+        with:
+          msystem: ${{ matrix.MSYSTEM }}
+          update: true
+          install: >-
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-cairo
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-freetype
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-gcc
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-gcc-libs
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-gettext
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-glib2
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-gobject-introspection
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-graphite2
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-icu
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-ninja
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-pkg-config
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-python3
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-python3-pip
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-ragel
+      - name: Install extra dependencies
+        run: |
+          pip install fonttools
+          pip install --upgrade meson==0.53.0
+          curl "https://raw.githubusercontent.com/mirror/mingw-w64/023eb04c396d4e8d8fcf604cfababc53dae13398/mingw-w64-headers/include/dwrite_1.h" > "$MINGW_PREFIX/$MINGW_CHOST/include/dwrite_1.h"
+      - name: Build
+        run: |
+          meson build \
+            --wrap-mode=nofallback \
+            -Dfreetype=enabled \
+            -Dglib=enabled \
+            -Dcairo=enabled \
+            -Dgobject=enabled \
+            -Dgdi=enabled \
+            -Ddirectwrite=enabled \
+            -Dgraphite=enabled
+          ninja -C build
+      - name: Test
+        run: |
+          meson test \
+            --print-errorlogs \
+            --suite=harfbuzz \
+            -C build

--- a/.github/workflows/msys2-ci.yml
+++ b/.github/workflows/msys2-ci.yml
@@ -36,27 +36,21 @@ jobs:
             mingw-w64-${{ matrix.MSYS2_ARCH }}-gobject-introspection
             mingw-w64-${{ matrix.MSYS2_ARCH }}-graphite2
             mingw-w64-${{ matrix.MSYS2_ARCH }}-icu
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-meson
             mingw-w64-${{ matrix.MSYS2_ARCH }}-ninja
             mingw-w64-${{ matrix.MSYS2_ARCH }}-pkg-config
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-python-fonttools
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python3
-            mingw-w64-${{ matrix.MSYS2_ARCH }}-python3-pip
             mingw-w64-${{ matrix.MSYS2_ARCH }}-ragel
-      - name: Install extra dependencies
-        run: |
-          pip install fonttools
-          pip install --upgrade meson==0.53.0
-          curl "https://raw.githubusercontent.com/mirror/mingw-w64/023eb04c396d4e8d8fcf604cfababc53dae13398/mingw-w64-headers/include/dwrite_1.h" > "$MINGW_PREFIX/$MINGW_CHOST/include/dwrite_1.h"
       - name: Build
         run: |
           meson build \
-            --wrap-mode=nofallback \
-            -Dfreetype=enabled \
-            -Dglib=enabled \
-            -Dcairo=enabled \
-            -Dgobject=enabled \
-            -Dgdi=enabled \
+            --wrap-mode=nodownload \
+            --auto-features=enabled \
             -Ddirectwrite=enabled \
-            -Dgraphite=enabled
+            -Dgdi=enabled \
+            -Dgraphite=enabled \
+            -Dbenchmark=disabled
           ninja -C build
       - name: Test
         run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,25 +19,7 @@ environment:
       vcvarsallpath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat
       arch: amd64
 
-    - compiler: msys2
-      MINGW_PREFIX: /mingw64
-      MINGW_CHOST: x86_64-w64-mingw32
-      MSYS2_ARCH: x86_64
-      MSYSTEM: MINGW64
-
-    - compiler: msys2
-      MINGW_PREFIX: /mingw32
-      MINGW_CHOST: i686-w64-mingw32
-      MSYS2_ARCH: i686
-      MSYSTEM: MINGW32
-
 build_script:
-  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "pacman --noconfirm --force -S --needed mingw-w64-$MSYS2_ARCH-{gcc,freetype,cairo,icu,gettext,gobject-introspection,gcc,gcc-libs,glib2,graphite2,pkg-config,python3,python3-pip,ragel,ninja}"'
-  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "pip install fonttools"'
-  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "pip install --upgrade meson==0.53.0"'
-  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "curl https://raw.githubusercontent.com/mirror/mingw-w64/023eb04c396d4e8d8fcf604cfababc53dae13398/mingw-w64-headers/include/dwrite_1.h > %MINGW_PREFIX%/%MINGW_CHOST%/include/dwrite_1.h"'
-  - 'if "%compiler%"=="msys2" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; meson build --wrap-mode=nofallback -Dfreetype=enabled -Dglib=enabled -Dcairo=enabled -Dgobject=enabled -Dgdi=enabled -Ddirectwrite=enabled -Dgraphite=enabled && meson test -Cbuild --print-errorlogs"'
-
   - set "PYTHON_ROOT=C:\python37-x64"
   - set "PATH=%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%"
   - 'if "%compiler%"=="msvc" pip install --upgrade meson'


### PR DESCRIPTION
This is motivated by our new github action https://github.com/msys2/setup-msys2 which makes spawning a MSYS2 env easy and hides the install/update details..

(and also github actions has 20 parallel jobs.. compared to 1 in appveyor)