### PR TITLE
hb-algs.hh: Fix build on Visual Studio 2015

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -226,8 +226,14 @@ struct
   template <typename T> constexpr auto
   impl (const T& v, hb_priority<2>) const HB_RETURN (uint32_t, hb_deref (v).hash ())
 
+/* Sadly, we must give further hints to VS2015 to build the following template item */
+#if !defined (_MSC_VER) || defined (__clang__) || (_MSC_VER >= 1910)
   template <typename T> constexpr auto
   impl (const T& v, hb_priority<1>) const HB_RETURN (uint32_t, std::hash<hb_decay<decltype (hb_deref (v))>>{} (hb_deref (v)))
+#else
+  template <typename T> constexpr auto
+  impl (const T& v, hb_priority<1>) const HB_RETURN (uint32_t, std::hash<hb_decay<decltype (hb_deref (v).hash ())>>{} (hb_deref (v)))
+#endif
 
   template <typename T,
 	    hb_enable_if (std::is_integral<T>::value)> constexpr auto


### PR DESCRIPTION
Hi,

This attempts to fix the build for the tip of the main branch when Visual Studio 2015 is being used, as a `static_assert` (error C2338) is triggered during the build, where the compiler does not recognize the `std::hash` call on `hb_decay<decltype (hb_deref (v)>`, so give it a shove so that it is recognized.

With blessings, thank you!