### PR TITLE
Update glyph properties during AAT substitutions so that mark zeroing works as expected

### DIFF
--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -30,6 +30,9 @@
 #include "hb-aat-layout.hh"
 #include "hb-open-type.hh"
 
+namespace OT {
+struct GDEF;
+};
 
 namespace AAT {
 
@@ -863,6 +866,7 @@ struct hb_aat_apply_context_t :
   hb_buffer_t *buffer;
   hb_sanitize_context_t sanitizer;
   const ankr *ankr_table;
+  const OT::GDEF *gdef_table;
 
   /* Unused. For debug tracing only. */
   unsigned int lookup_index;

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -30,6 +30,7 @@
 #include "hb-open-type.hh"
 #include "hb-aat-layout-common.hh"
 #include "hb-ot-layout-common.hh"
+#include "hb-ot-layout-gdef-table.hh"
 #include "hb-aat-map.hh"
 
 /*
@@ -215,7 +216,9 @@ struct ContextualSubtable
 			     hb_aat_apply_context_t *c_) :
 	ret (false),
 	c (c_),
+	gdef (*c->gdef_table),
 	mark_set (false),
+	has_glyph_classes (gdef.has_glyph_classes ()),
 	mark (0),
 	table (table_),
 	subs (table+table->substitutionTables) {}
@@ -263,6 +266,9 @@ struct ContextualSubtable
       {
 	buffer->unsafe_to_break (mark, hb_min (buffer->idx + 1, buffer->len));
 	buffer->info[mark].codepoint = *replacement;
+	if (has_glyph_classes)
+	  _hb_glyph_info_set_glyph_props (&buffer->info[mark],
+					  gdef.get_glyph_props (*replacement));
 	ret = true;
       }
 
@@ -287,6 +293,9 @@ struct ContextualSubtable
       if (replacement)
       {
 	buffer->info[idx].codepoint = *replacement;
+	if (has_glyph_classes)
+	  _hb_glyph_info_set_glyph_props (&buffer->info[idx],
+					  gdef.get_glyph_props (*replacement));
 	ret = true;
       }
 
@@ -301,7 +310,9 @@ struct ContextualSubtable
     bool ret;
     private:
     hb_aat_apply_context_t *c;
+    const OT::GDEF &gdef;
     bool mark_set;
+    bool has_glyph_classes;
     unsigned int mark;
     const ContextualSubtable *table;
     const UnsizedListOfOffset16To<Lookup<HBGlyphID>, HBUINT, false> &subs;
@@ -599,6 +610,9 @@ struct NoncontextualSubtable
   {
     TRACE_APPLY (this);
 
+    const OT::GDEF &gdef (*c->gdef_table);
+    bool has_glyph_classes = gdef.has_glyph_classes ();
+
     bool ret = false;
     unsigned int num_glyphs = c->face->get_num_glyphs ();
 
@@ -610,6 +624,9 @@ struct NoncontextualSubtable
       if (replacement)
       {
 	info[i].codepoint = *replacement;
+	if (has_glyph_classes)
+	  _hb_glyph_info_set_glyph_props (&info[i],
+					  gdef.get_glyph_props (*replacement));
 	ret = true;
       }
     }

--- a/src/hb-aat-layout.cc
+++ b/src/hb-aat-layout.cc
@@ -55,6 +55,7 @@ AAT::hb_aat_apply_context_t::hb_aat_apply_context_t (const hb_ot_shape_plan_t *p
 						       buffer (buffer_),
 						       sanitizer (),
 						       ankr_table (&Null (AAT::ankr)),
+						       gdef_table (face->table.GDEF->table),
 						       lookup_index (0)
 {
   sanitizer.init (blob);
@@ -79,7 +80,7 @@ AAT::hb_aat_apply_context_t::set_ankr_table (const AAT::ankr *ankr_table_)
  * @short_description: Apple Advanced Typography Layout
  * @include: hb-aat.h
  *
- * Functions for querying AAT Layout features in the font face. 
+ * Functions for querying AAT Layout features in the font face.
  *
  * HarfBuzz supports all of the AAT tables used to implement shaping. Other
  * AAT tables and their associated features are not supported.
@@ -172,13 +173,13 @@ static const hb_aat_feature_mapping_t feature_mappings[] =
   {HB_TAG ('z','e','r','o'), HB_AAT_LAYOUT_FEATURE_TYPE_TYPOGRAPHIC_EXTRAS,      HB_AAT_LAYOUT_FEATURE_SELECTOR_SLASHED_ZERO_ON,                HB_AAT_LAYOUT_FEATURE_SELECTOR_SLASHED_ZERO_OFF},
 };
 
-/** 
+/**
  * hb_aat_layout_find_feature_mapping:
  * @tag: The requested #hb_tag_t feature tag
  *
  * Fetches the AAT feature-and-selector combination that corresponds
  * to a given OpenType feature tag.
- *  
+ *
  * Return value: the AAT features and selectors corresponding to the
  * OpenType feature tag queried
  *

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -193,6 +193,12 @@ hb_ot_shape_planner_t::compile (hb_ot_shape_plan_t           &plan,
 				   script_fallback_mark_positioning;
 
 #ifndef HB_NO_AAT_SHAPE
+  /* If we're using morx shaping, we cancel mark position adjustment because
+     Apple Color Emoji assumes this will NOT be done when forming emoji sequences;
+     https://github.com/harfbuzz/harfbuzz/issues/2967. */
+  if (plan.apply_morx)
+    plan.adjust_mark_positioning_when_zeroing = false;
+
   /* Currently we always apply trak. */
   plan.apply_trak = plan.requested_tracking && hb_aat_layout_has_tracking (face);
 #endif
@@ -1164,7 +1170,7 @@ _hb_ot_shape (hb_shape_plan_t    *shape_plan,
  * @lookup_indexes: (out): The #hb_set_t set of lookups returned
  *
  * Computes the complete set of GSUB or GPOS lookups that are applicable
- * under a given @shape_plan. 
+ * under a given @shape_plan.
  *
  * Since: 0.9.7
  **/

--- a/test/shaping/data/in-house/tests/macos.tests
+++ b/test/shaping/data/in-house/tests/macos.tests
@@ -132,3 +132,6 @@
 /System/Library/Fonts/Supplemental/Apple Chancery.ttf@4ec49cba0d4e68d025ada0498c4df1b2f9fd57ac:--font-funcs ot --features liga=0,dlig=1:U+0066,U+0069,U+0072,U+0073,U+0074:[f=0+639|i=1+606|r=2+853|s_t=3+1438]
 /System/Library/Fonts/Supplemental/Skia.ttf@caee56fc4085009c1a29a863500908050ea6248f:--font-funcs ot:U+0041,U+0056:[A=0+1345|V=1@-12,0+1346]
 /System/Library/Fonts/Supplemental/Devanagari Sangam MN.ttc@214b7ffa672bc936745df5a72644f2b705b24b4b:--font-funcs ot:U+092D,U+0941:[dn_bha=0+1339|dn_u_matra.mrk=0@-296,11+0]
+
+# 11.1
+/System/Library/Fonts/Apple Color Emoji.ttc@6b0fa4926a1c8a32267e93e18c5eff21558de83a:--font-funcs ot:U+1F469,U+1F3FD,U+200D,U+1F91D,U+200D,U+1F468,U+1F3FE:[u1F469.3.L=0+0|space=0+0|space=0+0|u1F468.4.RA=0+800]


### PR DESCRIPTION
When zeroing by GDEF late, we need to re-check the GDEF table
(if it is the source of glyph classes) because substitutions may
mean that we now have mark glyphs in slots that were not flagged
as such initially.

Fixes #2967.