### PR TITLE
More tracing

### DIFF
--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1881,7 +1881,7 @@ void hb_ot_map_t::substitute (const hb_ot_shape_plan_t *plan, hb_font_t *font, h
   GSUBProxy proxy (font->face);
   if (!buffer->message (font, "start table GSUB")) return;
   apply (proxy, plan, font, buffer);
-  (void)buffer->message (font, "end table GSUB");
+  (void) buffer->message (font, "end table GSUB");
 }
 
 void hb_ot_map_t::position (const hb_ot_shape_plan_t *plan, hb_font_t *font, hb_buffer_t *buffer) const
@@ -1889,7 +1889,7 @@ void hb_ot_map_t::position (const hb_ot_shape_plan_t *plan, hb_font_t *font, hb_
   GPOSProxy proxy (font->face);
   if (!buffer->message (font, "start table GPOS")) return;
   apply (proxy, plan, font, buffer);
-  (void)buffer->message (font, "end table GPOS");
+  (void) buffer->message (font, "end table GPOS");
 }
 
 void

--- a/src/hb-ot-shape-complex-indic.cc
+++ b/src/hb-ot-shape-complex-indic.cc
@@ -1013,7 +1013,7 @@ initial_reordering_indic (const hb_ot_shape_plan_t *plan,
 
   foreach_syllable (buffer, start, end)
     initial_reordering_syllable_indic (plan, font->face, buffer, start, end);
-  (void)buffer->message (font, "end reordering indic initial");
+  (void) buffer->message (font, "end reordering indic initial");
 }
 
 static void

