### PR TITLE
Enforce Regional_Indicators native direction to LTR

### DIFF
--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -1038,12 +1038,12 @@ struct Chain
 	goto skip;
 
       if (reverse)
-	_hb_ot_layout_reverse_graphemes (c->buffer);
+	c->buffer->reverse ();
 
       subtable->apply (c);
 
       if (reverse)
-	_hb_ot_layout_reverse_graphemes (c->buffer);
+	c->buffer->reverse ();
 
       (void) c->buffer->message (c->font, "end chainsubtable %d", c->lookup_index);
 

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -47,6 +47,9 @@
 
 #include "hb-aat-layout.hh"
 
+static inline bool
+_hb_codepoint_is_regional_indicator (hb_codepoint_t u)
+{ return hb_in_range<hb_codepoint_t> (u, 0x1F1E6u, 0x1F1FFu); }
 
 #ifndef HB_NO_AAT_SHAPE
 static inline bool
@@ -504,9 +507,9 @@ hb_set_unicode_props (hb_buffer_t *buffer)
     }
     /* Regional_Indicators are hairy as hell...
      * https://github.com/harfbuzz/harfbuzz/issues/2265 */
-    else if (unlikely (i && hb_in_range<hb_codepoint_t> (info[i].codepoint, 0x1F1E6u, 0x1F1FFu)))
+    else if (unlikely (i && _hb_codepoint_is_regional_indicator (info[i].codepoint)))
     {
-      if (hb_in_range<hb_codepoint_t> (info[i - 1].codepoint, 0x1F1E6u, 0x1F1FFu) &&
+      if (_hb_codepoint_is_regional_indicator (info[i - 1].codepoint) &&
 	  !_hb_glyph_info_is_continuation (&info[i - 1]))
 	_hb_glyph_info_set_continuation (&info[i]);
     }
@@ -621,7 +624,7 @@ hb_ensure_native_direction (hb_buffer_t *buffer)
 	found_letter = true;
 	break;
       }
-      else if (hb_in_range<hb_codepoint_t> (info[i].codepoint, 0x1F1E6u, 0x1F1FFu))
+      else if (_hb_codepoint_is_regional_indicator (info[i].codepoint))
 	found_ri = true;
     }
     if ((found_number || found_ri) && !found_letter)

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -600,7 +600,7 @@ hb_ensure_native_direction (hb_buffer_t *buffer)
    * https://github.com/harfbuzz/harfbuzz/issues/501
    *
    * Similar thing about Regional_Indicators; They are bidi=L, but Script=Common.
-   * If they are presentin a run of natively-RTL text, they get assigned a script
+   * If they are present in a run of natively-RTL text, they get assigned a script
    * with natively RTL direction, which would result in wrong shaping if we
    * assign such native RTL direction to them then. Detect that as well.
    *

--- a/test/shape/data/in-house/tests/macos.tests
+++ b/test/shape/data/in-house/tests/macos.tests
@@ -1,5 +1,11 @@
 # https://github.com/harfbuzz/harfbuzz/issues/3314
-/System/Library/Fonts/Apple\ Color\ Emoji.ttc;;U+05D0,U+1F1FA,U+1F1F8,U+1F1EE,U+1F1F1;[u1F1EE_u1F1F1=3+800|u1F1FA_u1F1F8=1+800|.notdef=0+800]
+/System/Library/Fonts/Apple\ Color\ Emoji.ttc;--script=hebrew --direction ltr;U+1F1FA,U+1F1F8,U+1F1EE,U+1F1F1;[u1F1FA_u1F1F8=0+800|u1F1EE_u1F1F1=2+800]
+
+# https://github.com/harfbuzz/harfbuzz/issues/3528
+/System/Library/Fonts/Supplemental/Bangla MN.ttc;;U+09AC,U+09BF;[bn_ikaar=0+474|bn_ba=0+998]
+
+# https://github.com/harfbuzz/harfbuzz/issues/3535
+/System/Library/Fonts/LucidaGrande.ttc;;U+20DD,U+1F174,U+1F175;[circlecmb=0+0|.notdef=1+1536|.notdef=2+1536]
 
 # https;//github.com/harfbuzz/harfbuzz/issues/3008
 /System/Library/Fonts/ヒラギノ丸ゴ\ ProN\ W4.ttc;--features=palt;U+FF11;[gid781=0@-78,0+842]


### PR DESCRIPTION
And undo the morx direction reversal change introduced in
https://github.com/harfbuzz/harfbuzz/pull/3315
23159084b43c1ce429d9e98035bf845919fd8a89

This fixes original bug https://github.com/harfbuzz/harfbuzz/issues/3314

And the reversion in morx code fixes regressions:
https://github.com/harfbuzz/harfbuzz/issues/3528
https://github.com/harfbuzz/harfbuzz/issues/3535

Supersedes:
https://github.com/harfbuzz/harfbuzz/pull/3529