### PR TITLE
[meson] Rename gtk_doc option to docs

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -3,7 +3,7 @@ if build_machine.system() == 'windows'
   subdir_done()
 endif
 
-if not find_program('gtkdoc-scan', required: get_option('gtk_doc')).found()
+if not find_program('gtkdoc-scan', required: get_option('docs')).found()
   message('Not building documentation as gtk-doc was not found')
   subdir_done()
 endif

--- a/meson.build
+++ b/meson.build
@@ -351,7 +351,7 @@ if not get_option('benchmark').disabled() and \
   subdir('perf')
 endif
 
-if not get_option('gtk_doc').disabled()
+if not get_option('docs').disabled()
   subdir('docs')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,7 +25,7 @@ option('tests', type: 'feature', value: 'enabled', yield: true,
   description: 'Enable or disable unit tests')
 option('introspection', type: 'feature', value: 'auto', yield: true,
   description: 'Generate gobject-introspection bindings (.gir/.typelib files)')
-option('gtk_doc',  type: 'feature', value: 'auto', yield: true,
+option('docs', type: 'feature', value: 'auto', yield: true,
   description: 'Generate documentation with gtk-doc')
 
 option('benchmark', type: 'feature', value: 'auto',


### PR DESCRIPTION
Feels like a better naming as used in fribidi https://github.com/fribidi/fribidi/blob/master/meson_options.txt also