### PR TITLE
Refactor shared code in syllabic shapers

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -121,6 +121,8 @@ HB_BASE_sources = \
 	hb-ot-shape-complex-machine-index.hh \
 	hb-ot-shape-complex-myanmar.cc \
 	hb-ot-shape-complex-myanmar.hh \
+	hb-ot-shape-complex-syllabic.cc \
+	hb-ot-shape-complex-syllabic.hh \
 	hb-ot-shape-complex-thai.cc \
 	hb-ot-shape-complex-use-table.cc \
 	hb-ot-shape-complex-use.cc \

--- a/src/harfbuzz.cc
+++ b/src/harfbuzz.cc
@@ -29,6 +29,7 @@
 #include "hb-ot-shape-complex-indic.cc"
 #include "hb-ot-shape-complex-khmer.cc"
 #include "hb-ot-shape-complex-myanmar.cc"
+#include "hb-ot-shape-complex-syllabic.cc"
 #include "hb-ot-shape-complex-thai.cc"
 #include "hb-ot-shape-complex-use-table.cc"
 #include "hb-ot-shape-complex-use.cc"

--- a/src/hb-ot-shape-complex-indic-machine.hh
+++ b/src/hb-ot-shape-complex-indic-machine.hh
@@ -395,7 +395,7 @@ static const int indic_syllable_machine_en_main = 39;
   HB_STMT_START { \
     if (0) fprintf (stderr, "syllable %d..%d %s\n", ts, te, #syllable_type); \
     for (unsigned int i = ts; i < te; i++) \
-      info[i].syllable() = (syllable_serial << 4) | indic_##syllable_type; \
+      info[i].syllable() = (syllable_serial << 4) | syllable_type; \
     syllable_serial++; \
     if (unlikely (syllable_serial == 16)) syllable_serial = 1; \
   } HB_STMT_END
@@ -461,7 +461,7 @@ _eof_trans:
 	break;
 	case 11:
 #line 89 "hb-ot-shape-complex-indic-machine.rl"
-	{te = p+1;{ found_syllable (non_indic_cluster); }}
+	{te = p+1;{ found_syllable (alien_cluster); }}
 	break;
 	case 13:
 #line 84 "hb-ot-shape-complex-indic-machine.rl"
@@ -469,15 +469,15 @@ _eof_trans:
 	break;
 	case 14:
 #line 85 "hb-ot-shape-complex-indic-machine.rl"
-	{te = p;p--;{ found_syllable (vowel_syllable); }}
+	{te = p;p--;{ found_syllable (indic_vowel_syllable); }}
 	break;
 	case 17:
 #line 86 "hb-ot-shape-complex-indic-machine.rl"
-	{te = p;p--;{ found_syllable (standalone_cluster); }}
+	{te = p;p--;{ found_syllable (indic_standalone_cluster); }}
 	break;
 	case 19:
 #line 87 "hb-ot-shape-complex-indic-machine.rl"
-	{te = p;p--;{ found_syllable (symbol_cluster); }}
+	{te = p;p--;{ found_syllable (indic_symbol_cluster); }}
 	break;
 	case 15:
 #line 88 "hb-ot-shape-complex-indic-machine.rl"
@@ -485,7 +485,7 @@ _eof_trans:
 	break;
 	case 16:
 #line 89 "hb-ot-shape-complex-indic-machine.rl"
-	{te = p;p--;{ found_syllable (non_indic_cluster); }}
+	{te = p;p--;{ found_syllable (alien_cluster); }}
 	break;
 	case 1:
 #line 84 "hb-ot-shape-complex-indic-machine.rl"
@@ -493,15 +493,15 @@ _eof_trans:
 	break;
 	case 3:
 #line 85 "hb-ot-shape-complex-indic-machine.rl"
-	{{p = ((te))-1;}{ found_syllable (vowel_syllable); }}
+	{{p = ((te))-1;}{ found_syllable (indic_vowel_syllable); }}
 	break;
 	case 7:
 #line 86 "hb-ot-shape-complex-indic-machine.rl"
-	{{p = ((te))-1;}{ found_syllable (standalone_cluster); }}
+	{{p = ((te))-1;}{ found_syllable (indic_standalone_cluster); }}
 	break;
 	case 8:
 #line 87 "hb-ot-shape-complex-indic-machine.rl"
-	{{p = ((te))-1;}{ found_syllable (symbol_cluster); }}
+	{{p = ((te))-1;}{ found_syllable (indic_symbol_cluster); }}
 	break;
 	case 4:
 #line 88 "hb-ot-shape-complex-indic-machine.rl"
@@ -517,7 +517,7 @@ _eof_trans:
 	{{p = ((te))-1;} found_syllable (broken_cluster); }
 	break;
 	case 6:
-	{{p = ((te))-1;} found_syllable (non_indic_cluster); }
+	{{p = ((te))-1;} found_syllable (alien_cluster); }
 	break;
 	}
 	}

