### PR TITLE
test: Dist the platform shaper test data

### DIFF
--- a/test/shape/data/in-house/Makefile.sources
+++ b/test/shape/data/in-house/Makefile.sources
@@ -71,5 +71,15 @@ TESTS = \
 	tests/zero-width-marks.tests \
 	$(NULL)
 
+if HAVE_CORETEXT
+TESTS += tests/coretext.tests
+endif
+if HAVE_DIRECTWRITE
+TESTS += tests/directwrite.tests
+endif
+if HAVE_UNISCRIBE
+TESTS += tests/uniscribe.tests
+endif
+
 DISABLED_TESTS = \
 	$(NULL)


### PR DESCRIPTION
Hi,

From the commit message--I presume the release tarballs are generated from the autotools builds?

<i>For builds from release tarballs, the tests fail in the DirectWrite and Uniscribe tests when these platform shapers are enabled, since the data files were not found in the source tree, when building with Meson at least.</i>

<i>Fix this by dist'ing the platform shaper test data files.</i>

This will fix the failing tests when building from the release tarballs when platform shapers are enabled.

Sorry, I am not that good in autotools to attempt to enable the platform shaper tests in the autotools builds, so I am not attempting to do that here in this PR.

With blessings, thank you!