### PR TITLE
[repacker] add 'virtual links' to the serializer.

### DIFF
--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -671,8 +671,9 @@ struct graph_t
         if (visited.has (link.objidx)) continue;
 
         const auto& child = vertices_[link.objidx].obj;
+        unsigned link_width = link.width ? link.width : 4; // treat virtual offsets as 32 bits wide
         int64_t child_weight = (child.tail - child.head) +
-                               ((int64_t) 1 << (link.width * 8)) * (vertices_[link.objidx].space + 1);
+                               ((int64_t) 1 << (link_width * 8)) * (vertices_[link.objidx].space + 1);
         int64_t child_distance = next_distance + child_weight;
 
         if (child_distance < vertices_[link.objidx].distance)
@@ -717,6 +718,10 @@ struct graph_t
   bool is_valid_offset (int64_t offset,
                         const hb_serialize_context_t::object_t::link_t& link) const
   {
+    if (unlikely (!link.width))
+      // Virtual links can't overflow.
+      return link.is_signed || offset >= 0;
+
     if (link.is_signed)
     {
       if (link.width == 4)
@@ -793,6 +798,9 @@ struct graph_t
   {
     switch (link.width)
     {
+    case 0:
+      // Virtual links aren't serialized.
+      return;
     case 4:
       if (link.is_signed)
       {

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -358,10 +358,16 @@ struct hb_serialize_context_t
       assert (packed.tail ()->head == tail);
   }
 
+  // Adds a virtual link from the current object to objidx. A virtual link is not associated with
+  // an actual offset field. They are solely used to enforce ordering constraints between objects.
+  // Adding a virtual link from object a to object b will ensure that object b is always packed after
+  // object a in the final serialized order.
+  //
+  // This is useful in certain situtations where there needs to be a specific ordering in the
+  // final serialization. Such as when platform bugs require certain orderings, or to provide
+  //  guidance to the repacker for better offset overflow resolution.
   void add_virtual_link (objidx_t objidx)
   {
-    // This link is not associated with an actual offset and exists merely to enforce
-    // an ordering constraint.
     if (unlikely (in_error ())) return;
 
     if (!objidx)

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -51,12 +51,6 @@ enum hb_serialize_error_t {
 };
 HB_MARK_AS_FLAG_T (hb_serialize_error_t);
 
-// This is a 0 byte wide offset, used to add virtual links to the serializer object graph.
-// It does not correspond to a real offset and exists soley to enforce an ordering constraint
-// in the graph's packed order.
-struct VirtualOffset {
-};
-
 struct hb_serialize_context_t
 {
   typedef unsigned objidx_t;
@@ -364,7 +358,7 @@ struct hb_serialize_context_t
       assert (packed.tail ()->head == tail);
   }
 
-  void add_link (VirtualOffset &ofs, objidx_t objidx)
+  void add_virtual_link (objidx_t objidx)
   {
     // This link is not associated with an actual offset and exists merely to enforce
     // an ordering constraint.
@@ -374,7 +368,6 @@ struct hb_serialize_context_t
       return;
 
     assert (current);
-    assert (current->head <= (const char *) &ofs);
 
     auto& link = *current->links.push ();
     if (current->links.in_error ())

--- a/src/test-repacker.cc
+++ b/src/test-repacker.cc
@@ -67,8 +67,7 @@ static void add_wide_offset (unsigned id,
 static void add_virtual_offset (unsigned id,
                                 hb_serialize_context_t* c)
 {
-  VirtualOffset* offset = c->start_embed<VirtualOffset> ();
-  c->add_link (*offset, id);
+  c->add_virtual_link (id);
 }
 
 static void


### PR DESCRIPTION
These aren't associated with an offset field, but instead exist solely to add an ordering constraint to the object graph.