### PR TITLE
[test] Remove timeout from test runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - run: meson build --buildtype=debugoptimized
       - run: ninja -Cbuild -j9
       # TOOD: increase timeouts and remove --no-suite=slow
-      - run: RUN_VALGRIND=1 HB_TEST_SHAPE_FUZZER_TIMEOUT=5 meson test -Cbuild --no-suite=slow --wrap='valgrind --leak-check=full --error-exitcode=1' --print-errorlogs
+      - run: RUN_VALGRIND=1 meson test -Cbuild --no-suite=slow --wrap='valgrind --leak-check=full --error-exitcode=1' --print-errorlogs
 
   alpine:
     docker:

--- a/test/fuzzing/meson.build
+++ b/test/fuzzing/meson.build
@@ -31,7 +31,6 @@ endforeach
 
 env = environment()
 env.set('srcdir', meson.current_source_dir())
-env.set('HB_TEST_SUBSET_FUZZER_TIMEOUT', '50')
 
 test('shape_fuzzer', find_program('run-shape-fuzzer-tests.py'),
   args: [

--- a/test/fuzzing/run-draw-fuzzer-tests.py
+++ b/test/fuzzing/run-draw-fuzzer-tests.py
@@ -9,7 +9,7 @@ def cmd (command):
 		p = subprocess.Popen (command, stderr=tempf)
 
 		try:
-			p.wait (timeout=int (os.getenv ("HB_TEST_SHAPE_FUZZER_TIMEOUT", "2")))
+			p.wait ()
 			tempf.seek (0)
 			text = tempf.read ()
 

--- a/test/fuzzing/run-shape-fuzzer-tests.py
+++ b/test/fuzzing/run-shape-fuzzer-tests.py
@@ -9,7 +9,7 @@ def cmd (command):
 		p = subprocess.Popen (command, stderr=tempf)
 
 		try:
-			p.wait (timeout=int (os.getenv ("HB_TEST_SHAPE_FUZZER_TIMEOUT", "2")))
+			p.wait ()
 			tempf.seek (0)
 			text = tempf.read ()
 

--- a/test/fuzzing/run-subset-fuzzer-tests.py
+++ b/test/fuzzing/run-subset-fuzzer-tests.py
@@ -9,7 +9,7 @@ def cmd (command):
 		p = subprocess.Popen (command, stderr=tempf)
 
 		try:
-			p.wait (timeout=int (os.getenv ("HB_TEST_SUBSET_FUZZER_TIMEOUT", "12")))
+			p.wait ()
 			tempf.seek (0)
 			text = tempf.read ()
 


### PR DESCRIPTION
See https://github.com/harfbuzz/harfbuzz/issues/2707#issuecomment-707744079

This wasn’t inconsistent as well, `HB_TEST_SUBSET_FUZZER_TIMEOUT` defaulted to 12 in the test runner, but it was overridden to 50 in meson.build, and then meson has its own test timeout.