### PR TITLE
[subset] Fix bug in composite operation counting.

### DIFF
--- a/src/hb-ot-glyf-table.hh
+++ b/src/hb-ot-glyf-table.hh
@@ -1118,7 +1118,7 @@ struct glyf
       while (it)
       {
         auto item = *(it++);
-        operation_count +=
+        operation_count =
             add_gid_and_children (item.get_glyph_index (), gids_to_retain, depth, operation_count);
       }
 


### PR DESCRIPTION
Adding the result of add_gid_and_children to operation count over counts the number of operations.