### PR TITLE
[docs] Describe buffer context applicability more explicitly

### DIFF
--- a/docs/usermanual-buffers-language-script-and-direction.xml
+++ b/docs/usermanual-buffers-language-script-and-direction.xml
@@ -136,10 +136,12 @@
       determine which glyph to return.
     </para>
     <para>
-      The safest approach is to add all of the text available, then
-      use <parameter>item_offset</parameter> and
+      The safest approach is to add all of the text available (even
+      if your text contains a mix of scripts, directions, languages
+      and fonts), then use <parameter>item_offset</parameter> and
       <parameter>item_length</parameter> to indicate which characters you
-      want shaped, so that HarfBuzz has access to any context.
+      want shaped (which must all have the same script, direction,
+      language and font), so that HarfBuzz has access to any context.
     </para>
     <para>
       You can also add Unicode code points directly with


### PR DESCRIPTION
Make it abundantly clear that the context's script etc. don't matter.

Fixes https://github.com/harfbuzz/harfbuzz/issues/2730