### PR TITLE
Post build artifacts from CI jobs

### DIFF
--- a/.ci/publish_release_artifact.sh
+++ b/.ci/publish_release_artifact.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+if [[ -z $GITHUB_TOKEN ]]; then
+	echo "No GITHUB_TOKEN secret found, artifact publishing skipped"
+	exit
+fi
+
+mkdir -p $HOME/.local/bin
+export _GHR_VER=v0.13.0
+export _GHR=ghr_${_GHR_VER}_linux_amd64
+curl -sfL https://github.com/tcnksm/ghr/releases/download/$_GHR_VER/$_GHR.tar.gz |
+	tar xz -C $HOME/.local/bin --strip-components=1 $_GHR/ghr
+
+ghr -replace \
+	-u $CIRCLE_PROJECT_USERNAME \
+	-r $CIRCLE_PROJECT_REPONAME \
+	$CIRCLE_TAG \
+	$1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ executors:
   win32-executor:
     docker:
       - image: cimg/base:edge-20.04
+  autotools-executor:
+    docker:
+      - image: cimg/base:edge-20.04
 
 jobs:
 
@@ -53,11 +56,10 @@ jobs:
 
   # will be dropped with autotools removal
   distcheck:
-    docker:
-      - image: ubuntu:20.04
+    executor: autotools-executor
     steps:
       - checkout
-      - run: apt update && DEBIAN_FRONTEND=noninteractive apt install -y git ninja-build binutils libtool autoconf automake make gcc g++ pkg-config ragel gtk-doc-tools libfontconfig1-dev libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip cmake
+      - run: sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y git ninja-build binutils libtool autoconf automake make gcc g++ pkg-config ragel gtk-doc-tools libfontconfig1-dev libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip cmake
       - run: pip3 install fonttools meson --upgrade
       - run: ./autogen.sh
       - run: make -j32

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
-version: 2
+version: 2.1
+
+executors:
+  win32-executor:
+    docker:
+      - image: cimg/base:edge-20.04
 
 jobs:
 
@@ -124,11 +129,10 @@ jobs:
       - run: clang -c src/hb-*.cc -DHB_NO_MT -Werror -Weverything -Wno-old-style-cast -Wno-documentation -Wno-documentation-unknown-command -Wno-c++98-compat -Wno-cast-qual -Wno-c++98-compat-pedantic -Wno-sign-conversion -Wno-padded -Wno-shorten-64-to-32 -Wno-reserved-id-macro -Wno-float-conversion -Wno-format-pedantic -Wno-shadow -Wno-conversion -Wno-zero-as-null-pointer-constant -Wno-missing-field-initializers -Wno-used-but-marked-unused -Wno-unused-macros -Wno-comma -Wno-float-equal -Wno-disabled-macro-expansion -Wno-weak-vtables -Wno-unused-parameter -Wno-covered-switch-default -Wno-unreachable-code -Wno-unused-template -DHB_WITH_WIN1256
 
   crossbuild-win32:
-    docker:
-      - image: ubuntu:20.04
+    executor: win32-executor
     steps:
       - checkout
-      - run: apt update && DEBIAN_FRONTEND=noninteractive apt install -y ninja-build binutils meson gcc g++ pkg-config ragel gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip git g++-mingw-w64-i686 zip
+      - run: sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y ninja-build binutils meson gcc g++ pkg-config ragel gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip git g++-mingw-w64-i686 zip
       - run: .ci/build-win32.sh
       - store_artifacts:
           path: harfbuzz-win32.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 
 jobs:
 
-  macos-10.12.6-aat-fonts:
+  macos-10_12_6-aat-fonts:
     macos:
       xcode: "9.0.1"
     steps:
@@ -21,7 +21,7 @@ jobs:
       - run: meson compile -Cbuild # or ninja -Cbuild
       - run: meson test -Cbuild --print-errorlogs
 
-  macos-10.13.6-aat-fonts:
+  macos-10_13_6-aat-fonts:
     macos:
       xcode: "10.1.0"
     steps:
@@ -32,7 +32,7 @@ jobs:
       - run: meson compile -Cbuild
       - run: meson test -Cbuild --print-errorlogs
 
-  macos-10.14.4-aat-fonts:
+  macos-10_14_4-aat-fonts:
     macos:
       xcode: "11.1.0"
     steps:
@@ -43,7 +43,7 @@ jobs:
       - run: meson compile -Cbuild
       - run: meson test -Cbuild --print-errorlogs
 
-  macos-10.15.3-aat-fonts:
+  macos-10_15_3-aat-fonts:
     macos:
       xcode: "11.4.0"
     steps:
@@ -170,10 +170,10 @@ workflows:
 
   build:
     jobs:
-      - macos-10.12.6-aat-fonts
-      - macos-10.13.6-aat-fonts
-      - macos-10.14.4-aat-fonts
-      - macos-10.15.3-aat-fonts
+      - macos-10_12_6-aat-fonts
+      - macos-10_13_6-aat-fonts
+      - macos-10_14_4-aat-fonts
+      - macos-10_15_3-aat-fonts
       - distcheck # will be dropped with autotools removal
       - publish-dist:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,9 +136,19 @@ jobs:
       - run: .ci/build-win32.sh
       - store_artifacts:
           path: harfbuzz-win32.zip
+      - persist_to_workspace:
+          root: .
+          paths: harfbuzz-win32.zip
+
+  publish-win32:
+    executor: win32-executor
+    steps:
+      - attach_workspace:
+          at: .
 
 workflows:
   version: 2
+
   build:
     jobs:
       - macos-10.12.6-aat-fonts
