### PR TITLE
[subet/COLR] Default initialize firstLayerIdx

### DIFF
--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -214,10 +214,9 @@ struct COLR
 				if (unlikely (!old_record))
 				  return hb_pair_t<bool, BaseGlyphRecord> (false, Null (BaseGlyphRecord));
 
-				BaseGlyphRecord new_record;
+				BaseGlyphRecord new_record = {0};
 				new_record.glyphId = new_gid;
 				new_record.numLayers = old_record->numLayers;
-				new_record.firstLayerIdx = 0; // Updated during serialization.
 				return hb_pair_t<bool, BaseGlyphRecord> (true, new_record);
 			      })
     | hb_filter (hb_first)

--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -214,7 +214,7 @@ struct COLR
 				if (unlikely (!old_record))
 				  return hb_pair_t<bool, BaseGlyphRecord> (false, Null (BaseGlyphRecord));
 
-				BaseGlyphRecord new_record = {0};
+				BaseGlyphRecord new_record = {};
 				new_record.glyphId = new_gid;
 				new_record.numLayers = old_record->numLayers;
 				return hb_pair_t<bool, BaseGlyphRecord> (true, new_record);

--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -217,6 +217,7 @@ struct COLR
 				BaseGlyphRecord new_record;
 				new_record.glyphId = new_gid;
 				new_record.numLayers = old_record->numLayers;
+				new_record.firstLayerIdx = 0; // Updated during serialization.
 				return hb_pair_t<bool, BaseGlyphRecord> (true, new_record);
 			      })
     | hb_filter (hb_first)


### PR DESCRIPTION
Coverity reported that this value was uninitialized. It is set later during serialization (line 181) as the number of layers is needed to compute this value. However, the value should be default initialized (to 0).

This should fix #2829