### PR TITLE
[util/hb-shape] Cache blob/face in batch mode

### DIFF
--- a/util/options.cc
+++ b/util/options.cc
@@ -681,10 +681,7 @@ output_options_t::add_options (option_parser_t *parser)
 }
 
 
-const char *font_options_t::cached_font_path = nullptr;
-hb_blob_t *font_options_t::cached_blob = nullptr;
-unsigned font_options_t::cached_face_index = (unsigned) -1;
-hb_face_t *font_options_t::cached_face = nullptr;
+font_options_t::cache_t font_options_t::cache {};
 
 hb_font_t *
 font_options_t::get_font () const
@@ -708,8 +705,8 @@ font_options_t::get_font () const
 #endif
   }
 
-  if (cached_font_path && 0 == strcmp (cached_font_path, font_path))
-    blob = hb_blob_reference (cached_blob);
+  if (cache.font_path && 0 == strcmp (cache.font_path, font_path))
+    blob = hb_blob_reference (cache.blob);
   else
   {
     blob = hb_blob_create_from_file_or_fail (font_path);
@@ -719,27 +716,27 @@ font_options_t::get_font () const
 
     /* Update caches. */
 
-    hb_face_destroy (cached_face);
-    cached_face = nullptr;
-    cached_face_index = (unsigned) -1;
+    hb_face_destroy (cache.face);
+    cache.face = nullptr;
+    cache.face_index = (unsigned) -1;
 
-    free ((char *) cached_font_path);
-    cached_font_path = strdup (font_path);
-    hb_blob_destroy (cached_blob);
-    cached_blob = hb_blob_reference (blob);
+    free ((char *) cache.font_path);
+    cache.font_path = strdup (font_path);
+    hb_blob_destroy (cache.blob);
+    cache.blob = hb_blob_reference (blob);
   }
 
   hb_face_t *face = nullptr;
-  if (cached_face_index == face_index)
-    face = hb_face_reference (cached_face);
+  if (cache.face_index == face_index)
+    face = hb_face_reference (cache.face);
   else
   {
     face = hb_face_create (blob, face_index);
     hb_blob_destroy (blob);
 
-    cached_face_index = face_index;
-    hb_face_destroy (cached_face);
-    cached_face = hb_face_reference (face);
+    cache.face_index = face_index;
+    hb_face_destroy (cache.face);
+    cache.face = hb_face_reference (face);
   }
 
 

--- a/util/options.hh
+++ b/util/options.hh
@@ -491,7 +491,7 @@ struct font_options_t : option_group_t
 
   char *font_file;
   mutable hb_blob_t *blob;
-  int face_index;
+  unsigned face_index;
   hb_variation_t *variations;
   unsigned int num_variations;
   int default_font_size;
@@ -506,6 +506,11 @@ struct font_options_t : option_group_t
 
   private:
   mutable hb_font_t *font;
+
+  static const char *cached_font_path;
+  static hb_blob_t *cached_blob;
+  static unsigned cached_face_index;
+  static hb_face_t *cached_face;
 };
 
 

--- a/util/options.hh
+++ b/util/options.hh
@@ -507,10 +507,20 @@ struct font_options_t : option_group_t
   private:
   mutable hb_font_t *font;
 
-  static const char *cached_font_path;
-  static hb_blob_t *cached_blob;
-  static unsigned cached_face_index;
-  static hb_face_t *cached_face;
+  static struct cache_t
+  {
+    ~cache_t ()
+    {
+      free ((void *) font_path);
+      hb_blob_destroy (blob);
+      hb_face_destroy (face);
+    }
+
+    const char *font_path = nullptr;
+    hb_blob_t *blob = nullptr;
+    unsigned face_index = (unsigned) -1;
+    hb_face_t *face = nullptr;
+  } cache;
 };
 
 


### PR DESCRIPTION
This speeds up `emoji-clusters` by 2x, but overall `time make check -j10` in `test/shaping` stays around 20s; mostly because most of our tests files have few tests in them. So I'm not impressed. Still, this is correct so I'm happy to take it. Specially so if it will also come handy for `hb-subset` batch mode https://github.com/harfbuzz/harfbuzz/issues/3089

Main slowdown seems to be spawning processes; so having test files that batch more tests will be much faster...