### PR TITLE
[subset] change input and plan flags to be bit sets.

### DIFF
--- a/src/hb-ot-glyf-table.hh
+++ b/src/hb-ot-glyf-table.hh
@@ -213,13 +213,15 @@ struct glyf
 		if (!plan->old_gid_for_new_gid (new_gid, &subset_glyph.old_gid))
 		  return subset_glyph;
 
-		if (new_gid == 0 && !plan->notdef_outline)
+		if (new_gid == 0 &&
+                    !(plan->flags & HB_SUBSET_FLAGS_NOTDEF_OUTLINE))
 		  subset_glyph.source_glyph = Glyph ();
 		else
 		  subset_glyph.source_glyph = glyf.glyph_for_gid (subset_glyph.old_gid, true);
-		if (plan->drop_hints) subset_glyph.drop_hints_bytes ();
-		else subset_glyph.dest_start = subset_glyph.source_glyph.get_bytes ();
-
+		if (plan->flags & HB_SUBSET_FLAGS_NO_HINTING)
+                  subset_glyph.drop_hints_bytes ();
+		else
+                  subset_glyph.dest_start = subset_glyph.source_glyph.get_bytes ();
 		return subset_glyph;
 	      })
     | hb_sink (glyphs)
@@ -1274,9 +1276,10 @@ struct glyf
 	  const_cast<CompositeGlyphChain &> (_).set_glyph_index (new_gid);
       }
 
-      if (plan->drop_hints) Glyph (dest_glyph).drop_hints ();
+      if (plan->flags & HB_SUBSET_FLAGS_NO_HINTING)
+        Glyph (dest_glyph).drop_hints ();
 
-      if (plan->overlaps_flag)
+      if (plan->flags & HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG)
         Glyph (dest_glyph).set_overlaps_flag ();
 
       return_trace (true);

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -2792,6 +2792,10 @@ struct VariationStore
     hb_set_t region_indices;
     for (unsigned int i = 0; i < inner_maps.length; i++)
       (src+src->dataSets[i]).collect_region_refs (region_indices, inner_maps[i]);
+
+    if (region_indices.in_error ())
+      return_trace (false);
+
     region_indices.del_range ((src_regions).regionCount, hb_set_t::INVALID);
 
     /* TODO use constructor when our data-structures support that. */

