### PR TITLE
[subset] Basic support for LookupType 9.

### DIFF
--- a/src/hb-subset.hh
+++ b/src/hb-subset.hh
@@ -54,6 +54,18 @@ struct hb_subset_context_t :
   dispatch (const T &obj, Ts&&... ds) HB_AUTO_RETURN
   ( _dispatch (obj, hb_prioritize, hb_forward<Ts> (ds)...) )
 
+  private:
+  template <typename T, typename F> auto
+  _may_dispatch (const T *obj, const F *format, hb_priority<1>) HB_AUTO_RETURN
+  ( format->subset (this) )
+  template <typename T, typename F> auto
+  _may_dispatch (const T *obj, const F *format, hb_priority<0>) HB_AUTO_RETURN
+  ( true )
+  public:
+  template <typename T, typename F> auto
+  may_dispatch (const T *obj, const F *format) HB_AUTO_RETURN
+  ( _may_dispatch (obj, format, hb_prioritize) )
+
   hb_blob_t *source_blob;
   hb_subset_plan_t *plan;
   hb_serialize_context_t *serializer;


### PR DESCRIPTION
Currently if subseting a LookupType 9 Extension Positioning table the
data written is that of the extension table, not the extension
positioning table which has an offset to the extension table. This
change makes that work in the most basic way possible. It makes no
attempt to place the extesion table later in the output, so may cause
issues as offsets grow large, but no more so than in the existing code.

In a better implementation all LookupType 9 subtables would be placed as
early as possible with the extension subtables referenced placed as
late as possible. An even better implementation would look at the
overall size of the subtables and output LookupType 9 subtables only
when needed.