### PR TITLE
[docs] Document unused language in get_baseline

### DIFF
--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1907,7 +1907,7 @@ hb_ot_layout_substitute_lookup (OT::hb_ot_apply_context_t *c,
  * @baseline_tag: a baseline tag
  * @direction: text direction.
  * @script_tag:  script tag.
- * @language_tag: language tag.
+ * @language_tag: language tag, currently unused.
  * @coord: (out): baseline value if found.
  *
  * Fetches a baseline value from the face.


### PR DESCRIPTION
Document that language_tag in hb_ot_layout_get_baseline() is currently unused.

Fixes https://github.com/harfbuzz/harfbuzz/issues/2662