### PR TITLE
[subset] Remove retain all layout features flag.

### DIFF
--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -451,21 +451,6 @@ static void set_flag_value (hb_subset_input_t *input, hb_subset_flags_t flag, hb
 }
 
 void
-hb_subset_input_set_retain_all_features (hb_subset_input_t *subset_input,
-                                         hb_bool_t value)
-{
-  return set_flag_value (subset_input,
-                         HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES,
-                         value);
-}
-
-hb_bool_t
-hb_subset_input_get_retain_all_features (hb_subset_input_t *subset_input)
-{
-  return (bool) (hb_subset_input_get_flags (subset_input) & HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES);
-}
-
-void
 hb_subset_input_set_drop_hints (hb_subset_input_t *subset_input,
 				hb_bool_t drop_hints)
 {

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -87,12 +87,13 @@ _remap_indexes (const hb_set_t *indexes,
 #ifndef HB_NO_SUBSET_LAYOUT
 typedef void (*layout_collect_func_t) (hb_face_t *face, hb_tag_t table_tag, const hb_tag_t *scripts, const hb_tag_t *languages, const hb_tag_t *features, hb_set_t *lookup_indexes /* OUT */);
 
+
 template <typename T>
-static void _collect_subset_layout (hb_face_t		 *face,
-                                    const T&              table,
-				    const hb_set_t	 *layout_features_to_retain,
-				    layout_collect_func_t layout_collect_func,
-				    hb_set_t		 *lookup_indices /* OUT */)
+static void _collect_layout_indices (hb_face_t		  *face,
+                                     const T&              table,
+                                     const hb_set_t	  *layout_features_to_retain,
+                                     layout_collect_func_t layout_collect_func,
+                                     hb_set_t		  *lookup_indices /* OUT */)
 {
   hb_vector_t<hb_tag_t> features;
   if (!features.alloc (table.get_feature_count () + 1))
@@ -143,11 +144,11 @@ _closure_glyphs_lookups_features (hb_face_t	     *face,
   hb_blob_ptr_t<T> table = hb_sanitize_context_t ().reference_table<T> (face);
   hb_tag_t table_tag = table->tableTag;
   hb_set_t lookup_indices;
-  _collect_subset_layout<T> (face,
-                             *table,
-                             layout_features_to_retain,
-                             hb_ot_layout_collect_lookups,
-                             &lookup_indices);
+  _collect_layout_indices<T> (face,
+                              *table,
+                              layout_features_to_retain,
+                              hb_ot_layout_collect_lookups,
+                              &lookup_indices);
 
   if (table_tag == HB_OT_TAG_GSUB)
     hb_ot_layout_lookups_substitute_closure (face,
@@ -160,11 +161,11 @@ _closure_glyphs_lookups_features (hb_face_t	     *face,
 
   // Collect and prune features
   hb_set_t feature_indices;
-  _collect_subset_layout<T> (face,
-                             *table,
-                             layout_features_to_retain,
-                             hb_ot_layout_collect_features,
-                             &feature_indices);
+  _collect_layout_indices<T> (face,
+                              *table,
+                              layout_features_to_retain,
+                              hb_ot_layout_collect_features,
+                              &feature_indices);
 
   table->prune_features (lookups, &feature_indices);
   hb_map_t duplicate_feature_map;

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -61,10 +61,6 @@ typedef struct hb_subset_input_t hb_subset_input_t;
  * in the final subset.
  * @HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES: If set then the unicode ranges in
  * OS/2 will not be recalculated.
- * @HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES: If set all layout features will be
- * retained. If unset then the set accessed by
- * hb_subset_input_layout_features_set() will be used to determine the features
- * to be retained.
  *
  * List of boolean properties that can be configured on the subset input.
  *
@@ -81,7 +77,6 @@ typedef enum { /*< flags >*/
   HB_SUBSET_FLAGS_NOTDEF_OUTLINE =	     0x00000040u,
   HB_SUBSET_FLAGS_GLYPH_NAMES =		     0x00000080u,
   HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES =  0x00000100u,
-  HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES =	     0x00000200u,
 } hb_subset_flags_t;
 
 HB_EXTERN hb_subset_input_t *
@@ -141,12 +136,6 @@ hb_subset_or_fail (hb_face_t *source, const hb_subset_input_t *input);
  * The methods below are part of the legacy harfbuzz subsetting API and will be
  * Removed as of version 3.0.0
  */
-
-HB_EXTERN void
-hb_subset_input_set_retain_all_features (hb_subset_input_t *subset_input,
-                                         hb_bool_t value);
-HB_EXTERN hb_bool_t
-hb_subset_input_get_retain_all_features (hb_subset_input_t *subset_input);
 
 HB_EXTERN void
 hb_subset_input_set_drop_hints (hb_subset_input_t *subset_input,

--- a/test/api/test-subset.c
+++ b/test/api/test-subset.c
@@ -114,13 +114,13 @@ test_subset_set_flags (void)
   hb_subset_input_set_flags (input,
                              HB_SUBSET_FLAGS_NAME_LEGACY |
                              HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
-                             HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES);
+                             HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES);
 
   g_assert (hb_subset_input_get_flags (input) ==
             (hb_subset_flags_t) (
             HB_SUBSET_FLAGS_NAME_LEGACY |
             HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
-            HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES));
+            HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES));
 
 
   hb_subset_input_destroy (input);

--- a/util/hb-subset.cc
+++ b/util/hb-subset.cc
@@ -492,15 +492,9 @@ parse_layout_features (const char *name,
 
   if (0 == strcmp (arg, "*"))
   {
-    if (last_name_char == '-')
-    {
-      hb_set_clear (layout_features);
-      hb_subset_input_set_flags (subset_main->input,
-				 hb_subset_input_get_flags (subset_main->input) & ~HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES);
-    } else {
-      hb_subset_input_set_flags (subset_main->input,
-				 hb_subset_input_get_flags (subset_main->input) | HB_SUBSET_FLAGS_RETAIN_ALL_FEATURES);
-    }
+    hb_set_clear (layout_features);
+    if (last_name_char != '-')
+      hb_set_invert (layout_features);
     return true;
   }
 


### PR DESCRIPTION
Instead use inverted sets to handle requesting all features. Modifies feature collection in subset plan to intersect the set of requested features against the features in the font. This prevents iterating a fully filled feature tag set.