--- a/src/hb-ot-shape-complex-indic-machine.rl
+++ b/src/hb-ot-shape-complex-indic-machine.rl
@@ -82,11 +82,11 @@ other =			any;
 
 main := |*
 	consonant_syllable	=> { found_syllable (consonant_syllable); };
-	vowel_syllable		=> { found_syllable (vowel_syllable); };
-	standalone_cluster	=> { found_syllable (standalone_cluster); };
-	symbol_cluster		=> { found_syllable (symbol_cluster); };
+	vowel_syllable		=> { found_syllable (indic_vowel_syllable); };
+	standalone_cluster	=> { found_syllable (indic_standalone_cluster); };
+	symbol_cluster		=> { found_syllable (indic_symbol_cluster); };
 	broken_cluster		=> { found_syllable (broken_cluster); };
-	other			=> { found_syllable (non_indic_cluster); };
+	other			=> { found_syllable (alien_cluster); };
 *|;
 
 
@@ -96,7 +96,7 @@ main := |*
   HB_STMT_START { \
     if (0) fprintf (stderr, "syllable %d..%d %s\n", ts, te, #syllable_type); \
     for (unsigned int i = ts; i < te; i++) \
-      info[i].syllable() = (syllable_serial << 4) | indic_##syllable_type; \
+      info[i].syllable() = (syllable_serial << 4) | syllable_type; \
     syllable_serial++; \
     if (unlikely (syllable_serial == 16)) syllable_serial = 1; \
   } HB_STMT_END

--- a/src/hb-ot-shape-complex-khmer-machine.hh
+++ b/src/hb-ot-shape-complex-khmer-machine.hh
@@ -226,7 +226,7 @@ static const int khmer_syllable_machine_en_main = 20;
   HB_STMT_START { \
     if (0) fprintf (stderr, "syllable %d..%d %s\n", ts, te, #syllable_type); \
     for (unsigned int i = ts; i < te; i++) \
-      info[i].syllable() = (syllable_serial << 4) | khmer_##syllable_type; \
+      info[i].syllable() = (syllable_serial << 4) | syllable_type; \
     syllable_serial++; \
     if (unlikely (syllable_serial == 16)) syllable_serial = 1; \
   } HB_STMT_END
@@ -292,7 +292,7 @@ _eof_trans:
 	break;
 	case 8:
 #line 76 "hb-ot-shape-complex-khmer-machine.rl"
-	{te = p+1;{ found_syllable (non_khmer_cluster); }}
+	{te = p+1;{ found_syllable (alien_cluster); }}
 	break;
 	case 10:
 #line 74 "hb-ot-shape-complex-khmer-machine.rl"
@@ -304,7 +304,7 @@ _eof_trans:
 	break;
 	case 11:
 #line 76 "hb-ot-shape-complex-khmer-machine.rl"
-	{te = p;p--;{ found_syllable (non_khmer_cluster); }}
+	{te = p;p--;{ found_syllable (alien_cluster); }}
 	break;
 	case 1:
 #line 74 "hb-ot-shape-complex-khmer-machine.rl"
@@ -321,7 +321,7 @@ _eof_trans:
 	{{p = ((te))-1;} found_syllable (broken_cluster); }
 	break;
 	case 3:
-	{{p = ((te))-1;} found_syllable (non_khmer_cluster); }
+	{{p = ((te))-1;} found_syllable (alien_cluster); }
 	break;
 	}
 	}

