### PR TITLE
remove duplicate file names

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -266,9 +266,7 @@ HB_SUBSET_sources = \
 	hb-subset-input.hh \
 	hb-subset-plan.cc \
 	hb-subset-plan.hh \
-	hb-subset-plan.hh \
 	hb-subset.cc \
-	hb-subset.hh \
 	hb-subset.hh \
 	$(NULL)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -272,9 +272,7 @@ hb_subset_sources = files(
   'hb-subset-input.hh',
   'hb-subset-plan.cc',
   'hb-subset-plan.hh',
-  'hb-subset-plan.hh',
   'hb-subset.cc',
-  'hb-subset.hh',
   'hb-subset.hh',
 )
 


### PR DESCRIPTION
hb-subset-plant.hh and hu-subset.hh have been declared twice in build script, i.e. src/makefile.sources and src/meson.build