### PR TITLE
[constexpr] IntType

### DIFF
--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -576,7 +576,7 @@ struct StateTable
 	  if (unlikely (stop > states))
 	    return_trace (false);
 	  for (const HBUSHORT *p = states; stop < p; p--)
-	    num_entries = hb_max (num_entries, *(p - 1) + 1);
+	    num_entries = hb_max (num_entries, *(p - 1) + 1u);
 	  state_neg = min_state;
 	}
       }
@@ -597,7 +597,7 @@ struct StateTable
 	  if (unlikely (stop < states))
 	    return_trace (false);
 	  for (const HBUSHORT *p = &states[state_pos * num_classes]; p < stop; p++)
-	    num_entries = hb_max (num_entries, *p + 1);
+	    num_entries = hb_max (num_entries, *p + 1u);
 	  state_pos = max_state + 1;
 	}
       }

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -337,9 +337,9 @@ struct ContextualSubtable
       const EntryData &data = entries[i].data;
 
       if (data.markIndex != 0xFFFF)
-	num_lookups = hb_max (num_lookups, 1 + data.markIndex);
+	num_lookups = hb_max (num_lookups, 1u + data.markIndex);
       if (data.currentIndex != 0xFFFF)
-	num_lookups = hb_max (num_lookups, 1 + data.currentIndex);
+	num_lookups = hb_max (num_lookups, 1u + data.currentIndex);
     }
 
     return_trace (substitutionTables.sanitize (c, this, num_lookups));

--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -83,7 +83,8 @@ static inline constexpr uint16_t hb_uint16_swap (uint16_t v)
 static inline constexpr uint32_t hb_uint32_swap (uint32_t v)
 { return (hb_uint16_swap (v) << 16) | hb_uint16_swap (v >> 16); }
 
-template <typename Type, int Bytes = sizeof (Type)> struct BEInt;
+template <typename Type, int Bytes = sizeof (Type)>
+struct BEInt;
 template <typename Type>
 struct BEInt<Type, 1>
 {
@@ -124,14 +125,16 @@ struct BEInt<Type, 2>
 template <typename Type>
 struct BEInt<Type, 3>
 {
+  static_assert (!hb_is_signed (Type), "");
   public:
   BEInt () = default;
   constexpr BEInt (Type V) : v {uint8_t ((V >> 16) & 0xFF),
-			        uint8_t ((V >>  8) & 0xFF),
-			        uint8_t ((V      ) & 0xFF)} {}
+				uint8_t ((V >>  8) & 0xFF),
+				uint8_t ((V      ) & 0xFF)} {}
+
   constexpr operator Type () const { return (v[0] << 16)
-					     + (v[1] <<  8)
-					     + (v[2]      ); }
+					  + (v[1] <<  8)
+					  + (v[2]      ); }
   private: uint8_t v[3];
 };
 template <typename Type>

--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -62,6 +62,8 @@ struct IntType
   IntType () = default;
   explicit constexpr IntType (Type V) : v {V} {}
   IntType& operator = (Type i) { v = i; return *this; }
+  /* For reason we define cast out operator for signed/unsigned, instead of Type, see:
+   * https://github.com/harfbuzz/harfbuzz/pull/2875/commits/09836013995cab2b9f07577a179ad7b024130467 */
   operator hb_conditional<hb_is_signed (Type), signed, unsigned> () const { return v; }
 
   bool operator == (const IntType &o) const { return (Type) v == (Type) o.v; }

--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -64,6 +64,11 @@ struct IntType
   IntType& operator = (Type i) { v = i; return *this; }
   operator Type () const { return v; }
 
+  template <typename Type2 = hb_conditional<hb_is_signed (Type), signed, unsigned>,
+	   hb_enable_if (sizeof (Type) < sizeof (Type2))>
+  operator hb_type_identity_t<Type2> () const { return v; }
+
+
   bool operator == (const IntType &o) const { return (Type) v == (Type) o.v; }
   bool operator != (const IntType &o) const { return !(*this == o); }
 

--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -62,12 +62,7 @@ struct IntType
   IntType () = default;
   explicit constexpr IntType (Type V) : v {V} {}
   IntType& operator = (Type i) { v = i; return *this; }
-  operator Type () const { return v; }
-
-  template <typename Type2 = hb_conditional<hb_is_signed (Type), signed, unsigned>,
-	   hb_enable_if (sizeof (Type) < sizeof (Type2))>
-  operator hb_type_identity_t<Type2> () const { return v; }
-
+  operator hb_conditional<hb_is_signed (Type), signed, unsigned> () const { return v; }
 
   bool operator == (const IntType &o) const { return (Type) v == (Type) o.v; }
   bool operator != (const IntType &o) const { return !(*this == o); }

