### PR TITLE
[ENOMEM] Return true from _plan_execute only if the buffer is valid

### DIFF
--- a/src/hb-shape-plan.cc
+++ b/src/hb-shape-plan.cc
@@ -383,7 +383,7 @@ hb_shape_plan_execute (hb_shape_plan_t    *shape_plan,
 		  shape_plan->key.shaper_name);
 
   if (unlikely (!buffer->len))
-    return true;
+    return buffer->content_type == HB_BUFFER_CONTENT_TYPE_UNICODE;
 
   assert (!hb_object_is_immutable (buffer));
   assert (buffer->content_type == HB_BUFFER_CONTENT_TYPE_UNICODE);

--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -132,8 +132,6 @@ hb_shape_full (hb_font_t          *font,
 	       unsigned int        num_features,
 	       const char * const *shaper_list)
 {
-  if (unlikely (hb_object_is_immutable (buffer))) return false;
-
   hb_shape_plan_t *shape_plan = hb_shape_plan_create_cached2 (font->face, &buffer->props,
 							      features, num_features,
 							      font->coords, font->num_coords,


### PR DESCRIPTION
An alternative fix to https://github.com/harfbuzz/harfbuzz/pull/2606

More details on https://github.com/harfbuzz/harfbuzz/pull/2606#issuecomment-670325875

We are modifying the null pool hosted `hb_buffer_t` (which happens when `hb_buffer_create` gets ENOMEM) by returning true from `hb_shape_plan_execute` which makes `if (res) buffer->content_type = HB_BUFFER_CONTENT_TYPE_GLYPHS;` of `hb_shape_full` be triggered. This changes  returns false on INVALID buffers (which includes null pool hosted `hb_buffer_t`).