### PR TITLE
[meson] Don’t build FontConfig subproject from master

### DIFF
--- a/subprojects/fontconfig.wrap
+++ b/subprojects/fontconfig.wrap
@@ -3,4 +3,4 @@ directory=fontconfig
 url=https://gitlab.freedesktop.org/fontconfig/fontconfig.git
 depth=1
 push-url=git@gitlab.freedesktop.org/fontconfig/fontconfig.git
-revision=master
+revision=2.13.93


### PR DESCRIPTION
Pin it to a known working tag instead.