### PR TITLE
Disable benchmark feature by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -402,6 +402,11 @@ build_summary = {
     {'Documentation': conf.get('HAVE_GTK_DOC', 0) == 1,
      'GObject bindings': conf.get('HAVE_GOBJECT', 0) == 1,
      'Introspection': conf.get('HAVE_INTROSPECTION', 0) == 1,
+     'Experimental APIs': conf.get('HB_EXPERIMENTAL_API', 0) == 1,
+    },
+  'Testing':
+    {'Tests': get_option('tests').enabled(),
+     'Benchmark': get_option('benchmark').enabled(),
     },
 }
 if meson.version().version_compare('>=0.53')

--- a/meson.build
+++ b/meson.build
@@ -352,16 +352,8 @@ if not get_option('tests').disabled()
   subdir('test')
 endif
 
-# get_option('wrap_mode') isn't available in <0.49 and this
-# is just an internal tool
-if meson.version().version_compare('>=0.49')
-  if (not get_option('benchmark').disabled() and
-      get_option('wrap_mode') != 'nodownload' and
-      host_machine.system() != 'windows' and
-      not meson.is_subproject() and
-      not meson.is_cross_build())
-    subdir('perf')
-  endif
+if not get_option('benchmark').disabled()
+  subdir('perf')
 endif
 
 if not get_option('docs').disabled()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,7 +28,7 @@ option('introspection', type: 'feature', value: 'auto', yield: true,
 option('docs', type: 'feature', value: 'auto', yield: true,
   description: 'Generate documentation with gtk-doc')
 
-option('benchmark', type: 'feature', value: 'auto',
+option('benchmark', type: 'feature', value: 'disabled',
   description: 'Enable benchmark tests')
 option('icu_builtin', type: 'boolean', value: false,
   description: 'Don\'t separate ICU support as harfbuzz-icu module')


### PR DESCRIPTION
It downloads a dependency from the internet, and in the same time not used anywhere (one needs to explicitly call ninja benchmark), not even on the CI (not sure if it that would make much sense since it does not seem to ever fail).