### PR TITLE
[subset] de-duplicate the logic that finds unicodes corresponding to …

### DIFF
--- a/src/hb-ot-os2-table.hh
+++ b/src/hb-ot-os2-table.hh
@@ -30,7 +30,6 @@
 
 #include "hb-open-type.hh"
 #include "hb-ot-os2-unicode-ranges.hh"
-#include "hb-ot-cmap-table.hh"
 
 #include "hb-set.hh"
 
@@ -174,32 +173,14 @@ struct OS2
     if (unlikely (!os2_prime)) return_trace (false);
     if (!c->plan->prune_unicode_ranges) return_trace (true);
 
-    hb_set_t unicodes;
-    if (!c->plan->glyphs_requested->is_empty ())
-    {
-      hb_map_t unicode_glyphid_map;
-
-      OT::cmap::accelerator_t cmap;
-      cmap.init (c->plan->source);
-      cmap.collect_mapping (&unicodes, &unicode_glyphid_map);
-      cmap.fini ();
-
-      hb_set_set (&unicodes, c->plan->unicodes);
-
-      + unicode_glyphid_map.iter ()
-      | hb_filter (c->plan->glyphs_requested, hb_second)
-      | hb_map (hb_first)
-      | hb_sink (unicodes)
-      ;
-    }
     /* when --gids option is not used, no need to do collect_mapping that is
        * iterating all codepoints in each subtable, which is not efficient */
     uint16_t min_cp, max_cp;
-    find_min_and_max_codepoint (unicodes.is_empty () ? c->plan->unicodes : &unicodes, &min_cp, &max_cp);
+    find_min_and_max_codepoint (c->plan->unicodes, &min_cp, &max_cp);
     os2_prime->usFirstCharIndex = min_cp;
     os2_prime->usLastCharIndex = max_cp;
 
-    _update_unicode_ranges (unicodes.is_empty () ? c->plan->unicodes : &unicodes, os2_prime->ulUnicodeRange);
+    _update_unicode_ranges (c->plan->unicodes, os2_prime->ulUnicodeRange);
 
     return_trace (true);
   }


### PR DESCRIPTION
…requested glyphs.

Move the logic into subset planning and then re-use the results in cmap and OS2 subsetting. Removes depedency on cmap from os2. Which is needed for #681