--- a/src/hb-ot-layout-gpos-table.hh
+++ b/src/hb-ot-layout-gpos-table.hh
@@ -538,7 +538,7 @@ struct Anchor
     switch (u.format) {
     case 1: return_trace (bool (reinterpret_cast<Anchor *> (u.format1.copy (c->serializer))));
     case 2:
-      if (c->plan->drop_hints)
+      if (c->plan->flags & HB_SUBSET_FLAGS_NO_HINTING)
       {
         // AnchorFormat 2 just containins extra hinting information, so
         // if hints are being dropped convert to format 1.
@@ -1373,7 +1373,7 @@ struct PairPosFormat1
     out->format = format;
     out->valueFormat[0] = valueFormat[0];
     out->valueFormat[1] = valueFormat[1];
-    if (c->plan->drop_hints)
+    if (c->plan->flags & HB_SUBSET_FLAGS_NO_HINTING)
     {
       hb_pair_t<unsigned, unsigned> newFormats = compute_effective_value_formats (glyphset);
       out->valueFormat[0] = newFormats.first;
@@ -1591,7 +1591,7 @@ struct PairPosFormat2
     unsigned len2 = valueFormat2.get_len ();
 
     hb_pair_t<unsigned, unsigned> newFormats = hb_pair (valueFormat1, valueFormat2);
-    if (c->plan->drop_hints)
+    if (c->plan->flags & HB_SUBSET_FLAGS_NO_HINTING)
       newFormats = compute_effective_value_formats (klass1_map, klass2_map);
 
     out->valueFormat1 = newFormats.first;

--- a/src/hb-ot-maxp-table.hh
+++ b/src/hb-ot-maxp-table.hh
@@ -107,7 +107,7 @@ struct maxp
       maxpV1Tail *dest_v1 = c->serializer->embed<maxpV1Tail> (src_v1);
       if (unlikely (!dest_v1)) return_trace (false);
 
-      if (c->plan->drop_hints)
+      if (c->plan->flags & HB_SUBSET_FLAGS_NO_HINTING)
 	drop_hint_fields (dest_v1);
     }
 

--- a/src/hb-ot-name-table.hh
+++ b/src/hb-ot-name-table.hh
@@ -249,7 +249,11 @@ struct name
     + nameRecordZ.as_array (count)
     | hb_filter (c->plan->name_ids, &NameRecord::nameID)
     | hb_filter (c->plan->name_languages, &NameRecord::languageID)
-    | hb_filter ([&] (const NameRecord& namerecord) { return c->plan->name_legacy || namerecord.isUnicode (); })
+    | hb_filter ([&] (const NameRecord& namerecord) {
+      return
+          (c->plan->flags & HB_SUBSET_FLAGS_NAME_LEGACY)
+          || namerecord.isUnicode ();
+    })
     ;
 
     name_prime->serialize (c->serializer, it, hb_addressof (this + stringOffset));

--- a/src/hb-ot-os2-table.hh
+++ b/src/hb-ot-os2-table.hh
@@ -171,7 +171,8 @@ struct OS2
     TRACE_SUBSET (this);
     OS2 *os2_prime = c->serializer->embed (this);
     if (unlikely (!os2_prime)) return_trace (false);
-    if (!c->plan->prune_unicode_ranges) return_trace (true);
+    if (c->plan->flags & HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES)
+      return_trace (true);
 
     /* when --gids option is not used, no need to do collect_mapping that is
        * iterating all codepoints in each subtable, which is not efficient */

--- a/src/hb-ot-post-table.hh
+++ b/src/hb-ot-post-table.hh
@@ -98,10 +98,11 @@ struct post
     post *post_prime = c->serializer->start_embed<post> ();
     if (unlikely (!post_prime)) return_trace (false);
 
-    if (!serialize (c->serializer, c->plan->glyph_names))
+    bool glyph_names = c->plan->flags & HB_SUBSET_FLAGS_GLYPH_NAMES;
+    if (!serialize (c->serializer, glyph_names))
       return_trace (false);
 
-    if (c->plan->glyph_names && version.major == 2)
+    if (glyph_names && version.major == 2)
       return_trace (v2X.subset (c));
 
     return_trace (true);

--- a/src/hb-ot-var-gvar-table.hh
+++ b/src/hb-ot-var-gvar-table.hh
@@ -419,7 +419,9 @@ struct gvar
     out->glyphCount = num_glyphs;
 
     unsigned int subset_data_size = 0;
-    for (hb_codepoint_t gid = c->plan->notdef_outline ? 0 : 1; gid < num_glyphs; gid++)
+    for (hb_codepoint_t gid = (c->plan->flags & HB_SUBSET_FLAGS_NOTDEF_OUTLINE) ? 0 : 1;
+         gid < num_glyphs;
+         gid++)
     {
       hb_codepoint_t old_gid;
       if (!c->plan->old_gid_for_new_gid (gid, &old_gid)) continue;
@@ -449,7 +451,9 @@ struct gvar
     out->dataZ = subset_data - (char *) out;
 
     unsigned int glyph_offset = 0;
-    for (hb_codepoint_t gid = c->plan->notdef_outline ? 0 : 1; gid < num_glyphs; gid++)
+    for (hb_codepoint_t gid = (c->plan->flags & HB_SUBSET_FLAGS_NOTDEF_OUTLINE) ? 0 : 1;
+         gid < num_glyphs;
+         gid++)
     {
       hb_codepoint_t old_gid;
       hb_bytes_t var_data_bytes = c->plan->old_gid_for_new_gid (gid, &old_gid)

--- a/src/hb-ot-var-hvar-table.hh
+++ b/src/hb-ot-var-hvar-table.hh
@@ -272,7 +272,7 @@ struct hvarvvar_subset_plan_t
     index_map_plans[0].init (*index_maps[0], outer_map, inner_sets, plan);
     if (index_maps[0] == &Null (DeltaSetIndexMap))
     {
-      retain_adv_map = plan->retain_gids;
+      retain_adv_map = plan->flags & HB_SUBSET_FLAGS_RETAIN_GIDS;
       outer_map.add (0);
       for (hb_codepoint_t gid = 0; gid < plan->num_output_glyphs (); gid++)
       {

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -259,7 +259,10 @@ struct subr_flattener_t
 	return false;
       cs_interpreter_t<ENV, OPSET, flatten_param_t> interp;
       interp.env.init (str, acc, fd);
-      flatten_param_t  param = { flat_charstrings[i], plan->drop_hints };
+      flatten_param_t  param = {
+        flat_charstrings[i],
+        (bool) (plan->flags & HB_SUBSET_FLAGS_NO_HINTING)
+      };
       if (unlikely (!interp.interpret (param)))
 	return false;
     }
@@ -636,7 +639,7 @@ struct subr_subsetter_t
       param.init (&parsed_charstrings[i],
 		  &parsed_global_subrs,  &parsed_local_subrs[fd],
 		  closures.global_closure, closures.local_closures[fd],
-		  plan->drop_hints);
+		  plan->flags & HB_SUBSET_FLAGS_NO_HINTING);
 
       if (unlikely (!interp.interpret (param)))
 	return false;
@@ -645,7 +648,7 @@ struct subr_subsetter_t
       SUBSETTER::complete_parsed_str (interp.env, param, parsed_charstrings[i]);
     }
 
-    if (plan->drop_hints)
+    if (plan->flags & HB_SUBSET_FLAGS_NO_HINTING)
     {
       /* mark hint ops and arguments for drop */
       for (unsigned int i = 0; i < plan->num_output_glyphs (); i++)
@@ -660,7 +663,7 @@ struct subr_subsetter_t
 	param.init (&parsed_charstrings[i],
 		    &parsed_global_subrs,  &parsed_local_subrs[fd],
 		    closures.global_closure, closures.local_closures[fd],
-		    plan->drop_hints);
+                    plan->flags & HB_SUBSET_FLAGS_NO_HINTING);
 
 	drop_hints_param_t  drop;
 	if (drop_hints_in_str (parsed_charstrings[i], param, drop))
@@ -685,7 +688,7 @@ struct subr_subsetter_t
 	param.init (&parsed_charstrings[i],
 		    &parsed_global_subrs,  &parsed_local_subrs[fd],
 		    closures.global_closure, closures.local_closures[fd],
-		    plan->drop_hints);
+                    plan->flags & HB_SUBSET_FLAGS_NO_HINTING);
 	collect_subr_refs_in_str (parsed_charstrings[i], param);
       }
     }

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -543,8 +543,8 @@ struct cff_subset_plan {
 
     num_glyphs = plan->num_output_glyphs ();
     orig_fdcount = acc.fdCount;
-    drop_hints = plan->drop_hints;
-    desubroutinize = plan->desubroutinize;
+    drop_hints = plan->flags & HB_SUBSET_FLAGS_NO_HINTING;
+    desubroutinize = plan->flags & HB_SUBSET_FLAGS_DESUBROUTINIZE;
 
     /* check whether the subset renumbers any glyph IDs */
     gid_renum = false;

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -262,8 +262,8 @@ struct cff2_subset_plan {
   {
     orig_fdcount = acc.fdArray->count;
 
-    drop_hints = plan->drop_hints;
-    desubroutinize = plan->desubroutinize;
+    drop_hints = plan->flags & HB_SUBSET_FLAGS_NO_HINTING;
+    desubroutinize = plan->flags & HB_SUBSET_FLAGS_DESUBROUTINIZE;
 
     if (desubroutinize)
     {

--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -55,7 +55,7 @@ hb_subset_input_create_or_fail (void)
   input->drop_tables = hb_set_create ();
   input->no_subset_tables = hb_set_create ();
 
-  input->flags = HB_SUBSET_FLAGS_NONE;
+  input->flags = HB_SUBSET_FLAGS_DEFAULT;
 
   hb_tag_t default_drop_tables[] = {
     // Layout disabled by default
@@ -357,36 +357,31 @@ hb_subset_input_no_subset_tables_set (hb_subset_input_t *input)
  * hb_subset_input_get_flags:
  * @input: a #hb_subset_input_t object.
  *
- * Return value: the subsetting flags bit array.
+ * Return value: the subsetting flags bit field.
  *
  * Since: REPLACE
  **/
 HB_EXTERN hb_subset_flags_t
 hb_subset_input_get_flags (hb_subset_input_t *input)
 {
-  return input->flags;
+  return (hb_subset_flags_t) input->flags;
 }
 
 /**
  * hb_subset_input_set_flags:
  * @input: a #hb_subset_input_t object.
- * @flag: which flag to set.
- * @mask: bit mask which specifies which flags to change.
- * @value: bit set of new values for those flags.
+ * @value: bit field of flags
  *
- * Updates the flags specified by the mask to the values in value.
+ * Set all of the flags in the input object to the values
+ * specified by the bit field.
  *
  * Since: REPLACE
  **/
 HB_EXTERN void
 hb_subset_input_set_flags (hb_subset_input_t *input,
-			   hb_subset_flags_t mask,
-			   hb_subset_flags_t value)
+			   unsigned value)
 {
-  // Set desired flags.
-  input->flags = (hb_subset_flags_t) (input->flags | (mask & value));
-  // Clear desired flags.
-  input->flags = (hb_subset_flags_t) (input->flags & ~(mask & ~value));
+  input->flags = (hb_subset_flags_t) value;
 }
 
 /**

--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -54,16 +54,8 @@ hb_subset_input_create_or_fail (void)
   input->layout_features = hb_set_create ();
   input->drop_tables = hb_set_create ();
   input->no_subset_tables = hb_set_create ();
-  input->drop_hints = false;
-  input->desubroutinize = false;
-  input->retain_gids = false;
-  input->name_legacy = false;
-  input->overlaps_flag = false;
-  input->notdef_outline = false;
-  input->glyph_names = false;
-  input->no_prune_unicode_ranges = false;
-  input->retain_all_layout_features = false;
-  input->passthrough_unrecognized = false;
+
+  input->flags = HB_SUBSET_FLAGS_NONE;
 
   hb_tag_t default_drop_tables[] = {
     // Layout disabled by default
@@ -362,98 +354,39 @@ hb_subset_input_no_subset_tables_set (hb_subset_input_t *input)
 
 
 /**
- * hb_subset_input_get_flag:
+ * hb_subset_input_get_flags:
  * @input: a #hb_subset_input_t object.
- * @flag: which flag to check.
  *
- * Get the value of the specified flag.
- *
- * Return value: value of the specified flag.
+ * Return value: the subsetting flags bit array.
  *
  * Since: REPLACE
  **/
-HB_EXTERN hb_bool_t
-hb_subset_input_get_flag (hb_subset_input_t *input,
-			  hb_subset_flag_t flag)
+HB_EXTERN hb_subset_flags_t
+hb_subset_input_get_flags (hb_subset_input_t *input)
 {
-  switch (flag)
-  {
-    case HB_SUBSET_FLAG_HINTING:
-      return !input->drop_hints;
-    case HB_SUBSET_FLAG_RETAIN_GIDS:
-      return input->retain_gids;
-    case HB_SUBSET_FLAG_DESUBROUTINIZE:
-      return input->desubroutinize;
-    case HB_SUBSET_FLAG_NAME_LEGACY:
-      return input->name_legacy;
-    case HB_SUBSET_FLAG_SET_OVERLAPS_FLAG:
-      return input->overlaps_flag;
-    case HB_SUBSET_FLAG_PASSTHROUGH_UNRECOGNIZED:
-      return input->passthrough_unrecognized;
-    case HB_SUBSET_FLAG_NOTDEF_OUTLINE:
-      return input->notdef_outline;
-    case HB_SUBSET_FLAG_GLYPH_NAMES:
-      return input->glyph_names;
-    case HB_SUBSET_FLAG_NO_PRUNE_UNICODE_RANGES:
-      return input->no_prune_unicode_ranges;
-    case HB_SUBSET_FLAG_RETAIN_ALL_FEATURES:
-      return input->retain_all_layout_features;
-    default:
-      return false;
-  }
+  return input->flags;
 }
 
 /**
- * hb_subset_input_set_flag:
+ * hb_subset_input_set_flags:
  * @input: a #hb_subset_input_t object.
  * @flag: which flag to set.
- * @value: new value for the flag.
+ * @mask: bit mask which specifies which flags to change.
+ * @value: bit set of new values for those flags.
  *
- * Set the specified flag to @value.
+ * Updates the flags specified by the mask to the values in value.
  *
  * Since: REPLACE
  **/
 HB_EXTERN void
-hb_subset_input_set_flag (hb_subset_input_t *input,
-			  hb_subset_flag_t flag,
-			  hb_bool_t value)
+hb_subset_input_set_flags (hb_subset_input_t *input,
+			   hb_subset_flags_t mask,
+			   hb_subset_flags_t value)
 {
-  switch (flag)
-  {
-    case HB_SUBSET_FLAG_HINTING:
-      input->drop_hints = !value;
-      break;
-    case HB_SUBSET_FLAG_RETAIN_GIDS:
-      input->retain_gids = value;
-      break;
-    case HB_SUBSET_FLAG_DESUBROUTINIZE:
-      input->desubroutinize = value;
-      break;
-    case HB_SUBSET_FLAG_NAME_LEGACY:
-      input->name_legacy = value;
-      break;
-    case HB_SUBSET_FLAG_SET_OVERLAPS_FLAG:
-      input->overlaps_flag = value;
-      break;
-    case HB_SUBSET_FLAG_PASSTHROUGH_UNRECOGNIZED:
-      input->passthrough_unrecognized = value;
-      break;
-    case HB_SUBSET_FLAG_NOTDEF_OUTLINE:
-      input->notdef_outline = value;
-      break;
-    case HB_SUBSET_FLAG_GLYPH_NAMES:
-      input->glyph_names = value;
-      break;
-    case HB_SUBSET_FLAG_NO_PRUNE_UNICODE_RANGES:
-      input->no_prune_unicode_ranges = value;
-      break;
-    case HB_SUBSET_FLAG_RETAIN_ALL_FEATURES:
-      input->retain_all_layout_features = value;
-      break;
-    default:
-      // Do nothing.
-      break;
-  }
+  // Set desired flags.
+  input->flags = (hb_subset_flags_t) (input->flags | (mask & value));
+  // Clear desired flags.
+  input->flags = (hb_subset_flags_t) (input->flags & ~(mask & ~value));
 }
 
 /**

--- a/src/hb-subset-input.hh
+++ b/src/hb-subset-input.hh
@@ -46,17 +46,7 @@ struct hb_subset_input_t
   hb_set_t *drop_tables;
   hb_set_t *layout_features;
 
-  //use hb_bool_t to be consistent with G option parser
-  hb_bool_t drop_hints;
-  hb_bool_t desubroutinize;
-  hb_bool_t retain_gids;
-  hb_bool_t name_legacy;
-  hb_bool_t overlaps_flag;
-  hb_bool_t notdef_outline;
-  hb_bool_t glyph_names;
-  hb_bool_t no_prune_unicode_ranges;
-  hb_bool_t retain_all_layout_features;
-  hb_bool_t passthrough_unrecognized;
+  hb_subset_flags_t flags;
 
   /* TODO
    *

--- a/src/hb-subset-input.hh
+++ b/src/hb-subset-input.hh
@@ -34,6 +34,8 @@
 
 #include "hb-font.hh"
 
+HB_MARK_AS_FLAG_T (hb_subset_flags_t);
+
 struct hb_subset_input_t
 {
   hb_object_header_t header;
@@ -46,7 +48,7 @@ struct hb_subset_input_t
   hb_set_t *drop_tables;
   hb_set_t *layout_features;
 
-  hb_subset_flags_t flags;
+  unsigned flags;
 
   /* TODO
    *

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -423,16 +423,16 @@ hb_subset_plan_create (hb_face_t	 *face,
     return const_cast<hb_subset_plan_t *> (&Null (hb_subset_plan_t));
 
   plan->successful = true;
-  plan->drop_hints = input->drop_hints;
-  plan->desubroutinize = input->desubroutinize;
-  plan->retain_gids = input->retain_gids;
-  plan->name_legacy = input->name_legacy;
-  plan->overlaps_flag = input->overlaps_flag;
-  plan->notdef_outline = input->notdef_outline;
-  plan->glyph_names = input->glyph_names;
-  plan->prune_unicode_ranges = !input->no_prune_unicode_ranges;
-  plan->retain_all_layout_features = input->retain_all_layout_features;
-  plan->passthrough_unrecognized = input->passthrough_unrecognized;
+  plan->drop_hints = input->flags & HB_SUBSET_FLAGS_NO_HINTING;
+  plan->desubroutinize = input->flags & HB_SUBSET_FLAGS_DESUBROUTINIZE;
+  plan->retain_gids = input->flags & HB_SUBSET_FLAGS_RETAIN_GIDS;
+  plan->name_legacy = input->flags & HB_SUBSET_FLAGS_NAME_LEGACY;
+  plan->overlaps_flag = input->flags & HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG;
+  plan->notdef_outline = input->flags & HB_SUBSET_FLAGS_NOTDEF_OUTLINE;
+  plan->glyph_names = input->flags & HB_SUBSET_FLAGS_GLYPH_NAMES;
+  plan->prune_unicode_ranges = !(input->flags & HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES);
+  plan->retain_all_layout_features = input->flags & HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES;
+  plan->passthrough_unrecognized = input->flags & HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED;
   plan->unicodes = hb_set_create ();
   plan->name_ids = hb_set_copy (input->name_ids);
   _nameid_closure (face, plan->name_ids);
@@ -478,7 +478,7 @@ hb_subset_plan_create (hb_face_t	 *face,
 			    !input->drop_tables->has (HB_OT_TAG_GDEF));
 
   _create_old_gid_to_new_gid_map (face,
-				  input->retain_gids,
+                                  input->flags & HB_SUBSET_FLAGS_RETAIN_GIDS,
 				  plan->_glyphset,
 				  plan->glyph_map,
 				  plan->reverse_glyph_map,

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -296,10 +296,24 @@ _populate_gids_to_retain (hb_subset_plan_t* plan,
 #ifndef HB_NO_SUBSET_LAYOUT
   if (close_over_gsub)
     // closure all glyphs/lookups/features needed for GSUB substitutions.
-    _closure_glyphs_lookups_features<OT::GSUB> (plan->source, plan->_glyphset_gsub, plan->layout_features, plan->retain_all_layout_features, plan->gsub_lookups, plan->gsub_features, plan->gsub_langsys);
+    _closure_glyphs_lookups_features<OT::GSUB> (
+        plan->source,
+        plan->_glyphset_gsub,
+        plan->layout_features,
+        plan->flags & HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES,
+        plan->gsub_lookups,
+        plan->gsub_features,
+        plan->gsub_langsys);
 
   if (close_over_gpos)
-    _closure_glyphs_lookups_features<OT::GPOS> (plan->source, plan->_glyphset_gsub, plan->layout_features, plan->retain_all_layout_features, plan->gpos_lookups, plan->gpos_features, plan->gpos_langsys);
+    _closure_glyphs_lookups_features<OT::GPOS> (
+        plan->source,
+        plan->_glyphset_gsub,
+        plan->layout_features,
+        plan->flags & HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES,
+        plan->gpos_lookups,
+        plan->gpos_features,
+        plan->gpos_langsys);
 #endif
   _remove_invalid_gids (plan->_glyphset_gsub, plan->source->get_num_glyphs ());
 
@@ -423,16 +437,7 @@ hb_subset_plan_create (hb_face_t	 *face,
     return const_cast<hb_subset_plan_t *> (&Null (hb_subset_plan_t));
 
   plan->successful = true;
-  plan->drop_hints = input->flags & HB_SUBSET_FLAGS_NO_HINTING;
-  plan->desubroutinize = input->flags & HB_SUBSET_FLAGS_DESUBROUTINIZE;
-  plan->retain_gids = input->flags & HB_SUBSET_FLAGS_RETAIN_GIDS;
-  plan->name_legacy = input->flags & HB_SUBSET_FLAGS_NAME_LEGACY;
-  plan->overlaps_flag = input->flags & HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG;
-  plan->notdef_outline = input->flags & HB_SUBSET_FLAGS_NOTDEF_OUTLINE;
-  plan->glyph_names = input->flags & HB_SUBSET_FLAGS_GLYPH_NAMES;
-  plan->prune_unicode_ranges = !(input->flags & HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES);
-  plan->retain_all_layout_features = input->flags & HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES;
-  plan->passthrough_unrecognized = input->flags & HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED;
+  plan->flags = input->flags;
   plan->unicodes = hb_set_create ();
   plan->name_ids = hb_set_copy (input->name_ids);
   _nameid_closure (face, plan->name_ids);

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -39,17 +39,8 @@ struct hb_subset_plan_t
 {
   hb_object_header_t header;
 
-  bool successful : 1;
-  bool drop_hints : 1;
-  bool desubroutinize : 1;
-  bool retain_gids : 1;
-  bool name_legacy : 1;
-  bool overlaps_flag : 1;
-  bool notdef_outline : 1;
-  bool glyph_names : 1;
-  bool prune_unicode_ranges : 1;
-  bool retain_all_layout_features : 1;
-  bool passthrough_unrecognized : 1;
+  bool successful;
+  hb_subset_flags_t flags;
 
   // For each cp that we'd like to retain maps to the corresponding gid.
   hb_set_t *unicodes;

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -40,7 +40,7 @@ struct hb_subset_plan_t
   hb_object_header_t header;
 
   bool successful;
-  hb_subset_flags_t flags;
+  unsigned flags;
 
   // For each cp that we'd like to retain maps to the corresponding gid.
   hb_set_t *unicodes;

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -246,7 +246,7 @@ _should_drop_table (hb_subset_plan_t *plan, hb_tag_t tag)
   case HB_TAG ('p','r','e','p'): /* hint table, fallthrough */
   case HB_TAG ('h','d','m','x'): /* hint table, fallthrough */
   case HB_TAG ('V','D','M','X'): /* hint table, fallthrough */
-    return plan->drop_hints;
+    return plan->flags & HB_SUBSET_FLAGS_NO_HINTING;
 
 #ifdef HB_NO_SUBSET_LAYOUT
     // Drop Layout Tables if requested.
@@ -322,7 +322,7 @@ _subset_table (hb_subset_plan_t *plan, hb_tag_t tag)
 #endif
 
   default:
-    if (plan->passthrough_unrecognized)
+    if (plan->flags & HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED)
       return _passthrough (plan, tag);
 
     // Drop table

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -40,9 +40,8 @@ HB_BEGIN_DECLS
 typedef struct hb_subset_input_t hb_subset_input_t;
 
 /**
- * TODO(garretrieger): update to match added values, and no hinting change.
  * hb_subset_flags_t:
- * @HB_SUBSET_FLAGS_NONE: bit set with no flags set.
+ * @HB_SUBSET_FLAGS_DEFAULT: all flags at their default value.
  * @HB_SUBSET_FLAGS_NO_HINTING: If set hinting instructions will be dropped in
  * the produced subset. Otherwise hinting instructions will be retained.
  * Defaults to true.
@@ -54,7 +53,7 @@ typedef struct hb_subset_input_t hb_subset_input_t;
  * Defaults to false.
  * @HB_SUBSET_FLAGS_NAME_LEGACY: If set non-unicode name records will be
  * retained in the subset. Defaults to false.
- * @HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG:  If set the subsetter will set the
+ * @HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG:	If set the subsetter will set the
  * OVERLAP_SIMPLE flag on each simple glyph. Defaults to false.
  * @HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED: If set the subsetter will not
  * drop unrecognized tables and instead pass them through untouched.
@@ -69,26 +68,23 @@ typedef struct hb_subset_input_t hb_subset_input_t;
  * retained. If unset then the set accessed by
  * hb_subset_input_layout_features_set() will be used to determine the features
  * to be retained.
- * HB_SUBSET_FLAGS_ALL: bit set with all flags set.
  *
  * List of boolean properties that can be configured on the subset input.
  *
  * Since: REPLACE
  **/
-typedef enum
-{
-  HB_SUBSET_FLAGS_NONE = 0,
-  HB_SUBSET_FLAGS_NO_HINTING = 1,
-  HB_SUBSET_FLAGS_RETAIN_GIDS = 1 << 1,
-  HB_SUBSET_FLAGS_DESUBROUTINIZE = 1 << 2,
-  HB_SUBSET_FLAGS_NAME_LEGACY = 1 << 3,
-  HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG = 1 << 4,
-  HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED = 1 << 5,
-  HB_SUBSET_FLAGS_NOTDEF_OUTLINE = 1 << 6,
-  HB_SUBSET_FLAGS_GLYPH_NAMES = 1 << 7,
-  HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES = 1 << 8,
-  HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES = 1 << 9,
-  HB_SUBSET_FLAGS_ALL = -1,
+typedef enum { /*< flags >*/
+  HB_SUBSET_FLAGS_DEFAULT =		     0x00000000u,
+  HB_SUBSET_FLAGS_NO_HINTING =		     0x00000001u,
+  HB_SUBSET_FLAGS_RETAIN_GIDS =		     0x00000002u,
+  HB_SUBSET_FLAGS_DESUBROUTINIZE =	     0x00000004u,
+  HB_SUBSET_FLAGS_NAME_LEGACY =		     0x00000008u,
+  HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG =	     0x00000010u,
+  HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED = 0x00000020u,
+  HB_SUBSET_FLAGS_NOTDEF_OUTLINE =	     0x00000040u,
+  HB_SUBSET_FLAGS_GLYPH_NAMES =		     0x00000080u,
+  HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES =  0x00000100u,
+  HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES =	     0x00000200u,
 } hb_subset_flags_t;
 
 HB_EXTERN hb_subset_input_t *
@@ -137,8 +133,7 @@ hb_subset_input_get_flags (hb_subset_input_t *input);
 
 HB_EXTERN void
 hb_subset_input_set_flags (hb_subset_input_t *input,
-                           hb_subset_flags_t mask,
-                           hb_subset_flags_t value);
+			   unsigned value);
 
 HB_EXTERN hb_face_t *
 hb_subset_or_fail (hb_face_t *source, const hb_subset_input_t *input);

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -40,33 +40,36 @@ HB_BEGIN_DECLS
 typedef struct hb_subset_input_t hb_subset_input_t;
 
 /**
- * hb_subset_flag_t:
- * @HB_SUBSET_FLAG_HINTING: If set hinting instructions will be retained in
- * the produced subset. Otherwise hinting instructions will be dropped.
+ * TODO(garretrieger): update to match added values, and no hinting change.
+ * hb_subset_flags_t:
+ * @HB_SUBSET_FLAGS_NONE: bit set with no flags set.
+ * @HB_SUBSET_FLAGS_NO_HINTING: If set hinting instructions will be dropped in
+ * the produced subset. Otherwise hinting instructions will be retained.
  * Defaults to true.
- * @HB_SUBSET_FLAG_RETAIN_GIDS: If set glyph indices will not be modified in
+ * @HB_SUBSET_FLAGS_RETAIN_GIDS: If set glyph indices will not be modified in
  * the produced subset. If glyphs are dropped their indices will be retained
  * as an empty glyph. Defaults to false.
- * @HB_SUBSET_FLAG_DESUBROUTINIZE: If set and subsetting a CFF font the
+ * @HB_SUBSET_FLAGS_DESUBROUTINIZE: If set and subsetting a CFF font the
  * subsetter will attempt to remove subroutines from the CFF glyphs.
  * Defaults to false.
- * @HB_SUBSET_FLAG_NAME_LEGACY: If set non-unicode name records will be
+ * @HB_SUBSET_FLAGS_NAME_LEGACY: If set non-unicode name records will be
  * retained in the subset. Defaults to false.
- * @HB_SUBSET_FLAG_SET_OVERLAPS_FLAG:  If set the subsetter will set the
+ * @HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG:  If set the subsetter will set the
  * OVERLAP_SIMPLE flag on each simple glyph. Defaults to false.
- * @HB_SUBSET_FLAG_PASSTHROUGH_UNRECOGNIZED: If set the subsetter will not
+ * @HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED: If set the subsetter will not
  * drop unrecognized tables and instead pass them through untouched.
  * Defaults to false.
- * @HB_SUBSET_FLAG_NOTDEF_OUTLINE: If set the notdef glyph outline will be
+ * @HB_SUBSET_FLAGS_NOTDEF_OUTLINE: If set the notdef glyph outline will be
  * retained in the final subset. Defaults to false.
- * @HB_SUBSET_FLAG_GLYPH_NAMES: If set the PS glyph names will be retained
+ * @HB_SUBSET_FLAGS_GLYPH_NAMES: If set the PS glyph names will be retained
  * in the final subset. Defaults to false.
- * @HB_SUBSET_FLAG_NO_PRUNE_UNICODE_RANGES: If set then the unicode ranges in
+ * @HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES: If set then the unicode ranges in
  * OS/2 will not be recalculated.
- * @HB_SUBSET_FLAG_RETAIN_ALL_FEATURES: If set all layout features will be
+ * @HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES: If set all layout features will be
  * retained. If unset then the set accessed by
  * hb_subset_input_layout_features_set() will be used to determine the features
  * to be retained.
+ * HB_SUBSET_FLAGS_ALL: bit set with all flags set.
  *
  * List of boolean properties that can be configured on the subset input.
  *
@@ -74,17 +77,19 @@ typedef struct hb_subset_input_t hb_subset_input_t;
  **/
 typedef enum
 {
-  HB_SUBSET_FLAG_HINTING = 0,
-  HB_SUBSET_FLAG_RETAIN_GIDS,
-  HB_SUBSET_FLAG_DESUBROUTINIZE,
-  HB_SUBSET_FLAG_NAME_LEGACY,
-  HB_SUBSET_FLAG_SET_OVERLAPS_FLAG,
-  HB_SUBSET_FLAG_PASSTHROUGH_UNRECOGNIZED,
-  HB_SUBSET_FLAG_NOTDEF_OUTLINE,
-  HB_SUBSET_FLAG_GLYPH_NAMES,
-  HB_SUBSET_FLAG_NO_PRUNE_UNICODE_RANGES,
-  HB_SUBSET_FLAG_RETAIN_ALL_FEATURES,
-} hb_subset_flag_t;
+  HB_SUBSET_FLAGS_NONE = 0,
+  HB_SUBSET_FLAGS_NO_HINTING = 1,
+  HB_SUBSET_FLAGS_RETAIN_GIDS = 1 << 1,
+  HB_SUBSET_FLAGS_DESUBROUTINIZE = 1 << 2,
+  HB_SUBSET_FLAGS_NAME_LEGACY = 1 << 3,
+  HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG = 1 << 4,
+  HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED = 1 << 5,
+  HB_SUBSET_FLAGS_NOTDEF_OUTLINE = 1 << 6,
+  HB_SUBSET_FLAGS_GLYPH_NAMES = 1 << 7,
+  HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES = 1 << 8,
+  HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES = 1 << 9,
+  HB_SUBSET_FLAGS_ALL = -1,
+} hb_subset_flags_t;
 
 HB_EXTERN hb_subset_input_t *
 hb_subset_input_create_or_fail (void);
@@ -127,14 +132,13 @@ hb_subset_input_no_subset_tables_set (hb_subset_input_t *input);
 HB_EXTERN hb_set_t *
 hb_subset_input_drop_tables_set (hb_subset_input_t *input);
 
-HB_EXTERN hb_bool_t
-hb_subset_input_get_flag (hb_subset_input_t *input,
-			  hb_subset_flag_t flag);
+HB_EXTERN hb_subset_flags_t
+hb_subset_input_get_flags (hb_subset_input_t *input);
 
 HB_EXTERN void
-hb_subset_input_set_flag (hb_subset_input_t *input,
-			  hb_subset_flag_t flag,
-			  hb_bool_t value);
+hb_subset_input_set_flags (hb_subset_input_t *input,
+                           hb_subset_flags_t mask,
+                           hb_subset_flags_t value);
 
 HB_EXTERN hb_face_t *
 hb_subset_or_fail (hb_face_t *source, const hb_subset_input_t *input);

--- a/test/api/hb-subset-test.h
+++ b/test/api/hb-subset-test.h
@@ -75,7 +75,9 @@ hb_subset_test_create_input_from_nameids (const hb_set_t *name_ids)
   hb_set_t *name_langids = hb_subset_input_namelangid_set (input);
   hb_set_add_range (name_langids, 0, 0x5FFF);
 
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_NAME_LEGACY, true);
+  hb_subset_input_set_flags (input,
+                             HB_SUBSET_FLAGS_NAME_LEGACY,
+                             HB_SUBSET_FLAGS_ALL);
   return input;
 }
 

--- a/test/api/hb-subset-test.h
+++ b/test/api/hb-subset-test.h
@@ -76,8 +76,7 @@ hb_subset_test_create_input_from_nameids (const hb_set_t *name_ids)
   hb_set_add_range (name_langids, 0, 0x5FFF);
 
   hb_subset_input_set_flags (input,
-                             HB_SUBSET_FLAGS_NAME_LEGACY,
-                             HB_SUBSET_FLAGS_ALL);
+                             HB_SUBSET_FLAGS_NAME_LEGACY);
   return input;
 }
 

