### PR TITLE
[ot-tag] Add HB_SCRIPT_MATH (Zmth) and map it to OT ‘math’ tag

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -191,6 +191,7 @@ HB_SCRIPT_CANADIAN_ABORIGINAL
 hb_font_funcs_set_glyph_func
 hb_font_get_glyph_func_t
 HB_MATH_GLYPH_PART_FLAG_EXTENDER
+HB_OT_MATH_SCRIPT
 hb_ot_layout_table_choose_script
 hb_ot_layout_table_find_script
 hb_ot_tag_from_language
@@ -542,7 +543,7 @@ hb_ot_layout_glyph_sequence_func_t
 <SECTION>
 <FILE>hb-ot-math</FILE>
 HB_OT_TAG_MATH
-HB_OT_MATH_SCRIPT
+HB_OT_TAG_MATH_SCRIPT
 hb_ot_math_constant_t
 hb_ot_math_kern_t
 hb_ot_math_glyph_variant_t

--- a/src/hb-common.h
+++ b/src/hb-common.h
@@ -481,6 +481,7 @@ hb_language_get_default (void);
  * @HB_SCRIPT_TANGSA: `Tnsa`, Since: 3.0.0
  * @HB_SCRIPT_TOTO: `Toto`, Since: 3.0.0
  * @HB_SCRIPT_VITHKUQI: `Vith`, Since: 3.0.0
+ * @HB_SCRIPT_MATH: `Zmth`, Since: REPLACEME
  * @HB_SCRIPT_INVALID: No script set
  *
  * Data type for scripts. Each #hb_script_t's value is an #hb_tag_t corresponding
@@ -696,6 +697,11 @@ typedef enum
   HB_SCRIPT_TANGSA			= HB_TAG ('T','n','s','a'), /*14.0*/
   HB_SCRIPT_TOTO			= HB_TAG ('T','o','t','o'), /*14.0*/
   HB_SCRIPT_VITHKUQI			= HB_TAG ('V','i','t','h'), /*14.0*/
+
+  /*
+   * Since REPLACEME
+   */
+  HB_SCRIPT_MATH			= HB_TAG ('Z','m','t','h'),
 
   /* No script set. */
   HB_SCRIPT_INVALID			= HB_TAG_NONE,

--- a/src/hb-ot-deprecated.h
+++ b/src/hb-ot-deprecated.h
@@ -50,6 +50,21 @@ HB_BEGIN_DECLS
  */
 #define HB_MATH_GLYPH_PART_FLAG_EXTENDER HB_OT_MATH_GLYPH_PART_FLAG_EXTENDER
 
+/* https://github.com/harfbuzz/harfbuzz/pull/3417 */
+/**
+ * HB_OT_MATH_SCRIPT:
+ *
+ * Use #HB_SCRIPT_MATH or #HB_OT_TAG_MATH_SCRIPT instead.
+ *
+ * <note>Previous versions of this documentation recommended passing
+ * #HB_OT_MATH_SCRIPT to hb_buffer_set_script() to enable math shaping, but this
+ * usage is no longer supported. Use #HB_SCRIPT_MATH instead.</note>
+ *
+ * Since: 1.3.3
+ * Deprecated: REPLACEME
+ */
+#define HB_OT_MATH_SCRIPT HB_OT_TAG_MATH_SCRIPT
+
 
 /* Like hb_ot_layout_table_find_script, but takes zero-terminated array of scripts to test */
 HB_EXTERN HB_DEPRECATED_FOR (hb_ot_layout_table_select_script) hb_bool_t

--- a/src/hb-ot-math.h
+++ b/src/hb-ot-math.h
@@ -50,14 +50,18 @@ HB_BEGIN_DECLS
 #define HB_OT_TAG_MATH HB_TAG('M','A','T','H')
 
 /**
- * HB_OT_MATH_SCRIPT:
+ * HB_OT_TAG_MATH_SCRIPT:
  *
- * OpenType script tag for math shaping, for use with
- * Use with hb_buffer_set_script().
+ * OpenType script tag, `math`, for features specific to math shaping.
  *
- * Since: 1.3.3
+ * <note>#HB_OT_TAG_MATH_SCRIPT is not a valid #hb_script_t and should only be
+ * used with functions that accept raw OpenType script tags, such as
+ * #hb_ot_layout_collect_features. In other cases, #HB_SCRIPT_MATH should be
+ * used instead.</note>
+ *
+ * Since: REPLACEME
  */
-#define HB_OT_MATH_SCRIPT HB_TAG('m','a','t','h')
+#define HB_OT_TAG_MATH_SCRIPT HB_TAG('m','a','t','h')
 
 /* Types */
 

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -41,6 +41,7 @@ hb_ot_old_tag_from_script (hb_script_t script)
   switch ((hb_tag_t) script)
   {
     case HB_SCRIPT_INVALID:		return HB_OT_TAG_DEFAULT_SCRIPT;
+    case HB_SCRIPT_MATH:		return HB_OT_TAG_MATH_SCRIPT;
 
     /* KATAKANA and HIRAGANA both map to 'kana' */
     case HB_SCRIPT_HIRAGANA:		return HB_TAG('k','a','n','a');
@@ -63,6 +64,8 @@ hb_ot_old_tag_to_script (hb_tag_t tag)
 {
   if (unlikely (tag == HB_OT_TAG_DEFAULT_SCRIPT))
     return HB_SCRIPT_INVALID;
+  if (unlikely (tag == HB_OT_TAG_MATH_SCRIPT))
+    return HB_SCRIPT_MATH;
 
   /* This side of the conversion is fully algorithmic. */
 

--- a/test/api/test-ot-tag.c
+++ b/test/api/test-ot-tag.c
@@ -140,6 +140,8 @@ test_ot_tag_script_simple (void)
   test_simple_tags ("kana", HB_SCRIPT_KATAKANA);
   test_simple_tags ("latn", HB_SCRIPT_LATIN);
 
+  test_simple_tags ("math", HB_SCRIPT_MATH);
+
   /* These are trickier since their OT script tags have space. */
   test_simple_tags ("lao ", HB_SCRIPT_LAO);
   test_simple_tags ("yi  ", HB_SCRIPT_YI);


### PR DESCRIPTION
The [ISO 15924 code](https://unicode.org/iso15924/iso15924-codes.html) for mathematical notation is `Zmth`, but the corresponding [OpenType script tag](https://docs.microsoft.com/en-us/typography/opentype/spec/scripttags) is `math`. HarfBuzz needs to know about the mapping, or else OpenType features that depend on the `math` script won’t be applied. This PR adds `HB_SCRIPT_MATH` to `hb_script_t` (for convenience) and changes `hb_ot_tags_from_script_and_language` and `hb_ot_tag_to_script` to do the necessary conversion.