--- a/src/hb-ot-shape-complex-khmer-machine.rl
+++ b/src/hb-ot-shape-complex-khmer-machine.rl
@@ -73,7 +73,7 @@ other =			any;
 main := |*
 	consonant_syllable	=> { found_syllable (consonant_syllable); };
 	broken_cluster		=> { found_syllable (broken_cluster); };
-	other			=> { found_syllable (non_khmer_cluster); };
+	other			=> { found_syllable (alien_cluster); };
 *|;
 
 
@@ -83,7 +83,7 @@ main := |*
   HB_STMT_START { \
     if (0) fprintf (stderr, "syllable %d..%d %s\n", ts, te, #syllable_type); \
     for (unsigned int i = ts; i < te; i++) \
-      info[i].syllable() = (syllable_serial << 4) | khmer_##syllable_type; \
+      info[i].syllable() = (syllable_serial << 4) | syllable_type; \
     syllable_serial++; \
     if (unlikely (syllable_serial == 16)) syllable_serial = 1; \
   } HB_STMT_END

--- a/src/hb-ot-shape-complex-khmer.cc
+++ b/src/hb-ot-shape-complex-khmer.cc
@@ -29,6 +29,7 @@
 #ifndef HB_NO_OT_SHAPE
 
 #include "hb-ot-shape-complex-khmer.hh"
+#include "hb-ot-shape-complex-syllabic.hh"
 #include "hb-ot-layout.hh"
 
 
@@ -186,13 +187,6 @@ data_destroy_khmer (void *data)
   free (data);
 }
 
-
-enum khmer_syllable_type_t {
-  khmer_consonant_syllable,
-  khmer_broken_cluster,
-  khmer_non_khmer_cluster,
-};
-
 #include "hb-ot-shape-complex-khmer-machine.hh"
 
 static void
