### PR TITLE
[meson] add icu DEFS required for compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -123,6 +123,13 @@ if not get_option('icu').disabled()
   endif
 endif
 
+if icu_dep.found()
+  icu_defs = icu_dep.get_variable(pkgconfig: 'DEFS', default_value: '')
+  if icu_defs != ''
+    add_project_arguments(icu_defs, language: ['c', 'cpp'])
+  endif
+endif
+
 cairo_dep = null_dep
 cairo_ft_dep = null_dep
 if not get_option('cairo').disabled()


### PR DESCRIPTION
In some cases we need to add additionl defs to build against icu if icu has certain options configured.

ICU warns about this when building:

*** WARNING: You must set the following flags before code compiled against this ICU will function properly:

    -DU_DISABLE_RENAMING=1

We can fetch these flags from the icu pkgconfig and add them if required.

This fixes symbol errors if ICU is built without renaming.