### PR TITLE
[meson] Don’t scan files outside src for docs

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -52,8 +52,8 @@ endif
 
 gnome.gtkdoc('harfbuzz',
   main_sgml: 'harfbuzz-docs.xml',
-  src_dir: [join_paths(meson.current_source_dir(), '..'),
-            join_paths(meson.current_build_dir(), '..'),
+  src_dir: [join_paths(meson.current_source_dir(), '../src'),
+            join_paths(meson.current_build_dir(), '../src'),
            ],
   scan_args: ['--deprecated-guards=HB_DISABLE_DEPRECATED',
               '--ignore-decorators=HB_EXTERN|HB_DEPRECATED',


### PR DESCRIPTION
Similar to what we do in `Makefile.am`.