### PR TITLE
[meson] Switch GLib subproject to latest version

### DIFF
--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -3,4 +3,4 @@ directory=glib
 url=https://gitlab.gnome.org/GNOME/glib.git
 depth=1
 push-url=git@gitlab.gnome.org:GNOME/glib.git
-revision=2.58.1
+revision=2.70.0


### PR DESCRIPTION
Lets see if it fixes CI breakage.