### PR TITLE
meson.build: Fix configuration if ICU was found via find_library()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -129,7 +129,7 @@ if not get_option('icu').disabled()
   endif
 endif
 
-if icu_dep.found()
+if icu_dep.found() and icu_dep.type_name() == 'pkgconfig'
   icu_defs = icu_dep.get_variable(pkgconfig: 'DEFS', default_value: '')
   if icu_defs != ''
     add_project_arguments(icu_defs, language: ['c', 'cpp'])


### PR DESCRIPTION
Hi,

This attempts to fix the build when ICU is found via `meson.get_compiler('cpp').find_library()` instead of pkg-config, as one can call `get_variable()` on the `icu_dep` dependency object only if ICU was found via pkg-config.

With blessings, thank you!