### PR TITLE
Consider continuations before reversing buffer in Chain::apply

### DIFF
--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -1037,13 +1037,15 @@ struct Chain
       if (!c->buffer->message (c->font, "start chainsubtable %d", c->lookup_index))
 	goto skip;
 
-      if (reverse)
-	c->buffer->reverse ();
+      if (reverse) {
+        _reverse_buffer_preserve_graphemes(c->buffer);
+      }
 
       subtable->apply (c);
 
-      if (reverse)
-	c->buffer->reverse ();
+      if (reverse) {
+        _reverse_buffer_preserve_graphemes(c->buffer);
+      }
 
       (void) c->buffer->message (c->font, "end chainsubtable %d", c->lookup_index);
 

--- a/src/hb-buffer.hh
+++ b/src/hb-buffer.hh
@@ -204,6 +204,7 @@ struct hb_buffer_t
   HB_INTERNAL void reverse_range (unsigned int start, unsigned int end);
   HB_INTERNAL void reverse ();
   HB_INTERNAL void reverse_clusters ();
+  HB_INTERNAL void reverse_preserve_graphemes ();
   HB_INTERNAL void guess_segment_properties ();
 
   HB_INTERNAL void swap_buffers ();

--- a/src/hb-ot-layout.hh
+++ b/src/hb-ot-layout.hh
@@ -370,6 +370,22 @@ _hb_next_grapheme (hb_buffer_t *buffer, unsigned int start)
   return start;
 }
 
+static inline void
+_reverse_buffer_preserve_graphemes (hb_buffer_t* buffer) {
+    if (buffer->cluster_level == HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS) {
+      foreach_grapheme (buffer, start, end) {
+        buffer->merge_clusters (start, end);
+        buffer->reverse_range (start, end);
+      }
+    } else {
+      foreach_grapheme (buffer, start, end) {
+        /* form_clusters() merged clusters already, we don't merge. */
+        buffer->reverse_range (start, end);
+      }
+    }
+    buffer->reverse();
+}
+
 static inline bool
 _hb_glyph_info_is_unicode_format (const hb_glyph_info_t *info)
 {

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -629,19 +629,7 @@ hb_ensure_native_direction (hb_buffer_t *buffer)
        direction != HB_DIRECTION_TTB))
   {
 
-    if (buffer->cluster_level == HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS)
-      foreach_grapheme (buffer, start, end)
-      {
-	buffer->merge_clusters (start, end);
-	buffer->reverse_range (start, end);
-      }
-    else
-      foreach_grapheme (buffer, start, end)
-	/* form_clusters() merged clusters already, we don't merge. */
-	buffer->reverse_range (start, end);
-
-    buffer->reverse ();
-
+    _reverse_buffer_preserve_graphemes(buffer);
     buffer->props.direction = HB_DIRECTION_REVERSE (buffer->props.direction);
   }
 }


### PR DESCRIPTION
Do not reverse continuations.

Introduce a helper method reverse_preserve_graphemes()

Fixes #3314