### PR TITLE
hb-config: Include config-override earlier

### DIFF
--- a/src/hb-config.hh
+++ b/src/hb-config.hh
@@ -86,6 +86,9 @@
 #define HB_NO_LEGACY
 #endif
 
+#ifdef HAVE_CONFIG_OVERRIDE_H
+#include "config-override.h"
+#endif
 
 /* Closure of options. */
 
@@ -153,10 +156,6 @@
 #ifndef HB_OPTIMIZE_SIZE
 #define HB_OPTIMIZE_SIZE
 #endif
-#endif
-
-#ifdef HAVE_CONFIG_OVERRIDE_H
-#include "config-override.h"
 #endif
 
 


### PR DESCRIPTION
Currently config-override.h is included at the end of this file. This caused a problem for me while undefing HB_DISABLE_DEPRECATED, namely HB_IF_NOT_DEPRECATED was defined before actual undef took place and broke the whole build. I believe it would break builds for some other defines, too. Moving config-override.h include right after predefined configs is more sane and fixes all potential problems with includes.