### PR TITLE
meson.build: check for pthread.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -284,13 +284,15 @@ endif
 # threads
 thread_dep = null_dep
 if host_machine.system() != 'windows'
-  thread_dep = dependency('threads', required: false)
+  if cpp.has_header('pthread.h')
+    thread_dep = dependency('threads', required: false)
+  endif
 
   if thread_dep.found()
     conf.set('HAVE_PTHREAD', 1)
   else
     check_headers += ['sched.h']
-    check_funcs += ['sched_yield', {'link_with': 'rt'}]
+    check_funcs += [['sched_yield', {'link_with': 'rt'}]]
   endif
 endif
 


### PR DESCRIPTION
Check for pthread.h otherwise the build will fail with some toolchains that have libphtread.so but not pthread.h:

```
Run-time dependency threads found: YES

../src/hb-mutex.hh:53:10: fatal error: pthread.h: No such file or directory
 #include <pthread.h>
          ^~~~~~~~~~~
```

Moreover, fix detection of pthread fallback

Fixes:
 - http://autobuild.buildroot.org/results/70c98e89b1d5e5b651d1f6928dc53f465103f57a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>