### PR TITLE
[blob] Add failing versions of create API

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -21,7 +21,9 @@ hb_aat_layout_has_tracking
 <SECTION>
 <FILE>hb-blob</FILE>
 hb_blob_create
+hb_blob_create_or_fail
 hb_blob_create_from_file
+hb_blob_create_from_file_or_fail
 hb_blob_create_sub_blob
 hb_blob_copy_writable_or_fail
 hb_blob_destroy

--- a/docs/usermanual-getting-started.xml
+++ b/docs/usermanual-getting-started.xml
@@ -241,7 +241,7 @@
       </listitem>
     </orderedlist>
     <programlisting language="C">
-      hb_blob_t *blob = hb_blob_create_from_file(filename);
+      hb_blob_t *blob = hb_blob_create_from_file(filename); /* or hb_blob_create_from_file_or_fail() */
       hb_face_t *face = hb_face_create(blob, 0);
       hb_font_t *font = hb_font_create(face);
     </programlisting>

--- a/perf/perf-draw.hh
+++ b/perf/perf-draw.hh
@@ -58,8 +58,8 @@ static void draw (benchmark::State &state, const char *font_path, bool is_var, b
   hb_font_t *font;
   unsigned num_glyphs;
   {
-    hb_blob_t *blob = hb_blob_create_from_file (font_path);
-    assert (hb_blob_get_length (blob));
+    hb_blob_t *blob = hb_blob_create_from_file_or_fail (font_path);
+    assert (blob);
     hb_face_t *face = hb_face_create (blob, 0);
     hb_blob_destroy (blob);
     num_glyphs = hb_face_get_glyph_count (face);

--- a/perf/perf-extents.hh
+++ b/perf/perf-extents.hh
@@ -13,8 +13,8 @@ static void extents (benchmark::State &state, const char *font_path, bool is_var
   hb_font_t *font;
   unsigned num_glyphs;
   {
-    hb_blob_t *blob = hb_blob_create_from_file (font_path);
-    assert (hb_blob_get_length (blob));
+    hb_blob_t *blob = hb_blob_create_from_file_or_fail (font_path);
+    assert (blob);
     hb_face_t *face = hb_face_create (blob, 0);
     hb_blob_destroy (blob);
     num_glyphs = hb_face_get_glyph_count (face);

--- a/perf/perf-shaping.hh
+++ b/perf/perf-shaping.hh
@@ -8,18 +8,18 @@ static void shape (benchmark::State &state, const char *text_path,
 {
   hb_font_t *font;
   {
-    hb_blob_t *blob = hb_blob_create_from_file (font_path);
-    assert (hb_blob_get_length (blob));
+    hb_blob_t *blob = hb_blob_create_from_file_or_fail (font_path);
+    assert (blob);
     hb_face_t *face = hb_face_create (blob, 0);
     hb_blob_destroy (blob);
     font = hb_font_create (face);
     hb_face_destroy (face);
   }
 
-  hb_blob_t *text_blob = hb_blob_create_from_file (text_path);
+  hb_blob_t *text_blob = hb_blob_create_from_file_or_fail (text_path);
+  assert (text_blob);
   unsigned text_length;
   const char *text = hb_blob_get_data (text_blob, &text_length);
-  assert (text_length);
 
   hb_buffer_t *buf = hb_buffer_create ();
   for (auto _ : state)

--- a/src/hb-blob.h
+++ b/src/hb-blob.h
@@ -91,7 +91,17 @@ hb_blob_create (const char        *data,
 		hb_destroy_func_t  destroy);
 
 HB_EXTERN hb_blob_t *
+hb_blob_create_or_fail (const char        *data,
+			unsigned int       length,
+			hb_memory_mode_t   mode,
+			void              *user_data,
+			hb_destroy_func_t  destroy);
+
+HB_EXTERN hb_blob_t *
 hb_blob_create_from_file (const char *file_name);
+
+HB_EXTERN hb_blob_t *
+hb_blob_create_from_file_or_fail (const char *file_name);
 
 /* Always creates with MEMORY_MODE_READONLY.
  * Even if the parent blob is writable, we don't

--- a/src/main.cc
+++ b/src/main.cc
@@ -33,12 +33,13 @@
 #include "hb.h"
 #include "hb-ot.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 
 #ifdef HB_NO_OPEN
-#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#define hb_blob_create_from_file_or_fail(x)  hb_blob_get_empty ()
 #endif
 
 #if !defined(HB_NO_COLOR) && !defined(HB_NO_DRAW) && defined(HB_EXPERIMENTAL_API)
@@ -505,7 +506,8 @@ main (int argc, char **argv)
     exit (1);
   }
 
-  hb_blob_t *blob = hb_blob_create_from_file (argv[1]);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[1]);
+  assert (blob);
   printf ("Opened font file %s: %d bytes long\n", argv[1], hb_blob_get_length (blob));
 #ifndef MAIN_CC_NO_PRIVATE_API
   print_layout_info_using_private_api (blob);

--- a/src/test-buffer-serialize.cc
+++ b/src/test-buffer-serialize.cc
@@ -33,7 +33,7 @@
 #endif
 
 #ifdef HB_NO_OPEN
-#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#define hb_blob_create_from_file_or_fail(x)  hb_blob_get_empty ()
 #endif
 
 int
@@ -48,7 +48,8 @@ main (int argc, char **argv)
     exit (1);
   }
 
-  hb_blob_t *blob = hb_blob_create_from_file (argv[1]);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[1]);
+  assert (blob);
   hb_face_t *face = hb_face_create (blob, 0 /* first face */);
   hb_blob_destroy (blob);
   blob = nullptr;

--- a/src/test-gpos-size-params.cc
+++ b/src/test-gpos-size-params.cc
@@ -30,7 +30,7 @@
 #include "hb-ot.h"
 
 #ifdef HB_NO_OPEN
-#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#define hb_blob_create_from_file_or_fail(x)  hb_blob_get_empty ()
 #endif
 
 int
@@ -42,7 +42,8 @@ main (int argc, char **argv)
   }
 
   /* Create the face */
-  hb_blob_t *blob = hb_blob_create_from_file (argv[1]);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[1]);
+  assert (blob);
   hb_face_t *face = hb_face_create (blob, 0 /* first face */);
   hb_blob_destroy (blob);
   blob = nullptr;

--- a/src/test-gsub-would-substitute.cc
+++ b/src/test-gsub-would-substitute.cc
@@ -34,7 +34,7 @@
 #endif
 
 #ifdef HB_NO_OPEN
-#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#define hb_blob_create_from_file_or_fail(x)  hb_blob_get_empty ()
 #endif
 
 int
@@ -46,7 +46,8 @@ main (int argc, char **argv)
   }
 
   /* Create the face */
-  hb_blob_t *blob = hb_blob_create_from_file (argv[1]);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[1]);
+  assert (blob);
   hb_face_t *face = hb_face_create (blob, 0 /* first face */);
   hb_blob_destroy (blob);
   blob = nullptr;

--- a/src/test-ot-glyphname.cc
+++ b/src/test-ot-glyphname.cc
@@ -28,7 +28,7 @@
 #include "hb-ot.h"
 
 #ifdef HB_NO_OPEN
-#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#define hb_blob_create_from_file_or_fail(x)  hb_blob_get_empty ()
 #endif
 
 int
@@ -39,7 +39,8 @@ main (int argc, char **argv)
     exit (1);
   }
 
