### PR TITLE
meson: avoid regenerating hb-version.h unnecessarily

### DIFF
--- a/src/gen-hb-version.py
+++ b/src/gen-hb-version.py
@@ -2,7 +2,7 @@
 
 "This tool is intended to be used from meson"
 
-import os, sys, shutil
+import os, sys, shutil, re
 
 if len (sys.argv) < 4:
 	sys.exit(__doc__)
@@ -13,6 +13,15 @@ major, minor, micro = version.split (".")
 OUTPUT = sys.argv[2]
 INPUT = sys.argv[3]
 CURRENT_SOURCE_DIR = os.path.dirname(INPUT)
+
+try:
+	with open (OUTPUT, "r") as old_output:
+		for line in old_output:
+			old_version = re.match (r"#define HB_VERSION_STRING \"(\d.\d.\d)\"", line)
+			if old_version and old_version[1] == version:
+				sys.exit ()
+except IOError:
+	pass
 
 with open (INPUT, "r", encoding='utf-8') as template:
 	with open (OUTPUT, "wb") as output:


### PR DESCRIPTION
The file is a dependency for the library as a whole, so previously editing the Meson build files at all would force a full rebuild. This will only rebuild it if the version has changed.