### PR TITLE
[hb-view] Use Chafa for terminal graphics if available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - checkout
       - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config ragel freetype glib cairo python3 icu4c graphite2 gobject-introspection gtk-doc ninja
       - run: pip3 install meson --upgrade
-      - run: PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig" meson build -Dcoretext=enabled -Dgraphite=enabled -Dauto_features=enabled
+      - run: PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig" meson build -Dcoretext=enabled -Dgraphite=enabled -Dauto_features=enabled -Dchafa=disabled
       - run: meson compile -Cbuild
       - run: meson test -Cbuild --print-errorlogs
       - store_artifacts:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -16,7 +16,7 @@ jobs:
       run: sudo apt-get install pkg-config gcc ragel gcovr gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-setuptools ninja-build gobject-introspection libgirepository1.0-dev
     - run: sudo pip3 install fonttools meson==0.47.0
     - name: run
-      run: meson build -Db_coverage=true --auto-features=enabled -Dgraphite=enabled -Doptimization=2
+      run: meson build -Db_coverage=true --auto-features=enabled -Dgraphite=enabled -Dchafa=disabled -Doptimization=2
     - name: ci
       run: meson test --print-errorlogs -Cbuild
 

--- a/.github/workflows/msys2-ci.yml
+++ b/.github/workflows/msys2-ci.yml
@@ -54,7 +54,8 @@ jobs:
             --auto-features=enabled \
             -Ddirectwrite=enabled \
             -Dgdi=enabled \
-            -Dgraphite=enabled
+            -Dgraphite=enabled \
+            -Dchafa=disabled
           ninja -C build
       - name: Test
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -214,6 +214,24 @@ AM_CONDITIONAL(HAVE_CAIRO_FT, $have_cairo_ft)
 
 dnl ==========================================================================
 
+AC_ARG_WITH(chafa,
+	[AS_HELP_STRING([--with-chafa=@<:@yes/no/auto@:>@],
+			[Use chafa @<:@default=auto@:>@])],,
+	[with_chafa=auto])
+have_chafa=false
+if test "x$with_chafa" = "xyes" -o "x$with_chafa" = "xauto"; then
+	PKG_CHECK_MODULES(CHAFA, chafa >= 1.6.0, have_chafa=true, :)
+fi
+if test "x$with_chafa" = "xyes" -a "x$have_chafa" != "xtrue"; then
+	AC_MSG_ERROR([chafa support requested but not found])
+fi
+if $have_chafa; then
+	AC_DEFINE(HAVE_CHAFA, 1, [Have chafa terminal graphics library])
+fi
+AM_CONDITIONAL(HAVE_CHAFA, $have_chafa)
+
+dnl ==========================================================================
+
 AC_ARG_WITH(icu,
 	[AS_HELP_STRING([--with-icu=@<:@yes/no/builtin/auto@:>@],
 			[Use ICU @<:@default=auto@:>@])],,
@@ -448,6 +466,7 @@ Font callbacks (the more the merrier):
 
 Tools used for command-line utilities:
 	Cairo:			${have_cairo}
+	Chafa:			${have_chafa}
 
 Additional shapers:
 	Graphite2:		${have_graphite2}

--- a/meson.build
+++ b/meson.build
@@ -154,6 +154,8 @@ if not get_option('cairo').disabled()
   endif
 endif
 
+chafa_dep = dependency('chafa', version: '>= 1.6.0', required: get_option('chafa'))
+
 conf = configuration_data()
 incconfig = include_directories('.')
 
@@ -179,6 +181,10 @@ endif
 
 if cairo_ft_dep.found()
   conf.set('HAVE_CAIRO_FT', 1)
+endif
+
+if chafa_dep.found()
+  conf.set('HAVE_CHAFA', 1)
 endif
 
 if graphite2_dep.found()
@@ -363,6 +369,7 @@ build_summary = {
     },
   'Dependencies used for command-line utilities':
     {'Cairo': conf.get('HAVE_CAIRO', 0) == 1,
+     'Chafa': conf.get('HAVE_CHAFA', 0) == 1,
     },
   'Additional shapers':
     {'Graphite2': conf.get('HAVE_GRAPHITE2', 0) == 1,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,8 @@ option('gobject', type: 'feature', value: 'auto',
   description: 'Enable GObject bindings')
 option('cairo', type: 'feature', value: 'auto',
   description: 'Use Cairo graphics library')
+option('chafa', type: 'feature', value: 'auto',
+  description: 'Use Chafa terminal graphics library')
 option('icu', type: 'feature', value: 'auto',
   description: 'Enable ICU library unicode functions')
 option('graphite', type: 'feature', value: 'disabled',

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -25,6 +25,7 @@ AM_CPPFLAGS = \
 	$(GLIB_CFLAGS) \
 	$(FREETYPE_CFLAGS) \
 	$(CAIRO_FT_CFLAGS) \
+	$(CHAFA_CFLAGS) \
 	$(NULL)
 LDADD = \
 	$(top_builddir)/src/libharfbuzz.la \
@@ -42,6 +43,7 @@ hb_view_LDADD = \
 	$(LDADD) \
 	$(CAIRO_LIBS) \
 	$(CAIRO_FT_LIBS) \
+	$(CHAFA_LIBS) \
 	$(NULL)
 bin_PROGRAMS += hb-view
 endif # HAVE_CAIRO_FT

--- a/util/meson.build
+++ b/util/meson.build
@@ -31,7 +31,7 @@ if conf.get('HAVE_GLIB', 0) == 1
     hb_view = executable('hb-view', hb_view_sources,
       cpp_args: cpp_args,
       include_directories: [incconfig, incsrc],
-      dependencies: util_deps,
+      dependencies: [util_deps, chafa_dep],
       link_with: [libharfbuzz],
       install: true,
     )


### PR DESCRIPTION
Link with and use Chafa if available. This produces high-quality terminal graphics using symbols or sixels according to the detected terminal capabilities.

Fixes #2430.