@@ -308,80 +302,17 @@ reorder_syllable_khmer (const hb_ot_shape_plan_t *plan,
 			hb_buffer_t *buffer,
 			unsigned int start, unsigned int end)
 {
-  khmer_syllable_type_t syllable_type = (khmer_syllable_type_t) (buffer->info[start].syllable() & 0x0F);
+  syllable_type_t syllable_type = (syllable_type_t) (buffer->info[start].syllable() & 0x0F);
   switch (syllable_type)
   {
-    case khmer_broken_cluster: /* We already inserted dotted-circles, so just call the consonant_syllable. */
-    case khmer_consonant_syllable:
+    case broken_cluster: /* We already inserted dotted-circles, so just call the consonant_syllable. */
+    case consonant_syllable:
      reorder_consonant_syllable (plan, face, buffer, start, end);
      break;
 
-    case khmer_non_khmer_cluster:
+    case alien_cluster:
       break;
   }
-}
-
-static inline void
-insert_dotted_circles_khmer (const hb_ot_shape_plan_t *plan HB_UNUSED,
-			     hb_font_t *font,
-			     hb_buffer_t *buffer)
-{
-  if (unlikely (buffer->flags & HB_BUFFER_FLAG_DO_NOT_INSERT_DOTTED_CIRCLE))
-    return;
-
-  /* Note: This loop is extra overhead, but should not be measurable.
-   * TODO Use a buffer scratch flag to remove the loop. */
-  bool has_broken_syllables = false;
-  unsigned int count = buffer->len;
-  hb_glyph_info_t *info = buffer->info;
-  for (unsigned int i = 0; i < count; i++)
-    if ((info[i].syllable() & 0x0F) == khmer_broken_cluster)
-    {
-      has_broken_syllables = true;
-      break;
-    }
-  if (likely (!has_broken_syllables))
-    return;
-
-
-  hb_codepoint_t dottedcircle_glyph;
-  if (!font->get_nominal_glyph (0x25CCu, &dottedcircle_glyph))
-    return;
-
-  hb_glyph_info_t dottedcircle = {0};
-  dottedcircle.codepoint = 0x25CCu;
-  set_khmer_properties (dottedcircle);
-  dottedcircle.codepoint = dottedcircle_glyph;
-
-  buffer->clear_output ();
-
-  buffer->idx = 0;
-  unsigned int last_syllable = 0;
-  while (buffer->idx < buffer->len && buffer->successful)
-  {
-    unsigned int syllable = buffer->cur().syllable();
-    khmer_syllable_type_t syllable_type = (khmer_syllable_type_t) (syllable & 0x0F);
-    if (unlikely (last_syllable != syllable && syllable_type == khmer_broken_cluster))
-    {
-      last_syllable = syllable;
-
-      hb_glyph_info_t ginfo = dottedcircle;
-      ginfo.cluster = buffer->cur().cluster;
-      ginfo.mask = buffer->cur().mask;
-      ginfo.syllable() = buffer->cur().syllable();
-
-      /* Insert dottedcircle after possible Repha. */
-      while (buffer->idx < buffer->len && buffer->successful &&
-	     last_syllable == buffer->cur().syllable() &&
-	     buffer->cur().khmer_category() == OT_Repha)
-	buffer->next_glyph ();
-
-      buffer->output_info (ginfo);
-    }
-    else
-      buffer->next_glyph ();
-  }
-  buffer->swap_buffers ();
 }
 
 static void
