### PR TITLE
Don’t disable getenv on Windows

### DIFF
--- a/src/hb.hh
+++ b/src/hb.hh
@@ -383,7 +383,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #      define HB_NO_SETLOCALE
 #      define HB_NO_ERRNO
 #    endif
-#  elif WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#  elif !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #    ifndef HB_NO_GETENV
 #      define HB_NO_GETENV
 #    endif


### PR DESCRIPTION
The condition is inverted, regression from 40ec187dec07e97ed4004b9831e7be844e6e7948.