### PR TITLE
[buffer] Change nil buffer have_output to false

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -630,7 +630,7 @@ DEFINE_NULL_INSTANCE (hb_buffer_t) =
   HB_BUFFER_CONTENT_TYPE_INVALID,
   HB_SEGMENT_PROPERTIES_DEFAULT,
   false, /* successful */
-  true, /* have_output */
+  false, /* have_output */
   true  /* have_positions */
 
   /* Zero is good enough for everything else. */


### PR DESCRIPTION
Seems like a historical artefact that it was true.