### PR TITLE
[set fuzzer] limit the total number of set members in a fuzzing input.

### DIFF
--- a/test/fuzzing/hb-set-fuzzer.cc
+++ b/test/fuzzing/hb-set-fuzzer.cc
@@ -7,6 +7,12 @@
 
 #include "hb.h"
 
+// Only allow ~5,000 set values between the two input sets.
+// Arbitarily long input sets do not trigger any meaningful
+// differences in behaviour so there's no benefit from allowing
+// the fuzzer to create super large sets.
+#define MAX_INPUT_SIZE 20000
+
 enum set_operation_t : uint8_t
 {
   INTERSECT = 0,
@@ -35,6 +41,9 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   alloc_state = size; /* see src/failing-alloc.c */
 
   if (size < sizeof (instructions_t))
+    return 0;
+
+  if (size > MAX_INPUT_SIZE)
     return 0;
 
 #pragma GCC diagnostic push


### PR DESCRIPTION
Currently the fuzzer can create arbitarily long inputs which once big enough will trigger a timeout.