### PR TITLE
Build and runtime fixes for Visual Studio 2015

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -226,14 +226,8 @@ struct
   template <typename T> constexpr auto
   impl (const T& v, hb_priority<2>) const HB_RETURN (uint32_t, hb_deref (v).hash ())
 
-/* Sadly, we must give further hints to VS2015 to build the following template item */
-#if !defined (_MSC_VER) || defined (__clang__) || (_MSC_VER >= 1910)
   template <typename T> constexpr auto
   impl (const T& v, hb_priority<1>) const HB_RETURN (uint32_t, std::hash<hb_decay<decltype (hb_deref (v))>>{} (hb_deref (v)))
-#else
-  template <typename T> constexpr auto
-  impl (const T& v, hb_priority<1>) const HB_RETURN (uint32_t, std::hash<hb_decay<decltype (hb_deref (v).hash ())>>{} (hb_deref (v)))
-#endif
 
   template <typename T,
 	    hb_enable_if (std::is_integral<T>::value)> constexpr auto

--- a/src/hb-ot-post-table-v2subset.hh
+++ b/src/hb-ot-post-table-v2subset.hh
@@ -131,4 +131,14 @@ HB_INTERNAL bool postV2Tail::subset (hb_subset_context_t *c) const
 }
 
 } /* namespace OT */
+
+/* Sadly, we must specialize std::hash for hb_bytes_t for Visual Studio 2015 */
+namespace std
+{
+  template <>
+  struct hash<hb_bytes_t>
+    {
+      size_t operator ()(hb_bytes_t value) const {return value.hash();}
+    };
+}
 #endif /* HB_OT_POST_TABLE_V2SUBSET_HH */

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -680,4 +680,15 @@ struct hb_serialize_context_t
 	       nullptr, 0> packed_map;
 };
 
+
+/* Sadly, we must specialize std::hash for struct hb_serialize_context_t::object_t for Visual Studio 2015 */
+namespace std
+{
+  template <>
+  struct hash<struct hb_serialize_context_t::object_t>
+    {
+      size_t operator ()(struct hb_serialize_context_t::object_t value) const {return value.hash();}
+    };
+}
+
 #endif /* HB_SERIALIZE_HH */

--- a/util/main-font-text.hh
+++ b/util/main-font-text.hh
@@ -31,8 +31,8 @@
 
 /* main() body for utilities taking font and processing text.*/
 
-template <typename consumer_t, typename font_options_t, typename text_options_t>
-struct main_font_text_t : option_parser_t, font_options_t, text_options_t, consumer_t
+template <typename consumer_t, typename font_options_t, typename text_options_type>
+struct main_font_text_t : option_parser_t, font_options_t, text_options_type, consumer_t
 {
   int operator () (int argc, char **argv)
   {
@@ -54,7 +54,7 @@ struct main_font_text_t : option_parser_t, font_options_t, text_options_t, consu
   void add_options ()
   {
     font_options_t::add_options (this);
-    text_options_t::add_options (this);
+    text_options_type::add_options (this);
     consumer_t::add_options (this);
 
     GOptionEntry entries[] =


### PR DESCRIPTION
Hi,

This attempts to improve the build and runtime situation when using Visual Studio 2015, by:

*  Adding specializations for `std::hash` for `hb_bytes_t` and `struct hb_serialize_context_t::object_t`, so that the build will not fail due to a C2338 error (`The C++ Standard doesn't provide a hash for this type`) on Visual Studio 2015.  This will replace (and revert) commit 52c536b.

*  Fix #3379, where the templatized implementation of `struct main_font_text_t` confuses the template type `text_options_t` with the actual `text_options_t`, where we inherit from the actual `text_options_t` with `shape_text_options_t`.

Things now build properly with Visual Studio 2015 and tests now pass, with the full list of options that we can pass into `hb-shape.exe`.

With blessings, thank you!