### PR TITLE
Fix for: Warnings with gcc 8 and earlier #2972

### DIFF
--- a/src/hb-ot-shape-complex-use-machine.hh
+++ b/src/hb-ot-shape-complex-use-machine.hh
@@ -375,7 +375,9 @@ hb_iter_with_fallback_t<machine_index_t<Iter>,
 typename Iter::item_t>
 {
 	machine_index_t (const Iter& it) : it (it) {}
-	machine_index_t (const machine_index_t& o) : it (o.it) {}
+	machine_index_t (const machine_index_t& o) :
+	  hb_iter_with_fallback_t<machine_index_t<Iter>, typename Iter::item_t>(o),
+	  it (o.it) {}
 	
 	static constexpr bool is_random_access_iterator = Iter::is_random_access_iterator;
 	static constexpr bool is_sorted_iterator = Iter::is_sorted_iterator;


### PR DESCRIPTION
Hi,

Please consider this fix for a build warning with gcc 8 and earlier. This causes problems in OpenJDK, see issue for details.

Thank you!

..Thomas