### PR TITLE
meson.build: Improve FreeType2 dependency search

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,17 @@ m_dep = cpp.find_library('m', required: false)
 
 freetype_dep = null_dep
 if not get_option('freetype').disabled()
-  freetype_dep = dependency('freetype2', required: false)
+  # The package names for FreeType2 are different for pkg-config and CMake
+  check_freetype_pkgs = [
+    ['freetype2', 'pkg-config'],
+    ['freetype', 'cmake'],
+  ]
+
+  foreach ft_pkg: check_freetype_pkgs
+    if not freetype_dep.found()
+      freetype_dep = dependency(ft_pkg[0], method: ft_pkg[1], required: false)
+    endif
+  endforeach
 
   if (not freetype_dep.found() and
       cpp.get_id() == 'msvc' and


### PR DESCRIPTION
Hi,

From the commit message:

<i>The package names for the pkg-config files and CMake config files for FreeType2 are different, so match the package names to the dependency search type, and look for FreeType2 first with pkg-config, then with CMake, and then on Visual Studio-style compilers, the actual .lib file.</i>

This can become useful as CMake has built-in support for looking for FreeType2.

With blessings, thank you!