### PR TITLE
Config.h filename configuration

### DIFF
--- a/src/hb-config.hh
+++ b/src/hb-config.hh
@@ -32,7 +32,10 @@
 #endif
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#ifndef HB_CONFIG_H_FILENAME
+#define HB_CONFIG_H_FILENAME "config.h"
+#endif
+#include HB_CONFIG_H_FILENAME
 #endif
 
 
@@ -87,7 +90,10 @@
 #endif
 
 #ifdef HAVE_CONFIG_OVERRIDE_H
-#include "config-override.h"
+#ifndef HB_CONFIG_OVERRIDE_H_FILENAME
+#define HB_CONFIG_OVERRIDE_H_FILENAME "config-override.h"
+#endif
+#include HB_CONFIG_OVERRIDE_H_FILENAME
 #endif
 
 /* Closure of options. */


### PR DESCRIPTION
Hi,

We want to be able to have several config.h configuration, for various platform.
Maybe we can add HB_CONFIG_H_FILENAME and HB_CONFIG_OVERRIDE_H_FILENAME to allow config filenames customization.