### PR TITLE
[subset] Always serialize objects point to by OffsetTo to a new serializer object.

### DIFF
--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -355,6 +355,23 @@ struct OffsetTo : Offset<OffsetType, has_null>
     return ret;
   }
 
+
+  template <typename ...Ts>
+  bool serialize_serialize (hb_serialize_context_t *c, Ts&&... ds)
+  {
+    *this = 0;
+
+    Type* obj = c->push<Type> ();
+    bool ret = obj->serialize (c, hb_forward<Ts> (ds)...);
+
+    if (ret)
+      c->add_link (*this, c->pop_pack ());
+    else
+      c->pop_discard ();
+
+    return ret;
+  }
+
   /* TODO: Somehow merge this with previous function into a serialize_dispatch(). */
   /* Workaround clang bug: https://bugs.llvm.org/show_bug.cgi?id=23029
    * Can't compile: whence = hb_serialize_context_t::Head followed by Ts&&...

--- a/src/hb-ot-layout-gdef-table.hh
+++ b/src/hb-ot-layout-gdef-table.hh
@@ -98,8 +98,7 @@ struct AttachList
     | hb_map (glyph_map)
     | hb_sink (new_coverage)
     ;
-    out->coverage.serialize (c->serializer, out)
-		 .serialize (c->serializer, new_coverage.iter ());
+    out->coverage.serialize_serialize (c->serializer, new_coverage.iter ());
     return_trace (bool (new_coverage));
   }
 
@@ -386,8 +385,7 @@ struct LigCaretList
     | hb_map (glyph_map)
     | hb_sink (new_coverage)
     ;
-    out->coverage.serialize (c->serializer, out)
-		 .serialize (c->serializer, new_coverage.iter ());
+    out->coverage.serialize_serialize (c->serializer, new_coverage.iter ());
     return_trace (bool (new_coverage));
   }
 

--- a/src/hb-ot-layout-gpos-table.hh
+++ b/src/hb-ot-layout-gpos-table.hh
@@ -823,8 +823,7 @@ struct SinglePosFormat1
     | hb_map_retains_sorting (hb_first)
     ;
 
-    // TODO(garretrieger): serialize_subset this.
-    coverage.serialize (c, this).serialize (c, glyphs);
+    coverage.serialize_serialize (c, glyphs);
   }
 
   bool subset (hb_subset_context_t *c) const
@@ -942,7 +941,7 @@ struct SinglePosFormat2
     | hb_map_retains_sorting (hb_first)
     ;
 
-    coverage.serialize (c, this).serialize (c, glyphs);
+    coverage.serialize_serialize (c, glyphs);
   }
 
   bool subset (hb_subset_context_t *c) const
@@ -1404,8 +1403,7 @@ struct PairPosFormat1
     | hb_sink (new_coverage)
     ;
 
-    out->coverage.serialize (c->serializer, out)
-		 .serialize (c->serializer, new_coverage.iter ());
+    out->coverage.serialize_serialize (c->serializer, new_coverage.iter ());
 
     return_trace (bool (new_coverage));
   }
@@ -1618,7 +1616,7 @@ struct PairPosFormat2
     | hb_map_retains_sorting (glyph_map)
     ;
 
-    out->coverage.serialize (c->serializer, out).serialize (c->serializer, it);
+    out->coverage.serialize_serialize (c->serializer, it);
     return_trace (out->class1Count && out->class2Count && bool (it));
   }
 
@@ -1911,7 +1909,7 @@ struct CursivePosFormat1
     | hb_map_retains_sorting (hb_first)
     ;
 
-    coverage.serialize (c->serializer, this).serialize (c->serializer, glyphs);
+    coverage.serialize_serialize (c->serializer, glyphs);
   }
 
   bool subset (hb_subset_context_t *c) const
@@ -2118,8 +2116,7 @@ struct MarkBasePosFormat1
     | hb_sink (new_coverage)
     ;
 
-    if (!out->markCoverage.serialize (c->serializer, out)
-			  .serialize (c->serializer, new_coverage.iter ()))
+    if (!out->markCoverage.serialize_serialize (c->serializer, new_coverage.iter ()))
       return_trace (false);
 
     out->markArray.serialize_subset (c, markArray, this,
@@ -2139,8 +2136,7 @@ struct MarkBasePosFormat1
     | hb_sink (new_coverage)
     ;
 
-    if (!out->baseCoverage.serialize (c->serializer, out)
-			  .serialize (c->serializer, new_coverage.iter ()))
+    if (!out->baseCoverage.serialize_serialize (c->serializer, new_coverage.iter ()))
       return_trace (false);
 
     hb_sorted_vector_t<unsigned> base_indexes;
@@ -2377,8 +2373,7 @@ struct MarkLigPosFormat1
     | hb_map_retains_sorting (glyph_map)
     ;
 
-    if (!out->markCoverage.serialize (c->serializer, out)
-			  .serialize (c->serializer, new_mark_coverage))
+    if (!out->markCoverage.serialize_serialize (c->serializer, new_mark_coverage))
       return_trace (false);
 
     out->markArray.serialize_subset (c, markArray, this,
@@ -2391,8 +2386,7 @@ struct MarkLigPosFormat1
     | hb_map_retains_sorting (glyph_map)
     ;
 
-    if (!out->ligatureCoverage.serialize (c->serializer, out)
-			      .serialize (c->serializer, new_ligature_coverage))
+    if (!out->ligatureCoverage.serialize_serialize (c->serializer, new_ligature_coverage))
       return_trace (false);
 
     out->ligatureArray.serialize_subset (c, ligatureArray, this,
@@ -2581,8 +2575,7 @@ struct MarkMarkPosFormat1
     | hb_sink (new_coverage)
     ;
 
-    if (!out->mark1Coverage.serialize (c->serializer, out)
-			   .serialize (c->serializer, new_coverage.iter ()))
+    if (!out->mark1Coverage.serialize_serialize (c->serializer, new_coverage.iter ()))
       return_trace (false);
 
     out->mark1Array.serialize_subset (c, mark1Array, this,
@@ -2602,8 +2595,7 @@ struct MarkMarkPosFormat1
     | hb_sink (new_coverage)
     ;
 
-    if (!out->mark2Coverage.serialize (c->serializer, out)
-			   .serialize (c->serializer, new_coverage.iter ()))
+    if (!out->mark2Coverage.serialize_serialize (c->serializer, new_coverage.iter ()))
       return_trace (false);
 
     hb_sorted_vector_t<unsigned> mark2_indexes;

--- a/src/hb-ot-layout-gsub-table.hh
+++ b/src/hb-ot-layout-gsub-table.hh
@@ -211,7 +211,7 @@ struct SingleSubstFormat2
       ;
     if (unlikely (!c->extend_min (*this))) return_trace (false);
     if (unlikely (!substitute.serialize (c, substitutes))) return_trace (false);
-    if (unlikely (!coverage.serialize (c, this).serialize (c, glyphs))) return_trace (false);
+    if (unlikely (!coverage.serialize_serialize (c, glyphs))) return_trace (false);
     return_trace (true);
   }
 
@@ -449,12 +449,12 @@ struct MultipleSubstFormat1
     for (unsigned int i = 0; i < glyphs.length; i++)
     {
       unsigned int substitute_len = substitute_len_list[i];
-      if (unlikely (!sequence[i].serialize (c, this)
-				.serialize (c, substitute_glyphs_list.sub_array (0, substitute_len))))
+      if (unlikely (!sequence[i]
+                        .serialize_serialize (c, substitute_glyphs_list.sub_array (0, substitute_len))))
 	return_trace (false);
       substitute_glyphs_list += substitute_len;
     }
-    return_trace (coverage.serialize (c, this).serialize (c, glyphs));
+    return_trace (coverage.serialize_serialize (c, glyphs));
   }
 
   bool subset (hb_subset_context_t *c) const
@@ -475,8 +475,7 @@ struct MultipleSubstFormat1
     | hb_map (glyph_map)
     | hb_sink (new_coverage)
     ;
-    out->coverage.serialize (c->serializer, out)
-		 .serialize (c->serializer, new_coverage.iter ());
+    out->coverage.serialize_serialize (c->serializer, new_coverage.iter ());
     return_trace (bool (new_coverage));
   }
 
@@ -688,12 +687,12 @@ struct AlternateSubstFormat1
     for (unsigned int i = 0; i < glyphs.length; i++)
     {
       unsigned int alternate_len = alternate_len_list[i];
-      if (unlikely (!alternateSet[i].serialize (c, this)
-				    .serialize (c, alternate_glyphs_list.sub_array (0, alternate_len))))
+      if (unlikely (!alternateSet[i]
+                        .serialize_serialize (c, alternate_glyphs_list.sub_array (0, alternate_len))))
 	return_trace (false);
       alternate_glyphs_list += alternate_len;
     }
-    return_trace (coverage.serialize (c, this).serialize (c, glyphs));
+    return_trace (coverage.serialize_serialize (c, glyphs));
   }
 
   bool subset (hb_subset_context_t *c) const
@@ -714,8 +713,7 @@ struct AlternateSubstFormat1
     | hb_map (glyph_map)
     | hb_sink (new_coverage)
     ;
-    out->coverage.serialize (c->serializer, out)
-		 .serialize (c->serializer, new_coverage.iter ());
+    out->coverage.serialize_serialize (c->serializer, new_coverage.iter ());
     return_trace (bool (new_coverage));
   }
 
@@ -952,10 +950,9 @@ struct LigatureSet
     for (unsigned int i = 0; i < ligatures.length; i++)
     {
       unsigned int component_count = (unsigned) hb_max ((int) component_count_list[i] - 1, 0);
-      if (unlikely (!ligature[i].serialize (c, this)
-				.serialize (c,
-					    ligatures[i],
-					    component_list.sub_array (0, component_count))))
+      if (unlikely (!ligature[i].serialize_serialize (c,
+                                                      ligatures[i],
+                                                      component_list.sub_array (0, component_count))))
 	return_trace (false);
       component_list += component_count;
     }
@@ -1065,15 +1062,15 @@ struct LigatureSubstFormat1
     for (unsigned int i = 0; i < first_glyphs.length; i++)
     {
       unsigned int ligature_count = ligature_per_first_glyph_count_list[i];
-      if (unlikely (!ligatureSet[i].serialize (c, this)
-				   .serialize (c,
-					       ligatures_list.sub_array (0, ligature_count),
-					       component_count_list.sub_array (0, ligature_count),
-					       component_list))) return_trace (false);
+      if (unlikely (!ligatureSet[i]
+                        .serialize_serialize (c,
+                                              ligatures_list.sub_array (0, ligature_count),
+                                              component_count_list.sub_array (0, ligature_count),
+                                              component_list))) return_trace (false);
       ligatures_list += ligature_count;
       component_count_list += ligature_count;
     }
-    return_trace (coverage.serialize (c, this).serialize (c, first_glyphs));
+    return_trace (coverage.serialize_serialize (c, first_glyphs));
   }
 
   bool subset (hb_subset_context_t *c) const
@@ -1094,8 +1091,7 @@ struct LigatureSubstFormat1
     | hb_map (glyph_map)
     | hb_sink (new_coverage)
     ;
-    out->coverage.serialize (c->serializer, out)
-		 .serialize (c->serializer, new_coverage.iter ());
+    out->coverage.serialize_serialize (c->serializer, new_coverage.iter ());
     return_trace (bool (new_coverage));
   }
 
@@ -1325,7 +1321,7 @@ struct ReverseChainSingleSubstFormat1
     if (unlikely (! c->serializer->check_success (substitute_out->serialize (c->serializer, substitutes))))
         return_trace (false);
 
-    if (unlikely (!out->coverage.serialize (c->serializer, out).serialize (c->serializer, glyphs)))
+    if (unlikely (!out->coverage.serialize_serialize (c->serializer, glyphs)))
       return_trace (false);
     return_trace (true);
   }

--- a/src/hb-ot-layout-gsub-table.hh
+++ b/src/hb-ot-layout-gsub-table.hh
@@ -101,7 +101,7 @@ struct SingleSubstFormat1
   {
     TRACE_SERIALIZE (this);
     if (unlikely (!c->extend_min (*this))) return_trace (false);
-    if (unlikely (!coverage.serialize (c, this).serialize (c, glyphs))) return_trace (false);
+    if (unlikely (!coverage.serialize_serialize (c, glyphs))) return_trace (false);
     c->check_assign (deltaGlyphID, delta, HB_SERIALIZE_ERROR_INT_OVERFLOW);
     return_trace (true);
   }

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -1898,8 +1898,7 @@ struct ContextFormat1
     | hb_sink (new_coverage)
     ;
 
-    out->coverage.serialize (c->serializer, out)
-		 .serialize (c->serializer, new_coverage.iter ());
+    out->coverage.serialize_serialize (c->serializer, new_coverage.iter ());
     return_trace (bool (new_coverage));
   }
 
@@ -2866,8 +2865,7 @@ struct ChainContextFormat1
     | hb_sink (new_coverage)
     ;
 
-    out->coverage.serialize (c->serializer, out)
-		 .serialize (c->serializer, new_coverage.iter ());
+    out->coverage.serialize_serialize (c->serializer, new_coverage.iter ());
     return_trace (bool (new_coverage));
   }
 


### PR DESCRIPTION
Fixes GSUB/GPOS table size inflation noticed in #2986

There's an often used pattern in the current serialization code to serialize an object point to an offset by calling serialize() on the OffsetTo which embeds the pointed to structure at the current serializer head. This bypasses the push()/pop_pack() mechanism which can prevent the point to structure from being deduplicated. Ultimately this can result in inflated table sizes.

This PR introduces a new serialize_serialize() method on OffsetTo which wraps push()/pop_pack() around the serialization of the pointed to structure to enable correct deduplication.
