### PR TITLE
[myanmar] Reword confusing comment about masks

### DIFF
--- a/src/hb-ot-shape-complex-myanmar.cc
+++ b/src/hb-ot-shape-complex-myanmar.cc
@@ -105,8 +105,7 @@ setup_masks_myanmar (const hb_ot_shape_plan_t *plan HB_UNUSED,
   HB_BUFFER_ALLOCATE_VAR (buffer, myanmar_category);
   HB_BUFFER_ALLOCATE_VAR (buffer, myanmar_position);
 
-  /* We cannot setup masks here.  We save information about characters
-   * and setup masks later on in a pause-callback. */
+  /* No masks, we just save information about characters. */
 
   unsigned int count = buffer->len;
   hb_glyph_info_t *info = buffer->info;


### PR DESCRIPTION
The Myanmar shaper doesn't use masks, but a comment taken from the Indic shaper implies that it does.