--- a/src/hb-ot-shape-complex-indic.cc
+++ b/src/hb-ot-shape-complex-indic.cc
@@ -1491,7 +1491,7 @@ final_reordering_indic (const hb_ot_shape_plan_t *plan,
   if (buffer->message (font, "start reordering indic final")) {
     foreach_syllable (buffer, start, end)
       final_reordering_syllable_indic (plan, buffer, start, end);
-    buffer->message (font, "end reordering indic final");
+    (void) buffer->message (font, "end reordering indic final");
   }
 
   HB_BUFFER_DEALLOCATE_VAR (buffer, indic_category);

--- a/src/hb-ot-shape-complex-indic.cc
+++ b/src/hb-ot-shape-complex-indic.cc
@@ -1006,8 +1006,8 @@ initial_reordering_indic (const hb_ot_shape_plan_t *plan,
 			  hb_font_t *font,
 			  hb_buffer_t *buffer)
 {
-	if (!buffer->message (font, "start reordering indic initial"))
-		return;
+  if (!buffer->message (font, "start reordering indic initial"))
+    return;
   update_consonant_positions_indic (plan, font, buffer);
   insert_dotted_circles_indic (plan, font, buffer);
 
@@ -1488,10 +1488,10 @@ final_reordering_indic (const hb_ot_shape_plan_t *plan,
   unsigned int count = buffer->len;
   if (unlikely (!count)) return;
 
-	if (buffer->message (font, "start reordering indic final")) {
-	  foreach_syllable (buffer, start, end)
-	    final_reordering_syllable_indic (plan, buffer, start, end);
-	  buffer->message (font, "end reordering indic final");
+  if (buffer->message (font, "start reordering indic final")) {
+    foreach_syllable (buffer, start, end)
+      final_reordering_syllable_indic (plan, buffer, start, end);
+    buffer->message (font, "end reordering indic final");
   }
 
   HB_BUFFER_DEALLOCATE_VAR (buffer, indic_category);

--- a/src/hb-ot-shape-complex-indic.cc
+++ b/src/hb-ot-shape-complex-indic.cc
@@ -1006,11 +1006,14 @@ initial_reordering_indic (const hb_ot_shape_plan_t *plan,
 			  hb_font_t *font,
 			  hb_buffer_t *buffer)
 {
+	if (!buffer->message (font, "start reordering indic initial"))
+		return;
   update_consonant_positions_indic (plan, font, buffer);
   insert_dotted_circles_indic (plan, font, buffer);
 
   foreach_syllable (buffer, start, end)
     initial_reordering_syllable_indic (plan, font->face, buffer, start, end);
+  (void)buffer->message (font, "end reordering indic initial");
 }
 
 static void
@@ -1485,8 +1488,11 @@ final_reordering_indic (const hb_ot_shape_plan_t *plan,
   unsigned int count = buffer->len;
   if (unlikely (!count)) return;
 
-  foreach_syllable (buffer, start, end)
-    final_reordering_syllable_indic (plan, buffer, start, end);
+	if (buffer->message (font, "start reordering indic final")) {
+	  foreach_syllable (buffer, start, end)
+	    final_reordering_syllable_indic (plan, buffer, start, end);
+	  buffer->message (font, "end reordering indic final");
+  }
 
   HB_BUFFER_DEALLOCATE_VAR (buffer, indic_category);
   HB_BUFFER_DEALLOCATE_VAR (buffer, indic_position);

--- a/src/hb-ot-shape-complex-khmer.cc
+++ b/src/hb-ot-shape-complex-khmer.cc
@@ -394,7 +394,7 @@ reorder_khmer (const hb_ot_shape_plan_t *plan,
 
     foreach_syllable (buffer, start, end)
       reorder_syllable_khmer (plan, font->face, buffer, start, end);
-    (void)buffer->message (font, "end reordering khmer");
+    (void) buffer->message (font, "end reordering khmer");
   }
   HB_BUFFER_DEALLOCATE_VAR (buffer, khmer_category);
 }

--- a/src/hb-ot-shape-complex-khmer.cc
+++ b/src/hb-ot-shape-complex-khmer.cc
@@ -389,11 +389,13 @@ reorder_khmer (const hb_ot_shape_plan_t *plan,
 	       hb_font_t *font,
 	       hb_buffer_t *buffer)
 {
-  insert_dotted_circles_khmer (plan, font, buffer);
+  if (buffer->message (font, "start reordering khmer")) {
+    insert_dotted_circles_khmer (plan, font, buffer);
 
-  foreach_syllable (buffer, start, end)
-    reorder_syllable_khmer (plan, font->face, buffer, start, end);
-
+    foreach_syllable (buffer, start, end)
+      reorder_syllable_khmer (plan, font->face, buffer, start, end);
+    (void)buffer->message (font, "end reordering khmer");
+  }
   HB_BUFFER_DEALLOCATE_VAR (buffer, khmer_category);
 }
 

--- a/src/hb-ot-shape-complex-myanmar.cc
+++ b/src/hb-ot-shape-complex-myanmar.cc
@@ -332,7 +332,7 @@ reorder_myanmar (const hb_ot_shape_plan_t *plan,
 
     foreach_syllable (buffer, start, end)
       reorder_syllable_myanmar (plan, font->face, buffer, start, end);
-    buffer->message (font, "end reordering myanmar");
+    (void)buffer->message (font, "end reordering myanmar");
   }
 
   HB_BUFFER_DEALLOCATE_VAR (buffer, myanmar_category);

--- a/src/hb-ot-shape-complex-myanmar.cc
+++ b/src/hb-ot-shape-complex-myanmar.cc
@@ -332,7 +332,7 @@ reorder_myanmar (const hb_ot_shape_plan_t *plan,
 
     foreach_syllable (buffer, start, end)
       reorder_syllable_myanmar (plan, font->face, buffer, start, end);
-    (void)buffer->message (font, "end reordering myanmar");
+    (void) buffer->message (font, "end reordering myanmar");
   }
 
   HB_BUFFER_DEALLOCATE_VAR (buffer, myanmar_category);

--- a/src/hb-ot-shape-complex-myanmar.cc
+++ b/src/hb-ot-shape-complex-myanmar.cc
@@ -327,10 +327,13 @@ reorder_myanmar (const hb_ot_shape_plan_t *plan,
 		 hb_font_t *font,
 		 hb_buffer_t *buffer)
 {
-  insert_dotted_circles_myanmar (plan, font, buffer);
+  if (buffer->message (font, "start reordering myanmar")) {
+    insert_dotted_circles_myanmar (plan, font, buffer);
 
-  foreach_syllable (buffer, start, end)
-    reorder_syllable_myanmar (plan, font->face, buffer, start, end);
+    foreach_syllable (buffer, start, end)
+      reorder_syllable_myanmar (plan, font->face, buffer, start, end);
+    buffer->message (font, "end reordering myanmar");
+  }
 
   HB_BUFFER_DEALLOCATE_VAR (buffer, myanmar_category);
   HB_BUFFER_DEALLOCATE_VAR (buffer, myanmar_position);

--- a/src/hb-ot-shape-complex-use.cc
+++ b/src/hb-ot-shape-complex-use.cc
@@ -517,10 +517,14 @@ reorder_use (const hb_ot_shape_plan_t *plan,
 	     hb_font_t *font,
 	     hb_buffer_t *buffer)
 {
-  insert_dotted_circles_use (plan, font, buffer);
+	if (buffer->message (font, "start reordering USE")) {
+	  insert_dotted_circles_use (plan, font, buffer);
 
-  foreach_syllable (buffer, start, end)
-    reorder_syllable_use (buffer, start, end);
+	  foreach_syllable (buffer, start, end)
+	    reorder_syllable_use (buffer, start, end);
+
+	  (void)buffer->message (font, "end reordering USE");
+  }
 
   HB_BUFFER_DEALLOCATE_VAR (buffer, use_category);
 }

--- a/src/hb-ot-shape-complex-use.cc
+++ b/src/hb-ot-shape-complex-use.cc
@@ -523,7 +523,7 @@ reorder_use (const hb_ot_shape_plan_t *plan,
 	  foreach_syllable (buffer, start, end)
 	    reorder_syllable_use (buffer, start, end);
 
-	  (void)buffer->message (font, "end reordering USE");
+	  (void) buffer->message (font, "end reordering USE");
   }
 
   HB_BUFFER_DEALLOCATE_VAR (buffer, use_category);

--- a/src/hb-ot-shape-normalize.cc
+++ b/src/hb-ot-shape-normalize.cc
@@ -373,7 +373,7 @@ _hb_ot_shape_normalize (const hb_ot_shape_plan_t *plan,
 
   /* Second round, reorder (inplace) */
 
-  if (!all_simple)
+  if (!all_simple && buffer->message(font, "start reorder"))
   {
     count = buffer->len;
     for (unsigned int i = 0; i < count; i++)
@@ -399,6 +399,7 @@ _hb_ot_shape_normalize (const hb_ot_shape_plan_t *plan,
 
       i = end;
     }
+    (void) buffer->message(font, "end reorder");
   }
   if (buffer->scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_CGJ)
   {

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -902,7 +902,7 @@ hb_ot_substitute_post (const hb_ot_shape_context_t *c)
   if (c->plan->shaper->postprocess_glyphs &&
     c->buffer->message(c->font, "start postprocess-glyphs")) {
     c->plan->shaper->postprocess_glyphs (c->plan, c->buffer, c->font);
-    (void)c->buffer->message(c->font, "end postprocess-glyphs");
+    (void) c->buffer->message(c->font, "end postprocess-glyphs");
   }
 }
 
@@ -1129,7 +1129,7 @@ hb_ot_shape_internal (hb_ot_shape_context_t *c)
   if (c->plan->shaper->preprocess_text &&
     c->buffer->message(c->font, "start preprocess-text")) {
     c->plan->shaper->preprocess_text (c->plan, c->buffer, c->font);
-    (void)c->buffer->message(c->font, "end preprocess-text");
+    (void) c->buffer->message(c->font, "end preprocess-text");
   }
 
   hb_ot_substitute_pre (c);

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -851,7 +851,10 @@ hb_ot_substitute_default (const hb_ot_shape_context_t *c)
 
   HB_BUFFER_ALLOCATE_VAR (buffer, glyph_index);
 
-  _hb_ot_shape_normalize (c->plan, buffer, c->font);
+  if (buffer->message(c->font, "begin normalize")) {
+    _hb_ot_shape_normalize (c->plan, buffer, c->font);
+    buffer->message(c->font, "end normalize");
+  }
 
   hb_ot_shape_setup_masks (c);
 
@@ -896,8 +899,11 @@ hb_ot_substitute_post (const hb_ot_shape_context_t *c)
     hb_aat_layout_remove_deleted_glyphs (c->buffer);
 #endif
 
-  if (c->plan->shaper->postprocess_glyphs)
+  if (c->plan->shaper->postprocess_glyphs &&
+    c->buffer->message(c->font, "begin postprocess")) {
     c->plan->shaper->postprocess_glyphs (c->plan, c->buffer, c->font);
+    (void)c->buffer->message(c->font, "end postprocess");
+  }
 }
 
 
@@ -1120,8 +1126,11 @@ hb_ot_shape_internal (hb_ot_shape_context_t *c)
 
   hb_ensure_native_direction (c->buffer);
 
-  if (c->plan->shaper->preprocess_text)
+  if (c->plan->shaper->preprocess_text &&
+    c->buffer->message(c->font, "begin preprocess")) {
     c->plan->shaper->preprocess_text (c->plan, c->buffer, c->font);
+    (void)c->buffer->message(c->font, "end preprocess");
+  }
 
   hb_ot_substitute_pre (c);
   hb_ot_position (c);

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -851,10 +851,7 @@ hb_ot_substitute_default (const hb_ot_shape_context_t *c)
 
   HB_BUFFER_ALLOCATE_VAR (buffer, glyph_index);
 
-  if (buffer->message(c->font, "start normalize")) {
-    _hb_ot_shape_normalize (c->plan, buffer, c->font);
-    buffer->message(c->font, "end normalize");
-  }
+  _hb_ot_shape_normalize (c->plan, buffer, c->font);
 
   hb_ot_shape_setup_masks (c);
 

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -900,9 +900,9 @@ hb_ot_substitute_post (const hb_ot_shape_context_t *c)
 #endif
 
   if (c->plan->shaper->postprocess_glyphs &&
-    c->buffer->message(c->font, "start postprocess")) {
+    c->buffer->message(c->font, "start postprocess-glyphs")) {
     c->plan->shaper->postprocess_glyphs (c->plan, c->buffer, c->font);
-    (void)c->buffer->message(c->font, "end postprocess");
+    (void)c->buffer->message(c->font, "end postprocess-glyphs");
   }
 }
 
@@ -1127,9 +1127,9 @@ hb_ot_shape_internal (hb_ot_shape_context_t *c)
   hb_ensure_native_direction (c->buffer);
 
   if (c->plan->shaper->preprocess_text &&
-    c->buffer->message(c->font, "start preprocess")) {
+    c->buffer->message(c->font, "start preprocess-text")) {
     c->plan->shaper->preprocess_text (c->plan, c->buffer, c->font);
-    (void)c->buffer->message(c->font, "end preprocess");
+    (void)c->buffer->message(c->font, "end preprocess-text");
   }
 
   hb_ot_substitute_pre (c);

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -851,7 +851,7 @@ hb_ot_substitute_default (const hb_ot_shape_context_t *c)
 
   HB_BUFFER_ALLOCATE_VAR (buffer, glyph_index);
 
-  if (buffer->message(c->font, "begin normalize")) {
+  if (buffer->message(c->font, "start normalize")) {
     _hb_ot_shape_normalize (c->plan, buffer, c->font);
     buffer->message(c->font, "end normalize");
   }
@@ -900,7 +900,7 @@ hb_ot_substitute_post (const hb_ot_shape_context_t *c)
 #endif
 
   if (c->plan->shaper->postprocess_glyphs &&
-    c->buffer->message(c->font, "begin postprocess")) {
+    c->buffer->message(c->font, "start postprocess")) {
     c->plan->shaper->postprocess_glyphs (c->plan, c->buffer, c->font);
     (void)c->buffer->message(c->font, "end postprocess");
   }
@@ -1127,7 +1127,7 @@ hb_ot_shape_internal (hb_ot_shape_context_t *c)
   hb_ensure_native_direction (c->buffer);
 
   if (c->plan->shaper->preprocess_text &&
-    c->buffer->message(c->font, "begin preprocess")) {
+    c->buffer->message(c->font, "start preprocess")) {
     c->plan->shaper->preprocess_text (c->plan, c->buffer, c->font);
     (void)c->buffer->message(c->font, "end preprocess");
   }


### PR DESCRIPTION
Fixes #2683

```
$ ./util/hb-shape -V dalekh_si.ttf '<1a2f><1a6e><1a6c><1a65><1a41>'
trace: begin preprocess        buffer: [U+1A2F|U+1A6E|U+1A6C|U+1A65|U+1A41]
trace: end preprocess   buffer: [U+1A2F|U+1A6E|U+1A6C|U+1A65|U+1A41]
trace: begin normalize  buffer: [U+1A2F|U+1A6E|U+1A6C|U+1A65|U+1A41]
trace: end normalize    buffer: [U+1A2F|U+1A6E|U+1A6C|U+1A65|U+1A41]
trace: start table GSUB buffer: [uni1A2F=0|uni1A6E=0|uni1A6C=0|uni1A65=0|uni1A41=4]
...
trace: start reordering USE     buffer: [uni1A2F=0|uni1A6E=0|.notdef=0|uni1A6C=0|uni1A65=0|uni1A41=4]
trace: end reordering USE       buffer: [uni1A6E=0|uni1A2F=0|.notdef=0|uni1A6C=0|uni25CC=0|uni1A65=0|uni1A41=4]
```