### PR TITLE
meson: Fix cairo_ft_dep when fontconfig is a subproject

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,8 @@ jobs:
     executor: win32-executor
     steps:
       - checkout
-      - run: sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y ninja-build binutils meson gcc g++ pkg-config gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip git g++-mingw-w64-i686 zip
+      - run: sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y ninja-build binutils gcc g++ pkg-config gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip git g++-mingw-w64-i686 zip
+      - run: pip3 install meson==0.56.0 --upgrade
       - run: .ci/build-win32.sh
       - store_artifacts:
           path: harfbuzz-win32.zip

--- a/meson.build
+++ b/meson.build
@@ -127,34 +127,31 @@ cairo_dep = null_dep
 cairo_ft_dep = null_dep
 if not get_option('cairo').disabled()
   cairo_dep = dependency('cairo', required: false)
+  cairo_ft_dep = dependency('cairo-ft', required: false)
 
   if (not cairo_dep.found() and
       cpp.get_id() == 'msvc' and
       cpp.has_header('cairo.h'))
     cairo_dep = cpp.find_library('cairo', required: false)
+    if cairo_dep.found() and cpp.has_function('cairo_ft_font_face_create_for_ft_face',
+                                              prefix: '#include <cairo-ft.h>',
+                                              dependencies: cairo_dep)
+      cairo_ft_dep = cairo_dep
+    endif
   endif
 
   if not cairo_dep.found()
-    # Note that we don't have harfbuzz -> cairo -> freetype2 -> harfbuzz fallback
-    # dependency cycle here because we have configured freetype2 above with
-    # harfbuzz support disabled, so when cairo will lookup freetype2 dependency
-    # it will be forced to use that one.
-    cairo_dep = dependency('cairo', fallback: ['cairo', 'libcairo_dep'],
-                           required: get_option('cairo'))
-  endif
-
-  # Ensure that cairo-ft is fetched from the same library as cairo itself
-  if cairo_dep.found()
-    if cairo_dep.type_name() == 'internal'
-      # It is true at least for the port we have
-      cairo_ft_dep = cairo_dep
-    elif (cairo_dep.type_name() == 'library' and
-          cpp.has_function('cairo_ft_font_face_create_for_ft_face',
-                           prefix: '#include <cairo-ft.h>',
-                           dependencies: cairo_dep))
-      cairo_ft_dep = cairo_dep
-    else # including the most important type for us, 'pkgconfig'
-      cairo_ft_dep = dependency('cairo-ft', required: get_option('cairo'))
+    # Requires Meson 0.54.0 to use cairo subproject
+    if meson.version().version_compare('>=0.54.0')
+      # Note that we don't have harfbuzz -> cairo -> freetype2 -> harfbuzz fallback
+      # dependency cycle here because we have configured freetype2 above with
+      # harfbuzz support disabled, so when cairo will lookup freetype2 dependency
+      # it will be forced to use that one.
+      cairo_dep = dependency('cairo', fallback: 'cairo', required: get_option('cairo'))
+      cairo_ft_dep = dependency('cairo-ft', fallback: 'cairo', required: get_option('cairo'))
+    elif get_option('cairo').enabled()
+      error('cairo feature is enabled but it cannot be found on the system and ' +
+            'meson>=0.54.0 is required to build it as subproject')
     endif
   endif
 endif

--- a/subprojects/cairo.wrap
+++ b/subprojects/cairo.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory=cairo
-url=https://github.com/ebraminio/cairo.git
+url=https://gitlab.freedesktop.org/cairo/cairo.git
 depth=1
-revision=meson
+revision=master

--- a/subprojects/expat.wrap
+++ b/subprojects/expat.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
-directory = expat-2.2.5
+directory = expat-2.2.9
+source_url = https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.xz
+source_filename = expat-2.2.9.tar.bz2
+source_hash = 1ea6965b15c2106b6bbe883397271c80dfa0331cdf821b2c319591b55eadc0a4
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/expat/2.2.9/3/get_zip
+patch_filename = expat-2.2.9-3-wrap.zip
+patch_hash = e9aaace62e9a158b5e96f5c38c9f81f369179206acd87697653d777c0d3975d3
 