--- a/test/api/test-subset-cff1.c
+++ b/test/api/test-subset-cff1.c
@@ -80,7 +80,7 @@ test_subset_cff1_strip_hints (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -103,7 +103,7 @@ test_subset_cff1_desubr (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_DESUBROUTINIZE, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -126,8 +126,9 @@ test_subset_cff1_desubr_strip_hints (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_DESUBROUTINIZE, true);
+  hb_subset_input_set_flags (input,
+                             HB_SUBSET_FLAGS_NO_HINTING | HB_SUBSET_FLAGS_DESUBROUTINIZE,
+                             HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -170,7 +171,7 @@ test_subset_cff1_j_strip_hints (void)
   hb_set_add (codepoints, 0x41);
   hb_set_add (codepoints, 0x4C2E);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
   face_41_3041_4c2e_subset = hb_subset_test_create_subset (face_41_3041_4c2e, input);
   hb_set_destroy (codepoints);
 
@@ -193,7 +194,7 @@ test_subset_cff1_j_desubr (void)
   hb_set_add (codepoints, 0x41);
   hb_set_add (codepoints, 0x4C2E);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_DESUBROUTINIZE, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE, HB_SUBSET_FLAGS_ALL);
   face_41_3041_4c2e_subset = hb_subset_test_create_subset (face_41_3041_4c2e, input);
   hb_set_destroy (codepoints);
 
@@ -216,8 +217,9 @@ test_subset_cff1_j_desubr_strip_hints (void)
   hb_set_add (codepoints, 0x41);
   hb_set_add (codepoints, 0x4C2E);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_DESUBROUTINIZE, true);
+  hb_subset_input_set_flags (input,
+                             HB_SUBSET_FLAGS_NO_HINTING | HB_SUBSET_FLAGS_DESUBROUTINIZE,
+                             HB_SUBSET_FLAGS_ALL);
   face_41_3041_4c2e_subset = hb_subset_test_create_subset (face_41_3041_4c2e, input);
   hb_set_destroy (codepoints);
 
@@ -279,7 +281,7 @@ test_subset_cff1_dotsection (void)
   hb_face_t *face_test;
   hb_set_add (codepoints, 0x69);  /* i */
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
   face_test = hb_subset_test_create_subset (face, input);
   hb_set_destroy (codepoints);
 
@@ -302,7 +304,7 @@ test_subset_cff1_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -325,7 +327,7 @@ test_subset_cff1_j_retaingids (void)
   hb_set_add (codepoints, 0x41);
   hb_set_add (codepoints, 0x4C2E);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_41_3041_4c2e_subset = hb_subset_test_create_subset (face_41_3041_4c2e, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-cff1.c
+++ b/test/api/test-subset-cff1.c
@@ -80,7 +80,7 @@ test_subset_cff1_strip_hints (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -103,7 +103,7 @@ test_subset_cff1_desubr (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -127,8 +127,7 @@ test_subset_cff1_desubr_strip_hints (void)
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
   hb_subset_input_set_flags (input,
-                             HB_SUBSET_FLAGS_NO_HINTING | HB_SUBSET_FLAGS_DESUBROUTINIZE,
-                             HB_SUBSET_FLAGS_ALL);
+                             HB_SUBSET_FLAGS_NO_HINTING | HB_SUBSET_FLAGS_DESUBROUTINIZE);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -171,7 +170,7 @@ test_subset_cff1_j_strip_hints (void)
   hb_set_add (codepoints, 0x41);
   hb_set_add (codepoints, 0x4C2E);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING);
   face_41_3041_4c2e_subset = hb_subset_test_create_subset (face_41_3041_4c2e, input);
   hb_set_destroy (codepoints);
 
@@ -194,7 +193,7 @@ test_subset_cff1_j_desubr (void)
   hb_set_add (codepoints, 0x41);
   hb_set_add (codepoints, 0x4C2E);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE);
   face_41_3041_4c2e_subset = hb_subset_test_create_subset (face_41_3041_4c2e, input);
   hb_set_destroy (codepoints);
 
@@ -218,8 +217,7 @@ test_subset_cff1_j_desubr_strip_hints (void)
   hb_set_add (codepoints, 0x4C2E);
   input = hb_subset_test_create_input (codepoints);
   hb_subset_input_set_flags (input,
-                             HB_SUBSET_FLAGS_NO_HINTING | HB_SUBSET_FLAGS_DESUBROUTINIZE,
-                             HB_SUBSET_FLAGS_ALL);
+                             HB_SUBSET_FLAGS_NO_HINTING | HB_SUBSET_FLAGS_DESUBROUTINIZE);
   face_41_3041_4c2e_subset = hb_subset_test_create_subset (face_41_3041_4c2e, input);
   hb_set_destroy (codepoints);
 
