### PR TITLE
CMake: Define HAVE_GOBJECT when harfbuzz-gobject is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ if (WIN32 AND HB_HAVE_DIRECTWRITE)
 endif ()
 
 if (HB_HAVE_GOBJECT)
+  add_definitions(-DHAVE_GOBJECT)
   include (FindPerl)
 
   # Use the hints from glib-2.0.pc to find glib-mkenums


### PR DESCRIPTION
Hi,

From the commit message (I am aware the CMake build system is going out, but, anyways :)):

<i>Without this, the built library for harfbuzz-gobject is unuseful.</i>

The reason is because the code in there are only built if `HAVE_GOBJECT` is defined during compilation, so without that, we are more or less building an empty harfbuzz-gobject dll|lib|so.

With blessings, thank you!