### PR TITLE
src/hb-gobject-enums.cc.tmpl: write out only the filename, not the full path

### DIFF
--- a/src/hb-gobject-enums.cc.tmpl
+++ b/src/hb-gobject-enums.cc.tmpl
@@ -43,7 +43,7 @@
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/
-/* enumerations from "@filename@" */
+/* enumerations from "@basename@" */
 /*** END file-production ***/
 
 /*** BEGIN file-tail ***/


### PR DESCRIPTION
This is beneficial for reproducible builds, as build paths can vary
between builds.