### PR TITLE
CMakeLists.txt: also match 'AppleClang' compiler to not link with libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,7 +462,9 @@ if (UNIX OR MINGW)
     link_libraries(-Bsymbolic-functions)
   endif ()
 
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # As of CMake 3.0.0, the compiler id for Apple-provided Clang is now "AppleClang";
+  # thus we use MATCHES instead of STREQUAL to include either regular Clang or AppleClang
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Make sure we don't link to libstdc++
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
     set (CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "m") # libm


### PR DESCRIPTION
As of CMake 3.0.0, the `CMAKE_*_COMPILER_ID` for the Apple-provided Clang is no longer "Clang" but "AppleClang".

https://cmake.org/cmake/help/v3.0/release/3.0.0.html#other-changes

This PR ensures that we match either "Clang" or "AppleClang" when adding the flags which prevent from linking with the libc++.
Without this, we currently end up with a shared library on macOS that links with libc++, which is undersirable for pure-C projects like https://github.com/rougier/freetype-py/pull/148