@@ -151,3 +161,11 @@ workflows:
       - archlinux
       - sanitizers
       - crossbuild-win32
+      - publish-win32:
+          requires:
+            - crossbuild-win32
+          filters:
+            tags:
+              only: /^\d+.\d+.\d+$/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,16 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - run: |
+          if [[ -n $GITHUB_TOKEN ]]; then
+            export _GHR=ghr_v0.13.0_linux_amd64
+            curl -sL https://github.com/tcnksm/ghr/releases/download/v0.13.0/$_GHR.tar.gz | tar xz --strip-components=1 $_GHR/ghr
+            mv harfbuzz-win32{,-$CIRCLE_TAG}.zip
+            echo TOKEN IS = $GITHUB_TOKEN
+            ./ghr -replace -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME $CIRCLE_TAG harfbuzz-win32-$CIRCLE_TAG.zip
+          else
+            echo "No GITHUB_TOKEN secret found, artifact publishing skipped"
+          fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,25 @@ jobs:
       - run: rm harfbuzz-* && make distdir
       - run: cd harfbuzz-* && meson build && ninja -Cbuild test
       - run: cd harfbuzz-* && cmake -Bcmakebuild -H. && cmake --build cmakebuild
+      - run: make dist
+      - persist_to_workspace:
+          root: .
+          paths: harfbuzz-*.tar.xz
+
+  publish-dist:
+    executor: autotools-executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run: |
+          if [[ -n $GITHUB_TOKEN ]]; then
+            export _GHR=ghr_v0.13.0_linux_amd64
+            curl -sL https://github.com/tcnksm/ghr/releases/download/v0.13.0/$_GHR.tar.gz | tar xz --strip-components=1 $_GHR/ghr
+            echo TOKEN IS = $GITHUB_TOKEN
+            ./ghr -replace -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME $CIRCLE_TAG harfbuzz-$CIRCLE_TAG.tar.xz
+          else
+            echo "No GITHUB_TOKEN secret found, artifact publishing skipped"
+          fi
 
   fedora-valgrind:
     docker:
@@ -168,6 +187,14 @@ workflows:
       - macos-10.14.4-aat-fonts
       - macos-10.15.3-aat-fonts
       - distcheck # will be dropped with autotools removal
+      - publish-dist:
+          requires:
+            - distcheck
+          filters:
+            tags:
+              only: /^\d+.\d+.\d+$/
+            branches:
+              ignore: /.*/
       - fedora-valgrind
       - alpine
       - archlinux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,17 +75,11 @@ jobs:
   publish-dist:
     executor: autotools-executor
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run: |
-          if [[ -n $GITHUB_TOKEN ]]; then
-            export _GHR=ghr_v0.13.0_linux_amd64
-            curl -sL https://github.com/tcnksm/ghr/releases/download/v0.13.0/$_GHR.tar.gz | tar xz --strip-components=1 $_GHR/ghr
-            echo TOKEN IS = $GITHUB_TOKEN
-            ./ghr -replace -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME $CIRCLE_TAG harfbuzz-$CIRCLE_TAG.tar.xz
-          else
-            echo "No GITHUB_TOKEN secret found, artifact publishing skipped"
-          fi
+          .ci/publish_release_artifact.sh harfbuzz-$CIRCLE_TAG.tar.xz
 
   fedora-valgrind:
     docker:
@@ -164,18 +158,12 @@ jobs:
   publish-win32:
     executor: win32-executor
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run: |
-          if [[ -n $GITHUB_TOKEN ]]; then
-            export _GHR=ghr_v0.13.0_linux_amd64
-            curl -sL https://github.com/tcnksm/ghr/releases/download/v0.13.0/$_GHR.tar.gz | tar xz --strip-components=1 $_GHR/ghr
-            mv harfbuzz-win32{,-$CIRCLE_TAG}.zip
-            echo TOKEN IS = $GITHUB_TOKEN
-            ./ghr -replace -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME $CIRCLE_TAG harfbuzz-win32-$CIRCLE_TAG.zip
-          else
-            echo "No GITHUB_TOKEN secret found, artifact publishing skipped"
-          fi
+          mv harfbuzz-win32{,-$CIRCLE_TAG}.zip
+          .ci/publish_release_artifact.sh harfbuzz-win32-$CIRCLE_TAG.zip
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,25 +174,31 @@ workflows:
       - macos-10_13_6-aat-fonts
       - macos-10_14_4-aat-fonts
       - macos-10_15_3-aat-fonts
-      - distcheck # will be dropped with autotools removal
+      - distcheck: # will be dropped with autotools removal
+          filters:
+            tags:
+              only: /^\d+.\d+.\d+$/
       - publish-dist:
           requires:
             - distcheck
           filters:
             tags:
-              only: /^\d+.\d+.\d+$/
+              only: /^\d+\.\d+\.\d+$/
             branches:
               ignore: /.*/
       - fedora-valgrind
       - alpine
       - archlinux
       - sanitizers
-      - crossbuild-win32
+      - crossbuild-win32:
+          filters:
+            tags:
+              only: /^\d+.\d+.\d+$/
       - publish-win32:
           requires:
             - crossbuild-win32
           filters:
             tags:
-              only: /^\d+.\d+.\d+$/
+              only: /^\d+\.\d+\.\d+$/
             branches:
               ignore: /.*/


### PR DESCRIPTION
Closes #2663.

...and more besides — in addition to posting the prebuilt Windows artifacts (`harfbuzz-win32-<version>.zip`) this also posts the autotools generated dist file (`harfbuz-<version>.tar.xz`).

See [this caveat](https://github.com/harfbuzz/harfbuzz/issues/2663#issuecomment-691089335) about the API token I currently configured in Circle CI.