### PR TITLE
[vector] Move semantics when resizing

### DIFF
--- a/src/hb-ot-color-cbdt-table.hh
+++ b/src/hb-ot-color-cbdt-table.hh
@@ -360,6 +360,16 @@ struct IndexSubtable
 
 struct IndexSubtableRecord
 {
+  /* XXX Remove this and fix by not inserting it into vector. */
+  IndexSubtableRecord& operator = (const IndexSubtableRecord &o)
+  {
+    firstGlyphIndex = o.firstGlyphIndex;
+    lastGlyphIndex = o.lastGlyphIndex;
+    offsetToSubtable = (unsigned) o.offsetToSubtable;
+    assert (offsetToSubtable.is_null ());
+    return *this;
+  }
+
   bool sanitize (hb_sanitize_context_t *c, const void *base) const
   {
     TRACE_SANITIZE (this);

--- a/src/test-vector.cc
+++ b/src/test-vector.cc
@@ -26,6 +26,7 @@
 #include "hb.hh"
 #include "hb-vector.hh"
 #include "hb-set.hh"
+#include <string>
 
 
 int
@@ -135,6 +136,19 @@ main (int argc, char **argv)
     assert (v2.length == 3);
     assert (v2[2] == 3);
   }
+
+#if 0
+  {
+    hb_vector_t<std::string> v;
+
+    std::string s;
+    for (unsigned i = 1; i < 100; i++)
+    {
+      s += "x";
+      v.push (s);
+    }
+  }
+#endif
 
   return 0;
 }


### PR DESCRIPTION
Compiler catches cases where types are not safe to do so. We should fix these. Most are in CFF code but a few are not.

We should fix this in main branch and rebase this on top till it's happy, then this branch can continue to make vector follow C++ memory semantics.