@@ -281,7 +279,7 @@ test_subset_cff1_dotsection (void)
   hb_face_t *face_test;
   hb_set_add (codepoints, 0x69);  /* i */
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING);
   face_test = hb_subset_test_create_subset (face, input);
   hb_set_destroy (codepoints);
 
@@ -304,7 +302,7 @@ test_subset_cff1_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -327,7 +325,7 @@ test_subset_cff1_j_retaingids (void)
   hb_set_add (codepoints, 0x41);
   hb_set_add (codepoints, 0x4C2E);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_41_3041_4c2e_subset = hb_subset_test_create_subset (face_41_3041_4c2e, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-cff2.c
+++ b/test/api/test-subset-cff2.c
@@ -80,7 +80,7 @@ test_subset_cff2_strip_hints (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -103,7 +103,7 @@ test_subset_cff2_desubr (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -127,8 +127,7 @@ test_subset_cff2_desubr_strip_hints (void)
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
   hb_subset_input_set_flags (input,
-                             HB_SUBSET_FLAGS_DESUBROUTINIZE | HB_SUBSET_FLAGS_NO_HINTING,
-                             HB_SUBSET_FLAGS_ALL);
+                             HB_SUBSET_FLAGS_DESUBROUTINIZE | HB_SUBSET_FLAGS_NO_HINTING);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -151,7 +150,7 @@ test_subset_cff2_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-cff2.c
+++ b/test/api/test-subset-cff2.c
@@ -80,7 +80,7 @@ test_subset_cff2_strip_hints (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -103,7 +103,7 @@ test_subset_cff2_desubr (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_DESUBROUTINIZE, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_DESUBROUTINIZE, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -126,8 +126,9 @@ test_subset_cff2_desubr_strip_hints (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_DESUBROUTINIZE, true);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
+  hb_subset_input_set_flags (input,
+                             HB_SUBSET_FLAGS_DESUBROUTINIZE | HB_SUBSET_FLAGS_NO_HINTING,
+                             HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -150,7 +151,7 @@ test_subset_cff2_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-glyf.c
+++ b/test/api/test-subset-glyf.c
@@ -92,7 +92,7 @@ test_subset_glyf_set_overlaps_flag (void)
   hb_set_add (codepoints, 508);
 
   hb_subset_input_t* input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG);
   face_abcAE_subset = hb_subset_test_create_subset (face_abcAE, input);
   hb_set_destroy (codepoints);
 
@@ -239,7 +239,7 @@ test_subset_glyf_strip_hints_simple (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -263,7 +263,7 @@ test_subset_glyf_strip_hints_composite (void)
   hb_face_t *face_generated_subset;
   hb_set_add (codepoints, 0x1fc);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING);
 
   face_generated_subset = hb_subset_test_create_subset (face_components, input);
   hb_set_destroy (codepoints);
@@ -298,7 +298,7 @@ test_subset_glyf_strip_hints_invalid (void)
   }
 
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING);
   hb_set_destroy (codepoints);
 
   face_subset = hb_subset_or_fail (face, input);
@@ -320,7 +320,7 @@ test_subset_glyf_retain_gids (void)
   hb_set_add (codepoints, 99);
 
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -344,7 +344,7 @@ test_subset_glyf_retain_gids_truncates (void)
   hb_set_add (codepoints, 97);
 
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-glyf.c
+++ b/test/api/test-subset-glyf.c
@@ -92,7 +92,7 @@ test_subset_glyf_set_overlaps_flag (void)
   hb_set_add (codepoints, 508);
 
   hb_subset_input_t* input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_SET_OVERLAPS_FLAG, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG, HB_SUBSET_FLAGS_ALL);
   face_abcAE_subset = hb_subset_test_create_subset (face_abcAE, input);
   hb_set_destroy (codepoints);
 
@@ -239,7 +239,7 @@ test_subset_glyf_strip_hints_simple (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -263,7 +263,7 @@ test_subset_glyf_strip_hints_composite (void)
   hb_face_t *face_generated_subset;
   hb_set_add (codepoints, 0x1fc);
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
 
   face_generated_subset = hb_subset_test_create_subset (face_components, input);
   hb_set_destroy (codepoints);
@@ -298,7 +298,7 @@ test_subset_glyf_strip_hints_invalid (void)
   }
 
   input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, false);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_NO_HINTING, HB_SUBSET_FLAGS_ALL);
   hb_set_destroy (codepoints);
 
   face_subset = hb_subset_or_fail (face, input);
