### PR TITLE
Include C headers with their C++ names

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -35,9 +35,6 @@
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */
 
-#include <stdio.h>
-#include <stdlib.h>
-
 
 /**
  * SECTION: hb-blob

--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -34,7 +34,6 @@
 
 #include "hb-coretext.h"
 #include "hb-aat-layout.hh"
-#include <math.h>
 
 
 /**

--- a/src/hb-ot-color.cc
+++ b/src/hb-ot-color.cc
@@ -37,9 +37,6 @@
 #include "hb-ot-color-sbix-table.hh"
 #include "hb-ot-color-svg-table.hh"
 
-#include <stdlib.h>
-#include <string.h>
-
 
 /**
  * SECTION:hb-ot-color

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -176,15 +176,15 @@
 #include "hb-aat.h"
 #define HB_AAT_H_IN
 
-#include <limits.h>
-#include <math.h>
-#include <float.h>
-#include <stdlib.h>
-#include <stddef.h>
-#include <string.h>
-#include <assert.h>
-#include <stdio.h>
-#include <stdarg.h>
+#include <cassert>
+#include <cfloat>
+#include <climits>
+#include <cmath>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #if (defined(_MSC_VER) && _MSC_VER >= 1500) || defined(__MINGW32__)
 #ifdef __MINGW32_VERSION
@@ -391,7 +391,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #endif
 
 #ifndef HB_NO_ERRNO
-#  include <errno.h>
+#  include <cerrno>
 #else
 static int HB_UNUSED _hb_errno = 0;
 #  undef errno

--- a/src/test-buffer-serialize.cc
+++ b/src/test-buffer-serialize.cc
@@ -32,8 +32,6 @@
 #include "hb-ft.h"
 #endif
 
-#include <stdio.h>
-
 #ifdef HB_NO_OPEN
 #define hb_blob_create_from_file(x)  hb_blob_get_empty ()
 #endif

--- a/src/test-gpos-size-params.cc
+++ b/src/test-gpos-size-params.cc
@@ -29,8 +29,6 @@
 #include "hb.h"
 #include "hb-ot.h"
 
-#include <stdio.h>
-
 #ifdef HB_NO_OPEN
 #define hb_blob_create_from_file(x)  hb_blob_get_empty ()
 #endif

--- a/src/test-gsub-would-substitute.cc
+++ b/src/test-gsub-would-substitute.cc
@@ -29,8 +29,6 @@
 #include "hb.h"
 #include "hb-ot.h"
 
-#include <stdio.h>
-
 #ifdef HAVE_FREETYPE
 #include "hb-ft.h"
 #endif

--- a/src/test-ot-glyphname.cc
+++ b/src/test-ot-glyphname.cc
@@ -27,9 +27,6 @@
 #include "hb.hh"
 #include "hb-ot.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-
 #ifdef HB_NO_OPEN
 #define hb_blob_create_from_file(x)  hb_blob_get_empty ()
 #endif

--- a/src/test-ot-meta.cc
+++ b/src/test-ot-meta.cc
@@ -25,9 +25,6 @@
 #include "hb.hh"
 #include "hb-ot.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-
 #ifdef HB_NO_OPEN
 #define hb_blob_create_from_file(x)  hb_blob_get_empty ()
 #endif

--- a/src/test-ot-name.cc
+++ b/src/test-ot-name.cc
@@ -27,9 +27,6 @@
 #include "hb.hh"
 #include "hb-ot.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-
 #ifdef HB_NO_OPEN
 #define hb_blob_create_from_file(x)  hb_blob_get_empty ()
 #endif

--- a/src/test.cc
+++ b/src/test.cc
@@ -26,10 +26,6 @@
 
 #include "hb.hh"
 
-#include "hb.h"
-
-#include <stdio.h>
-
 #ifdef HAVE_FREETYPE
 #include "hb-ft.h"
 #endif


### PR DESCRIPTION
Remove unnecessary includes.

Fixes build with some known broken SDKs (Nintendo Switch?)

https://en.cppreference.com/w/cpp/header

Fixes https://github.com/harfbuzz/harfbuzz/pull/2881