@@ -390,7 +321,7 @@ reorder_khmer (const hb_ot_shape_plan_t *plan,
 	       hb_buffer_t *buffer)
 {
   if (buffer->message (font, "start reordering khmer")) {
-    insert_dotted_circles_khmer (plan, font, buffer);
+	  hb_syllabic_insert_dotted_circles (buffer, font, OT_Repha, set_khmer_properties);
 
     foreach_syllable (buffer, start, end)
       reorder_syllable_khmer (plan, font->face, buffer, start, end);

--- a/src/hb-ot-shape-complex-myanmar-machine.hh
+++ b/src/hb-ot-shape-complex-myanmar-machine.hh
@@ -304,7 +304,7 @@ static const int myanmar_syllable_machine_en_main = 0;
   HB_STMT_START { \
     if (0) fprintf (stderr, "syllable %d..%d %s\n", ts, te, #syllable_type); \
     for (unsigned int i = ts; i < te; i++) \
-      info[i].syllable() = (syllable_serial << 4) | myanmar_##syllable_type; \
+      info[i].syllable() = (syllable_serial << 4) | syllable_type; \
     syllable_serial++; \
     if (unlikely (syllable_serial == 16)) syllable_serial = 1; \
   } HB_STMT_END
@@ -370,7 +370,7 @@ _eof_trans:
 	break;
 	case 4:
 #line 87 "hb-ot-shape-complex-myanmar-machine.rl"
-	{te = p+1;{ found_syllable (non_myanmar_cluster); }}
+	{te = p+1;{ found_syllable (alien_cluster); }}
 	break;
 	case 10:
 #line 88 "hb-ot-shape-complex-myanmar-machine.rl"
@@ -382,7 +382,7 @@ _eof_trans:
 	break;
 	case 3:
 #line 90 "hb-ot-shape-complex-myanmar-machine.rl"
-	{te = p+1;{ found_syllable (non_myanmar_cluster); }}
+	{te = p+1;{ found_syllable (alien_cluster); }}
 	break;
 	case 5:
 #line 86 "hb-ot-shape-complex-myanmar-machine.rl"
@@ -394,7 +394,7 @@ _eof_trans:
 	break;
 	case 9:
 #line 90 "hb-ot-shape-complex-myanmar-machine.rl"
-	{te = p;p--;{ found_syllable (non_myanmar_cluster); }}
+	{te = p;p--;{ found_syllable (alien_cluster); }}
 	break;
 #line 400 "hb-ot-shape-complex-myanmar-machine.hh"
 	}

--- a/src/hb-ot-shape-complex-myanmar-machine.rl
+++ b/src/hb-ot-shape-complex-myanmar-machine.rl
@@ -84,10 +84,10 @@ other =			any;
 
 main := |*
 	consonant_syllable	=> { found_syllable (consonant_syllable); };
-	j			=> { found_syllable (non_myanmar_cluster); };
+	j			=> { found_syllable (alien_cluster); };
 	punctuation_cluster	=> { found_syllable (punctuation_cluster); };
 	broken_cluster		=> { found_syllable (broken_cluster); };
-	other			=> { found_syllable (non_myanmar_cluster); };
+	other			=> { found_syllable (alien_cluster); };
 *|;
 
 
@@ -97,7 +97,7 @@ main := |*
   HB_STMT_START { \
     if (0) fprintf (stderr, "syllable %d..%d %s\n", ts, te, #syllable_type); \
     for (unsigned int i = ts; i < te; i++) \
-      info[i].syllable() = (syllable_serial << 4) | myanmar_##syllable_type; \
+      info[i].syllable() = (syllable_serial << 4) | syllable_type; \
     syllable_serial++; \
     if (unlikely (syllable_serial == 16)) syllable_serial = 1; \
   } HB_STMT_END

--- a/src/hb-ot-shape-complex-syllabic.cc
+++ b/src/hb-ot-shape-complex-syllabic.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2020  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Author(s): Simon Cozens
+ */
+
+#include "hb.hh"
+#include "hb-ot-shape-complex-syllabic.hh"
+#include "hb-ot-layout.hh"
+
+#define syllabic_category() complex_var_u8_0()
+
+HB_INTERNAL void
+hb_syllabic_insert_dotted_circles (hb_buffer_t *buffer, hb_font_t *font,
+			       int repha_category,
+			       void (*set_properties)(hb_glyph_info_t &info)) {
+  if (unlikely (buffer->flags & HB_BUFFER_FLAG_DO_NOT_INSERT_DOTTED_CIRCLE))
+    return;
+
+  /* Note: This loop is extra overhead, but should not be measurable.
+   * TODO Use a buffer scratch flag to remove the loop. */
+  bool has_broken_syllables = false;
+  unsigned int count = buffer->len;
+  hb_glyph_info_t *info = buffer->info;
+  for (unsigned int i = 0; i < count; i++)
+    if ((info[i].syllable() & 0x0F) == broken_cluster)
+    {
+      has_broken_syllables = true;
+      break;
+    }
+  if (likely (!has_broken_syllables))
+    return;
+
+
+  hb_codepoint_t dottedcircle_glyph;
+  if (!font->get_nominal_glyph (0x25CCu, &dottedcircle_glyph))
+    return;
+
+  hb_glyph_info_t dottedcircle = {0};
+  dottedcircle.codepoint = 0x25CCu;
+  set_properties (dottedcircle);
+  dottedcircle.codepoint = dottedcircle_glyph;
+
+  buffer->clear_output ();
+
+  buffer->idx = 0;
+  unsigned int last_syllable = 0;
+  while (buffer->idx < buffer->len && buffer->successful)
+  {
+    unsigned int syllable = buffer->cur().syllable();
+    syllable_type_t syllable_type = (syllable_type_t) (syllable & 0x0F);
+    if (unlikely (last_syllable != syllable && syllable_type == broken_cluster))
+    {
+      last_syllable = syllable;
+
+      hb_glyph_info_t ginfo = dottedcircle;
+      ginfo.cluster = buffer->cur().cluster;
+      ginfo.mask = buffer->cur().mask;
+      ginfo.syllable() = buffer->cur().syllable();
+
+
+      /* Insert dottedcircle after possible Repha. */
+      if (repha_category)
+      {
+	      while (buffer->idx < buffer->len && buffer->successful &&
+		     last_syllable == buffer->cur().syllable() &&
+		     buffer->cur().syllabic_category() == repha_category)
+		buffer->next_glyph ();
+      }
+
+      buffer->output_info (ginfo);
+    }
+    else
+      buffer->next_glyph ();
+  }
+  buffer->swap_buffers ();
+}

--- a/src/hb-ot-shape-complex-syllabic.cc
+++ b/src/hb-ot-shape-complex-syllabic.cc
@@ -58,7 +58,8 @@ hb_syllabic_insert_dotted_circles (hb_buffer_t *buffer, hb_font_t *font,
 
   hb_glyph_info_t dottedcircle = {0};
   dottedcircle.codepoint = 0x25CCu;
-  set_properties (dottedcircle);
+  if (set_properties)
+	  set_properties (dottedcircle);
   dottedcircle.codepoint = dottedcircle_glyph;
 
   buffer->clear_output ();

--- a/src/hb-ot-shape-complex-syllabic.hh
+++ b/src/hb-ot-shape-complex-syllabic.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Author(s): Simon Cozens
+ */
+
+#ifndef HB_OT_SHAPE_COMPLEX_SYLLABIC_HH
+#define HB_OT_SHAPE_COMPLEX_SYLLABIC_HH
+
+#include "hb.hh"
+
+#include "hb-ot-shape-complex.hh"
+
+enum syllable_type_t {
+  broken_cluster,
+  alien_cluster,
+  consonant_syllable,
+  indic_vowel_syllable,
+  indic_standalone_cluster,
+  indic_symbol_cluster,
+};
+
+void
+hb_syllabic_insert_dotted_circles (hb_buffer_t *buffer, hb_font_t *font,
+			       int repha_category,
+			       void (*set_properties)(hb_glyph_info_t &info));
+
+#endif /* HB_OT_SHAPE_COMPLEX_SYLLABIC_HH */

--- a/src/hb-ot-shape-complex-syllabic.hh
+++ b/src/hb-ot-shape-complex-syllabic.hh
@@ -35,6 +35,7 @@ enum syllable_type_t {
   broken_cluster,
   alien_cluster,
   consonant_syllable,
+  punctuation_cluster,
   indic_vowel_syllable,
   indic_standalone_cluster,
   indic_symbol_cluster,

--- a/src/hb-ot-shape-complex-syllabic.hh
+++ b/src/hb-ot-shape-complex-syllabic.hh
@@ -39,6 +39,14 @@ enum syllable_type_t {
   indic_vowel_syllable,
   indic_standalone_cluster,
   indic_symbol_cluster,
+  use_independent_cluster,
+  use_virama_terminated_cluster,
+  use_sakot_terminated_cluster,
+  use_standard_cluster,
+  use_number_joiner_terminated_cluster,
+  use_numeral_cluster,
+  use_symbol_cluster,
+  use_hieroglyph_cluster
 };
 
 void

--- a/src/hb-ot-shape-complex-use-machine.hh
+++ b/src/hb-ot-shape-complex-use-machine.hh
@@ -315,7 +315,7 @@ static const int use_syllable_machine_en_main = 2;
   HB_STMT_START { \
     if (0) fprintf (stderr, "syllable %d..%d %s\n", (*ts).second.first, (*te).second.first, #syllable_type); \
     for (unsigned i = (*ts).second.first; i < (*te).second.first; ++i) \
-      info[i].syllable() = (syllable_serial << 4) | use_##syllable_type; \
+      info[i].syllable() = (syllable_serial << 4) | syllable_type; \
     syllable_serial++; \
     if (unlikely (syllable_serial == 16)) syllable_serial = 1; \
   } HB_STMT_END
@@ -402,11 +402,11 @@ _eof_trans:
 	break;
 	case 5:
 #line 141 "hb-ot-shape-complex-use-machine.rl"
-	{te = p+1;{ found_syllable (independent_cluster); }}
+	{te = p+1;{ found_syllable (use_independent_cluster); }}
 	break;
 	case 9:
 #line 144 "hb-ot-shape-complex-use-machine.rl"
-	{te = p+1;{ found_syllable (standard_cluster); }}
+	{te = p+1;{ found_syllable (use_standard_cluster); }}
 	break;
 	case 7:
 #line 149 "hb-ot-shape-complex-use-machine.rl"
@@ -414,35 +414,35 @@ _eof_trans:
 	break;
 	case 6:
 #line 150 "hb-ot-shape-complex-use-machine.rl"
-	{te = p+1;{ found_syllable (non_cluster); }}
+	{te = p+1;{ found_syllable (alien_cluster); }}
 	break;
 	case 10:
 #line 142 "hb-ot-shape-complex-use-machine.rl"
-	{te = p;p--;{ found_syllable (virama_terminated_cluster); }}
+	{te = p;p--;{ found_syllable (use_virama_terminated_cluster); }}
 	break;
 	case 11:
 #line 143 "hb-ot-shape-complex-use-machine.rl"
-	{te = p;p--;{ found_syllable (sakot_terminated_cluster); }}
+	{te = p;p--;{ found_syllable (use_sakot_terminated_cluster); }}
 	break;
 	case 8:
 #line 144 "hb-ot-shape-complex-use-machine.rl"
-	{te = p;p--;{ found_syllable (standard_cluster); }}
+	{te = p;p--;{ found_syllable (use_standard_cluster); }}
 	break;
 	case 13:
 #line 145 "hb-ot-shape-complex-use-machine.rl"
-	{te = p;p--;{ found_syllable (number_joiner_terminated_cluster); }}
+	{te = p;p--;{ found_syllable (use_number_joiner_terminated_cluster); }}
 	break;
 	case 12:
 #line 146 "hb-ot-shape-complex-use-machine.rl"
-	{te = p;p--;{ found_syllable (numeral_cluster); }}
+	{te = p;p--;{ found_syllable (use_numeral_cluster); }}
 	break;
 	case 14:
 #line 147 "hb-ot-shape-complex-use-machine.rl"
-	{te = p;p--;{ found_syllable (symbol_cluster); }}
+	{te = p;p--;{ found_syllable (use_symbol_cluster); }}
 	break;
 	case 17:
 #line 148 "hb-ot-shape-complex-use-machine.rl"
-	{te = p;p--;{ found_syllable (hieroglyph_cluster); }}
+	{te = p;p--;{ found_syllable (use_hieroglyph_cluster); }}
 	break;
 	case 15:
 #line 149 "hb-ot-shape-complex-use-machine.rl"
@@ -450,7 +450,7 @@ _eof_trans:
 	break;
 	case 16:
 #line 150 "hb-ot-shape-complex-use-machine.rl"
-	{te = p;p--;{ found_syllable (non_cluster); }}
+	{te = p;p--;{ found_syllable (alien_cluster); }}
 	break;
 	case 1:
 #line 149 "hb-ot-shape-complex-use-machine.rl"

--- a/src/hb-ot-shape-complex-use-machine.rl
+++ b/src/hb-ot-shape-complex-use-machine.rl
@@ -138,16 +138,16 @@ independent_cluster = O;
 other = any;
 
 main := |*
-	independent_cluster			=> { found_syllable (independent_cluster); };
-	virama_terminated_cluster		=> { found_syllable (virama_terminated_cluster); };
-	sakot_terminated_cluster		=> { found_syllable (sakot_terminated_cluster); };
-	standard_cluster			=> { found_syllable (standard_cluster); };
-	number_joiner_terminated_cluster	=> { found_syllable (number_joiner_terminated_cluster); };
-	numeral_cluster				=> { found_syllable (numeral_cluster); };
-	symbol_cluster				=> { found_syllable (symbol_cluster); };
-	hieroglyph_cluster			=> { found_syllable (hieroglyph_cluster); };
+	independent_cluster			=> { found_syllable (use_independent_cluster); };
+	virama_terminated_cluster		=> { found_syllable (use_virama_terminated_cluster); };
+	sakot_terminated_cluster		=> { found_syllable (use_sakot_terminated_cluster); };
+	standard_cluster			=> { found_syllable (use_standard_cluster); };
+	number_joiner_terminated_cluster	=> { found_syllable (use_number_joiner_terminated_cluster); };
+	numeral_cluster				=> { found_syllable (use_numeral_cluster); };
+	symbol_cluster				=> { found_syllable (use_symbol_cluster); };
+	hieroglyph_cluster			=> { found_syllable (use_hieroglyph_cluster); };
 	broken_cluster				=> { found_syllable (broken_cluster); };
-	other					=> { found_syllable (non_cluster); };
+	other					=> { found_syllable (alien_cluster); };
 *|;
 
 
@@ -157,7 +157,7 @@ main := |*
   HB_STMT_START { \
     if (0) fprintf (stderr, "syllable %d..%d %s\n", (*ts).second.first, (*te).second.first, #syllable_type); \
     for (unsigned i = (*ts).second.first; i < (*te).second.first; ++i) \
-      info[i].syllable() = (syllable_serial << 4) | use_##syllable_type; \
+      info[i].syllable() = (syllable_serial << 4) | syllable_type; \
     syllable_serial++; \
     if (unlikely (syllable_serial == 16)) syllable_serial = 1; \
   } HB_STMT_END

--- a/src/meson.build
+++ b/src/meson.build
@@ -126,6 +126,8 @@ hb_base_sources = files(
   'hb-ot-shape-complex-khmer.hh',
   'hb-ot-shape-complex-myanmar.cc',
   'hb-ot-shape-complex-myanmar.hh',
+  'hb-ot-shape-complex-syllabic.cc',
+  'hb-ot-shape-complex-syllabic.hh',
   'hb-ot-shape-complex-thai.cc',
   'hb-ot-shape-complex-use-table.cc',
   'hb-ot-shape-complex-use.cc',

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,4 +1,4 @@
-subdir('api')
-subdir('fuzzing')
+# subdir('api')
+#subdir('fuzzing')
 subdir('shaping')
 subdir('subset')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,4 +1,4 @@
-# subdir('api')
-#subdir('fuzzing')
+subdir('api')
+subdir('fuzzing')
 subdir('shaping')
 subdir('subset')


### PR DESCRIPTION
This is an idea, and I'm submitting it here as a draft, to get a read on whether or not we want to go in this direction.

While implementing fontFeatures.shaperLib, I realised how much repeated code there is in Harfbuzz to handle the different syllable-based complex shapers (Indic, Myanmar, Khmer, USE). All of these things are actually structurally (and in terms of actual lines of code) very similar. In Python we can handle that with inheritance from a common base class. In C it's a bit harder because all the syllable type enums are different, but...

So far, this PR:

* Proposes a common `enum syllable_type_t` shared by all syllabic shapers.
* Refactors all the `insert_dotted_circles_...` into a common routine.
* Provides a "base class" into which we can also put other common routines (`setup_syllables_...`, `reorder_...`, `reorder_syllable...`)

We could go a lot further done this road of refactoring if it's desirable. I think we could have much of the syllabic shaper behaviour driven by a data structure similar to the `hb_ot_complex_shaper_t`: e.g. a function pointer to reorder each syllable type, the reph class to insert dotted circles, the kinds of position/category data structure to allocate, and so on.

I haven't moved any other common code over yet, because I want to see if we feel this is a good thing to be doing before potentially wasting time on implementation. I can see benefits in keeping each shaper completely independent of the others, but it does mean a lot of repetition with all of the complexity and maintenance nightmare that implies.