### PR TITLE
Disambiguate OT language system tags when the primary tag is not first

### DIFF
--- a/src/gen-tag-table.py
+++ b/src/gen-tag-table.py
@@ -1079,6 +1079,10 @@ def verify_disambiguation_dict ():
 			expect (ot_tag not in disambiguation, 'unnecessary disambiguation for OT tag: %s' % ot_tag)
 			if '-' in primary_tags[0]:
 				disambiguation[ot_tag] = primary_tags[0]
+			else:
+				first_tag = sorted (t for t in bcp_47_tags if t not in bcp_47.grandfathered and ot_tag in ot.from_bcp_47.get (t))[0]
+				if primary_tags[0] != first_tag:
+					disambiguation[ot_tag] = primary_tags[0]
 		elif len (primary_tags) == 0:
 			expect (ot_tag not in disambiguation, 'There is no possible valid disambiguation for %s' % ot_tag)
 		else:

--- a/src/hb-ot-tag-table.hh
+++ b/src/hb-ot-tag-table.hh
@@ -7,7 +7,7 @@
  * on files with these headers:
  *
  * <meta name="updated_at" content="2019-05-22 06:05 PM" />
- * File-Date: 2020-05-12
+ * File-Date: 2020-07-17
  */
 
 #ifndef HB_OT_TAG_TABLE_HH
@@ -2082,6 +2082,8 @@ hb_ot_ambiguous_tag_to_language (hb_tag_t tag)
     return hb_language_from_string ("hmn", -1);  /* Hmong */
   case HB_TAG('H','N','D',' '):  /* Hindko */
     return hb_language_from_string ("hnd", -1);  /* Southern Hindko */
+  case HB_TAG('H','Y','E',' '):  /* Armenian */
+    return hb_language_from_string ("hyw", -1);  /* Western Armenian */
   case HB_TAG('I','J','O',' '):  /* Ijo */
     return hb_language_from_string ("ijo", -1);  /* Ijo */
   case HB_TAG('I','N','U',' '):  /* Inuktitut */
@@ -2160,6 +2162,10 @@ hb_ot_ambiguous_tag_to_language (hb_tag_t tag)
     return hb_language_from_string ("tmh", -1);  /* Tamashek */
   case HB_TAG('T','N','E',' '):  /* Tundra Nenets */
     return hb_language_from_string ("yrk", -1);  /* Nenets */
+  case HB_TAG('T','O','D',' '):  /* Todo */
+    return hb_language_from_string ("xwo", -1);  /* Written Oirat */
+  case HB_TAG('T','W','I',' '):  /* Twi */
+    return hb_language_from_string ("tw", -1);  /* Twi */
   case HB_TAG('Z','H','H',' '):  /* Chinese, Hong Kong SAR */
     return hb_language_from_string ("zh-HK", -1);  /* Chinese; Hong Kong */
   case HB_TAG('Z','H','S',' '):  /* Chinese Simplified */

--- a/test/api/test-ot-tag.c
+++ b/test/api/test-ot-tag.c
@@ -306,6 +306,9 @@ test_ot_tag_language (void)
   test_language_two_way ("HAL", "cfm"); /* BCP47 and current ISO639-3 code for Halam/Falam Chin */
   test_tag_from_language ("HAL", "flm"); /* Retired ISO639-3 code for Halam/Falam Chin */
 
+  test_language_two_way ("HYE0", "hy");
+  test_language_two_way ("HYE", "hyw");
+
   test_tag_from_language ("QIN", "bgr"); /* Bawm Chin */
   test_tag_from_language ("QIN", "cbl"); /* Bualkhaw Chin */
   test_tag_from_language ("QIN", "cka"); /* Khumi Awa Chin */


### PR DESCRIPTION
'TWI ' has a single primary BCP 47 candidate ("tw"), so gen-tag-table.py treated it as unambiguous. However, 'TWI ' also has the non-primary candidate "ak", which alphabetically precedes it, so 'TWI ' was being converted to "ak". That is wrong.

'TWI ' is now converted to "tw". Similarly, 'HYE ' and 'TOD ' are now converted to "hyw" and "xwo". It is a bit odd to convert 'HYE ' (Armenian) to "hyw" (Western Armenian) instead of the more likely "hy" (Armenian, implicitly Eastern Armenian), but this is necessary to make the mapping bijective.