### PR TITLE
Turn -Wunused-but-set-variable to warning

### DIFF
--- a/src/hb.hh
+++ b/src/hb.hh
@@ -107,6 +107,7 @@
 #pragma GCC diagnostic warning "-Wmaybe-uninitialized"
 #pragma GCC diagnostic warning "-Wmissing-format-attribute"
 #pragma GCC diagnostic warning "-Wundef"
+#pragma GCC diagnostic warning "-Wunused-but-set-variable"
 #endif
 
 /* Ignored currently, but should be fixed at some point. */


### PR DESCRIPTION
As #2555 turned out some glib headers are imposing that so let's turn it to warning

Fixes #2555