### PR TITLE
[ci] Drop macos-10_13_6-aat-fonts job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,19 +10,6 @@ executors:
 
 jobs:
 
-  macos-10_13_6-aat-fonts:
-    macos:
-      xcode: "10.1.0"
-    steps:
-      - checkout
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config ragel freetype glib cairo python3 ninja
-      - run: pip3 install meson --upgrade
-      - run: meson build
-      - run: meson compile -Cbuild
-      - run: meson test -Cbuild --print-errorlogs
-      - store_artifacts:
-          path: build/meson-logs/
-
   macos-10_14_4-aat-fonts:
     macos:
       xcode: "11.1.0"
@@ -157,7 +144,6 @@ workflows:
 
   build:
     jobs:
-      - macos-10_13_6-aat-fonts
       - macos-10_14_4-aat-fonts
       - macos-10_15_3-aat-fonts
       - distcheck: # will be dropped with autotools removal


### PR DESCRIPTION
This version of macOS is no longer supported by Homebrew, it takes 26 minutes to brew the dependencies before it fails.