### PR TITLE
[ci] `windows-2016` image is going away in a bit

### DIFF
--- a/.github/workflows/msvc-ci.yml
+++ b/.github/workflows/msvc-ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2016, windows-latest]
+        os: [windows-2019, windows-latest]
         include:
-          - name: msvc-2017-x86
-            os: windows-2016
+          - name: msvc-2019-x86
+            os: windows-2019
             ARCH: x86
           - name: msvc-2019-amd64
             os: windows-latest


### PR DESCRIPTION
https://github.com/actions/virtual-environments/issues/4312

`windows-latest` is the same as `windows-2019`, but we are using explicit `windows-2019` image for when they become different.