### PR TITLE
[build] Don’t look for FontConfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
     executor: autotools-executor
     steps:
       - checkout
-      - run: sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y git ninja-build binutils libtool autoconf automake make gcc g++ pkg-config ragel gtk-doc-tools gobject-introspection libfontconfig1-dev libfreetype6-dev libglib2.0-dev libgirepository1.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip
+      - run: sudo apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y git ninja-build binutils libtool autoconf automake make gcc g++ pkg-config ragel gtk-doc-tools gobject-introspection libfreetype6-dev libglib2.0-dev libgirepository1.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-pip
       - run: pip3 install fonttools meson --upgrade
       - run: ./autogen.sh
       - run: make -j32

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,6 @@ EXTRA_DIST = \
 	meson.build \
 	meson_options.txt \
 	subprojects/expat.wrap \
-	subprojects/fontconfig.wrap \
 	subprojects/freetype2.wrap \
 	subprojects/glib.wrap \
 	subprojects/libffi.wrap \

--- a/configure.ac
+++ b/configure.ac
@@ -214,24 +214,6 @@ AM_CONDITIONAL(HAVE_CAIRO_FT, $have_cairo_ft)
 
 dnl ==========================================================================
 
-AC_ARG_WITH(fontconfig,
-	[AS_HELP_STRING([--with-fontconfig=@<:@yes/no/auto@:>@],
-			[Use fontconfig @<:@default=auto@:>@])],,
-	[with_fontconfig=auto])
-have_fontconfig=false
-if test "x$with_fontconfig" = "xyes" -o "x$with_fontconfig" = "xauto"; then
-	PKG_CHECK_MODULES(FONTCONFIG, fontconfig, have_fontconfig=true, :)
-fi
-if test "x$with_fontconfig" = "xyes" -a "x$have_fontconfig" != "xtrue"; then
-	AC_MSG_ERROR([fontconfig support requested but not found])
-fi
-if $have_fontconfig; then
-	AC_DEFINE(HAVE_FONTCONFIG, 1, [Have fontconfig library])
-fi
-AM_CONDITIONAL(HAVE_FONTCONFIG, $have_fontconfig)
-
-dnl ==========================================================================
-
 AC_ARG_WITH(icu,
 	[AS_HELP_STRING([--with-icu=@<:@yes/no/builtin/auto@:>@],
 			[Use ICU @<:@default=auto@:>@])],,
@@ -466,7 +448,6 @@ Font callbacks (the more the merrier):
 
 Tools used for command-line utilities:
 	Cairo:			${have_cairo}
-	Fontconfig:		${have_fontconfig}
 
 Additional shapers:
 	Graphite2:		${have_graphite2}

--- a/docs/usermanual-install-harfbuzz.xml
+++ b/docs/usermanual-install-harfbuzz.xml
@@ -239,26 +239,6 @@
 	</varlistentry>
 	
 	<varlistentry>
-	  <term><command>-Dfontconfig=enabled</command></term>
-	  <listitem>
-	    <para>
-	      Use <ulink url="https://www.freedesktop.org/wiki/Software/fontconfig/">Fontconfig</ulink>. <emphasis>(Default = auto)</emphasis>
-	    </para>
-	    <para>
-	      This option enables or disables usage of the Fontconfig
-	      library, which provides font-matching functions and
-	      provides access to font properties. The default setting
-	      is to check for the presence of Fontconfig and, if it is
-	      found, build with Fontconfig support.
-	    </para>
-	    <para>
-	      Note: Fontconfig is used only by the HarfBuzz
-	      command-line utilities, and not by the HarfBuzz library.
-	    </para>
-	  </listitem>
-	</varlistentry>
-	
-	<varlistentry>
 	  <term><command>-Dicu=enabled</command></term>
 	  <listitem>
 	    <para>

--- a/meson.build
+++ b/meson.build
@@ -95,8 +95,6 @@ glib_dep = dependency('glib-2.0', required: get_option('glib'),
                       fallback: ['glib', 'libglib_dep'])
 gobject_dep = dependency('gobject-2.0', required: get_option('gobject'),
                          fallback: ['glib', 'libgobject_dep'])
-fontconfig_dep = dependency('fontconfig', required: get_option('fontconfig'),
-                            fallback: ['fontconfig', 'fontconfig_dep'])
 graphite2_dep = dependency('graphite2', required: get_option('graphite'))
 
 icu_dep = null_dep
@@ -215,10 +213,6 @@ if freetype_dep.found()
   else
     check_funcs += check_freetype_funcs
   endif
-endif
-
-if fontconfig_dep.found()
-  conf.set('HAVE_FONTCONFIG', 1)
 endif
 
 gdi_uniscribe_deps = []
@@ -369,7 +363,6 @@ build_summary = {
     },
   'Dependencies used for command-line utilities':
     {'Cairo': conf.get('HAVE_CAIRO', 0) == 1,
-     'Fontconfig': conf.get('HAVE_FONTCONFIG', 0) == 1,
     },
   'Additional shapers':
     {'Graphite2': conf.get('HAVE_GRAPHITE2', 0) == 1,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,8 +5,6 @@ option('gobject', type: 'feature', value: 'auto',
   description: 'Enable GObject bindings')
 option('cairo', type: 'feature', value: 'auto',
   description: 'Use Cairo graphics library')
-option('fontconfig', type: 'feature', value: 'auto',
-  description: 'Use fontconfig')
 option('icu', type: 'feature', value: 'auto',
   description: 'Enable ICU library unicode functions')
 option('graphite', type: 'feature', value: 'disabled',

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,7 +1,6 @@
 /expat-2.2.5
 /freetype2
 /glib
-/fontconfig
 /libffi
 /proxy-libintl
 /zlib

--- a/subprojects/fontconfig.wrap
+++ b/subprojects/fontconfig.wrap
@@ -1,6 +1,0 @@
-[wrap-git]
-directory=fontconfig
-url=https://gitlab.freedesktop.org/fontconfig/fontconfig.git
-depth=1
-push-url=git@gitlab.freedesktop.org/fontconfig/fontconfig.git
-revision=2.13.93


### PR DESCRIPTION
We don’t currently use it anywhere. It was used briefly for the `hb-fc-list` tool, but this tool have not been built since 2015:

```
commit cd042fc8c4a3984c3647cd22a27c34f00636f6e8
Author: Behdad Esfahbod <behdad@behdad.org>
Date:   Thu Jun 18 10:55:13 2015 -0700

    [util] Disable hb-fc-list for now

    Until I figure out what to do about the API, and finalize
    the tool.
```