### PR TITLE
Fixed various misc. typos

### DIFF
--- a/docs/serializer.md
+++ b/docs/serializer.md
@@ -33,7 +33,7 @@ Here Obj N, is the object currently being written.
 ## Complex Tables
 
 Complex tables are made up of graphs of objects, where offset's are used
-to form the edges of the graphs. Each object is a continous slice of bytes
+to form the edges of the graphs. Each object is a continuous slice of bytes
 that contains zero or more offsets pointing to more objects.
 
 In this case the serialization buffer has a different layout:

--- a/src/hb-buffer-deserialize-text.hh
+++ b/src/hb-buffer-deserialize-text.hh
@@ -478,7 +478,7 @@ _resume:
 	case 18:
 #line 58 "hb-buffer-deserialize-text.rl"
 	{
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))
@@ -535,7 +535,7 @@ _resume:
 	case 16:
 #line 58 "hb-buffer-deserialize-text.rl"
 	{
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))
@@ -635,7 +635,7 @@ _resume:
 }
 #line 58 "hb-buffer-deserialize-text.rl"
 	{
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))
@@ -645,7 +645,7 @@ _resume:
 	case 17:
 #line 58 "hb-buffer-deserialize-text.rl"
 	{
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))
@@ -674,7 +674,7 @@ _resume:
 }
 #line 58 "hb-buffer-deserialize-text.rl"
 	{
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))
@@ -701,7 +701,7 @@ _resume:
 }
 #line 58 "hb-buffer-deserialize-text.rl"
 	{
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))
@@ -733,7 +733,7 @@ _again:
 	case 16:
 #line 58 "hb-buffer-deserialize-text.rl"
 	{
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))
@@ -820,7 +820,7 @@ _again:
 }
 #line 58 "hb-buffer-deserialize-text.rl"
 	{
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))

--- a/src/hb-buffer-deserialize-text.rl
+++ b/src/hb-buffer-deserialize-text.rl
@@ -56,7 +56,7 @@ action ensure_glyphs { if (unlikely (!buffer->ensure_glyphs ())) return false; }
 action ensure_unicode { if (unlikely (!buffer->ensure_unicode ())) return false; }
 
 action parse_glyph {
-	/* TODO Unescape delimeters. */
+	/* TODO Unescape delimiters. */
 	if (!hb_font_glyph_from_string (font,
 					tok, p - tok,
 					&info.codepoint))

--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -117,7 +117,7 @@ typedef struct hb_glyph_info_t {
  * 				   from there, and repeat.
  * 				   At the start of next line a similar algorithm can
  * 				   be implemented. That is: 1. Iterate forward from
- * 				   the line-break position untill the first cluster
+ * 				   the line-break position until the first cluster
  * 				   start position that is NOT unsafe-to-concat, 2.
  * 				   shape the segment from beginning of the line to
  * 				   that position, 3. check whether the resulting


### PR DESCRIPTION
Found via `codespell -q 3 -S ./perf/texts -L actualy,als,ba,beng,clen,crasher,dependant,eachother,fo,gir,inout,ist,nd,ned,ot,pres,ro,statics,te,teh,timne`