### PR TITLE
Handle ragel better with meson

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -50,7 +50,8 @@ jobs:
           -Dgraphite=enabled \
           -Doptimization=2 \
           -Ddoc_tests=true \
-          -Dragel_subproject=true
+          -Dragel=enabled \
+          -Dwrap_mode=default
     - name: Build
       run: meson compile -Cbuild
     - name: Test

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -54,6 +54,7 @@ jobs:
           -Dcoretext=enabled \
           -Dgraphite=enabled \
           -Doptimization=2 \
+          -Dragel=disabled
     - name: Build
       run: meson compile -Cbuild
     - name: Test

--- a/.github/workflows/msys2-ci.yml
+++ b/.github/workflows/msys2-ci.yml
@@ -69,7 +69,8 @@ jobs:
           -Ddirectwrite=enabled \
           -Dgdi=enabled \
           -Dgraphite=enabled \
-          -Dchafa=disabled
+          -Dchafa=disabled \
+          -Dragel=disabled
     - name: Build
       run: meson compile -Cbuild
     - name: Test

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -44,8 +44,8 @@ option('with_libstdcxx', type: 'boolean', value: false,
   description: 'Allow linking with libstdc++')
 option('experimental_api', type: 'boolean', value: false,
   description: 'Enable experimental APIs')
-option('ragel_subproject', type: 'boolean', value: false,
-  description: 'Build Ragel subproject if no suitable version is found')
+option('ragel', type: 'feature', value: 'auto',
+  description: 'Whether to regenerate ragel sources as needed')
 option('fuzzer_ldflags', type: 'string',
   description: 'Extra LDFLAGS used during linking of fuzzing binaries')
 

--- a/src/gen-ragel-artifacts.py
+++ b/src/gen-ragel-artifacts.py
@@ -4,22 +4,32 @@
 
 import os, os.path, sys, subprocess, shutil
 
-ragel = sys.argv[1]
-if not ragel:
-	sys.exit ('You have to install ragel if you are going to develop HarfBuzz itself')
+uninstalled_error = """
+'ragel' is missing on your system. In order to develop HarfBuzz itself,
+specifically, by editing the *.rl source files, you have to install ragel
+in order to transpile them to C++ headers.
+""".strip()
 
-if len (sys.argv) < 4:
+ragel = sys.argv[1]
+
+if len (sys.argv) != 5:
 	sys.exit (__doc__)
 
-OUTPUT = sys.argv[2]
+hh = sys.argv[2]
 CURRENT_SOURCE_DIR = sys.argv[3]
-INPUT = sys.argv[4]
+rl = sys.argv[4]
 
-outdir = os.path.dirname (OUTPUT)
-shutil.copy (INPUT, outdir)
-rl = os.path.basename (INPUT)
-hh = rl.replace ('.rl', '.hh')
-subprocess.Popen (ragel.split() + ['-e', '-F1', '-o', hh, rl], cwd=outdir).wait ()
+outdir = os.path.dirname (hh)
+hh_in_src = os.path.join (CURRENT_SOURCE_DIR, os.path.basename (hh))
 
-# copy it also to src/
-shutil.copyfile (os.path.join (outdir, hh), os.path.join (CURRENT_SOURCE_DIR, hh))
+# We check to see if rl sources are newer than the generated files, with a 1
+# second tolerance (pretend they are a bit older than they actually are) since
+# git clone has a habit of producing inconsistent timestamps.
+if (os.stat (rl).st_mtime - 1) <= os.stat (hh_in_src).st_mtime:
+	shutil.copy (hh_in_src, hh)
+else:
+	if ragel == 'error' or not os.path.exists (ragel):
+		sys.exit (uninstalled_error)
+	subprocess.check_call ([ragel, '-e', '-F1', '-o', hh, rl])
+	# copy it also to src/
+	shutil.copyfile (hh, hh_in_src)

--- a/src/gen-ragel-artifacts.py
+++ b/src/gen-ragel-artifacts.py
@@ -7,7 +7,8 @@ import os, os.path, sys, subprocess, shutil
 uninstalled_error = """
 'ragel' is missing on your system. In order to develop HarfBuzz itself,
 specifically, by editing the *.rl source files, you have to install ragel
-in order to transpile them to C++ headers.
+in order to transpile them to C++ headers. Try configuring meson with
+`--wrap-mode=default -Dragel=enabled`
 """.strip()
 
 ragel = sys.argv[1]

--- a/src/meson.build
+++ b/src/meson.build
@@ -411,12 +411,8 @@ hb_gobject_headers = files(
   'hb-gobject-structs.h',
 )
 
-ragel = find_program('ragel', version: '6.10', required: false)
+ragel = find_program('ragel', version: '6.10', required: get_option('ragel'))
 has_ragel = ragel.found()
-if not has_ragel and get_option('ragel_subproject')
-    ragel = subproject('ragel').get_variable('ragel')
-    has_ragel = true
-endif
 if not has_ragel
   if not meson.is_subproject()
     message('You have to install ragel if you are going to develop HarfBuzz itself')

--- a/src/meson.build
+++ b/src/meson.build
@@ -419,20 +419,20 @@ if not has_ragel and get_option('ragel_subproject')
 endif
 if not has_ragel
   if not meson.is_subproject()
-    warning('You have to install ragel if you are going to develop HarfBuzz itself')
+    message('You have to install ragel if you are going to develop HarfBuzz itself')
   endif
-else
-  ragel_helper = find_program('gen-ragel-artifacts.py')
-  foreach rl : hb_base_ragel_sources
-    hh = rl.split('.')[0] + '.hh'
-    custom_target('@0@'.format(hh),
-      build_by_default: true,
-      input: rl,
-      output: hh,
-      command: [ragel_helper, ragel, '@OUTPUT@', meson.current_source_dir(), '@INPUT@'],
-    )
-  endforeach
+  ragel = 'error'
 endif
+ragel_helper = find_program('gen-ragel-artifacts.py')
+foreach rl : hb_base_ragel_sources
+  hh = rl.split('.')[0] + '.hh'
+  custom_target('@0@'.format(hh),
+    build_by_default: true,
+    input: rl,
+    output: hh,
+    command: [ragel_helper, ragel, '@OUTPUT@', meson.current_source_dir(), '@INPUT@'],
+  )
+endforeach
 
 custom_target('harfbuzz.cc',
   build_by_default: true,

--- a/subprojects/packagefiles/ragel/meson.build
+++ b/subprojects/packagefiles/ragel/meson.build
@@ -3,6 +3,7 @@ project('ragel', 'c', 'cpp',
   default_options: [
     'cpp_eh=default',
   ],
+  meson_version: '>=0.50.0',
 )
 
 cpp = meson.get_compiler('cpp')
@@ -64,3 +65,5 @@ ragel = executable(
   include_directories : ['aapl', 'ragel'],
   native : true,
 )
+
+meson.override_find_program('ragel', ragel)

--- a/subprojects/ragel.wrap
+++ b/subprojects/ragel.wrap
@@ -6,6 +6,4 @@ source_hash = 5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f
 patch_directory = ragel
 
 [provide]
-ragel = ragel
-
-
+program_names = ragel


### PR DESCRIPTION
Just like autotools, ragel should only be required when rl sources are actually out of date.

Fixes #3378