-  hb_blob_t *blob = hb_blob_create_from_file (argv[1]);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[1]);
+  assert (blob);
   hb_face_t *face = hb_face_create (blob, 0 /* first face */);
   hb_font_t *font = hb_font_create (face);
   hb_blob_destroy (blob);

--- a/src/test-ot-meta.cc
+++ b/src/test-ot-meta.cc
@@ -26,7 +26,7 @@
 #include "hb-ot.h"
 
 #ifdef HB_NO_OPEN
-#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#define hb_blob_create_from_file_or_fail(x)  hb_blob_get_empty ()
 #endif
 
 int
@@ -37,7 +37,8 @@ main (int argc, char **argv)
     exit (1);
   }
 
-  hb_blob_t *blob = hb_blob_create_from_file (argv[1]);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[1]);
+  assert (blob);
   hb_face_t *face = hb_face_create (blob, 0 /* first face */);
   hb_blob_destroy (blob);
   blob = nullptr;

--- a/src/test-ot-name.cc
+++ b/src/test-ot-name.cc
@@ -28,7 +28,7 @@
 #include "hb-ot.h"
 
 #ifdef HB_NO_OPEN
-#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#define hb_blob_create_from_file_or_fail(x)  hb_blob_get_empty ()
 #endif
 
 int
