### PR TITLE
Fix various typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -384,7 +384,7 @@ Friday, May 24, 2019
   code-base changes.  We now require C++11.  Support for gcc 4.8 and earlier has been
   dropped.
 - New hb-config.hh facility for compiling smaller library for embedded and web usecases.
-- New Unicode Character Databse implementation that is half the size of previously-used
+- New Unicode Character Database implementation that is half the size of previously-used
   UCDN.
 - Subsetter improvements.
 - Improved documentation, thanks to Nathan Willis.
@@ -1232,7 +1232,7 @@ Thursday, February 25, 2016
   due to bug in glyph class of ASCII double-quote character.  This should
   address "regression" introduced in 1.2.0 when we switched mark zeroing
   in most shapers from BY_UNICODE_LATE to BY_GDEF_LATE.
-  This fourth release in a week should finally stablize things...
+  This fourth release in a week should finally stabilize things...
 
 - hb-ot-font's get_glyph() implementation saw some optimizations.  Though,
   might be really hard to measure in real-world situations.
@@ -2280,7 +2280,7 @@ o Changed API:
   - hb_buffer_create() takes zero arguments now.
     Use hb_buffer_pre_allocate() to pre-allocate.
 
-  - hb_buffer_add_utf*() now accept -1 for length parameteres,
+  - hb_buffer_add_utf*() now accept -1 for length parameters,
     meaning "nul-terminated".
 
   - hb_direction_t enum values changed.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,7 +28,7 @@
 - [ ] Commit NEWS, meson.build, configure.ac, and src/hb-version.h, as well as any REPLACEME changes you made.
         The commit message is simply the release number, e. g. "1.4.7"
 
-- [ ] Do a `meson dist -Cbuild` that runs the tests against the latest commited changes.
+- [ ] Do a `meson dist -Cbuild` that runs the tests against the latest committed changes.
    If doesn't pass, something fishy is going on, reset the repo and start over.
 
 - [ ] Tag the release and sign it: e.g. `git tag -s 1.4.7 -m 1.4.7`.

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -83,7 +83,7 @@ content_files=	\
 	usermanual-integration.xml \
 	version.xml
 
-# SGML files where gtk-doc abbrevations (#GtkWidget) are expanded
+# SGML files where gtk-doc abbreviations (#GtkWidget) are expanded
 # These files must be listed here *and* in content_files
 # e.g. expand_content_files=running.sgml
 expand_content_files=

--- a/docs/repacker.md
+++ b/docs/repacker.md
@@ -40,7 +40,7 @@ Other implementations exist, such as in
 
 There's four key pieces to the harfbuzz approach:
 
-*  Subtable Graph: a table's internal structure is abstraced out into a lightweight graph
+*  Subtable Graph: a table's internal structure is abstracted out into a lightweight graph
    representation where each subtable is a node and each offset forms an edge. The nodes only need
    to know how many bytes the corresponding subtable occupies. This lightweight representation can
    be easily modified to test new ordering's and strategies as the repacking algorithm iterates.
@@ -54,7 +54,7 @@ There's four key pieces to the harfbuzz approach:
    to calculate the final position of each subtable and then check if any offsets to it will
    overflow.
    
-*  Offset resolution strategies: given a particular occurence of an overflow these strategies
+*  Offset resolution strategies: given a particular occurrence of an overflow these strategies
    modify the graph to attempt to resolve the overflow.
    
 # High Level Algorithm
@@ -111,7 +111,7 @@ to be as fast as possible. There's a few things that are done to speed up subseq
 operations:
 
 *  The number of incoming edges to each node is cached. This is required by the Kahn's algorithm
-   portion of boths sorts. Where possible when the graph is modified we manually update the cached
+   portion of both sorts. Where possible when the graph is modified we manually update the cached
    edge counts of affected nodes.
    
 *  The distance to each node is cached. Where possible when the graph is modified we manually update
@@ -165,7 +165,7 @@ The above is an ideal situation where the subgraphs are disconnected from each o
 this is often not this case. So this idea can be generalized as follows:
 
 If there is a subgraph that is only reachable from one or more 32 bit offsets, then:
