### PR TITLE
[meson] Make compatbile with 0.47.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,8 @@ jobs:
       - image: alpine
     steps:
       - checkout
-      - run: apk update && apk add ragel meson gcc g++ glib-dev freetype-dev cairo-dev git
+      - run: apk update && apk add ragel gcc g++ glib-dev freetype-dev cairo-dev git py3-pip ninja
+      - run: pip3 install meson==0.49.0
       - run: meson build --buildtype=minsize
       - run: ninja -Cbuild -j9
       - run: meson test -Cbuild --print-errorlogs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
       - checkout
       - run: apk update && apk add ragel gcc g++ glib-dev freetype-dev cairo-dev git py3-pip ninja
-      - run: pip3 install meson==0.49.0
+      - run: pip3 install meson==0.47.0
       - run: meson build --buildtype=minsize
       - run: ninja -Cbuild -j9
       - run: meson test -Cbuild --print-errorlogs

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -52,8 +52,8 @@ endif
 
 gnome.gtkdoc('harfbuzz',
   main_sgml: 'harfbuzz-docs.xml',
-  src_dir: [meson.current_source_dir() / '..',
-            meson.current_build_dir() / '..',
+  src_dir: [join_paths(meson.current_source_dir(), '..'),
+            join_paths(meson.current_build_dir(), '..'),
            ],
   scan_args: ['--deprecated-guards=HB_DISABLE_DEPRECATED',
               '--ignore-decorators=HB_EXTERN',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('harfbuzz', 'c', 'cpp',
-  meson_version: '>= 0.49.0',
+  meson_version: '>= 0.47.0',
   version: '2.7.0',
   default_options: [
     'cpp_eh=none',          # Just to support msvc, we are passing -fno-rtti also anyway
@@ -348,12 +348,16 @@ if not get_option('tests').disabled()
   subdir('test')
 endif
 
-if (not get_option('benchmark').disabled() and
-    get_option('wrap_mode') != 'nodownload' and
-    host_machine.system() != 'windows' and
-    not meson.is_subproject() and
-    not meson.is_cross_build())
-  subdir('perf')
+# get_option('wrap_mode') isn't available in <0.49 and this
+# is just an internal tool
+if meson.version().version_compare('>=0.49')
+  if (not get_option('benchmark').disabled() and
+      get_option('wrap_mode') != 'nodownload' and
+      host_machine.system() != 'windows' and
+      not meson.is_subproject() and
+      not meson.is_cross_build())
+    subdir('perf')
+  endif
 endif
 
 if not get_option('docs').disabled()

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('harfbuzz', 'c', 'cpp',
-  meson_version: '>= 0.53.0',
+  meson_version: '>= 0.49.0',
   version: '2.7.0',
   default_options: [
     'cpp_eh=none',          # Just to support msvc, we are passing -fno-rtti also anyway
@@ -107,7 +107,12 @@ if not get_option('icu').disabled()
   endif
 
   if not icu_dep.found() and cpp.get_id() == 'msvc'
-    icu_dep = cpp.find_library(get_option('buildtype') == 'debug' ? 'icuucd' : 'icuuc',
+    if get_option('buildtype') == 'debug'
+      icu_dep_name = 'icuucd'
+    else
+      icu_dep_name = 'icuuc'
+    endif
+    icu_dep = cpp.find_library(icu_dep_name,
                                required: get_option('icu'),
                                has_headers: ['unicode/uchar.h',
                                              'unicode/unorm2.h',
@@ -142,10 +147,10 @@ if not get_option('cairo').disabled()
     if cairo_dep.type_name() == 'internal'
       # It is true at least for the port we have
       cairo_ft_dep = cairo_dep
-    elif cairo_dep.type_name() == 'library' and \
-         cpp.has_function('cairo_ft_font_face_create_for_ft_face',
-                          prefix: '#include <cairo-ft.h>',
-                          dependencies: cairo_dep)
+    elif (cairo_dep.type_name() == 'library' and
+          cpp.has_function('cairo_ft_font_face_create_for_ft_face',
+                           prefix: '#include <cairo-ft.h>',
+                           dependencies: cairo_dep))
       cairo_ft_dep = cairo_dep
     else # including the most important type for us, 'pkgconfig'
       cairo_ft_dep = dependency('cairo-ft', required: get_option('cairo'))
@@ -343,11 +348,11 @@ if not get_option('tests').disabled()
   subdir('test')
 endif
 
-if not get_option('benchmark').disabled() and \
-    get_option('wrap_mode') != 'nodownload' and \
-    host_machine.system() != 'windows' and \
-    not meson.is_subproject() and \
-    not meson.is_cross_build()
+if (not get_option('benchmark').disabled() and
+    get_option('wrap_mode') != 'nodownload' and
+    host_machine.system() != 'windows' and
+    not meson.is_subproject() and
+    not meson.is_cross_build())
   subdir('perf')
 endif
 
@@ -357,28 +362,53 @@ endif
 
 configure_file(output: 'config.h', configuration: conf)
 
-summary({'prefix': get_option('prefix'),
-         'bindir': get_option('bindir'),
-         'libdir': get_option('libdir'),
-         'includedir': get_option('includedir'),
-         'datadir': get_option('datadir'),
-        }, section: 'Directories')
-summary({'Builtin': true,
-         'Glib': conf.get('HAVE_GLIB', 0) == 1,
-         'ICU': conf.get('HAVE_ICU', 0) == 1,
-        }, bool_yn: true, section: 'Unicode callbacks (you want at least one)')
-summary({'FreeType': conf.get('HAVE_FREETYPE', 0) == 1,
-        }, bool_yn: true, section: 'Font callbacks (the more the merrier)')
-summary({'Cairo': conf.get('HAVE_CAIRO', 0) == 1,
-         'Fontconfig': conf.get('HAVE_FONTCONFIG', 0) == 1,
-        }, bool_yn: true, section: 'Dependencies used for command-line utilities')
-summary({'Graphite2': conf.get('HAVE_GRAPHITE2', 0) == 1,
-        }, bool_yn: true, section: 'Additional shapers')
-summary({'CoreText': conf.get('HAVE_CORETEXT', 0) == 1,
-         'DirectWrite': conf.get('HAVE_DIRECTWRITE', 0) == 1,
-         'GDI/Uniscribe': (conf.get('HAVE_GDI', 0) == 1) and (conf.get('HAVE_UNISCRIBE', 0) == 1),
-        }, bool_yn: true, section: 'Platform shapers (not normally needed)')
-summary({'Documentation': conf.get('HAVE_GTK_DOC', 0) == 1,
-         'GObject bindings': conf.get('HAVE_GOBJECT', 0) == 1,
-         'Introspection': conf.get('HAVE_INTROSPECTION', 0) == 1,
-        }, bool_yn: true, section: 'Other features')
+build_summary = {
+  'Directories':
+    {'prefix': get_option('prefix'),
+     'bindir': get_option('bindir'),
+     'libdir': get_option('libdir'),
+     'includedir': get_option('includedir'),
+     'datadir': get_option('datadir'),
+    },
+  'Unicode callbacks (you want at least one)':
+    {'Builtin': true,
+     'Glib': conf.get('HAVE_GLIB', 0) == 1,
+     'ICU': conf.get('HAVE_ICU', 0) == 1,
+    },
+  'Font callbacks (the more the merrier)':
+    {'FreeType': conf.get('HAVE_FREETYPE', 0) == 1,
+    },
+  'Dependencies used for command-line utilities':
+    {'Cairo': conf.get('HAVE_CAIRO', 0) == 1,
+     'Fontconfig': conf.get('HAVE_FONTCONFIG', 0) == 1,
+    },
+  'Additional shapers':
+    {'Graphite2': conf.get('HAVE_GRAPHITE2', 0) == 1,
+    },
+  'Platform shapers (not normally needed)':
+    {'CoreText': conf.get('HAVE_CORETEXT', 0) == 1,
+     'DirectWrite': conf.get('HAVE_DIRECTWRITE', 0) == 1,
+     'GDI/Uniscribe': (conf.get('HAVE_GDI', 0) == 1) and (conf.get('HAVE_UNISCRIBE', 0) == 1),
+    },
+  'Other features':
+    {'Documentation': conf.get('HAVE_GTK_DOC', 0) == 1,
+     'GObject bindings': conf.get('HAVE_GOBJECT', 0) == 1,
+     'Introspection': conf.get('HAVE_INTROSPECTION', 0) == 1,
+    },
+}
+if meson.version().version_compare('>=0.53')
+  foreach section_title, section : build_summary
+    summary(section, bool_yn: true, section: section_title)
+  endforeach
+else
+  summary = ['']
+  foreach section_title, section : build_summary
+    summary += '  @0@:'.format(section_title)
+    foreach feature, value : section
+      summary += '    @0@:'.format(feature)
+      summary += '          @0@'.format(value)
+    endforeach
+    summary += ''
+  endforeach
+  message('\n'.join(summary))
+endif

--- a/meson.build
+++ b/meson.build
@@ -227,8 +227,12 @@ endif
 gdi_uniscribe_deps = []
 # GDI (Uniscribe) (Windows)
 if host_machine.system() == 'windows' and not get_option('gdi').disabled()
-  gdi_deps_found = cpp.has_header('usp10.h') and cpp.has_header('windows.h')
+  if (get_option('directwrite').enabled() and
+      not (cpp.has_header('usp10.h') and cpp.has_header('windows.h')))
+    error('GDI/Uniscribe was enabled explicitly, but required headers are missing.')
+  endif
 
+  gdi_deps_found = true
   foreach usplib : ['usp10', 'gdi32', 'rpcrt4']
     dep = cpp.find_library(usplib, required: get_option('gdi'))
     gdi_deps_found = gdi_deps_found and dep.found()

--- a/meson.build
+++ b/meson.build
@@ -77,9 +77,10 @@ freetype_dep = null_dep
 if not get_option('freetype').disabled()
   freetype_dep = dependency('freetype2', required: false)
 
-  if not freetype_dep.found() and cpp.get_id() == 'msvc'
-    freetype_dep = cpp.find_library('freetype', required: false,
-                                    has_headers: ['ft2build.h'])
+  if (not freetype_dep.found() and
+      cpp.get_id() == 'msvc' and
+      cpp.has_header('ft2build.h'))
+    freetype_dep = cpp.find_library('freetype', required: false)
   endif
 
   if not freetype_dep.found()
@@ -102,24 +103,23 @@ icu_dep = null_dep
 if not get_option('icu').disabled()
   icu_dep = dependency('icu-uc', required: false)
 
-  if not icu_dep.found() and get_option('icu').enabled()
-    icu_dep = dependency('icu-uc', required: cpp.get_id() != 'msvc')
+  if (not icu_dep.found() and
+      cpp.get_id() == 'msvc' and
+      cpp.has_header('unicode/uchar.h') and
+      cpp.has_header('unicode/unorm2.h') and
+      cpp.has_header('unicode/ustring.h') and
+      cpp.has_header('unicode/utf16.h') and
+      cpp.has_header('unicode/uversion.h') and
+      cpp.has_header('unicode/uscript.h'))
+    if get_option('buildtype') == 'debug'
+      icu_dep = cpp.find_library('icuucd', required: false)
+    else
+      icu_dep = cpp.find_library('icuuc', required: false)
+    endif
   endif
 
-  if not icu_dep.found() and cpp.get_id() == 'msvc'
-    if get_option('buildtype') == 'debug'
-      icu_dep_name = 'icuucd'
-    else
-      icu_dep_name = 'icuuc'
-    endif
-    icu_dep = cpp.find_library(icu_dep_name,
-                               required: get_option('icu'),
-                               has_headers: ['unicode/uchar.h',
-                                             'unicode/unorm2.h',
-                                             'unicode/ustring.h',
-                                             'unicode/utf16.h',
-                                             'unicode/uversion.h',
-                                             'unicode/uscript.h'])
+  if not icu_dep.found()
+    icu_dep = dependency('icu-uc', required: get_option('icu'))
   endif
 endif
 
@@ -128,9 +128,10 @@ cairo_ft_dep = null_dep
 if not get_option('cairo').disabled()
   cairo_dep = dependency('cairo', required: false)
 
-  if not cairo_dep.found() and cpp.get_id() == 'msvc'
-    cairo_dep = cpp.find_library('cairo', required: false,
-                                 has_headers: ['cairo.h'])
+  if (not cairo_dep.found() and
+      cpp.get_id() == 'msvc' and
+      cpp.has_header('cairo.h'))
+    cairo_dep = cpp.find_library('cairo', required: false)
   endif
 
   if not cairo_dep.found()
@@ -226,11 +227,10 @@ endif
 gdi_uniscribe_deps = []
 # GDI (Uniscribe) (Windows)
 if host_machine.system() == 'windows' and not get_option('gdi').disabled()
-  gdi_deps_found = true
+  gdi_deps_found = cpp.has_header('usp10.h') and cpp.has_header('windows.h')
 
   foreach usplib : ['usp10', 'gdi32', 'rpcrt4']
-    dep = cpp.find_library(usplib, required: get_option('gdi'),
-                           has_headers: ['usp10.h', 'windows.h'])
+    dep = cpp.find_library(usplib, required: get_option('gdi'))
     gdi_deps_found = gdi_deps_found and dep.found()
     gdi_uniscribe_deps += dep
   endforeach
@@ -244,8 +244,11 @@ endif
 # DirectWrite (Windows)
 directwrite_dep = null_dep
 if host_machine.system() == 'windows' and not get_option('directwrite').disabled()
-  directwrite_dep = cpp.find_library('dwrite', required: get_option('directwrite'),
-                                     has_headers: ['dwrite_1.h'])
+  if get_option('directwrite').enabled() and not cpp.has_header('dwrite_1.h')
+    error('DirectWrite was enabled explicitly, but required header is missing.')
+  endif
+
+  directwrite_dep = cpp.find_library('dwrite', required: get_option('directwrite'))
 
   if directwrite_dep.found()
     conf.set('HAVE_DIRECTWRITE', 1)

--- a/perf/meson.build
+++ b/perf/meson.build
@@ -24,4 +24,4 @@ benchmark('perf', executable('perf', 'perf.cc',
   include_directories: [incconfig, incsrc],
   link_with: [libharfbuzz],
   install: false,
-), workdir: meson.current_source_dir() / '..', timeout: 100)
+), workdir: join_paths(meson.current_source_dir(), '..'), timeout: 100)

--- a/perf/meson.build
+++ b/perf/meson.build
@@ -6,6 +6,12 @@ if get_option('experimental_api') and add_languages('rust', required: false, nat
   ttf_parser_dep = subproject('ttf-parser').get_variable('ttf_parser_dep')
 endif
 
+if ttf_parser_dep.found()
+  benchmark_cpp_args = ['-DHAVE_TTFPARSER']
+else
+  benchmark_cpp_args = []
+endif
+
 benchmark('perf', executable('perf', 'perf.cc',
   dependencies: [
     google_benchmark_dep, freetype_dep,
@@ -14,7 +20,7 @@ benchmark('perf', executable('perf', 'perf.cc',
     # https://github.com/RazrFalcon/ttf-parser/issues/29
     ttf_parser_dep, thread_dep, cpp.find_library('dl'),
   ],
-  cpp_args: ttf_parser_dep.found() ? ['-DHAVE_TTFPARSER'] : [],
+  cpp_args: benchmark_cpp_args,
   include_directories: [incconfig, incsrc],
   link_with: [libharfbuzz],
   install: false,

--- a/src/meson.build
+++ b/src/meson.build
@@ -488,21 +488,20 @@ if get_option('tests').enabled()
   endforeach
 
   compiled_tests = {
+    'test-algs': ['test-algs.cc', 'hb-static.cc'],
     'test-array': 'test-array.cc',
+    'test-iter': ['test-iter.cc', 'hb-static.cc'],
+    'test-meta': ['test-meta.cc', 'hb-static.cc'],
     'test-number': ['test-number.cc', 'hb-number.cc'],
     'test-ot-tag': 'hb-ot-tag.cc',
     'test-unicode-ranges': 'test-unicode-ranges.cc',
+    'test-bimap': ['test-bimap.cc', 'hb-static.cc'],
   }
-  if cpp.get_id() != 'msvc'
-    # TODO: MSVC doesn't like these, fix them
-    compiled_tests += {
-      'test-algs': ['test-algs.cc', 'hb-static.cc'],
-      'test-bimap': ['test-bimap.cc', 'hb-static.cc'],
-      'test-iter': ['test-iter.cc', 'hb-static.cc'],
-      'test-meta': ['test-meta.cc', 'hb-static.cc'],
-    }
-  endif
   foreach name, source : compiled_tests
+    if cpp.get_id() == 'msvc' and ['test-algs', 'test-bimap', 'test-iter', 'test-meta'].contains(name)
+      # TODO: MSVC doesn't like these, fix them
+      continue
+    endif
     test(name, executable(name, source,
       include_directories: incconfig,
       cpp_args: cpp_args + ['-DMAIN', '-UNDEBUG'],
@@ -577,7 +576,7 @@ cmake_config.set('have_gobject', have_gobject_string)
 configure_file(input: 'harfbuzz-config.cmake.in',
   output: 'harfbuzz-config.cmake',
   configuration: cmake_config,
-  install_dir: get_option('libdir') / 'cmake' / 'harfbuzz',
+  install_dir: join_paths(get_option('libdir'), 'cmake', 'harfbuzz'),
 )
 
 libharfbuzz_gobject_dep = null_dep
@@ -615,7 +614,7 @@ if have_gobject
     output: 'hb-gobject-enums.h',
     command: [find_program('fix_get_types.py'), '@INPUT@', '@OUTPUT@'],
     install: true,
-    install_dir: get_option('prefix') / get_option('includedir') / meson.project_name(),
+    install_dir: join_paths(get_option('prefix'), get_option('includedir'), meson.project_name()),
   )
 
   hb_gobject_sources += [enum_c]

--- a/src/meson.build
+++ b/src/meson.build
@@ -489,17 +489,17 @@ if get_option('tests').enabled()
 
   compiled_tests = {
     'test-algs': ['test-algs.cc', 'hb-static.cc'],
-    'test-array': 'test-array.cc',
+    'test-array': ['test-array.cc'],
     'test-iter': ['test-iter.cc', 'hb-static.cc'],
     'test-meta': ['test-meta.cc', 'hb-static.cc'],
     'test-number': ['test-number.cc', 'hb-number.cc'],
-    'test-ot-tag': 'hb-ot-tag.cc',
-    'test-unicode-ranges': 'test-unicode-ranges.cc',
+    'test-ot-tag': ['hb-ot-tag.cc'],
+    'test-unicode-ranges': ['test-unicode-ranges.cc'],
     'test-bimap': ['test-bimap.cc', 'hb-static.cc'],
   }
   foreach name, source : compiled_tests
-    if cpp.get_id() == 'msvc' and ['test-algs', 'test-bimap', 'test-iter', 'test-meta'].contains(name)
-      # TODO: MSVC doesn't like these, fix them
+    if cpp.get_id() == 'msvc' and source.contains('hb-static.cc')
+      # TODO: MSVC doesn't like tests having hb-static.cc, fix them
       continue
     endif
     test(name, executable(name, source,

--- a/src/meson.build
+++ b/src/meson.build
@@ -562,17 +562,11 @@ endif
 
 have_gobject = conf.get('HAVE_GOBJECT', 0) == 1
 
-if have_gobject
-  have_gobject_string = 'true'
-else
-  have_gobject_string = 'false'
-endif
-
 cmake_config = configuration_data()
 cmake_config.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
 cmake_config.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
 cmake_config.set('HB_LIBTOOL_VERSION_INFO', hb_libtool_version_info)
-cmake_config.set('have_gobject', have_gobject_string)
+cmake_config.set('have_gobject', '@0@'.format(have_gobject))
 configure_file(input: 'harfbuzz-config.cmake.in',
   output: 'harfbuzz-config.cmake',
   configuration: cmake_config,
@@ -677,15 +671,15 @@ if have_gobject
   endif
 
   if build_gir
-    gobject_sources = hb_gen_files_gir
+    libharfbuzz_gobject_sources = hb_gen_files_gir
   else
-    gobject_sources = hb_gobject_sources
+    libharfbuzz_gobject_sources = hb_gobject_sources
   endif
 
   libharfbuzz_gobject_dep = declare_dependency(
     link_with: libharfbuzz_gobject,
     include_directories: incsrc,
-    sources: gobject_sources,
+    sources: libharfbuzz_gobject_sources,
     dependencies: [glib_dep, gobject_dep])
 
   pkgmod.generate(libharfbuzz_gobject,

--- a/src/meson.build
+++ b/src/meson.build
@@ -563,15 +563,22 @@ endif
 
 have_gobject = conf.get('HAVE_GOBJECT', 0) == 1
 
+if have_gobject
+  have_gobject_string = 'true'
+else
+  have_gobject_string = 'false'
+endif
+
 cmake_config = configuration_data()
 cmake_config.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
 cmake_config.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
 cmake_config.set('HB_LIBTOOL_VERSION_INFO', hb_libtool_version_info)
-cmake_config.set('have_gobject', have_gobject ? 'true' : 'false')
+cmake_config.set('have_gobject', have_gobject_string)
 configure_file(input: 'harfbuzz-config.cmake.in',
   output: 'harfbuzz-config.cmake',
   configuration: cmake_config,
-  install_dir: get_option('libdir') / 'cmake' / 'harfbuzz')
+  install_dir: get_option('libdir') / 'cmake' / 'harfbuzz',
+)
 
 libharfbuzz_gobject_dep = null_dep
 if have_gobject
@@ -670,10 +677,16 @@ if have_gobject
                     '--cflags-end'])
   endif
 
+  if build_gir
+    gobject_sources = hb_gen_files_gir
+  else
+    gobject_sources = hb_gobject_sources
+  endif
+
   libharfbuzz_gobject_dep = declare_dependency(
     link_with: libharfbuzz_gobject,
     include_directories: incsrc,
-    sources: build_gir ? hb_gen_files_gir : hb_gobject_sources,
+    sources: gobject_sources,
     dependencies: [glib_dep, gobject_dep])
 
   pkgmod.generate(libharfbuzz_gobject,
@@ -721,10 +734,15 @@ if get_option('tests').enabled()
   endif
 
   foreach name : dist_check_script
+    if name == 'check-symbols'
+      test_depends = defs_list
+    else
+      test_depends = []
+    endif
     test(name, find_program(name + '.py'),
       env: env,
-      depends: name == 'check-symbols' ? defs_list : [],
-      suite: ['src'] + (name == 'check-static-inits' ? ['slow'] : []),
+      depends: test_depends,
+      suite: ['src'],
     )
   endforeach
 endif

--- a/test/fuzzing/meson.build
+++ b/test/fuzzing/meson.build
@@ -39,7 +39,7 @@ test('shape_fuzzer', find_program('run-shape-fuzzer-tests.py'),
   ],
   timeout: 60,
   depends: [hb_shape_fuzzer_exe, libharfbuzz, libharfbuzz_subset],
-  workdir: meson.current_build_dir() / '..' / '..',
+  workdir: join_paths(meson.current_build_dir(), '..', '..'),
   env: env,
   suite: ['fuzzing', 'slow'],
 )
@@ -51,7 +51,7 @@ test('subset_fuzzer', find_program('run-subset-fuzzer-tests.py'),
   # as the tests are ran concurrently let's raise acceptable time here
   # ideally better to break and let meson handles them in parallel
   timeout: 300,
-  workdir: meson.current_build_dir() / '..' / '..',
+  workdir: join_paths(meson.current_build_dir(), '..', '..'),
   env: env,
   suite: ['fuzzing', 'slow'],
 )
@@ -60,7 +60,7 @@ test('draw_fuzzer', find_program('run-draw-fuzzer-tests.py'),
   args: [
     hb_draw_fuzzer_exe,
   ],
-  workdir: meson.current_build_dir() / '..' / '..',
+  workdir: join_paths(meson.current_build_dir(), '..', '..'),
   env: env,
   suite: ['fuzzing'],
 )

--- a/test/shaping/meson.build
+++ b/test/shaping/meson.build
@@ -14,10 +14,10 @@ foreach file_name : in_house_tests
   test(test_name, shaping_run_tests_py,
     args: [
       hb_shape,
-      meson.current_source_dir() / 'data' / 'in-house' / 'tests' / file_name,
+      join_paths(meson.current_source_dir(), 'data', 'in-house', 'tests', file_name),
     ],
     env: env,
-    workdir: meson.current_build_dir() / '..' / '..',
+    workdir: join_paths(meson.current_build_dir(), '..', '..'),
     suite: ['shaping', 'in-house'],
   )
 endforeach
@@ -28,10 +28,10 @@ foreach file_name : aots_tests
   test(test_name, shaping_run_tests_py,
     args: [
       hb_shape,
-      meson.current_source_dir() / 'data' / 'aots' / 'tests' / file_name,
+      join_paths(meson.current_source_dir(), 'data', 'aots', 'tests', file_name),
     ],
     env: env,
-    workdir: meson.current_build_dir() / '..' / '..',
+    workdir: join_paths(meson.current_build_dir(), '..', '..'),
     suite: ['shaping', 'aots'],
   )
 endforeach
@@ -42,10 +42,10 @@ foreach file_name : text_rendering_tests
   test(test_name, shaping_run_tests_py,
     args: [
       hb_shape,
-      meson.current_source_dir() / 'data' / 'text-rendering-tests' / 'tests' / file_name,
+      join_paths(meson.current_source_dir(), 'data', 'text-rendering-tests', 'tests', file_name),
     ],
     env: env,
-    workdir: meson.current_build_dir() / '..' / '..',
+    workdir: join_paths(meson.current_build_dir(), '..', '..'),
     suite: ['shaping', 'text-rendering-tests'],
   )
 endforeach

--- a/test/subset/meson.build
+++ b/test/subset/meson.build
@@ -32,12 +32,12 @@ foreach t : tests
   test(t, run_test,
     args: [
       hb_subset,
-      meson.current_source_dir() / 'data' / 'tests' / fname,
+      join_paths(meson.current_source_dir(), 'data', 'tests', fname),
     ],
     # as the tests are ran concurrently let's raise acceptable time here
     # ideally better to break and let meson handles them in parallel
     timeout: 500,
-    workdir: meson.current_build_dir() / '..' / '..',
+    workdir: join_paths(meson.current_build_dir(), '..', '..'),
     suite: ['subset', 'slow'],
   )
 endforeach


### PR DESCRIPTION
Contains a just put together summary feature polyfill and ternary operator avoidance as fixed by meson in https://github.com/mesonbuild/meson/pull/5007 later

` / ` operator were added in 0.49 so removed the use and turned to `join_paths`

fribidi uses 0.48 https://github.com/fribidi/fribidi/blob/master/meson.build and with this we will get 0.47.0.

Tested in CI also to protected future regressions.

`-Doption={auto,enabled,disabled}` and meson dictionaries aren't supported before 0.47 so likely that can be considered a good stop.

`<0.53`:
```
  Directories:
    prefix:
          /usr/local
    bindir:
          bin
    libdir:
          lib
    includedir:
          include
    datadir:
          share

  Unicode callbacks (you want at least one):
    Builtin:
          true
    Glib:
          true
    ICU:
          true

  Font callbacks (the more the merrier):
    FreeType:
          true

  Dependencies used for command-line utilities:
    Cairo:
          true
    Fontconfig:
          true

  Additional shapers:
    Graphite2:
          false

  Platform shapers (not normally needed):
    CoreText:
          false
    DirectWrite:
          false
    GDI/Uniscribe:
          false

  Other features:
    Documentation:
          true
    GObject bindings:
          true
    Introspection:
          true
```

`>=0.53`:
```
  Directories
              prefix: /usr/local
              bindir: bin
              libdir: lib
          includedir: include
             datadir: share

  Unicode callbacks (you want at least one)
             Builtin: YES
                Glib: YES
                 ICU: YES

  Font callbacks (the more the merrier)
            FreeType: YES

  Dependencies used for command-line utilities
               Cairo: YES
          Fontconfig: YES

  Additional shapers
           Graphite2: NO

  Platform shapers (not normally needed)
            CoreText: NO
         DirectWrite: NO
       GDI/Uniscribe: NO

  Other features
       Documentation: YES
    GObject bindings: YES
       Introspection: YES

  Subprojects
    google-benchmark: YES
```