### PR TITLE
[docs] Hide private enum values

### DIFF
--- a/src/hb-ot-layout.h
+++ b/src/hb-ot-layout.h
@@ -446,6 +446,7 @@ typedef enum {
   HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_TOP_OR_RIGHT	= HB_TAG ('i','d','t','p'),
   HB_OT_LAYOUT_BASELINE_TAG_MATH			= HB_TAG ('m','a','t','h'),
 
+  /*< private >*/
   _HB_OT_LAYOUT_BASELINE_TAG_MAX_VALUE = HB_TAG_MAX_SIGNED /*< skip >*/
 } hb_ot_layout_baseline_tag_t;
 

--- a/src/hb-ot-meta.h
+++ b/src/hb-ot-meta.h
@@ -54,6 +54,7 @@ typedef enum {
   HB_OT_META_TAG_DESIGN_LANGUAGES	= HB_TAG ('d','l','n','g'),
   HB_OT_META_TAG_SUPPORTED_LANGUAGES	= HB_TAG ('s','l','n','g'),
 
+  /*< private >*/
   _HB_OT_META_TAG_MAX_VALUE = HB_TAG_MAX_SIGNED /*< skip >*/
 } hb_ot_meta_tag_t;
 

--- a/src/hb-ot-metrics.h
+++ b/src/hb-ot-metrics.h
@@ -100,6 +100,7 @@ typedef enum {
   HB_OT_METRICS_TAG_UNDERLINE_SIZE		= HB_TAG ('u','n','d','s'),
   HB_OT_METRICS_TAG_UNDERLINE_OFFSET		= HB_TAG ('u','n','d','o'),
 
+  /*< private >*/
   _HB_OT_METRICS_TAG_MAX_VALUE = HB_TAG_MAX_SIGNED /*< skip >*/
 } hb_ot_metrics_tag_t;
 

--- a/src/hb-ot-var.h
+++ b/src/hb-ot-var.h
@@ -93,6 +93,7 @@ hb_ot_var_get_axis_count (hb_face_t *face);
 typedef enum { /*< flags >*/
   HB_OT_VAR_AXIS_FLAG_HIDDEN	= 0x00000001u,
 
+  /*< private >*/
   _HB_OT_VAR_AXIS_FLAG_MAX_VALUE= HB_TAG_MAX_SIGNED /*< skip >*/
 } hb_ot_var_axis_flags_t;
 

--- a/src/hb-style.cc
+++ b/src/hb-style.cc
@@ -65,6 +65,7 @@ typedef enum {
   HB_STYLE_TAG_WIDTH		= HB_TAG ('w','d','t','h'),
   HB_STYLE_TAG_WEIGHT		= HB_TAG ('w','g','h','t'),
 
+  /*< private >*/
   _HB_STYLE_TAG_MAX_VALUE	= HB_TAG_MAX_SIGNED /*< skip >*/
 } hb_style_tag_t;
 


### PR DESCRIPTION
`/*< skip >*/` does not seem to hide them.