-*  That subgraph can be treated as an indepedent unit and all nodes of the subgraph packed in isolation
+*  That subgraph can be treated as an independent unit and all nodes of the subgraph packed in isolation
    from the rest of the graph.
 *  In a table that occupies less than 4gb of space (in practice all fonts), that packed independent
    subgraph can be placed anywhere after the parent nodes without overflowing the 32 bit offsets from
@@ -217,7 +217,7 @@ and then assign each such subgraph to a unique non-zero space. The algorithm is 
 ## Manual Iterative Resolutions
 
 For each overflow in each iteration the algorithm will attempt to apply offset overflow resolution
-strategies to eliminate the overflow. The type of strategy applied is dependant on the characteristics
+strategies to eliminate the overflow. The type of strategy applied is dependent on the characteristics
 of the overflowing link:
 
 *  If the overflowing offset is inside a space other than space 0 and the subgraph space has more
@@ -235,7 +235,7 @@ of the overflowing link:
 
 The harfbuzz repacker has tests defined using generic graphs: https://github.com/harfbuzz/harfbuzz/blob/main/src/test-repacker.cc
    
-# Future Improvments
+# Future Improvements
 
 The above resolution strategies are not sufficient to resolve all overflows. For example consider
 the case where a single subtable is 65k and the graph structure requires an offset to point over it.

--- a/docs/usermanual-integration.xml
+++ b/docs/usermanual-integration.xml
@@ -347,7 +347,7 @@
       <structname>hb_glyph_position_t</structname> structures. 
     </para>
     <para>
-      Your client program only needs to ensure that it coverts
+      Your client program only needs to ensure that it converts
       correctly between HarfBuzz's low-level data types (such as
       <type>hb_position_t</type>) and Windows's corresponding types
       (such as <type>GOFFSET</type> and <type>ABC</type>). Be sure you
@@ -445,7 +445,7 @@
       is slightly lower-level than Core Text, provides
       <ulink url="https://developer.apple.com/documentation/coregraphics/cgfontref"><type>CGFontRef</type></ulink>, which enables access to typeface
       properties, but does not include size information. Core Text's
-      <ulink url="https://developer.apple.com/documentation/coretext/ctfont-q6r"><type>CTFontRef</type></ulink> is analagous to a HarfBuzz font object,
+      <ulink url="https://developer.apple.com/documentation/coretext/ctfont-q6r"><type>CTFontRef</type></ulink> is analogous to a HarfBuzz font object,
       with all of the properties required to render text at a specific
       size and configuration.
       Consequently, a HarfBuzz <type>hb_font_t</type> font object can

--- a/src/gen-os2-unicode-ranges.py
+++ b/src/gen-os2-unicode-ranges.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """Generates the code for a sorted unicode range array as used in hb-ot-os2-unicode-ranges.hh
-Input is a tab seperated list of unicode ranges from the otspec
+Input is a tab separated list of unicode ranges from the otspec
 (https://docs.microsoft.com/en-us/typography/opentype/spec/os2#ur).
 """
 

--- a/src/hb-aat-layout-just-table.hh
+++ b/src/hb-aat-layout-just-table.hh
@@ -146,7 +146,7 @@ struct DuctileGlyphAction
   HBUINT32	variationAxis;	/* The 4-byte tag identifying the ductile axis.
 				 * This would normally be 0x64756374 ('duct'),
 				 * but you may use any axis the font contains. */
