### PR TITLE
Fix CI workflow for publishing releases

### DIFF
--- a/.ci/publish_release_artifact.sh
+++ b/.ci/publish_release_artifact.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -e
 set -o pipefail
 
@@ -7,11 +8,13 @@ if [[ -z $GITHUB_TOKEN ]]; then
 	exit
 fi
 
-mkdir -p $HOME/.local/bin
-export _GHR_VER=v0.13.0
-export _GHR=ghr_${_GHR_VER}_linux_amd64
-curl -sfL https://github.com/tcnksm/ghr/releases/download/$_GHR_VER/$_GHR.tar.gz |
-	tar xz -C $HOME/.local/bin --strip-components=1 $_GHR/ghr
+if ! hash ghr 2> /dev/null; then
+	_GHR_VER=v0.14.0
+	_GHR=ghr_${_GHR_VER}_linux_amd64
+	mkdir -p $HOME/.local/bin
+	curl -sfL https://github.com/tcnksm/ghr/releases/download/$_GHR_VER/$_GHR.tar.gz |
+		tar xz -C $HOME/.local/bin --strip-components=1 $_GHR/ghr
+fi
 
 ghr -replace \
 	-u $CIRCLE_PROJECT_USERNAME \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,10 @@ workflows:
   build:
     jobs:
       - macos-aat-fonts
-      - distcheck
+      - distcheck:
+          filters: # must have filter or won't work as a dependency
+            tags:
+              only: /.*/
       - publish-dist:
           requires:
             - distcheck
@@ -169,8 +172,14 @@ workflows:
       - alpine
      #- archlinux
       - sanitizers
-      - crossbuild-win32
-      - crossbuild-win64
+      - crossbuild-win32:
+          filters: # must have filter or won't work as a dependency
+            tags:
+              only: /.*/
+      - crossbuild-win64:
+          filters: # must have filter or won't work as a dependency
+            tags:
+              only: /.*/
       - publish-win32:
           requires:
             - crossbuild-win32


### PR DESCRIPTION
This should fix the issue [noted here](https://github.com/harfbuzz/harfbuzz/issues/3078#issuecomment-900896994) in the 2.9.0 release cycle where the automatic release artifact publishing did not work.

The culprit here was d203267e5 which on first glance is quite logical. The trouble is Circle CI is not logical here and these filters were not "effectively ignored", they were effectively helping the jobs to not be ignored. In order for a job to run as a dependency of another job that has filters it must itself have a filter.

Since clearly the intent of d203267e5 was to also run `distcheck` on PRs and branch pushes, I went ahead and setup filters that will work for that as well as for use as a dependency for the ‘publish-*’ series of jobs.

The expected workflow output can be [previewed on CI for my fork](https://app.circleci.com/pipelines/github/alerque/harfbuzz) including a phony release cycle.