@@ -39,7 +39,8 @@ main (int argc, char **argv)
     exit (1);
   }
 
-  hb_blob_t *blob = hb_blob_create_from_file (argv[1]);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[1]);
+  assert (blob);
   hb_face_t *face = hb_face_create (blob, 0 /* first face */);
   hb_blob_destroy (blob);
   blob = nullptr;

--- a/src/test.cc
+++ b/src/test.cc
@@ -31,7 +31,7 @@
 #endif
 
 #ifdef HB_NO_OPEN
-#define hb_blob_create_from_file(x)  hb_blob_get_empty ()
+#define hb_blob_create_from_file_or_fail(x)  hb_blob_get_empty ()
 #endif
 
 int
@@ -42,7 +42,8 @@ main (int argc, char **argv)
     exit (1);
   }
 
-  hb_blob_t *blob = hb_blob_create_from_file (argv[1]);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[1]);
+  assert (blob);
   printf ("Opened font file %s: %u bytes long\n", argv[1], hb_blob_get_length (blob));
 
   /* Create the face */

--- a/test/api/hb-test.h
+++ b/test/api/hb-test.h
@@ -296,9 +296,9 @@ hb_test_open_font_file (const char *font_path)
   char *path = g_strdup (font_path);
 #endif
 
-  hb_blob_t *blob = hb_blob_create_from_file (path);
+  hb_blob_t *blob = hb_blob_create_from_file_or_fail (path);
   hb_face_t *face;
-  if (hb_blob_get_length (blob) == 0)
+  if (!blob)
     g_error ("Font %s not found.", path);
 
   face = hb_face_create (blob, 0);

--- a/test/fuzzing/main.cc
+++ b/test/fuzzing/main.cc
@@ -1,16 +1,18 @@
 #include "hb-fuzzer.hh"
 
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 int main (int argc, char **argv)
 {
   for (int i = 1; i < argc; i++)
   {
-    hb_blob_t *blob = hb_blob_create_from_file (argv[i]);
+    hb_blob_t *blob = hb_blob_create_from_file_or_fail (argv[i]);
+    assert (blob);
 
-    unsigned int len;
+    unsigned len = 0;
     const char *font_data = hb_blob_get_data (blob, &len);
-    printf ("%s%s\n", argv[i], len ? "" : " (note: not found or was empty)");
+    printf ("%s (%u bytes)\n", argv[i], len);
 
     LLVMFuzzerTestOneInput ((const uint8_t *) font_data, len);
 

--- a/util/options.cc
+++ b/util/options.cc
@@ -696,10 +696,10 @@ font_options_t::get_font () const
 #endif
   }
 
-  blob = hb_blob_create_from_file (font_path);
+  blob = hb_blob_create_from_file_or_fail (font_path);
 
-  if (blob == hb_blob_get_empty ())
-    fail (false, "Couldn't read or find %s, or it was empty.", font_path);
+  if (!blob)
+    fail (false, "%s: Failed reading file", font_path);
 
   /* Create the face */
   hb_face_t *face = hb_face_create (blob, face_index);


### PR DESCRIPTION
Fixes https://github.com/harfbuzz/harfbuzz/issues/2567

New API:
+hb_blob_create_or_fail()
+hb_blob_create_from_file_or_fail()

Use these in util/ to distinguish empty file from not-found file.
Only err on the latter.