### PR TITLE
2.8.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,19 @@
+Overview of changes leading to 2.8.2
+Tuesday, July 8, 2021
+====================================
+- Shaping LTR digits for RTL scripts now makes the native direction of the
+  digits LTR, applying shaping and positioning rules on the same glyph order as
+  Uniscribe. (Jonathan Kew, Khaled Hosny).
+- Subsetting COLR v1 and CPAL tables is now supported. (Garret Rieger, Qunxin Liu)
+- Various fixes and improvements to the subsetter. (Garret Rieger, Qunxin Liu, Behdad)
+- When applying morx table, mark glyph widths should not be zeroed. (Jonathan Kew)
+- GPOS is preferred over kerx, if GSUB was applied. (Behdad)
+- Regional_Indicator pairs are grouped together when clustering. (Behdad)
+- New API:
++hb_blob_create_or_fail()
++hb_blob_create_from_file_or_fail()
++hb_set_copy()
+
 Overview of changes leading to 2.8.1
 Tuesday, May 4, 2021
 ====================================

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.64])
 AC_INIT([HarfBuzz],
-        [2.8.1],
+        [2.8.2],
         [https://github.com/harfbuzz/harfbuzz/issues/new],
         [harfbuzz],
         [http://harfbuzz.org/])

--- a/docs/harfbuzz-docs.xml
+++ b/docs/harfbuzz-docs.xml
@@ -105,6 +105,7 @@
       <index id="api-index-full"><title>API Index</title><xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include></index>
       <index id="deprecated-api-index" role="deprecated"><title>Index of deprecated API</title><xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include></index>
 
+      <index id="api-index-2-8-2" role="2.8.2"><title>Index of new symbols in 2.8.2</title><xi:include href="xml/api-index-2.8.2.xml"><xi:fallback /></xi:include></index>
       <index id="api-index-2-7-3" role="2.7.3"><title>Index of new symbols in 2.7.3</title><xi:include href="xml/api-index-2.7.3.xml"><xi:fallback /></xi:include></index>
       <index id="api-index-2-6-8" role="2.6.8"><title>Index of new symbols in 2.6.8</title><xi:include href="xml/api-index-2.6.8.xml"><xi:fallback /></xi:include></index>
       <index id="api-index-2-6-5" role="2.6.5"><title>Index of new symbols in 2.6.5</title><xi:include href="xml/api-index-2.6.5.xml"><xi:fallback /></xi:include></index>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('harfbuzz', 'c', 'cpp',
   meson_version: '>= 0.47.0',
-  version: '2.8.1',
+  version: '2.8.2',
   default_options: [
     'cpp_eh=none',          # Just to support msvc, we are passing -fno-rtti also anyway
     'cpp_rtti=false',       # Just to support msvc, we are passing -fno-exceptions also anyway

--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -101,7 +101,7 @@ hb_blob_create (const char        *data,
  *
  * Return value: New blob, or %NULL if failed.  Destroy with hb_blob_destroy().
  *
- * Since: REPLACEME
+ * Since: 2.8.2
  **/
 hb_blob_t *
 hb_blob_create_or_fail (const char        *data,
@@ -622,7 +622,7 @@ hb_blob_create_from_file (const char *file_name)
  * Returns: An #hb_blob_t pointer with the content of the file,
  * or %NULL if failed.
  *
- * Since: REPLACEME
+ * Since: 2.8.2
  **/
 hb_blob_t *
 hb_blob_create_from_file_or_fail (const char *file_name)

--- a/src/hb-set.cc
+++ b/src/hb-set.cc
@@ -180,7 +180,7 @@ hb_set_allocation_successful (const hb_set_t  *set)
  *
  * Return value: Newly-allocated set.
  *
- * Since: REPLACEME
+ * Since: 2.8.2
  **/
 hb_set_t *
 hb_set_copy (const hb_set_t *set)

--- a/src/hb-version.h
+++ b/src/hb-version.h
@@ -53,14 +53,14 @@ HB_BEGIN_DECLS
  *
  * The micro component of the library version available at compile-time.
  */
-#define HB_VERSION_MICRO 1
+#define HB_VERSION_MICRO 2
 
 /**
  * HB_VERSION_STRING:
  *
  * A string literal containing the library version available at compile-time.
  */
-#define HB_VERSION_STRING "2.8.1"
+#define HB_VERSION_STRING "2.8.2"
 
 /**
  * HB_VERSION_ATLEAST:


### PR DESCRIPTION
- [x] Open gitk and review changes since last release.

	- [x] Print all public API changes:
        `git diff $(git describe | sed 's/-.*//').. src/*.h`

    - [x]  Document them in NEWS.
        All API and API semantic changes should be clearly marked as API additions, API changes, or API deletions.

    - [x] Document deprecations.
        Ensure all new API / deprecations are in listed correctly in docs/harfbuzz-sections.txt.
        If release added new API, add entry for new API index at the end of docs/harfbuzz-docs.xml.

     If there's a backward-incompatible API change (including deletions for API used anywhere), that's a release blocker.
     Do NOT release.

- [x] Based on severity of changes, decide whether it's a minor or micro release number bump.

- [x] Search for REPLACEME on the repository and replace it with the chosen version for the release.

- [x] Make sure you have correct date and new version at the top of NEWS file.

- [x] Bump version in line 3 of meson.build and configure.ac.

- [x] Do a `meson test -Cbuild` so it both checks the tests and updates hb-version.h (use `git diff` to see if is really updated).

- [x] Commit NEWS, meson.build, configure.ac, and src/hb-version.h, as well as any REPLACEME changes you made.
        The commit message is simply the release number, e. g. "1.4.7"

- [x] Do a `meson dist -Cbuild` that runs the tests against the latest commited changes.
   If doesn't pass, something fishy is going on, reset the repo and start over.

- [ ] Tag the release and sign it: e.g. `git tag -s 1.4.7 -m 1.4.7`.
	  Enter your GPG password.

- [ ] Push the commit and tag out: `git push --follow-tags`.