### PR TITLE
[meson] fix warning: use feature which were added in newer versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('harfbuzz', 'c', 'cpp',
-  meson_version: '>= 0.47.0',
+  meson_version: '>= 0.50.0',
   version: '2.8.1',
   default_options: [
     'cpp_eh=none',          # Just to support msvc, we are passing -fno-rtti also anyway


### PR DESCRIPTION

```
WARNING: Project targeting '>= 0.47.0' but tried to use feature introduced in '0.50.0': install arg in configure_file.

WARNING: Project specifies a minimum meson_version '>= 0.47.0' but uses features which were added in newer versions:
harfbuzz| * 0.50.0: {'install arg in configure_file'}
```