-source_url = https://github.com/libexpat/libexpat/releases/download/R_2_2_5/expat-2.2.5.tar.bz2
-source_filename = expat-2.2.5.tar.bz2
-source_hash = d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6
-
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/expat/2.2.5/4/get_zip
-patch_filename = expat-2.2.5-4-wrap.zip
-patch_hash = 25748839be2bbdd2ff586d1a05aa6fc37aeada75c78416df6e8347a6321abaac

--- a/subprojects/fontconfig.wrap
+++ b/subprojects/fontconfig.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory=fontconfig
-url=https://github.com/centricular/fontconfig.git
+url=https://gitlab.freedesktop.org/fontconfig/fontconfig.git
 depth=1
-push-url=git@github.com:centricular/fontconfig.git
-revision=meson
+push-url=git@gitlab.freedesktop.org/fontconfig/fontconfig.git
+revision=master

--- a/subprojects/google-benchmark.wrap
+++ b/subprojects/google-benchmark.wrap
@@ -1,8 +1,9 @@
 [wrap-file]
-directory = benchmark-1.4.1
-source_url = https://github.com/google/benchmark/archive/v1.4.1.zip
-source_filename = benchmark-1.4.1.zip
-source_hash = 61ae07eb5d4a0b02753419eb17a82b7d322786bb36ab62bd3df331a4d47c00a7
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/google-benchmark/1.4.1/1/get_zip
-patch_filename = google-benchmark-1.4.1-1-wrap.zip
-patch_hash = 4cc5fe02ebd4fc82e110919b7977d7463eb2a99e4ecb9feca920eab6fd911d67
+directory = benchmark-1.5.2
+source_url = https://github.com/google/benchmark/archive/v1.5.2.zip
+source_filename = benchmark-1.5.2.zip
+source_hash = 21e6e096c9a9a88076b46bd38c33660f565fa050ca427125f64c4a8bf60f336b
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/google-benchmark/1.5.2/1/get_zip
+patch_filename = google-benchmark-1.5.2-1-wrap.zip
+patch_hash = 49f41e4a7e68ac258b6509b9de9857441903be4fb473454c4cba8be885f0c6c3
+

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,10 +1,12 @@
 [wrap-file]
-directory = libpng-1.6.35
+directory = libpng-1.6.37
+source_url = https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz
+source_filename = libpng-1.6.37.tar.gz
+source_hash = ca74a0dace179a8422187671aee97dd3892b53e168627145271cad5b5ac81307
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.37/3/get_zip
+patch_filename = libpng-1.6.37-3-wrap.zip
+patch_hash = 6c9f32fd9150b3a96ab89be52af664e32207e10aa9f5fb9aa015989ee2dd7100
 
-source_url = https://github.com/glennrp/libpng/archive/v1.6.35.tar.gz
-source_filename = libpng-1.6.35.tar.gz
-source_hash = 6d59d6a154ccbb772ec11772cb8f8beb0d382b61e7ccc62435bf7311c9f4b210
+[provide]
+libpng = libpng_dep
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.35/5/get_zip
-patch_filename = libpng-1.6.35-5-wrap.zip
-patch_hash = da42b18e8d75a88615bdbc1c7bbf1f739ae19f63a8e70d96c90bc448326ae6b7

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,5 +1,12 @@
-[wrap-git]
-directory=zlib
-url=https://github.com/centricular/zlib.git
-depth=1
-revision=meson
+[wrap-file]
+directory = zlib-1.2.11
+source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
+source_filename = zlib-1.2.11.tar.gz
+source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/5/get_zip
+patch_filename = zlib-1.2.11-5-wrap.zip
+patch_hash = 728c8e24acbc2e6682fbd950fec39e2fc77528af361adb87259f8a8511434004
+
+[provide]
+zlib = zlib_dep
+


### PR DESCRIPTION
    When cairo comes from a subproject fallback it should still take
    cairo-ft dependency, otherwise it miss freetype2 cflags.
    
    Also update wrap file to use upstream repository now that meson support
    has been merged.
    
    This requires Meson >= 0.54.0 because cairo itself requires that version
    and we use the new `fallback: 'cairo'` syntax without specifying a
    variable name because cairo does not provide a variable name for
    cairo-ft.
