### PR TITLE
Bring back cmake config support but declare it as deprecated

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ hb_version_micro = hb_version_arr[2].to_int()
 
 # libtool versioning
 hb_version_int = hb_version_major*10000 + hb_version_minor*100 + hb_version_micro
+hb_libtool_version_info = '@0@:0:@0@'.format(hb_version_int)
 
 pkgmod = import('pkgconfig')
 cpp = meson.get_compiler('cpp')

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,6 @@ hb_version_micro = hb_version_arr[2].to_int()
 
 # libtool versioning
 hb_version_int = hb_version_major*10000 + hb_version_minor*100 + hb_version_micro
-hb_libtool_version_info = '@0@:0:@0@'.format(hb_version_int)
 
 pkgmod = import('pkgconfig')
 cpp = meson.get_compiler('cpp')

--- a/src/harfbuzz-config.cmake.in
+++ b/src/harfbuzz-config.cmake.in
@@ -1,0 +1,86 @@
+# Set these variables so that the `${prefix}/lib` expands to something we can
+# remove.
+set(_harfbuzz_remove_string "REMOVE_ME")
+set(exec_prefix "${_harfbuzz_remove_string}")
+set(prefix "${_harfbuzz_remove_string}")
+
+# Compute the installation prefix by stripping components from our current
+# location.
+get_filename_component(_harfbuzz_prefix "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+get_filename_component(_harfbuzz_prefix "${_harfbuzz_prefix}" DIRECTORY)
+set(_harfbuzz_libdir "@libdir@")
+string(REPLACE "${_harfbuzz_remove_string}/" "" _harfbuzz_libdir "${_harfbuzz_libdir}")
+set(_harfbuzz_libdir_iter "${_harfbuzz_libdir}")
+while (_harfbuzz_libdir_iter)
+  set(_harfbuzz_libdir_prev_iter "${_harfbuzz_libdir_iter}")
+  get_filename_component(_harfbuzz_libdir_iter "${_harfbuzz_libdir_iter}" DIRECTORY)
+  if (_harfbuzz_libdir_prev_iter STREQUAL _harfbuzz_libdir_iter)
+    break()
+  endif ()
+  get_filename_component(_harfbuzz_prefix "${_harfbuzz_prefix}" DIRECTORY)
+endwhile ()
+unset(_harfbuzz_libdir_iter)
+
+# Get the include subdir.
+set(_harfbuzz_includedir "@includedir@")
+string(REPLACE "${_harfbuzz_remove_string}/" "" _harfbuzz_includedir "${_harfbuzz_includedir}")
+
+# Extract version information from libtool.
+set(_harfbuzz_version_info "@HB_LIBTOOL_VERSION_INFO@")
+string(REPLACE ":" ";" _harfbuzz_version_info "${_harfbuzz_version_info}")
+list(GET _harfbuzz_version_info 0
+  _harfbuzz_current)
+list(GET _harfbuzz_version_info 1
+  _harfbuzz_revision)
+list(GET _harfbuzz_version_info 2
+  _harfbuzz_age)
+unset(_harfbuzz_version_info)
+
+if (APPLE)
+  set(_harfbuzz_lib_suffix ".0${CMAKE_SHARED_LIBRARY_SUFFIX}")
+elseif (UNIX)
+  set(_harfbuzz_lib_suffix "${CMAKE_SHARED_LIBRARY_SUFFIX}.0.${_harfbuzz_current}.${_harfbuzz_revision}")
+else ()
+  # Unsupported.
+  set(harfbuzz_FOUND 0)
+endif ()
+
+# Add the libraries.
+add_library(harfbuzz::harfbuzz SHARED IMPORTED)
+set_target_properties(harfbuzz::harfbuzz PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_prefix}/${_harfbuzz_includedir}/harfbuzz"
+  IMPORTED_LOCATION "${_harfbuzz_prefix}/${_harfbuzz_libdir}/libharfbuzz${_harfbuzz_lib_suffix}")
+
+add_library(harfbuzz::icu SHARED IMPORTED)
+set_target_properties(harfbuzz::icu PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_prefix}/${_harfbuzz_includedir}/harfbuzz"
+  INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
+  IMPORTED_LOCATION "${_harfbuzz_prefix}/${_harfbuzz_libdir}/libharfbuzz-icu${_harfbuzz_lib_suffix}")
+
+add_library(harfbuzz::subset SHARED IMPORTED)
+set_target_properties(harfbuzz::subset PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_prefix}/${_harfbuzz_includedir}/harfbuzz"
+  INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
+  IMPORTED_LOCATION "${_harfbuzz_prefix}/${_harfbuzz_libdir}/libharfbuzz-subset${_harfbuzz_lib_suffix}")
+
+# Only add the gobject library if it was built.
+set(_harfbuzz_have_gobject "@have_gobject@")
+if (_harfbuzz_have_gobject)
+  add_library(harfbuzz::gobject SHARED IMPORTED)
+  set_target_properties(harfbuzz::gobject PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_prefix}/${_harfbuzz_includedir}/harfbuzz"
+    INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
+    IMPORTED_LOCATION "${_harfbuzz_prefix}/${_harfbuzz_libdir}/libharfbuzz-gobject${_harfbuzz_lib_suffix}")
+endif ()
+
+# Clean out variables we used in our scope.
+unset(_harfbuzz_lib_suffix)
+unset(_harfbuzz_current)
+unset(_harfbuzz_revision)
+unset(_harfbuzz_age)
+unset(_harfbuzz_includedir)
+unset(_harfbuzz_libdir)
+unset(_harfbuzz_prefix)
+unset(exec_prefix)
+unset(prefix)
+unset(_harfbuzz_remove_string)