--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -54,16 +54,15 @@ namespace OT {
 
 /* Integer types in big-endian order and no alignment requirement */
 template <typename Type,
-	  unsigned int Size = sizeof (Type),
-	  typename Wide = hb_conditional<hb_is_signed (Type), signed, unsigned>>
+	  unsigned int Size = sizeof (Type)>
 struct IntType
 {
   typedef Type type;
 
   IntType () = default;
-  explicit constexpr IntType (Wide V) : v {V} {}
-  IntType& operator = (Wide i) { v = i; return *this; }
-  operator Wide () const { return v; }
+  explicit constexpr IntType (Type V) : v {V} {}
+  IntType& operator = (Type i) { v = i; return *this; }
+  operator Type () const { return v; }
 
   bool operator == (const IntType &o) const { return (Type) v == (Type) o.v; }
   bool operator != (const IntType &o) const { return !(*this == o); }

--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -53,14 +53,18 @@ namespace OT {
  */
 
 /* Integer types in big-endian order and no alignment requirement */
-template <typename Type, unsigned int Size = sizeof (Type)>
+template <typename Type,
+	  unsigned int Size = sizeof (Type),
+	  typename Wide = hb_conditional<hb_is_signed (Type), signed, unsigned>>
 struct IntType
 {
   typedef Type type;
-  typedef hb_conditional<hb_is_signed (Type), signed, unsigned> wide_type;
 
-  IntType& operator = (wide_type i) { v = i; return *this; }
-  operator wide_type () const { return v; }
+  IntType () = default;
+  explicit constexpr IntType (Wide V) : v {V} {}
+  IntType& operator = (Wide i) { v = i; return *this; }
+  operator Wide () const { return v; }
+
   bool operator == (const IntType &o) const { return (Type) v == (Type) o.v; }
   bool operator != (const IntType &o) const { return !(*this == o); }
 

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -1821,8 +1821,7 @@ struct ClassDefFormat1
     }
     /* TODO Speed up, using set overlap first? */
     /* TODO(iter) Rewrite as dagger. */
-    HBUINT16 k; /* TODO(constexpr) use constructor to initialize. */
-    k = klass;
+    HBUINT16 k {klass};
     const HBUINT16 *arr = classValue.arrayZ;
     for (unsigned int i = 0; i < count; i++)
       if (arr[i] == k && glyphs->has (startGlyph + i))
@@ -1995,8 +1994,7 @@ struct ClassDefFormat2
     }
     /* TODO Speed up, using set overlap first? */
     /* TODO(iter) Rewrite as dagger. */
-    HBUINT16 k; /* TODO(constexpr) use constructor to initialize. */
-    k = klass;
+    HBUINT16 k {klass};
     const RangeRecord *arr = rangeRecord.arrayZ;
     for (unsigned int i = 0; i < count; i++)
       if (arr[i].value == k && arr[i].intersects (glyphs))

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -1788,7 +1788,7 @@ struct ClassDefFormat1
   }
 
   template <typename set_t>
-  bool collect_class (set_t *glyphs, unsigned int klass) const
+  bool collect_class (set_t *glyphs, unsigned klass) const
   {
     unsigned int count = classValue.len;
     for (unsigned int i = 0; i < count; i++)
@@ -1806,7 +1806,7 @@ struct ClassDefFormat1
       if (classValue[iter - start]) return true;
     return false;
   }
-  bool intersects_class (const hb_set_t *glyphs, unsigned int klass) const
+  bool intersects_class (const hb_set_t *glyphs, uint16_t klass) const
   {
     unsigned int count = classValue.len;
     if (klass == 0)
@@ -1973,7 +1973,7 @@ struct ClassDefFormat2
 	return true;
     return false;
   }
-  bool intersects_class (const hb_set_t *glyphs, unsigned int klass) const
+  bool intersects_class (const hb_set_t *glyphs, uint16_t klass) const
   {
     unsigned int count = rangeRecord.len;
     if (klass == 0)

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -2323,7 +2323,7 @@ struct ChainRule
   {
     c->copy (len);
     for (const auto g : it)
-      c->copy (HBUINT16 {g});
+      c->copy ((HBUINT16) g);
   }
 
   ChainRule* copy (hb_serialize_context_t *c,

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -2323,12 +2323,7 @@ struct ChainRule
   {
     c->copy (len);
     for (const auto g : it)
-    {
-      /* TODO(constexpr) Simplify. */
-      HBUINT16 gid;
-      gid = g;
-      c->copy (gid);
-    }
+      c->copy (HBUINT16 {g});
   }
 
   ChainRule* copy (hb_serialize_context_t *c,


### PR DESCRIPTION
This breaks tests on my Linux box, but passes on Mac. Sending to
bots to see if helps me figure out what's going on.

The main change is in cast operators of BEInt used to return Type,
now return Wide. I don't understand why that can fail tests (and
with no compiler diagnostic message...).

Nor do I remember why I made this change back in June...  I *think*
I made it to make the types be closer to regular small-int types by
involving just one conversion to signed/unsigned instead of two,
which becomes important in template matching. However, I don't
remember the exact details. Sigh...