### PR TITLE
Avoid a deprecation warning in graphite2

### DIFF
--- a/src/hb-graphite2.cc
+++ b/src/hb-graphite2.cc
@@ -128,7 +128,8 @@ _hb_graphite2_shaper_face_data_create (hb_face_t *face)
     return nullptr;
 
   data->face = face;
-  data->grface = gr_make_face (data, &hb_graphite2_get_table, gr_face_preloadAll);
+  const gr_face_ops ops = {sizeof(gr_face_ops), &hb_graphite2_get_table, NULL};
+  data->grface = gr_make_face_with_ops (data, &ops, gr_face_preloadAll);
 
   if (unlikely (!data->grface)) {
     free (data);


### PR DESCRIPTION
As of graphite2 1.3.7, `gr_make_face` is deprecated in favor of `gr_make_face_with_ops`. It's a one-liner to port over to using it.

This is potentially a compatibility break since I'm not sure when the `with_ops` API was added, but the minimum version of graphite2 that's supported by Harfbuzz doesn't seem to be documented anywhere anyway.