### PR TITLE
[meson] Add ragel_subproject option

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: sudo apt-get install pkg-config gcc ragel gcovr gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-setuptools ninja-build gobject-introspection libgirepository1.0-dev
+      run: sudo apt-get install pkg-config gcc gcovr gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-setuptools ninja-build gobject-introspection libgirepository1.0-dev
     - run: sudo pip3 install fonttools meson==0.52.0
     - name: run
-      run: meson build -Db_coverage=true --auto-features=enabled -Dgraphite=enabled -Dchafa=disabled -Doptimization=2
+      run: meson build -Db_coverage=true --auto-features=enabled -Dgraphite=enabled -Dchafa=disabled -Dragel_subproject=true -Doptimization=2
     - name: ci
       run: meson test --print-errorlogs -Cbuild
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: install dependencies
       run: sudo apt-get install pkg-config gcc gcovr gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-setuptools ninja-build gobject-introspection libgirepository1.0-dev
-    - run: sudo pip3 install fonttools meson==0.52.0
+    - run: sudo pip3 install fonttools meson==0.55.0
     - name: run
       run: meson build -Db_coverage=true --auto-features=enabled -Dgraphite=enabled -Dchafa=disabled -Dragel_subproject=true -Doptimization=2
     - name: ci

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: install dependencies
       run: sudo apt-get install pkg-config gcc gcovr gtk-doc-tools libfreetype6-dev libglib2.0-dev libcairo2-dev libicu-dev libgraphite2-dev python3 python3-setuptools ninja-build gobject-introspection libgirepository1.0-dev
-    - run: sudo pip3 install fonttools meson==0.55.0
+    - run: sudo pip3 install fonttools meson==0.56.0
     - name: run
       run: meson build -Db_coverage=true --auto-features=enabled -Dgraphite=enabled -Dchafa=disabled -Dragel_subproject=true -Doptimization=2
     - name: ci

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,5 +34,7 @@ option('icu_builtin', type: 'boolean', value: false,
   description: 'Don\'t separate ICU support as harfbuzz-icu module')
 option('experimental_api', type: 'boolean', value: false,
   description: 'Enable experimental APIs')
+option('ragel_subproject', type: 'boolean', value: false,
+  description: 'Build Ragel subproject if no suitable version is found')
 option('fuzzer_ldflags', type: 'string',
   description: 'Extra LDFLAGS used during linking of fuzzing binaries')

--- a/src/meson.build
+++ b/src/meson.build
@@ -291,10 +291,12 @@ hb_gobject_headers = files(
 )
 
 ragel = find_program('ragel', version: '6.10', required: false)
-if not ragel.found() and meson.can_run_host_binaries() and cpp.get_id() != 'msvc'
-  ragel = subproject('ragel').get_variable('ragel')
+has_ragel = ragel.found()
+if not has_ragel and get_option('ragel_subproject')
+    ragel = subproject('ragel').get_variable('ragel')
+    has_ragel = true
 endif
-if not ragel.found()
+if not has_ragel
   warning('You have to install ragel if you are going to develop HarfBuzz itself')
 else
   ragel_helper = find_program('gen-ragel-artifacts.py')


### PR DESCRIPTION
Add an option to build fallback ragel subproject when no suitable ragel version is found, and make it off by default since most builder don’t need ragel at all.

Fixes https://github.com/harfbuzz/harfbuzz/issues/3208 (hopefully)