### PR TITLE
[USE] Send Khitan Small Script and Yezidi to USE

### DIFF
--- a/src/hb-ot-shape-complex.hh
+++ b/src/hb-ot-shape-complex.hh
@@ -373,6 +373,8 @@ hb_ot_shape_complex_categorize (const hb_ot_shape_planner_t *planner)
     /* Unicode-13.0 additions */
     case HB_SCRIPT_CHORASMIAN:
     case HB_SCRIPT_DIVES_AKURU:
+    case HB_SCRIPT_KHITAN_SMALL_SCRIPT:
+    case HB_SCRIPT_YEZIDI:
 
     /* Unicode-14.0 additions */
     case HB_SCRIPT_CYPRO_MINOAN:


### PR DESCRIPTION
Khitan Small Script and Yezidi were the only scripts listed in the USE spec that HarfBuzz didn’t send to USE.