### PR TITLE
Convert fallback kwargs to [provide] entries.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -90,15 +90,12 @@ if not get_option('freetype').disabled()
   if not freetype_dep.found()
     # https://github.com/harfbuzz/harfbuzz/pull/2498
     freetype_dep = dependency('freetype2', required: get_option('freetype'),
-                              fallback: ['freetype2', 'freetype_dep'],
                               default_options: ['harfbuzz=disabled'])
   endif
 endif
 
-glib_dep = dependency('glib-2.0', required: get_option('glib'),
-                      fallback: ['glib', 'libglib_dep'])
-gobject_dep = dependency('gobject-2.0', required: get_option('gobject'),
-                         fallback: ['glib', 'libgobject_dep'])
+glib_dep = dependency('glib-2.0', required: get_option('glib'))
+gobject_dep = dependency('gobject-2.0', required: get_option('gobject'))
 graphite2_dep = dependency('graphite2', required: get_option('graphite2'))
 graphite_dep = dependency('graphite2', required: get_option('graphite'))
 
@@ -148,8 +145,8 @@ if not get_option('cairo').disabled()
     # dependency cycle here because we have configured freetype2 above with
     # harfbuzz support disabled, so when cairo will lookup freetype2 dependency
     # it will be forced to use that one.
-    cairo_dep = dependency('cairo', fallback: 'cairo', required: get_option('cairo'))
-    cairo_ft_dep = dependency('cairo-ft', fallback: 'cairo', required: get_option('cairo'))
+    cairo_dep = dependency('cairo', required: get_option('cairo'))
+    cairo_ft_dep = dependency('cairo-ft', required: get_option('cairo'))
   endif
 endif
 

--- a/subprojects/cairo.wrap
+++ b/subprojects/cairo.wrap
@@ -3,3 +3,6 @@ directory=cairo
 url=https://gitlab.freedesktop.org/cairo/cairo.git
 depth=1
 revision=1.17.4
+
+[provide]
+dependency_names = cairo, cairo-ft

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -2,3 +2,6 @@
 directory=freetype
 url=https://gitlab.freedesktop.org/freetype/freetype.git
 revision=VER-2-11-0
+
+[provide]
+freetype2 = freetype_dep

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -4,3 +4,7 @@ url=https://gitlab.gnome.org/GNOME/glib.git
 depth=1
 push-url=git@gitlab.gnome.org:GNOME/glib.git
 revision=2.58.1
+
+[provide]
+glib-2.0 = libglib_dep
+gobject-2.0 = libgobject_dep


### PR DESCRIPTION
This converts the "old style" `fallback` keyword arguments to use `[provide]` entries in wrap files instead. This makes it more convenient to use Harfbuzz as a subproject in other projects. Due to backwards compatibility issues having those `fallback` entries may cause unwanted subproject promotions. This is also more compatible with getting dependencies from WrapDB instead.

We are currently discussing how wrap files should be handled in release tarballs. Maybe they should be removed altogether, especially those that do Git checkouts. But that is a decision for another time.