### PR TITLE
hb-ot-var: Actually set in/out argument

### DIFF
--- a/src/hb-ot-var-fvar-table.hh
+++ b/src/hb-ot-var-fvar-table.hh
@@ -266,6 +266,7 @@ struct fvar
 							 .sub_array (0, *coords_length);
       for (unsigned int i = 0; i < instanceCoords.length; i++)
 	coords[i] = instanceCoords.arrayZ[i].to_float ();
+      *coords_length = instanceCoords.length;
     }
     return axisCount;
   }


### PR DESCRIPTION
The documentation for hb_ot_var_named_instance_get_design_coords
states that coords_length is set to the number of coordinates
that have been set, but that was not actually the case.