--- a/src/harfbuzz-config.cmake.in
+++ b/src/harfbuzz-config.cmake.in
@@ -4,6 +4,8 @@ set(_harfbuzz_remove_string "REMOVE_ME")
 set(exec_prefix "${_harfbuzz_remove_string}")
 set(prefix "${_harfbuzz_remove_string}")
 
+warning("Finding HarfBuzz through cmake config is deprecated, please use a pkg-config based solution one.")
+
 # Compute the installation prefix by stripping components from our current
 # location.
 get_filename_component(_harfbuzz_prefix "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)

--- a/src/harfbuzz-config.cmake.in
+++ b/src/harfbuzz-config.cmake.in
@@ -25,21 +25,10 @@ unset(_harfbuzz_libdir_iter)
 set(_harfbuzz_includedir "@includedir@")
 string(REPLACE "${_harfbuzz_remove_string}/" "" _harfbuzz_includedir "${_harfbuzz_includedir}")
 
-# Extract version information from libtool.
-set(_harfbuzz_version_info "@HB_LIBTOOL_VERSION_INFO@")
-string(REPLACE ":" ";" _harfbuzz_version_info "${_harfbuzz_version_info}")
-list(GET _harfbuzz_version_info 0
-  _harfbuzz_current)
-list(GET _harfbuzz_version_info 1
-  _harfbuzz_revision)
-list(GET _harfbuzz_version_info 2
-  _harfbuzz_age)
-unset(_harfbuzz_version_info)
-
 if (APPLE)
   set(_harfbuzz_lib_suffix ".0${CMAKE_SHARED_LIBRARY_SUFFIX}")
 elseif (UNIX)
-  set(_harfbuzz_lib_suffix "${CMAKE_SHARED_LIBRARY_SUFFIX}.0.${_harfbuzz_current}.${_harfbuzz_revision}")
+  set(_harfbuzz_lib_suffix "${CMAKE_SHARED_LIBRARY_SUFFIX}.0.@HB_VERSION@.0")
 else ()
   # Unsupported.
   set(harfbuzz_FOUND 0)
@@ -75,9 +64,6 @@ endif ()
 
 # Clean out variables we used in our scope.
 unset(_harfbuzz_lib_suffix)
-unset(_harfbuzz_current)
-unset(_harfbuzz_revision)
-unset(_harfbuzz_age)
 unset(_harfbuzz_includedir)
 unset(_harfbuzz_libdir)
 unset(_harfbuzz_prefix)

--- a/src/harfbuzz-config.cmake.in
+++ b/src/harfbuzz-config.cmake.in
@@ -25,10 +25,11 @@ unset(_harfbuzz_libdir_iter)
 set(_harfbuzz_includedir "@includedir@")
 string(REPLACE "${_harfbuzz_remove_string}/" "" _harfbuzz_includedir "${_harfbuzz_includedir}")
 
+set(_harfbuzz_version "@HB_VERSION@")
 if (APPLE)
   set(_harfbuzz_lib_suffix ".0${CMAKE_SHARED_LIBRARY_SUFFIX}")
 elseif (UNIX)
-  set(_harfbuzz_lib_suffix "${CMAKE_SHARED_LIBRARY_SUFFIX}.0.@HB_VERSION@.0")
+  set(_harfbuzz_lib_suffix "${CMAKE_SHARED_LIBRARY_SUFFIX}.0.${_harfbuzz_version}.0")
 else ()
   # Unsupported.
   set(harfbuzz_FOUND 0)
@@ -40,17 +41,21 @@ set_target_properties(harfbuzz::harfbuzz PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_prefix}/${_harfbuzz_includedir}/harfbuzz"
   IMPORTED_LOCATION "${_harfbuzz_prefix}/${_harfbuzz_libdir}/libharfbuzz${_harfbuzz_lib_suffix}")
 