@@ -320,7 +320,7 @@ test_subset_glyf_retain_gids (void)
   hb_set_add (codepoints, 99);
 
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -344,7 +344,7 @@ test_subset_glyf_retain_gids_truncates (void)
   hb_set_add (codepoints, 97);
 
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-gvar.c
+++ b/test/api/test-subset-gvar.c
@@ -79,7 +79,7 @@ test_subset_gvar_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-gvar.c
+++ b/test/api/test-subset-gvar.c
@@ -79,7 +79,7 @@ test_subset_gvar_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-hvar.c
+++ b/test/api/test-subset-hvar.c
@@ -79,7 +79,7 @@ test_subset_map_HVAR_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -160,7 +160,7 @@ test_subset_identity_HVAR_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-hvar.c
+++ b/test/api/test-subset-hvar.c
@@ -79,7 +79,7 @@ test_subset_map_HVAR_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 
@@ -160,7 +160,7 @@ test_subset_identity_HVAR_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-vvar.c
+++ b/test/api/test-subset-vvar.c
@@ -79,7 +79,7 @@ test_subset_VVAR_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset-vvar.c
+++ b/test/api/test-subset-vvar.c
@@ -79,7 +79,7 @@ test_subset_VVAR_retaingids (void)
   hb_set_add (codepoints, 'a');
   hb_set_add (codepoints, 'c');
   hb_subset_input_t *input = hb_subset_test_create_input (codepoints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, true);
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_RETAIN_GIDS, HB_SUBSET_FLAGS_ALL);
   face_abc_subset = hb_subset_test_create_subset (face_abc, input);
   hb_set_destroy (codepoints);
 

