### PR TITLE
[style] Try removing _USE_MATH_DEFINES

### DIFF
--- a/src/hb-style.cc
+++ b/src/hb-style.cc
@@ -26,9 +26,6 @@
 
 #ifndef HB_NO_STYLE
 
-#define _USE_MATH_DEFINES
-#include <math.h>
-
 #include "hb-ot-var-avar-table.hh"
 #include "hb-ot-var-fvar-table.hh"
 #include "hb-ot-stat-table.hh"

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -182,6 +182,9 @@
 #include <cassert>
 #include <cfloat>
 #include <climits>
+#ifdef _MSC_VER
+# define _USE_MATH_DEFINES
+#endif
 #include <cmath>
 #include <cstdarg>
 #include <cstddef>


### PR DESCRIPTION
Internets says I need it on MS compilers. I don't believe the internets.
GCC gives me unused-macros warning. Pushing to CI to check.