### PR TITLE
[subset] Expose --passthrough-tables option to hb-subset CLI tool

### DIFF
--- a/util/hb-subset.cc
+++ b/util/hb-subset.cc
@@ -801,6 +801,7 @@ subset_main_t::add_options ()
     {"notdef-outline",		0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_NOTDEF_OUTLINE>,		"Keep the outline of \'.notdef\' glyph", nullptr},
     {"no-prune-unicode-ranges",	0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES>,	"Don't change the 'OS/2 ulUnicodeRange*' bits.", nullptr},
     {"glyph-names",		0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_GLYPH_NAMES>,		"Keep PS glyph names in TT-flavored fonts. ", nullptr},
+    {"passthrough-tables",	0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED>,	"Do not drop tables that the tool does not know how to subset.", nullptr},
     {nullptr}
   };
   add_group (flag_entries,


### PR DESCRIPTION
With this I can keep the SVG table like this:

```
$ hb-subset --retain-gids --drop-tables-=SVG --passthrough-tables --output-file=build/Font.subset.ttf build/Font.ttf abc
```

I used `--passthrough-tables` instead of `--passthrough-unrecognized` to match the FontTools' pyftsubset CLI -- the respective hb-subset API flag is named HB_SUBSET_FLAG_PASSTHROUGH_UNRECOGNIZED -- but I can change it if you prefer.

FIxes #3532 