### PR TITLE
[fuzzer] Mark alloc_state as unused

### DIFF
--- a/test/fuzzing/hb-draw-fuzzer.cc
+++ b/test/fuzzing/hb-draw-fuzzer.cc
@@ -113,7 +113,7 @@ static void misc_calls_for_gid (hb_face_t *face, hb_font_t *font, hb_set_t *set,
   hb_ot_math_get_glyph_assembly (font, cp, HB_DIRECTION_BTT, 0, nullptr, nullptr, nullptr);
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 {
   alloc_state = size; /* see src/failing-alloc.c */
 

--- a/test/fuzzing/hb-fuzzer.hh
+++ b/test/fuzzing/hb-fuzzer.hh
@@ -3,10 +3,16 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
+#if defined(__GNUC__) && (__GNUC__ >= 4) || (__clang__)
+#define HB_UNUSED	__attribute__((unused))
+#else
+#define HB_UNUSED
+#endif
+
 #ifdef HB_IS_IN_FUZZER
 /* See src/failing-alloc.c */
 extern "C" int alloc_state;
 #else
 /* Just a dummy global variable */
-static int alloc_state = 0;
+static int HB_UNUSED alloc_state = 0;
 #endif

--- a/test/fuzzing/hb-fuzzer.hh
+++ b/test/fuzzing/hb-fuzzer.hh
@@ -1,7 +1,7 @@
 #include <hb.h>
 #include <stddef.h>
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size);
 
 #if defined(__GNUC__) && (__GNUC__ >= 4) || (__clang__)
 #define HB_UNUSED	__attribute__((unused))

--- a/test/fuzzing/hb-shape-fuzzer.cc
+++ b/test/fuzzing/hb-shape-fuzzer.cc
@@ -9,7 +9,7 @@
 #include "../api/test-ot-face.c"
 #undef TEST_OT_FACE_NO_MAIN
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 {
   alloc_state = size; /* see src/failing-alloc.c */
 

--- a/test/fuzzing/hb-subset-fuzzer.cc
+++ b/test/fuzzing/hb-subset-fuzzer.cc
@@ -29,9 +29,7 @@ trySubset (hb_face_t *face,
   }
 
   for (int i = 0; i < text_length; i++)
-  {
     hb_set_add (codepoints, text[i]);
-  }
 
   hb_face_t *result = hb_subset (face, input);
   {
@@ -65,16 +63,16 @@ trySubset (hb_face_t *face,
 	     drop_hints, drop_layout, retain_gids);
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 {
   alloc_state = size; /* see src/failing-alloc.c */
 
-  hb_blob_t *blob = hb_blob_create ((const char *)data, size,
+  hb_blob_t *blob = hb_blob_create ((const char *) data, size,
 				    HB_MEMORY_MODE_READONLY, nullptr, nullptr);
   hb_face_t *face = hb_face_create (blob, 0);
 
   /* Just test this API here quickly. */
-  hb_set_t *output = hb_set_create();
+  hb_set_t *output = hb_set_create ();
   hb_face_collect_unicodes (face, output);
   hb_set_destroy (output);
 
@@ -88,14 +86,14 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   trySubset (face, text, sizeof (text) / sizeof (hb_codepoint_t), flags);
 
   hb_codepoint_t text_from_data[16];
-  if (size > sizeof(text_from_data) + sizeof(flags)) {
+  if (size > sizeof (text_from_data) + sizeof (flags)) {
     memcpy (text_from_data,
-	    data + size - sizeof(text_from_data),
-	    sizeof(text_from_data));
+	    data + size - sizeof (text_from_data),
+	    sizeof (text_from_data));
 
     memcpy (flags,
-	    data + size - sizeof(text_from_data) - sizeof(flags),
-	    sizeof(flags));
+	    data + size - sizeof (text_from_data) - sizeof (flags),
+	    sizeof (flags));
     unsigned int text_size = sizeof (text_from_data) / sizeof (hb_codepoint_t);
 
     trySubset (face, text_from_data, text_size, flags);


### PR DESCRIPTION
It is really unused when failing-alloc isn't on.

As I use clang locally for sanitizer and things I didn't see it locally but in bot logs which use GCC so let's address it.