### PR TITLE
Fix for rendering of nuqtas in certain cases

### DIFF
--- a/src/hb-ot-layout.hh
+++ b/src/hb-ot-layout.hh
@@ -485,6 +485,8 @@ static inline uint8_t
 _hb_allocate_lig_id (hb_buffer_t *buffer)
 {
   uint8_t lig_id = buffer->next_serial () & 0x07;
+  if (unlikely (!lig_id))
+    lig_id = _hb_allocate_lig_id (buffer); /* in case of overflow */
   return lig_id;
 }
 


### PR DESCRIPTION
This PR fixes #3487 by adding 
```
  if (unlikely (!lig_id))
    lig_id = _hb_allocate_lig_id (buffer); /* in case of overflow */
```
back to `_hb_allocate_lig_id` function as suggested by @jfkthame in #3487.