### PR TITLE
[meson] fix generating introspection

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -645,8 +645,9 @@ if have_gobject
 
   if build_gir
     conf.set('HAVE_INTROSPECTION', 1)
-    hb_gen_files_gir = gnome.generate_gir(libharfbuzz, libharfbuzz_gobject,
+    hb_gen_files_gir = gnome.generate_gir(libharfbuzz_gobject,
       sources: [hb_headers, hb_sources, hb_gobject_headers, hb_gobject_sources, enum_h],
+      dependencies: libharfbuzz_dep,
       namespace: 'HarfBuzz',
       nsversion: '0.0',
       identifier_prefix: 'hb_',


### PR DESCRIPTION
Facing problems generating introspection files during the macOS build of
harfbuzz on conda-forge, inspired me to come up with this fix.

Only libharfbuzz_gobject is introspectable, not libharfbuzz. Therefore,
it makes no sense to target the latter for introspection: it should
instead be listed as a dependency.