### PR TITLE
[ci] Fix MSVC build

### DIFF
--- a/.github/workflows/msvc-ci.yml
+++ b/.github/workflows/msvc-ci.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch : ${{ matrix.ARCH }}
+      # https://github.com/mesonbuild/meson/issues/9955#issuecomment-1030843844
+      - name: Downgrade pip
+        run: |
+          python -m pip install -U pip==21.3.1
       - name: Install Dependencies
         run: |
           pip install --upgrade meson ninja fonttools


### PR DESCRIPTION
Downgrade pip, turns out, pip 22.0 is the source of the breakage: https://github.com/mesonbuild/meson/issues/9955#issuecomment-1030843844, https://github.com/pypa/pip/issues/10875