--- a/test/api/test-subset.c
+++ b/test/api/test-subset.c
@@ -98,13 +98,12 @@ test_subset_set_flags (void)
 {
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
 
-  g_assert (hb_subset_input_get_flags (input) == HB_SUBSET_FLAGS_NONE);
+  g_assert (hb_subset_input_get_flags (input) == HB_SUBSET_FLAGS_DEFAULT);
 
   hb_subset_input_set_flags (input,
                              HB_SUBSET_FLAGS_NAME_LEGACY |
                              HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
-                             HB_SUBSET_FLAGS_GLYPH_NAMES,
-                             HB_SUBSET_FLAGS_ALL);
+                             HB_SUBSET_FLAGS_GLYPH_NAMES);
 
   g_assert (hb_subset_input_get_flags (input) ==
             (hb_subset_flags_t) (
@@ -113,12 +112,6 @@ test_subset_set_flags (void)
             HB_SUBSET_FLAGS_GLYPH_NAMES));
 
   hb_subset_input_set_flags (input,
-
-                             HB_SUBSET_FLAGS_NAME_LEGACY |
-                             HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
-                             HB_SUBSET_FLAGS_GLYPH_NAMES |
-                             HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES,
-
                              HB_SUBSET_FLAGS_NAME_LEGACY |
                              HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
                              HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES);

