### PR TITLE
[sanitize] change max ops to track number of bytes processed.

### DIFF
--- a/src/hb-sanitize.hh
+++ b/src/hb-sanitize.hh
@@ -105,7 +105,7 @@
 #define HB_SANITIZE_MAX_EDITS 32
 #endif
 #ifndef HB_SANITIZE_MAX_OPS_FACTOR
-#define HB_SANITIZE_MAX_OPS_FACTOR 8
+#define HB_SANITIZE_MAX_OPS_FACTOR 64
 #endif
 #ifndef HB_SANITIZE_MAX_OPS_MIN
 #define HB_SANITIZE_MAX_OPS_MIN 16384
@@ -233,7 +233,7 @@ struct hb_sanitize_context_t :
 	      (this->start <= p &&
 	       p <= this->end &&
 	       (unsigned int) (this->end - p) >= len &&
-	       this->max_ops-- > 0);
+	       (this->max_ops -= len) > 0);
 
     DEBUG_MSG_LEVEL (SANITIZE, p, this->debug_depth+1, 0,
 		     "check_range [%p..%p]"


### PR DESCRIPTION
Counting bytes as the operations is likely to be a better proxy for how
much work processing the table will cost vs. the current approach of
counting the number of sub-objects.

This should allow checks for max features, max scripts, etc. to be removed.

I tested this change against the full collection of fonts at https://github.com/google/fonts
and a max ops factor of 3 was sufficient to successfully sanitize all of them.