### PR TITLE
[subset] fix --*-file options in hb-subset.

### DIFF
--- a/util/hb-subset.cc
+++ b/util/hb-subset.cc
@@ -660,7 +660,7 @@ parse_file_for (const char *name,
         *comment = '\0';
     }
 
-    line_parser (name, gs->str, data, error);
+    line_parser ("+", gs->str, data, error);
 
     if (*error)
       break;


### PR DESCRIPTION
The previous change to add -/+ versions of each set type broke all of the --*-file input options since all of the parse functions now default to replacing the set if the + variant is not being used. This fixes the issue by changing parse_file_for to pass '+' as the name to the parsing function. This triggers the append mode.