### PR TITLE
Bump minimum meson version to 0.53.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('harfbuzz', 'c', 'cpp',
-  meson_version: '>= 0.47.0',
+  meson_version: '>= 0.53.0',
   version: '2.7.2',
   default_options: [
     'cpp_eh=none',          # Just to support msvc, we are passing -fno-rtti also anyway


### PR DESCRIPTION
From a local build:
```
|WARNING: Project specifies a minimum meson_version '>= 0.47.0' but uses features which were added in newer versions:
| * 0.50.0: {'install arg in configure_file'}
| * 0.53.0: {'Fallback without variable name'}
```