### PR TITLE
[repacker] Clear distance and position cache when assigning a new space.

### DIFF
--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -742,6 +742,8 @@ struct graph_t
       num_roots_for_space_[node.space] = num_roots_for_space_[node.space] - 1;
       num_roots_for_space_[new_space] = num_roots_for_space_[new_space] + 1;
       node.space = new_space;
+      distance_invalid = true;
+      positions_invalid = true;
     }
   }
 


### PR DESCRIPTION
A change in space will effect the distance assigned to the node and any of it's children so clear the distance cache.