### PR TITLE
Update release notes to reflect actual current procedure

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,38 +1,37 @@
-HarfBuzz release walk-through checklist:
+# HarfBuzz release walk-through checklist:
 
-1. Open gitk and review changes since last release.
+- [ ] Open gitk and review changes since last release.
 
-   * `git diff $(git describe | sed 's/-.*//').. src/*.h` prints all public API
-     changes.
+	- [ ] Print all public API changes:
+        `git diff $(git describe | sed 's/-.*//').. src/*.h`
 
-     Document them in NEWS.  All API and API semantic changes should be clearly
-     marked as API additions, API changes, or API deletions.  Document
-     deprecations.  Ensure all new API / deprecations are in listed correctly in
-     docs/harfbuzz-sections.txt.  If release added new API, add entry for new
-     API index at the end of docs/harfbuzz-docs.xml.
+    - [ ]  Document them in NEWS.
+        All API and API semantic changes should be clearly marked as API additions, API changes, or API deletions.
 
-     If there's a backward-incompatible API change (including deletions for API
-     used anywhere), that's a release blocker.  Do NOT release.
+    - [ ] Document deprecations.
+        Ensure all new API / deprecations are in listed correctly in docs/harfbuzz-sections.txt.
+        If release added new API, add entry for new API index at the end of docs/harfbuzz-docs.xml.
 
-2. Based on severity of changes, decide whether it's a minor or micro release
-   number bump,
+     If there's a backward-incompatible API change (including deletions for API used anywhere), that's a release blocker.
+     Do NOT release.
 
-3. Search for REPLACEME on the repository and replace it with the chosen version
-   for the release.
+- [ ] Based on severity of changes, decide whether it's a minor or micro release number bump.
 
-4. Make sure you have correct date and new version at the top of NEWS file.
+- [ ] Search for REPLACEME on the repository and replace it with the chosen version for the release.
 
-5. Bump version in line 3 of meson.build and configure.ac.
-   Do a `meson test -Cbuild` so it both checks the tests and updates
-   hb-version.h (use `git diff` to see if is really updated).
+- [ ] Make sure you have correct date and new version at the top of NEWS file.
 
-6. Commit NEWS, meson.build, configure.ac, and src/hb-version.h, as well as any REPLACEME
-   changes you made.  The commit message is simply the release number.  Eg. "1.4.7"
+- [ ] Bump version in line 3 of meson.build and configure.ac.
 
-7. Do a `meson dist -Cbuild` that runs the tests against the latest commited changes.
+- [ ] Do a `meson test -Cbuild` so it both checks the tests and updates hb-version.h (use `git diff` to see if is really updated).
+
+- [ ] Commit NEWS, meson.build, configure.ac, and src/hb-version.h, as well as any REPLACEME changes you made.
+        The commit message is simply the release number, e. g. "1.4.7"
+
+- [ ] Do a `meson dist -Cbuild` that runs the tests against the latest commited changes.
    If doesn't pass, something fishy is going on, reset the repo and start over.
 
-8. Tag the release and sign it: Eg. "git tag -s 1.4.7 -m 1.4.7".  Enter your
-   GPG password.
+- [ ] Tag the release and sign it: e.g. `git tag -s 1.4.7 -m 1.4.7`.
+	  Enter your GPG password.
 
-9. Push the commit and tag out: "git push --follow-tags".
+- [ ] Push the commit and tag out: `git push --follow-tags`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,10 +35,4 @@ HarfBuzz release walk-through checklist:
 8. Tag the release and sign it: Eg. "git tag -s 1.4.7 -m 1.4.7".  Enter your
    GPG password.
 
-9. Build win32 bundle.  See [README.mingw.md](README.mingw.md).
-
-10. Push the commit and tag out: "git push --follow-tags".
-
-11. Go to GitHub release page [here](https://github.com/harfbuzz/harfbuzz/releases),
-    edit the tag, upload win32 bundle and NEWS entry and save.
-    No need to upload source tarball as we rely to GitHub's automatic tar.gz generation.
+9. Push the commit and tag out: "git push --follow-tags".


### PR DESCRIPTION
In anticipation of #3048 I checked the release notes file in the repo and realized it is a bit out of date. At least two points are completely obsoleted by CI changes. Possibly more but I did the ones I know about.

While I was at it I made the list a Markdown checklist suitable for copy/pasting into an issue or PR to track release progress if that is ever desired. I find it handy but that's really up to the fellow doing the work more than anything else.