### PR TITLE
Chromium build fixes for C++ 17 warning and missing _remap_indexes

### DIFF
--- a/src/hb-ot-color-colrv1-closure.hh
+++ b/src/hb-ot-color-colrv1-closure.hh
@@ -65,25 +65,25 @@ HB_INTERNAL void PaintColrGlyph::closurev1 (hb_colrv1_closure_context_t* c) cons
   (&baseglyphV1_list+baseglyphV1_record->paint).dispatch (c);
 }
 
-template <template<typename> typename Var>
+template <template<typename> class Var>
 HB_INTERNAL void PaintTransform<Var>::closurev1 (hb_colrv1_closure_context_t* c) const
 {
   (this+src).dispatch (c);
 }
 
-template <template<typename> typename Var>
+template <template<typename> class Var>
 HB_INTERNAL void PaintTranslate<Var>::closurev1 (hb_colrv1_closure_context_t* c) const
 {
   (this+src).dispatch (c);
 }
 
-template <template<typename> typename Var>
+template <template<typename> class Var>
 HB_INTERNAL void PaintRotate<Var>::closurev1 (hb_colrv1_closure_context_t* c) const
 {
   (this+src).dispatch (c);
 }
 
-template <template<typename> typename Var>
+template <template<typename> class Var>
 HB_INTERNAL void PaintSkew<Var>::closurev1 (hb_colrv1_closure_context_t* c) const
 {
   (this+src).dispatch (c);

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -56,7 +56,6 @@ _add_cff_seac_components (const OT::cff1::accelerator_t &cff,
 }
 #endif
 
-#ifndef HB_NO_SUBSET_LAYOUT
 static void
 _remap_indexes (const hb_set_t *indexes,
 		hb_map_t       *mapping /* OUT */)
@@ -68,6 +67,7 @@ _remap_indexes (const hb_set_t *indexes,
 
 }
 
+#ifndef HB_NO_SUBSET_LAYOUT
 static inline void
 _gsub_closure_glyphs_lookups_features (hb_face_t *face,
 				       hb_set_t *gids_to_retain,


### PR DESCRIPTION
Use class instead of typename, move _remap_indexes out of #ifndef.

Fixes #2979