### PR TITLE
Construct user_data in hb_object

### DIFF
--- a/src/hb-object.hh
+++ b/src/hb-object.hh
@@ -37,6 +37,7 @@
 #include "hb-mutex.hh"
 #include "hb-vector.hh"
 
+#include <new>
 
 /*
  * Lockable set
@@ -284,6 +285,7 @@ static inline void hb_object_fini (Type *obj)
   if (user_data)
   {
     user_data->fini ();
+    user_data->~hb_user_data_array_t();
     hb_free (user_data);
     user_data = nullptr;
   }
@@ -306,6 +308,7 @@ retry:
     user_data = (hb_user_data_array_t *) hb_calloc (sizeof (hb_user_data_array_t), 1);
     if (unlikely (!user_data))
       return false;
+    user_data = new (user_data) hb_user_data_array_t;
     user_data->init ();
     if (unlikely (!obj->header.user_data.cmpexch (nullptr, user_data)))
     {


### PR DESCRIPTION
hb_object's user_data is created lazily. The previous implementation of hb_object_set_user_data created space for the user_data but did not actually construct it. This means that hb_user_data_array_t's lock was not constructed. If hb_mutex_t is backed by an implementation which requires that it be constructed (not just zero initialized) then errors will occur when taking the lock when setting the user data.

Change hb_object_set_user_data to construct the user_data in the created space and hb_object_fini to call the destructor.