### PR TITLE
[CI] Don’t install ragel on circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       xcode: "9.0.1"
     steps:
       - checkout
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config ragel freetype glib cairo python3 ninja
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config freetype glib cairo python3 ninja
       - run: pip3 install meson --upgrade
       - run: meson build
       - run: meson compile -Cbuild # or ninja -Cbuild
@@ -26,7 +26,7 @@ jobs:
       xcode: "10.1.0"
     steps:
       - checkout
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config ragel freetype glib cairo python3 ninja
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config freetype glib cairo python3 ninja
       - run: pip3 install meson --upgrade
       - run: meson build
       - run: meson compile -Cbuild
@@ -37,7 +37,7 @@ jobs:
       xcode: "11.1.0"
     steps:
       - checkout
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config ragel freetype glib cairo python3 icu4c graphite2 ninja
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config freetype glib cairo python3 icu4c graphite2 ninja
       - run: pip3 install meson --upgrade
       - run: PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig" meson build -Dcoretext=enabled
       - run: meson compile -Cbuild
@@ -48,7 +48,7 @@ jobs:
       xcode: "11.4.0"
     steps:
       - checkout
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config ragel freetype glib cairo python3 icu4c graphite2 gobject-introspection gtk-doc ninja
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config freetype glib cairo python3 icu4c graphite2 gobject-introspection gtk-doc ninja
       - run: pip3 install meson --upgrade
       - run: PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig" meson build -Dcoretext=enabled -Dgraphite=enabled -Dauto_features=enabled
       - run: meson compile -Cbuild
@@ -86,7 +86,7 @@ jobs:
       - image: fedora
     steps:
       - checkout
-      - run: dnf install -y pkg-config ragel valgrind gcc gcc-c++ meson git glib2-devel freetype-devel cairo-devel libicu-devel gobject-introspection-devel graphite2-devel redhat-rpm-config python python-pip || true
+      - run: dnf install -y pkg-config valgrind gcc gcc-c++ meson git glib2-devel freetype-devel cairo-devel libicu-devel gobject-introspection-devel graphite2-devel redhat-rpm-config python python-pip || true
       - run: meson build --buildtype=debugoptimized
       - run: ninja -Cbuild -j9
       # TOOD: increase timeouts and remove --no-suite=slow
@@ -97,7 +97,7 @@ jobs:
       - image: alpine
     steps:
       - checkout
-      - run: apk update && apk add ragel gcc g++ glib-dev freetype-dev cairo-dev git py3-pip ninja
+      - run: apk update && apk add gcc g++ glib-dev freetype-dev cairo-dev git py3-pip ninja
       - run: pip3 install meson==0.47.0
       - run: meson build --buildtype=minsize
       - run: ninja -Cbuild -j9
@@ -108,7 +108,7 @@ jobs:
       - image: archlinux/base
     steps:
       - checkout
-      - run: pacman --noconfirm -Syu freetype2 meson git clang cairo icu gettext gobject-introspection gcc gcc-libs glib2 graphite pkg-config ragel python python-pip base-devel gtk-doc
+      - run: pacman --noconfirm -Syu freetype2 meson git clang cairo icu gettext gobject-introspection gcc gcc-libs glib2 graphite pkg-config python python-pip base-devel gtk-doc
       - run: pip install flake8 fonttools
       - run: pip install git+https://github.com/mesonbuild/meson
       - run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
@@ -147,7 +147,7 @@ jobs:
     executor: win32-executor
     steps:
       - checkout
-      - run: sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y ninja-build binutils meson gcc g++ pkg-config ragel gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip git g++-mingw-w64-i686 zip
+      - run: sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y ninja-build binutils meson gcc g++ pkg-config gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip git g++-mingw-w64-i686 zip
       - run: .ci/build-win32.sh
       - store_artifacts:
           path: harfbuzz-win32.zip


### PR DESCRIPTION
Latest ragel version is broken (https://github.com/adrian-thurston/ragel/issues/56), but we also don’t need to regenerate state machine on CI jobs.