### PR TITLE
Reformat gen-tag-table.py

### DIFF
--- a/src/gen-tag-table.py
+++ b/src/gen-tag-table.py
@@ -25,10 +25,8 @@ Input files:
 """
 
 import collections
+import html
 from html.parser import HTMLParser
-def write (s):
-	sys.stdout.flush ()
-	sys.stdout.buffer.write (s.encode ('utf-8'))
 import itertools
 import re
 import sys
@@ -37,15 +35,15 @@ import unicodedata
 if len (sys.argv) != 3:
 	sys.exit (__doc__)
 
-from html import unescape
-def html_unescape (parser, entity):
-	return unescape (entity)
-
 def expect (condition, message=None):
 	if not condition:
 		if message is None:
 			raise AssertionError
 		raise AssertionError (message)
+
+def write (s):
+	sys.stdout.flush ()
+	sys.stdout.buffer.write (s.encode ('utf-8'))
 
 DEFAULT_LANGUAGE_SYSTEM = ''
 
@@ -383,10 +381,10 @@ class OpenTypeRegistryParser (HTMLParser):
 			self._current_tr[-1] += data
 
 	def handle_charref (self, name):
-		self.handle_data (html_unescape (self, '&#%s;' % name))
+		self.handle_data (html.unescape ('&#%s;' % name))
 
 	def handle_entityref (self, name):
-		self.handle_data (html_unescape (self, '&%s;' % name))
+		self.handle_data (html.unescape ('&%s;' % name))
 
 	def parse (self, filename):
 		"""Parse the OpenType language system tag registry.


### PR DESCRIPTION
gen-tag-table.py had a couple strange formatting choices because it was originally written to be compatible with both Python 2 and Python 3. When [Python 2 support was removed](https://github.com/harfbuzz/harfbuzz/commit/e17fd0d91cbd69fa9c01b20bd5c448d0a4fe0e67#diff-99e33544113cf4657f80e03573b539f1aa59964a37f6aaf9a5670818e8cf2b16), the code was not reformatted.