### PR TITLE
[tests] Add missed test file to Makefile/meson

### DIFF
--- a/test/shaping/data/in-house/Makefile.sources
+++ b/test/shaping/data/in-house/Makefile.sources
@@ -57,6 +57,7 @@ TESTS = \
 	tests/use-indic3.tests \
 	tests/use-marchen.tests \
 	tests/use-syllable.tests \
+	tests/use-vowel-letter-spoofing.tests \
 	tests/use.tests \
 	tests/variations.tests \
 	tests/variations-rvrn.tests \

--- a/test/shaping/data/in-house/meson.build
+++ b/test/shaping/data/in-house/meson.build
@@ -57,6 +57,7 @@ in_house_tests = [
   'use-indic3.tests',
   'use-marchen.tests',
   'use-syllable.tests',
+  'use-vowel-letter-spoofing.tests',
   'use.tests',
   'variations.tests',
   'variations-rvrn.tests',


### PR DESCRIPTION
It was introduced in 205737acdc268b1c90cf00bde2d2038519a8bf48 but was not actually used.

See https://github.com/harfbuzz/harfbuzz/issues/2098