### PR TITLE
Replace "langstr" with more helpful help.

### DIFF
--- a/util/shape-options.hh
+++ b/util/shape-options.hh
@@ -421,7 +421,7 @@ shape_options_t::add_options (option_parser_t *parser)
 			      G_OPTION_ARG_CALLBACK,	(gpointer) &parse_shapers,	"Hidden duplicate of --shapers",	nullptr},
     {"shapers",		0, 0, G_OPTION_ARG_CALLBACK,	(gpointer) &parse_shapers,	"Set comma-separated list of shapers to try","list"},
     {"direction",	0, 0, G_OPTION_ARG_STRING,	&this->direction,		"Set text direction (default: auto)",	"ltr/rtl/ttb/btt"},
-    {"language",	0, 0, G_OPTION_ARG_STRING,	&this->language,		"Set text language (default: $LANG)",	"langstr"},
+    {"language",	0, 0, G_OPTION_ARG_STRING,	&this->language,		"Set text language (default: $LANG)",	"BCP 47 tag"},
     {"script",		0, 0, G_OPTION_ARG_STRING,	&this->script,			"Set text script (default: auto)",	"ISO-15924 tag"},
     {"bot",		0, 0, G_OPTION_ARG_NONE,	&this->bot,			"Treat text as beginning-of-paragraph",	nullptr},
     {"eot",		0, 0, G_OPTION_ARG_NONE,	&this->eot,			"Treat text as end-of-paragraph",	nullptr},


### PR DESCRIPTION
<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Today I lost half an hour to the fact that the OpenType language tag for Turkish is &quot;TRK &quot; and the ISO639-3 language tag is &quot;tur&quot; but if you want hb-shape to select Turkish you have to give it the ISO639-1 language tag, which is &quot;tr&quot;.</p>&mdash; Simon Cozens (@simoncozens) <a href="https://twitter.com/simoncozens/status/1427731577321267204?ref_src=twsrc%5Etfw">August 17, 2021</a></blockquote>