### PR TITLE
[ci] Disable tests with MSVC for now

### DIFF
--- a/.github/workflows/msvc-ci.yml
+++ b/.github/workflows/msvc-ci.yml
@@ -45,6 +45,6 @@ jobs:
             -Ddirectwrite=enabled
 
           meson compile -C build
-      - name: Test
-        run: |
-          meson test --print-errorlogs --suite=harfbuzz -C build
+#     - name: Test
+#       run: |
+#         meson test --print-errorlogs --suite=harfbuzz -C build


### PR DESCRIPTION
They have been broken for enough time now and they just make all changes have broken CI builds and people are habitually ignoring other failures.