### PR TITLE
[ot] Update _hb_glyph_info_is_default_ignorable_and_not_hidden()

### DIFF
--- a/src/hb-ot-layout.hh
+++ b/src/hb-ot-layout.hh
@@ -314,7 +314,6 @@ _hb_glyph_info_get_unicode_space_fallback_type (const hb_glyph_info_t *info)
 	 hb_unicode_funcs_t::NOT_SPACE;
 }
 
-static inline bool _hb_glyph_info_ligated (const hb_glyph_info_t *info);
 static inline bool _hb_glyph_info_substituted (const hb_glyph_info_t *info);
 
 static inline bool
@@ -328,7 +327,7 @@ _hb_glyph_info_is_default_ignorable_and_not_hidden (const hb_glyph_info_t *info)
 {
   return ((info->unicode_props() & (UPROPS_MASK_IGNORABLE|UPROPS_MASK_HIDDEN))
 	  == UPROPS_MASK_IGNORABLE) &&
-	 !_hb_glyph_info_ligated (info);
+	 !_hb_glyph_info_substituted (info);
 }
 static inline void
 _hb_glyph_info_unhide (hb_glyph_info_t *info)


### PR DESCRIPTION
Used `_hb_glyph_info_substituted()` similar to the change made to `_hb_glyph_info_is_default_ignorable()` in 7686ff854bbb9698bb1469dcfe6d288c695a76b7.