### PR TITLE
Meson: Look for FreeType2 via CMake too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,11 @@ m_dep = cpp.find_library('m', required: false)
 
 freetype_dep = null_dep
 if not get_option('freetype').disabled()
-  freetype_dep = dependency('freetype2', required: false)
+  freetype_dep = dependency('freetype2', method: 'pkg-config', required: false)
+
+  if not (freetype_dep.found())
+    freetype_dep = dependency('freetype', method: 'cmake', required: false)
+  endif
 
   if (not freetype_dep.found() and
       cpp.get_id() == 'msvc' and


### PR DESCRIPTION
Hi,

From the commit message:

<i>The package naming (and versioning) scheme for FreeType2 are different with pkg-config and CMake, so try to look for FreeType2 via CMake if we can't find it via pkg-config, as Visual Studio builds of FreeType2 is likely done with CMake as well as FreeType2 nowadays have more configurable options for its builds.  This means, we try to find 'freetype2' with pkg-config and then 'freetype' with CMake if necessary.</i>

<i>We continue to fallback to manually look for the FreeType2 libraries and headers for Visual Studio builds if we can't find it via pkg-config nor CMake</i>

With blessings, thank you!