-add_library(harfbuzz::icu SHARED IMPORTED)
-set_target_properties(harfbuzz::icu PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_prefix}/${_harfbuzz_includedir}/harfbuzz"
-  INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
-  IMPORTED_LOCATION "${_harfbuzz_prefix}/${_harfbuzz_libdir}/libharfbuzz-icu${_harfbuzz_lib_suffix}")
-
 add_library(harfbuzz::subset SHARED IMPORTED)
 set_target_properties(harfbuzz::subset PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_prefix}/${_harfbuzz_includedir}/harfbuzz"
   INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
   IMPORTED_LOCATION "${_harfbuzz_prefix}/${_harfbuzz_libdir}/libharfbuzz-subset${_harfbuzz_lib_suffix}")
+
+# Only add the icu library if it was built.
+set(_harfbuzz_have_icu "@have_icu@")
+if (_harfbuzz_have_icu)
+  add_library(harfbuzz::icu SHARED IMPORTED)
+  set_target_properties(harfbuzz::icu PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_prefix}/${_harfbuzz_includedir}/harfbuzz"
+    INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
+    IMPORTED_LOCATION "${_harfbuzz_prefix}/${_harfbuzz_libdir}/libharfbuzz-icu${_harfbuzz_lib_suffix}")
+endif ()
 
 # Only add the gobject library if it was built.
 set(_harfbuzz_have_gobject "@have_gobject@")
@@ -63,6 +68,9 @@ if (_harfbuzz_have_gobject)
 endif ()
 
 # Clean out variables we used in our scope.
+unset(_harfbuzz_version)
+unset(_harfbuzz_have_icu)
+unset(_harfbuzz_have_gobject)
 unset(_harfbuzz_lib_suffix)
 unset(_harfbuzz_includedir)
 unset(_harfbuzz_libdir)

--- a/src/meson.build
+++ b/src/meson.build
@@ -562,6 +562,16 @@ endif
 
 have_gobject = conf.get('HAVE_GOBJECT', 0) == 1
 
+cmake_config = configuration_data()
+cmake_config.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
+cmake_config.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
+cmake_config.set('HB_LIBTOOL_VERSION_INFO', hb_libtool_version_info)
+cmake_config.set('have_gobject', have_gobject ? 'true' : 'false')
+configure_file(input: 'harfbuzz-config.cmake.in',
+  output: 'harfbuzz-config.cmake',
+  configuration: cmake_config,
+  install_dir: get_option('libdir') / 'cmake' / 'harfbuzz')
+
 libharfbuzz_gobject_dep = null_dep
 if have_gobject
   gnome = import('gnome')

--- a/src/meson.build
+++ b/src/meson.build
@@ -566,6 +566,7 @@ cmake_config = configuration_data()
 cmake_config.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
 cmake_config.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
 cmake_config.set('HB_VERSION', '@0@'.format(hb_version_int))
+cmake_config.set('have_icu', have_icu and not have_icu_builtin ? 'true' : 'false')
 cmake_config.set('have_gobject', have_gobject ? 'true' : 'false')
 configure_file(input: 'harfbuzz-config.cmake.in',
   output: 'harfbuzz-config.cmake',

--- a/src/meson.build
+++ b/src/meson.build
@@ -565,7 +565,7 @@ have_gobject = conf.get('HAVE_GOBJECT', 0) == 1
 cmake_config = configuration_data()
 cmake_config.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
 cmake_config.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
-cmake_config.set('HB_LIBTOOL_VERSION_INFO', hb_libtool_version_info)
+cmake_config.set('HB_VERSION', '@0@'.format(hb_version_int))
 cmake_config.set('have_gobject', have_gobject ? 'true' : 'false')
 configure_file(input: 'harfbuzz-config.cmake.in',
   output: 'harfbuzz-config.cmake',


### PR DESCRIPTION
Reverts 75efa89

Just days ago I wanted to use harfbuzz in some cmake based project and I think when I used find_package(harfbuzz) I actually used this bit. Equally I fear many people are relying to this bit that's why am proposing this change.

This change brings back cmake config support only for meson build installs as I wanted to apply some optimizations also. Personally as I wanted to propose cmake as the main build system for HarfBuzz sometime, cmake isn't illegible to me and actually I used to like it so as the so called maintainer of the project am able to maintain this thing also but I just don't like issues like https://github.com/harfbuzz/harfbuzz/issues/2316 and https://github.com/harfbuzz/harfbuzz/issues/2597 popping out that's why I am declaring it as deprecated also (but that can be discussed also)

Let's discuss this first however, @mathstuf @lisyarus and @khaledhosny 