### PR TITLE
[subset] Improve lookup visit counting

### DIFF
--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -81,6 +81,9 @@ struct hb_closure_context_t :
     nesting_level_left++;
   }
 
+  void reset_lookup_visit_count ()
+  { lookup_count = 0; }
+
   bool lookup_limit_exceeded ()
   { return lookup_count > HB_MAX_LOOKUP_VISIT_COUNT; }
 

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -214,7 +214,11 @@ struct hb_closure_lookups_context_t :
       return;
 
     /* Return if new lookup was recursed to before. */
-    if (is_lookup_visited (lookup_index))
+    if (lookup_limit_exceeded ()
+        || visited_lookups->in_error ()
+        || visited_lookups->has (lookup_index))
+      // Don't increment lookup count here, that will be done in the call to closure_lookups()
+      // made by recurse_func.
       return;
 
     nesting_level_left--;

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1530,6 +1530,7 @@ hb_ot_layout_lookups_substitute_closure (hb_face_t      *face,
   unsigned int glyphs_length;
   do
   {
+    c.reset_lookup_visit_count ();
     glyphs_length = glyphs->get_population ();
     if (lookups)
     {


### PR DESCRIPTION
Fixes two problems:
1. Double counting of visited lookups in closure_lookups()
2. Reset the visited count between each iteration during the glyph closure. Each iteration potentially scans all lookups again thus should be working with the full limit.
Fixes #3323