--- a/test/api/test-subset.c
+++ b/test/api/test-subset.c
@@ -93,6 +93,46 @@ test_subset_crash (void)
   hb_face_destroy (face);
 }
 
+static void
+test_subset_set_flags (void)
+{
+  hb_subset_input_t *input = hb_subset_input_create_or_fail ();
+
+  g_assert (hb_subset_input_get_flags (input) == HB_SUBSET_FLAGS_NONE);
+
+  hb_subset_input_set_flags (input,
+                             HB_SUBSET_FLAGS_NAME_LEGACY |
+                             HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
+                             HB_SUBSET_FLAGS_GLYPH_NAMES,
+                             HB_SUBSET_FLAGS_ALL);
+
+  g_assert (hb_subset_input_get_flags (input) ==
+            (hb_subset_flags_t) (
+            HB_SUBSET_FLAGS_NAME_LEGACY |
+            HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
+            HB_SUBSET_FLAGS_GLYPH_NAMES));
+
+  hb_subset_input_set_flags (input,
+
+                             HB_SUBSET_FLAGS_NAME_LEGACY |
+                             HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
+                             HB_SUBSET_FLAGS_GLYPH_NAMES |
+                             HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES,
+
+                             HB_SUBSET_FLAGS_NAME_LEGACY |
+                             HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
+                             HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES);
+
+  g_assert (hb_subset_input_get_flags (input) ==
+            (hb_subset_flags_t) (
+            HB_SUBSET_FLAGS_NAME_LEGACY |
+            HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
+            HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES));
+
+
+  hb_subset_input_destroy (input);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -101,6 +141,7 @@ main (int argc, char **argv)
   hb_test_add (test_subset_32_tables);
   hb_test_add (test_subset_no_inf_loop);
   hb_test_add (test_subset_crash);
+  hb_test_add (test_subset_set_flags);
 
   return hb_test_run();
 }

--- a/test/fuzzing/hb-subset-fuzzer.cc
+++ b/test/fuzzing/hb-subset-fuzzer.cc
@@ -11,12 +11,12 @@ static void
 trySubset (hb_face_t *face,
 	   const hb_codepoint_t text[],
 	   int text_length,
-           hb_subset_flags_t flag_bits)
+           unsigned flag_bits)
 {
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
   if (!input) return;
 
-  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_ALL, flag_bits);
+  hb_subset_input_set_flags (input, (hb_subset_flags_t) flag_bits);
 
   hb_set_t *codepoints = hb_subset_input_unicode_set (input);
 
@@ -56,7 +56,7 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   hb_face_collect_unicodes (face, output);
   hb_set_destroy (output);
 
-  hb_subset_flags_t flags = HB_SUBSET_FLAGS_NONE;
+  unsigned flags = HB_SUBSET_FLAGS_DEFAULT;
   const hb_codepoint_t text[] =
       {
 	'A', 'B', 'C', 'D', 'E', 'X', 'Y', 'Z', '1', '2',

--- a/test/fuzzing/hb-subset-fuzzer.cc
+++ b/test/fuzzing/hb-subset-fuzzer.cc
@@ -11,22 +11,14 @@ static void
 trySubset (hb_face_t *face,
 	   const hb_codepoint_t text[],
 	   int text_length,
-	   bool drop_hints,
-	   bool drop_layout,
-	   bool retain_gids)
+           hb_subset_flags_t flag_bits)
 {
   hb_subset_input_t *input = hb_subset_input_create_or_fail ();
   if (!input) return;
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_HINTING, !drop_hints);
-  hb_subset_input_set_flag (input, HB_SUBSET_FLAG_RETAIN_GIDS, retain_gids);
-  hb_set_t *codepoints = hb_subset_input_unicode_set (input);
 
-  if (!drop_layout)
-  {
-    hb_set_del (hb_subset_input_drop_tables_set (input), HB_TAG ('G', 'S', 'U', 'B'));
-    hb_set_del (hb_subset_input_drop_tables_set (input), HB_TAG ('G', 'P', 'O', 'S'));
-    hb_set_del (hb_subset_input_drop_tables_set (input), HB_TAG ('G', 'D', 'E', 'F'));
-  }
+  hb_subset_input_set_flags (input, HB_SUBSET_FLAGS_ALL, flag_bits);
+
+  hb_set_t *codepoints = hb_subset_input_unicode_set (input);
 
   for (int i = 0; i < text_length; i++)
     hb_set_add (codepoints, text[i]);
@@ -51,19 +43,6 @@ trySubset (hb_face_t *face,
   hb_subset_input_destroy (input);
 }
 