-  HBFixed	minimumLimit;	/* The lowest value for the ductility axis tha
+  HBFixed	minimumLimit;	/* The lowest value for the ductility axis that
 				 * still yields an acceptable appearance. Normally
 				 * this will be 1.0. */
   HBFixed	noStretchValue; /* This is the default value that corresponds to

--- a/src/hb-array.hh
+++ b/src/hb-array.hh
@@ -412,7 +412,7 @@ bool hb_array_t<T>::operator == (const hb_array_t<T> &o) const
   return true;
 }
 
-/* TODO Specialize opeator== for hb_bytes_t and hb_ubytes_t. */
+/* TODO Specialize operator== for hb_bytes_t and hb_ubytes_t. */
 
 template <>
 inline uint32_t hb_array_t<const char>::hash () const {

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -202,7 +202,7 @@ struct cff2_cs_opset_t : cs_opset_t<blend_arg_t, OPSET, cff2_cs_interp_env_t, PA
     switch (op) {
       case OpCode_callsubr:
       case OpCode_callgsubr:
-	/* a subroutine number shoudln't be a blended value */
+	/* a subroutine number shouldn't be a blended value */
 	if (unlikely (env.argStack.peek ().blending ()))
 	{
 	  env.set_error ();

--- a/src/hb-draw.h
+++ b/src/hb-draw.h
@@ -50,7 +50,7 @@ typedef void (*hb_draw_close_path_func_t) (void *user_data);
  *
  * Glyph draw callbacks.
  *
- * _move_to, _line_to and _cubic_to calls are nessecary to be defined but we
+ * _move_to, _line_to and _cubic_to calls are necessary to be defined but we
  * translate _quadratic_to calls to _cubic_to if the callback isn't defined.
  *
  * Since: EXPERIMENTAL

--- a/src/hb-ot-color.cc
+++ b/src/hb-ot-color.cc
@@ -116,7 +116,7 @@ hb_ot_color_palette_get_name_id (hb_face_t *face,
  * @color_index: The index of the color
  *
  * Fetches the `name` table Name ID that provides display names for
- * the specificed color in a face's `CPAL` color palette.
+ * the specified color in a face's `CPAL` color palette.
  *
  * Display names can be generic (e.g., "Background") or specific
  * (e.g., "Eye color").

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -849,7 +849,7 @@ struct FeatureParamsSize
     if (unlikely (!c->check_struct (this))) return_trace (false);
 
     /* This subtable has some "history", if you will.  Some earlier versions of
-     * Adobe tools calculated the offset of the FeatureParams sutable from the
+     * Adobe tools calculated the offset of the FeatureParams subtable from the
      * beginning of the FeatureList table!  Now, that is dealt with in the
      * Feature implementation.  But we still need to be able to tell junk from
      * real data.  Note: We don't check that the nameID actually exists.

--- a/src/hb-ot-shape-complex-hangul.cc
+++ b/src/hb-ot-shape-complex-hangul.cc
@@ -140,7 +140,7 @@ preprocess_text_hangul (const hb_ot_shape_plan_t *plan HB_UNUSED,
    *
    *   - LV can be precomposed, or decomposed.  Lets call those
    *     <LV> and <L,V>,
-   *   - LVT can be fully precomposed, partically precomposed, or
+   *   - LVT can be fully precomposed, partially precomposed, or
    *     fully decomposed.  Ie. <LVT>, <LV,T>, or <L,V,T>.
    *
    * The composition / decomposition is mechanical.  However, not

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -1034,7 +1034,7 @@ hb_ot_position_complex (const hb_ot_shape_context_t *c)
    * hanging over the next glyph after the final reordering.
    *
    * Note: If fallback positinoing happens, we don't care about
-   * this as it will be overriden.
+   * this as it will be overridden.
    */
   bool adjust_offsets_when_zeroing = c->plan->adjust_mark_positioning_when_zeroing &&
 				     HB_DIRECTION_IS_FORWARD (c->buffer->props.direction);

--- a/src/hb-ot-var-gvar-table.hh
+++ b/src/hb-ot-var-gvar-table.hh
@@ -399,7 +399,7 @@ struct gvar
 				  get_offset (glyphCount) - get_offset (0)));
   }
 
-  /* GlyphVariationData not sanitized here; must be checked while accessing each glyph varation data */
+  /* GlyphVariationData not sanitized here; must be checked while accessing each glyph variation data */
   bool sanitize (hb_sanitize_context_t *c) const
   { return sanitize_shallow (c); }
 

--- a/src/hb-ot-var.h
+++ b/src/hb-ot-var.h
@@ -109,7 +109,7 @@ typedef enum { /*< flags >*/
  * @tag: The #hb_tag_t tag identifying the design variation of the axis
  * @name_id: The `name` table Name ID that provides display names for the axis
  * @flags: The #hb_ot_var_axis_flags_t flags for the axis
- * @min_value: The mininum value on the variation axis that the font covers
+ * @min_value: The minimum value on the variation axis that the font covers
  * @default_value: The position on the variation axis corresponding to the font's defaults
  * @max_value: The maximum value on the variation axis that the font covers
  * 

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -871,7 +871,7 @@ struct graph_t
     // Redundant ones are filtered out later on by the visited set.
     // According to https://www3.cs.stonybrook.edu/~rezaul/papers/TR-07-54.pdf
     // for practical performance this is faster then using a more advanced queue
-    // (such as a fibonaacci queue) with a fast decrease priority.
+    // (such as a fibonacci queue) with a fast decrease priority.
     for (unsigned i = 0; i < vertices_.length; i++)
     {
       if (i == vertices_.length - 1)

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -279,7 +279,7 @@ struct hb_serialize_context_t
     object_pool.release (obj);
   }
 
-  /* Set share to false when an object is unlikely sharable with others
+  /* Set share to false when an object is unlikely shareable with others
    * so not worth an attempt, or a contiguous table is serialized as
    * multiple consecutive objects in the reverse order so can't be shared.
    */
@@ -381,7 +381,7 @@ struct hb_serialize_context_t
   // Adding a virtual link from object a to object b will ensure that object b is always packed after
   // object a in the final serialized order.
   //
-  // This is useful in certain situtations where there needs to be a specific ordering in the
+  // This is useful in certain situations where there needs to be a specific ordering in the
   // final serialization. Such as when platform bugs require certain orderings, or to provide
   //  guidance to the repacker for better offset overflow resolution.
   void add_virtual_link (objidx_t objidx)

--- a/src/ms-use/IndicPositionalCategory-Additional.txt
+++ b/src/ms-use/IndicPositionalCategory-Additional.txt
@@ -2,7 +2,7 @@
 # Not derivable
 # Initial version based on Unicode 7.0 by Andrew Glass 2014-03-17
 # Updated for Unicode 10.0 by Andrew Glass 2017-07-25
-# Ammended for Unicode 10.0 by Andrew Glass 2018-09-21
+# Amended for Unicode 10.0 by Andrew Glass 2018-09-21
 # Updated for L2/19-083    by Andrew Glass 2019-05-06
 # Updated for Unicode 12.1 by Andrew Glass 2019-05-30
 # Updated for Unicode 13.0 by Andrew Glass 2020-07-28
@@ -58,16 +58,16 @@ AA35          ; Top     # Mn       CHAM CONSONANT SIGN
 # Indic_Positional_Category=Bottom
 0859..085B    ; Bottom # Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
 18A9          ; Bottom # Mn       MONGOLIAN LETTER ALI GALI DAGALGA
-10AE5         ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK ABOVE  # Overriden, ccc controls order
+10AE5         ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK ABOVE  # Overridden, ccc controls order
 10AE6         ; Bottom # Mn       MANICHAEAN ABBREVIATION MARK BELOW
 10F46..10F47  ; Bottom # Mn   [2] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING TWO DOTS BELOW
-10F48..10F4A  ; Bottom # Mn   [3] SOGDIAN COMBINING DOT ABOVE..SOGDIAN COMBINING CURVE ABOVE     # Overriden, ccc controls order
+10F48..10F4A  ; Bottom # Mn   [3] SOGDIAN COMBINING DOT ABOVE..SOGDIAN COMBINING CURVE ABOVE     # Overridden, ccc controls order
 10F4B         ; Bottom # Mn       SOGDIAN COMBINING CURVE BELOW
-10F4C         ; Bottom # Mn       SOGDIAN COMBINING HOOK ABOVE        # Overriden, ccc controls order
+10F4C         ; Bottom # Mn       SOGDIAN COMBINING HOOK ABOVE        # Overridden, ccc controls order
 10F4D..10F50  ; Bottom # Mn   [4] SOGDIAN COMBINING HOOK BELOW..SOGDIAN COMBINING STROKE BELOW
-10F82         ; Bottom # Mn       OLD UYGHUR COMBINING DOT ABOVE      # Overriden, ccc controls order
+10F82         ; Bottom # Mn       OLD UYGHUR COMBINING DOT ABOVE      # Overridden, ccc controls order
 10F83         ; Bottom # Mn       OLD UYGHUR COMBINING DOT BELOW
-10F84         ; Bottom # Mn       OLD UYGHUR COMBINING TWO DOTS ABOVE # Overriden, ccc controls order
+10F84         ; Bottom # Mn       OLD UYGHUR COMBINING TWO DOTS ABOVE # Overridden, ccc controls order
 10F85         ; Bottom # Mn       OLD UYGHUR COMBINING TWO DOTS BELOW
 16F4F         ; Bottom # Mn       MIAO SIGN CONSONANT MODIFIER BAR
 16F51..16F87  ; Bottom # Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI

--- a/test/api/test-ot-math.c
+++ b/test/api/test-ot-math.c
@@ -312,7 +312,7 @@ test_get_glyph_kerning (void)
   openFont("fonts/MathTestFontFull.otf");
   g_assert(hb_font_get_glyph_from_name (hb_font, "I", -1, &glyph));
 
-  g_assert_cmpint(hb_ot_math_get_glyph_kerning (hb_font, glyph, HB_OT_MATH_KERN_TOP_RIGHT, 7), ==, 62); // lower than min heigth
+  g_assert_cmpint(hb_ot_math_get_glyph_kerning (hb_font, glyph, HB_OT_MATH_KERN_TOP_RIGHT, 7), ==, 62); // lower than min height
   g_assert_cmpint(hb_ot_math_get_glyph_kerning (hb_font, glyph, HB_OT_MATH_KERN_TOP_RIGHT, 14), ==, 62); // equal to min height
   g_assert_cmpint(hb_ot_math_get_glyph_kerning (hb_font, glyph, HB_OT_MATH_KERN_TOP_RIGHT, 20), ==, 104);
   g_assert_cmpint(hb_ot_math_get_glyph_kerning (hb_font, glyph, HB_OT_MATH_KERN_TOP_RIGHT, 23), ==, 104);

--- a/test/fuzzing/hb-set-fuzzer.cc
+++ b/test/fuzzing/hb-set-fuzzer.cc
@@ -8,7 +8,7 @@
 #include "hb.h"
 
 // Only allow ~5,000 set values between the two input sets.
-// Arbitarily long input sets do not trigger any meaningful
+// Arbitrarily long input sets do not trigger any meaningful
 // differences in behaviour so there's no benefit from allowing
 // the fuzzer to create super large sets.
 #define MAX_INPUT_SIZE 20000

--- a/util/ansi-print.hh
+++ b/util/ansi-print.hh
@@ -249,7 +249,7 @@ block_best (const biimage_t &bi, bool *inverse)
       total_i += c_i;
     }
 
-  /* Make the sums cummulative */
+  /* Make the sums cumulative */
   for (unsigned int i = 1; i < bi.height; i++) {
     row_sum[i] += row_sum[i - 1];
     row_sum_i[i] += row_sum_i[i - 1];

--- a/util/hb-subset.cc
+++ b/util/hb-subset.cc
@@ -740,7 +740,7 @@ subset_main_t::add_options ()
     {"glyphs-",		0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_CALLBACK, (gpointer) &parse_glyphs,			"Specify glyph names to remove from the subset", "list of glyph names"},
 
 
-    {"glyphs-file",	0, 0, G_OPTION_ARG_CALLBACK, (gpointer) &parse_file_for<parse_glyphs>,	"Specify file to read glyph names fromt", "filename"},
+    {"glyphs-file",	0, 0, G_OPTION_ARG_CALLBACK, (gpointer) &parse_file_for<parse_glyphs>,	"Specify file to read glyph names from", "filename"},
 
     {"text",		0, 0, G_OPTION_ARG_CALLBACK, (gpointer) &parse_text,			"Specify text to include in the subset. Use --text-=... to subtract codepoints from the current set.", "string"},
     {"text-",		0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_CALLBACK, (gpointer) &parse_text,			"Specify text to remove from the subset", "string"},


### PR DESCRIPTION
Found via `codespell -q 3 -S ./perf/texts -L actualy,ba,beng,fo,gir,inout,nd,ot,pres,ro,te,teh,timne` 