### PR TITLE
meson: update minimum meson_version to 0.50.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('harfbuzz', 'c', 'cpp',
-  meson_version: '>= 0.47.0',
+  meson_version: '>= 0.50.0',
   version: '2.7.3',
   default_options: [
     'cpp_eh=none',          # Just to support msvc, we are passing -fno-rtti also anyway


### PR DESCRIPTION
As per the log error during meson.build, update the minimum to 0.50.0

```
WARNING: Project specifies a minimum meson_version '>= 0.47.0' but uses features which were added in newer versions:
 * 0.50.0: {'install arg in configure_file'}
```