### PR TITLE
Revert "Fix get_baseline when `baseline_tag` does not exist"

### DIFF
--- a/src/hb-ot-layout-base-table.hh
+++ b/src/hb-ot-layout-base-table.hh
@@ -379,20 +379,12 @@ struct Axis
 		     const BaseCoord **coord) const
   {
     const BaseScript &base_script = (this+baseScriptList).get_base_script (script_tag);
-    if (!base_script.has_data ())
-    {
-      *coord = nullptr;
-      return false;
-    }
+    if (!base_script.has_data ()) return false;
 
     if (likely (coord))
     {
       unsigned int tag_index = 0;
-      if (!(this+baseTagList).bfind (baseline_tag, &tag_index))
-      {
-        *coord = nullptr;
-        return false;
-      }
+      if (!(this+baseTagList).bfind (baseline_tag, &tag_index)) return false;
       *coord = &base_script.get_base_coord (tag_index);
     }
 
@@ -406,11 +398,7 @@ struct Axis
 		    const BaseCoord **max_coord) const
   {
     const BaseScript &base_script = (this+baseScriptList).get_base_script (script_tag);
-    if (!base_script.has_data ())
-    {
-      *min_coord = *max_coord = nullptr;
-      return false;
-    }
+    if (!base_script.has_data ()) return false;
 
     base_script.get_min_max (language_tag).get_min_max (feature_tag, min_coord, max_coord);
 

--- a/src/hb-ot-layout-base-table.hh
+++ b/src/hb-ot-layout-base-table.hh
@@ -384,7 +384,7 @@ struct Axis
     if (likely (coord))
     {
       unsigned int tag_index = 0;
-      if (!(this+baseTagList).bfind (baseline_tag, &tag_index)) return false;
+      (this+baseTagList).bfind (baseline_tag, &tag_index);
       *coord = &base_script.get_base_coord (tag_index);
     }
 


### PR DESCRIPTION
Reverts harfbuzz/harfbuzz#2648

Lets see if this fixes #2697.