### PR TITLE
Make failing allocator an opt-in for fuzzer runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,12 @@ jobs:
       # msan, needs --force-fallback-for=glib,freetype2 also which doesn't work yet but runs fuzzer cases at least
       - run: rm -rf build && meson build --default-library=static -Db_sanitize=memory --buildtype=debugoptimized --wrap-mode=nodownload -Dauto_features=disabled -Dtests=enabled -Dexperimental_api=true
       - run: ninja -Cbuild -j8 && meson test -Cbuild --print-errorlogs | asan_symbolize | c++filt
+      # asan fuzzer
+      - run: rm -rf build && CXXFLAGS="-fsanitize=address,fuzzer-no-link" meson build --default-library=static -Dfuzzer_ldflags="-fsanitize=address,fuzzer" --buildtype=debugoptimized --wrap-mode=nodownload
+      - run: ninja -Cbuild -j8 && meson test -Cbuild --suite fuzzing --print-errorlogs | asan_symbolize | c++filt
+      # asan fuzzer+failing-alloc
+      - run: rm -rf build && CXXFLAGS="-fsanitize=address,fuzzer-no-link" meson build --default-library=static -Dfuzzer_ldflags="-fsanitize=address,fuzzer" -Dfailing_alloc=true --buildtype=debugoptimized --wrap-mode=nodownload
+      - run: ninja -Cbuild -j8 && meson test -Cbuild --suite fuzzing --print-errorlogs | asan_symbolize | c++filt
       # test -std=c++2a and -Weverything of nightly clang builds
       - run: clang -c src/harfbuzz.cc src/hb-subset*.cc -DHB_NO_MT -Werror -std=c++2a
       - run: clang -c src/hb-*.cc -DHB_NO_MT -Werror -Weverything -Wno-old-style-cast -Wno-documentation -Wno-documentation-unknown-command -Wno-c++98-compat -Wno-cast-qual -Wno-c++98-compat-pedantic -Wno-sign-conversion -Wno-padded -Wno-shorten-64-to-32 -Wno-reserved-id-macro -Wno-float-conversion -Wno-format-pedantic -Wno-shadow -Wno-conversion -Wno-zero-as-null-pointer-constant -Wno-missing-field-initializers -Wno-used-but-marked-unused -Wno-unused-macros -Wno-comma -Wno-float-equal -Wno-disabled-macro-expansion -Wno-weak-vtables -Wno-unused-parameter -Wno-covered-switch-default -Wno-unreachable-code -Wno-unused-template -DHB_WITH_WIN1256

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -36,3 +36,5 @@ option('experimental_api', type: 'boolean', value: false,
   description: 'Enable experimental APIs')
 option('fuzzer_ldflags', type: 'string',
   description: 'Extra LDFLAGS used during linking of fuzzing binaries')
+option('failing_alloc', type: 'boolean', value: false,
+  description: 'Development only option to test what happens when allocator fails')

--- a/src/meson.build
+++ b/src/meson.build
@@ -401,7 +401,7 @@ else
   hb_so_version = '0'
 endif
 
-if get_option('fuzzer_ldflags') != ''
+if get_option('failing_alloc')
   extra_hb_cpp_args += ['-DHB_CUSTOM_MALLOC']
   hb_sources += 'failing-alloc.c'
   hb_subset_sources += 'failing-alloc.c'

--- a/test/fuzzing/hb-fuzzer.hh
+++ b/test/fuzzing/hb-fuzzer.hh
@@ -9,7 +9,7 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size);
 #define HB_UNUSED
 #endif
 
-#ifdef HB_IS_IN_FUZZER
+#ifdef HB_IS_FAILING_ALLOC
 /* See src/failing-alloc.c */
 extern "C" int alloc_state;
 #else

--- a/test/fuzzing/meson.build
+++ b/test/fuzzing/meson.build
@@ -16,7 +16,10 @@ foreach file_name : tests
     sources += 'main.cc'
   else
     fuzzer_ldflags += get_option('fuzzer_ldflags').split()
-    extra_cpp_args += '-DHB_IS_IN_FUZZER'
+  endif
+
+  if get_option('failing_alloc')
+    extra_cpp_args += '-DHB_IS_FAILING_ALLOC'
   endif
 
   exe = executable(test_name, sources,


### PR DESCRIPTION
Now that basic issues regarding malloc limits are fixed let's
turn failing allocator to an opt-in for fuzzer runs to separate
their runs.