### PR TITLE
Fix incorrect cairo color content detection

### DIFF
--- a/util/helper-cairo.cc
+++ b/util/helper-cairo.cc
@@ -406,9 +406,7 @@ helper_cairo_create_context (double w, double h,
 
   if (content == CAIRO_CONTENT_ALPHA)
   {
-    if (view_opts->annotate ||
-	br != bg || bg != bb ||
-	fr != fg || fg != fb)
+    if (view_opts->annotate || (ba == 255 && fa == 255))
       content = CAIRO_CONTENT_COLOR;
   }
   if (ba != 255)


### PR DESCRIPTION
hb-view triggers a use-of-uninitialized-value MSAN (https://github.com/google/sanitizers/wiki/MemorySanitizer) error when --background and --foreground are solid colors with no alpha.  The current logic (which I don't fully understand) will set CAIRO_CONTENT_COLOR when the RGB components of the foreground/background are non-equal.  This doesn't take in to account solid colors (e.g. #000000).  This change makes it such that if the foreground/background have no opacity, CAIRO_CONTENT_COLOR is set rather than CAIRO_CONTENT_ALPHA.