### PR TITLE
Place fixes from harfbuzz.github.io into main repo

### DIFF
--- a/docs/usermanual-getting-started.xml
+++ b/docs/usermanual-getting-started.xml
@@ -51,7 +51,7 @@
 
     <para>
       Although the default <function>hb_shape()</function> function is
-      sufficient for most use cases, a variant is also provide that
+      sufficient for most use cases, a variant is also provided that
       lets you specify which of HarfBuzz's shapers to use on a buffer. 
     </para>
 

--- a/docs/usermanual-install-harfbuzz.xml
+++ b/docs/usermanual-install-harfbuzz.xml
@@ -336,7 +336,7 @@
 	  <term><command>-Ddocs=enabled</command></term>
 	  <listitem>
 	    <para>
-	      Use <ulink url="https://www.gtk.org/gtk-doc/">GTK-Doc</ulink>. <emphasis>(Default = no)</emphasis>
+	      Use <ulink url="https://github.com/GNOME/gtk-doc">GTK-Doc</ulink>. <emphasis>(Default = no)</emphasis>
 	    </para>
 	    <para>
 	      This option enables the building of the documentation.


### PR DESCRIPTION
It turns out that the harfbuzz.github.io repo is merely a mirror of this existing doc repo, that is rewritten by a CI bot every night.

Two patches: one about a dead link, and one spelling error, were already merged there, only to be rewritten over by the CI process. This patch places the fixes in the main repo docs, so when the CI rewrites the harfbuzz.github.io repo, it will have the fixes behdad merged.