### PR TITLE
Skip hb_shape if buffer object is immutable

### DIFF
--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -132,6 +132,8 @@ hb_shape_full (hb_font_t          *font,
 	       unsigned int        num_features,
 	       const char * const *shaper_list)
 {
+  if (unlikely (hb_object_is_immutable (buffer))) return false;
+
   hb_shape_plan_t *shape_plan = hb_shape_plan_create_cached2 (font->face, &buffer->props,
 							      features, num_features,
 							      font->coords, font->num_coords,

--- a/test/fuzzing/hb-shape-fuzzer.cc
+++ b/test/fuzzing/hb-shape-fuzzer.cc
@@ -35,8 +35,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     hb_buffer_t *buffer = hb_buffer_create ();
     hb_buffer_add_utf8 (buffer, text, -1, 0, -1);
     hb_buffer_guess_segment_properties (buffer);
-    if (hb_buffer_get_content_type (buffer) != HB_BUFFER_CONTENT_TYPE_INVALID)
-      hb_shape (font, buffer, nullptr, 0);
+    hb_shape (font, buffer, nullptr, 0);
     hb_buffer_destroy (buffer);
   }
 
@@ -53,8 +52,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   hb_buffer_t *buffer = hb_buffer_create ();
   hb_buffer_add_utf32 (buffer, text32, sizeof (text32) / sizeof (text32[0]), 0, -1);
   hb_buffer_guess_segment_properties (buffer);
-  if (hb_buffer_get_content_type (buffer) != HB_BUFFER_CONTENT_TYPE_INVALID)
-    hb_shape (font, buffer, nullptr, 0);
+  hb_shape (font, buffer, nullptr, 0);
   hb_buffer_destroy (buffer);
 
   hb_font_destroy (font);


### PR DESCRIPTION
@khaledhosny does it make sense? Maybe doesn't worth it as it is highly unlikely or maybe not? Please have a look. Thanks!