### PR TITLE
meson: add hb-version.h to dependencies correctly

### DIFF
--- a/src/gen-hb-version.py
+++ b/src/gen-hb-version.py
@@ -4,15 +4,15 @@
 
 import os, sys, shutil
 
-if len (sys.argv) < 5:
+if len (sys.argv) < 4:
 	sys.exit(__doc__)
 
 version = sys.argv[1]
 major, minor, micro = version.split (".")
 
 OUTPUT = sys.argv[2]
-CURRENT_SOURCE_DIR = sys.argv[3]
-INPUT = sys.argv[4]
+INPUT = sys.argv[3]
+CURRENT_SOURCE_DIR = os.path.dirname(INPUT)
 
 with open (INPUT, "r", encoding='utf-8') as template:
 	with open (OUTPUT, "wb") as output:

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,10 @@
+hb_version_h = configure_file(
+               command: [find_program('gen-hb-version.py'), meson.project_version(), '@OUTPUT@', '@INPUT@'],
+               input: 'hb-version.h.in',
+               output: 'hb-version.h',
+               install: true,
+               install_dir: join_paths(get_option('includedir'), meson.project_name()))
+
 # Base and default-included sources and headers
 hb_base_sources = files(
   'hb-aat-layout-ankr-table.hh',
@@ -214,9 +221,9 @@ hb_base_headers = files(
   'hb-shape.h',
   'hb-style.h',
   'hb-unicode.h',
-  'hb-version.h',
   'hb.h',
 )
+hb_base_headers += hb_version_h
 
 # Optional Sources and Headers with external deps
 
@@ -279,14 +286,6 @@ hb_gobject_sources = files(
 hb_gobject_headers = files(
   'hb-gobject.h',
   'hb-gobject-structs.h',
-)
-
-custom_target('hb-version.h',
-  build_by_default: true,
-  input: 'hb-version.h.in',
-  output: 'hb-version.h',
-  command: [find_program('gen-hb-version.py'), meson.project_version(),
-            '@OUTPUT@', '@INPUT@'],
 )
 
 ragel = find_program('ragel', required: false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -286,7 +286,7 @@ custom_target('hb-version.h',
   input: 'hb-version.h.in',
   output: 'hb-version.h',
   command: [find_program('gen-hb-version.py'), meson.project_version(),
-            '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],
+            '@OUTPUT@', '@INPUT@'],
 )
 
 ragel = find_program('ragel', required: false)


### PR DESCRIPTION
We need to make sure that the generator for hb-version.h is tracked as a
dependency, otherwise it can be re-generated too late causing compile
errors.

Closes #2667