-static void
-trySubset (hb_face_t *face,
-	   const hb_codepoint_t text[],
-	   int text_length,
-	   const uint8_t flags[1])
-{
-  bool drop_hints =  flags[0] & (1 << 0);
-  bool drop_layout = flags[0] & (1 << 1);
-  bool retain_gids = flags[0] & (1 << 2);
-  trySubset (face, text, text_length,
-	     drop_hints, drop_layout, retain_gids);
-}
-
 extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 {
   alloc_state = size; /* see src/failing-alloc.c */
@@ -77,7 +56,7 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   hb_face_collect_unicodes (face, output);
   hb_set_destroy (output);
 
-  uint8_t flags[1] = {0};
+  hb_subset_flags_t flags = HB_SUBSET_FLAGS_NONE;
   const hb_codepoint_t text[] =
       {
 	'A', 'B', 'C', 'D', 'E', 'X', 'Y', 'Z', '1', '2',
@@ -92,7 +71,7 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 	    data + size - sizeof (text_from_data),
 	    sizeof (text_from_data));
 
-    memcpy (flags,
+    memcpy (&flags,
 	    data + size - sizeof (text_from_data) - sizeof (flags),
 	    sizeof (flags));
     unsigned int text_size = sizeof (text_from_data) / sizeof (hb_codepoint_t);

--- a/util/hb-subset.cc
+++ b/util/hb-subset.cc
@@ -43,7 +43,7 @@ struct subset_consumer_t
 	     const font_options_t *font_opts)
   {
     font = hb_font_reference (font_opts->get_font ());
-    input = hb_subset_input_reference (subset_options.input);
+    input = hb_subset_input_reference (subset_options.get_input ());
   }
 
   void consume_line (const char   *text,

--- a/util/options-subset.cc
+++ b/util/options-subset.cc
@@ -217,9 +217,12 @@ parse_layout_features (const char *name,
   if (0 == strcmp (arg, "*"))
   {
     if (last_name_char == '-')
+    {
       hb_set_clear (layout_features);
-    else
-      subset_opts->input->retain_all_layout_features = true;
+      *subset_opts->bool_for (HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES) = false;
+    } else {
+      *subset_opts->bool_for (HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES) = true;
+    }
     return true;
   }
 
@@ -288,14 +291,14 @@ subset_options_t::add_options (option_parser_t *parser)
 {
   GOptionEntry entries[] =
   {
-    {"no-hinting", 0, 0, G_OPTION_ARG_NONE,  &this->input->drop_hints,   "Whether to drop hints",   nullptr},
-    {"retain-gids", 0, 0, G_OPTION_ARG_NONE,  &this->input->retain_gids,   "If set don't renumber glyph ids in the subset.",   nullptr},
+    {"no-hinting", 0, 0, G_OPTION_ARG_NONE,  this->bool_for (HB_SUBSET_FLAGS_NO_HINTING),   "Whether to drop hints",   nullptr},
+    {"retain-gids", 0, 0, G_OPTION_ARG_NONE,  this->bool_for (HB_SUBSET_FLAGS_RETAIN_GIDS),   "If set don't renumber glyph ids in the subset.",   nullptr},
     {"gids", 0, 0, G_OPTION_ARG_CALLBACK,  (gpointer) &parse_gids,  "Specify glyph IDs or ranges to include in the subset", "list of comma/whitespace-separated int numbers or ranges"},
-    {"desubroutinize", 0, 0, G_OPTION_ARG_NONE,  &this->input->desubroutinize,   "Remove CFF/CFF2 use of subroutines",   nullptr},
+    {"desubroutinize", 0, 0, G_OPTION_ARG_NONE,  this->bool_for (HB_SUBSET_FLAGS_DESUBROUTINIZE),   "Remove CFF/CFF2 use of subroutines",   nullptr},
     {"name-IDs", 0, 0, G_OPTION_ARG_CALLBACK,  (gpointer) &parse_nameids,  "Subset specified nameids", "list of int numbers"},
     {"name-IDs-", 0, 0, G_OPTION_ARG_CALLBACK,  (gpointer) &parse_nameids,  "Subset specified nameids", "list of int numbers"},
     {"name-IDs+", 0, 0, G_OPTION_ARG_CALLBACK,  (gpointer) &parse_nameids,  "Subset specified nameids", "list of int numbers"},
-    {"name-legacy", 0, 0, G_OPTION_ARG_NONE,  &this->input->name_legacy,   "Keep legacy (non-Unicode) 'name' table entries",   nullptr},
+    {"name-legacy", 0, 0, G_OPTION_ARG_NONE,  this->bool_for (HB_SUBSET_FLAGS_NAME_LEGACY),   "Keep legacy (non-Unicode) 'name' table entries",   nullptr},
     {"name-languages", 0, 0, G_OPTION_ARG_CALLBACK,  (gpointer) &parse_name_languages,  "Subset nameRecords with specified language IDs", "list of int numbers"},
     {"name-languages-", 0, 0, G_OPTION_ARG_CALLBACK,  (gpointer) &parse_name_languages,  "Subset nameRecords with specified language IDs", "list of int numbers"},
     {"name-languages+", 0, 0, G_OPTION_ARG_CALLBACK,  (gpointer) &parse_name_languages,  "Subset nameRecords with specified language IDs", "list of int numbers"},
@@ -308,11 +311,11 @@ subset_options_t::add_options (option_parser_t *parser)
     {"num-iterations", 'n', 0, G_OPTION_ARG_INT,
      &this->num_iterations,
      "Run subsetter N times (default: 1)", "N"},
-    {"set-overlaps-flag", 0, 0, G_OPTION_ARG_NONE,  &this->input->overlaps_flag,
+    {"set-overlaps-flag", 0, 0, G_OPTION_ARG_NONE,  this->bool_for (HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG),
      "Set the overlaps flag on each glyph.",   nullptr},
-    {"notdef-outline", 0, 0, G_OPTION_ARG_NONE,  &this->input->notdef_outline,   "Keep the outline of \'.notdef\' glyph",   nullptr},
-    {"no-prune-unicode-ranges", 0, 0, G_OPTION_ARG_NONE,  &this->input->no_prune_unicode_ranges,   "Don't change the 'OS/2 ulUnicodeRange*' bits.",   nullptr},
-    {"glyph-names", 0, 0, G_OPTION_ARG_NONE,  &this->input->glyph_names,   "Keep PS glyph names in TT-flavored fonts. ",   nullptr},
+    {"notdef-outline", 0, 0, G_OPTION_ARG_NONE,  this->bool_for (HB_SUBSET_FLAGS_NOTDEF_OUTLINE),   "Keep the outline of \'.notdef\' glyph",   nullptr},
+    {"no-prune-unicode-ranges", 0, 0, G_OPTION_ARG_NONE,  this->bool_for (HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES),   "Don't change the 'OS/2 ulUnicodeRange*' bits.",   nullptr},
+    {"glyph-names", 0, 0, G_OPTION_ARG_NONE,  this->bool_for (HB_SUBSET_FLAGS_GLYPH_NAMES),   "Keep PS glyph names in TT-flavored fonts. ",   nullptr},
     {nullptr}
   };
   parser->add_group (entries,

--- a/util/options.hh
+++ b/util/options.hh
@@ -709,7 +709,7 @@ struct subset_options_t : option_group_t
   {
     for (unsigned i = 0; i < sizeof(int) * 8; i++)
     {
-      if (1 << i == flag)
+      if (1u << i == flag)
         return &flags[i];
     }
     return &flags[sizeof(int) * 8 - 1];
@@ -719,12 +719,13 @@ struct subset_options_t : option_group_t
 
   hb_subset_input_t * get_input ()
   {
+    hb_subset_flags_t flags_set = HB_SUBSET_FLAGS_DEFAULT;
     for (unsigned i = 0; i < sizeof(int) * 8; i++)
     {
-      hb_subset_input_set_flags (input,
-                                 (hb_subset_flags_t) (1 << i),
-                                 flags[i] ? HB_SUBSET_FLAGS_ALL : HB_SUBSET_FLAGS_NONE);
+      if (flags[i])
+        flags_set = (hb_subset_flags_t) (flags_set |  (1u << i));
     }
+    hb_subset_input_set_flags (input, flags_set);
     return input;
   }
 

--- a/util/options.hh
+++ b/util/options.hh
@@ -705,7 +705,31 @@ struct subset_options_t : option_group_t
 
   void add_options (option_parser_t *parser) override;
 
+  hb_bool_t* bool_for(hb_subset_flags_t flag)
+  {
+    for (unsigned i = 0; i < sizeof(int) * 8; i++)
+    {
+      if (1 << i == flag)
+        return &flags[i];
+    }
+    return &flags[sizeof(int) * 8 - 1];
+  }
+
   unsigned num_iterations;
+
+  hb_subset_input_t * get_input ()
+  {
+    for (unsigned i = 0; i < sizeof(int) * 8; i++)
+    {
+      hb_subset_input_set_flags (input,
+                                 (hb_subset_flags_t) (1 << i),
+                                 flags[i] ? HB_SUBSET_FLAGS_ALL : HB_SUBSET_FLAGS_NONE);
+    }
+    return input;
+  }
+
+  hb_bool_t flags[sizeof(int) * 8] = {0};
+
   hb_subset_input_t *input;
 };
 


### PR DESCRIPTION
By switching both to bit sets we can easily support a batch set/clear method and as an added bonus makes adding new flags trivial.

One other notable change is this updates the subset fuzzer to take the entire flags bit set from the fuzzer input, which will now allow the fuzzer to toggle any combination of flags.

For #3086 