### PR TITLE
[subset] Further cmap subsetting speed optimizations

### DIFF
--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -332,7 +332,6 @@ struct CmapSubtableFormat4
     if (unlikely (!c->extend_min (this))) return;
     this->format = 4;
 
-    // TODO(grieger): does pre-alloc make this faster?
     hb_vector_t<hb_pair_t<hb_codepoint_t, hb_codepoint_t>> cp_to_gid {
       format4_iter
     };
@@ -1664,13 +1663,7 @@ struct cmap
     if (unlikely (has_format12 && (!unicode_ucs4 && !ms_ucs4))) return_trace (false);
 
     auto it =
-    + hb_iter (c->plan->unicodes)
-    | hb_map ([&] (hb_codepoint_t _)
-	      {
-		hb_codepoint_t new_gid = HB_MAP_VALUE_INVALID;
-		c->plan->new_gid_for_codepoint (_, &new_gid);
-		return hb_pair_t<hb_codepoint_t, hb_codepoint_t> (_, new_gid);
-	      })
+    + c->plan->unicode_to_new_gid_list->iter ()
     | hb_filter ([&] (const hb_pair_t<hb_codepoint_t, hb_codepoint_t> _)
 		 { return (_.second != HB_MAP_VALUE_INVALID); })
     ;

--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -1663,7 +1663,7 @@ struct cmap
     if (unlikely (has_format12 && (!unicode_ucs4 && !ms_ucs4))) return_trace (false);
 
     auto it =
-    + c->plan->unicode_to_new_gid_list->iter ()
+    + c->plan->unicode_to_new_gid_list.iter ()
     | hb_filter ([&] (const hb_pair_t<hb_codepoint_t, hb_codepoint_t> _)
 		 { return (_.second != HB_MAP_VALUE_INVALID); })
     ;

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -308,7 +308,7 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
   {
     /* This is the fast path if it's anticipated that size of unicodes
      * is << than the number of codepoints in the font. */
-    plan->unicode_to_new_gid_list->alloc (unicodes->get_population ());
+    plan->unicode_to_new_gid_list.alloc (unicodes->get_population ());
     for (hb_codepoint_t cp : *unicodes)
     {
       hb_codepoint_t gid;
@@ -319,14 +319,14 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
       }
 
       plan->codepoint_to_glyph->set (cp, gid);
-      plan->unicode_to_new_gid_list->push (hb_pair (cp, gid));
+      plan->unicode_to_new_gid_list.push (hb_pair (cp, gid));
     }
   }
   else
   {
     hb_map_t unicode_glyphid_map;
     cmap.collect_mapping (hb_set_get_empty (), &unicode_glyphid_map);
-    plan->unicode_to_new_gid_list->alloc (unicode_glyphid_map.get_population ());
+    plan->unicode_to_new_gid_list.alloc (unicode_glyphid_map.get_population ());
 
     for (hb_pair_t<hb_codepoint_t, hb_codepoint_t> cp_gid :
 	 + unicode_glyphid_map.iter ())
@@ -335,10 +335,10 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
 	continue;
 
       plan->codepoint_to_glyph->set (cp_gid.first, cp_gid.second);
-      plan->unicode_to_new_gid_list->push (hb_pair (cp_gid.first, cp_gid.second));
+      plan->unicode_to_new_gid_list.push (hb_pair (cp_gid.first, cp_gid.second));
     }
 
-    plan->unicode_to_new_gid_list->qsort (_compare_cp_gid_pair);
+    plan->unicode_to_new_gid_list.qsort (_compare_cp_gid_pair);
 
     /* Add gids which where requested, but not mapped in cmap */
     // TODO(garretrieger):
@@ -352,9 +352,10 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
     }
   }
 
-  for (unsigned i = 0; i < plan->unicode_to_new_gid_list->length; i++)
+  for (unsigned i = 0; i < plan->unicode_to_new_gid_list.length; i++)
   {
-    hb_pair_t<hb_codepoint_t, hb_codepoint_t> pair = plan->unicode_to_new_gid_list->arrayZ[i];
+    // Use raw array access for performance.
+    hb_pair_t<hb_codepoint_t, hb_codepoint_t> pair = plan->unicode_to_new_gid_list.arrayZ[i];
     plan->unicodes->add(pair.first);
     plan->_glyphset_gsub->add(pair.second);
   }
@@ -503,10 +504,9 @@ hb_subset_plan_create_or_fail (hb_face_t	 *face,
   plan->successful = true;
   plan->flags = input->flags;
   plan->unicodes = hb_set_create ();
-  plan->unicode_to_new_gid_list =
-      (hb_vector_t<hb_pair_t<hb_codepoint_t, hb_codepoint_t>>*)
-      hb_calloc (1, sizeof(hb_vector_t<hb_pair_t<hb_codepoint_t, hb_codepoint_t>>));
-  plan->unicode_to_new_gid_list->init ();
+
+  plan->unicode_to_new_gid_list.init ();
+
   plan->name_ids = hb_set_copy (input->sets.name_ids);
   _nameid_closure (face, plan->name_ids);
   plan->name_languages = hb_set_copy (input->sets.name_languages);
@@ -559,10 +559,11 @@ hb_subset_plan_create_or_fail (hb_face_t	 *face,
 				  &plan->_num_output_glyphs);
 
   // Now that we have old to new gid map update the unicode to new gid list.
-  for (unsigned i = 0; i < plan->unicode_to_new_gid_list->length; i++)
+  for (unsigned i = 0; i < plan->unicode_to_new_gid_list.length; i++)
   {
-    plan->unicode_to_new_gid_list->arrayZ[i].second =
-        plan->glyph_map->get(plan->unicode_to_new_gid_list->arrayZ[i].second);
+    // Use raw array access for performance.
+    plan->unicode_to_new_gid_list.arrayZ[i].second =
+        plan->glyph_map->get(plan->unicode_to_new_gid_list.arrayZ[i].second);
   }
 
   if (unlikely (plan->in_error ())) {
@@ -587,11 +588,7 @@ hb_subset_plan_destroy (hb_subset_plan_t *plan)
   if (!hb_object_destroy (plan)) return;
 
   hb_set_destroy (plan->unicodes);
-  if (plan->unicode_to_new_gid_list)
-  {
-    plan->unicode_to_new_gid_list->fini ();
-    hb_free (plan->unicode_to_new_gid_list);
-  }
+  plan->unicode_to_new_gid_list.fini ();
   hb_set_destroy (plan->name_ids);
   hb_set_destroy (plan->name_languages);
   hb_set_destroy (plan->layout_features);

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -326,7 +326,8 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
     // them with cmap entries.
     hb_map_t unicode_glyphid_map;
     cmap.collect_mapping (hb_set_get_empty (), &unicode_glyphid_map);
-    plan->unicode_to_new_gid_list.alloc (unicode_glyphid_map.get_population ());
+    plan->unicode_to_new_gid_list.alloc (unicodes->get_population ()
+                                         + glyphs->get_population ());
 
     for (hb_pair_t<hb_codepoint_t, hb_codepoint_t> cp_gid :
 	 + unicode_glyphid_map.iter ())

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -302,12 +302,10 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
 {
   OT::cmap::accelerator_t cmap (plan->source);
 
-  constexpr static const int size_threshold = 4096;
-
-  if (glyphs->is_empty () && unicodes->get_population () < size_threshold)
+  if (glyphs->is_empty ())
   {
-    /* This is the fast path if it's anticipated that size of unicodes
-     * is << than the number of codepoints in the font. */
+    // This is approach to collection is faster, but can only be used  if glyphs
+    // are not being explicitly added to the subset.
     plan->unicode_to_new_gid_list.alloc (unicodes->get_population ());
     for (hb_codepoint_t cp : *unicodes)
     {
@@ -324,6 +322,8 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
   }
   else
   {
+    // This approach is slower, but can handle adding in glyphs to the subset and will match
+    // them with cmap entries.
     hb_map_t unicode_glyphid_map;
     cmap.collect_mapping (hb_set_get_empty (), &unicode_glyphid_map);
     plan->unicode_to_new_gid_list.alloc (unicode_glyphid_map.get_population ());

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -352,8 +352,12 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
     }
   }
 
-  + plan->codepoint_to_glyph->keys ()   | hb_sink (plan->unicodes);
-  + plan->codepoint_to_glyph->values () | hb_sink (plan->_glyphset_gsub);
+  for (unsigned i = 0; i < plan->unicode_to_new_gid_list->length; i++)
+  {
+    hb_pair_t<hb_codepoint_t, hb_codepoint_t> pair = plan->unicode_to_new_gid_list->arrayZ[i];
+    plan->unicodes->add(pair.first);
+    plan->_glyphset_gsub->add(pair.second);
+  }
 }
 
 static void

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -44,7 +44,7 @@ struct hb_subset_plan_t
 
   // For each cp that we'd like to retain maps to the corresponding gid.
   hb_set_t *unicodes;
-  hb_vector_t<hb_pair_t<hb_codepoint_t, hb_codepoint_t>>* unicode_to_new_gid_list;
+  hb_vector_t<hb_pair_t<hb_codepoint_t, hb_codepoint_t>> unicode_to_new_gid_list;
 
   // name_ids we would like to retain
   hb_set_t *name_ids;

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -44,6 +44,7 @@ struct hb_subset_plan_t
 
   // For each cp that we'd like to retain maps to the corresponding gid.
   hb_set_t *unicodes;
+  hb_vector_t<hb_pair_t<hb_codepoint_t, hb_codepoint_t>>* unicode_to_new_gid_list;
 
   // name_ids we would like to retain
   hb_set_t *name_ids;


### PR DESCRIPTION
- Cache an ordered list of unicode -> new glyph id. This saves from having to repeatedly generate the ordered list from the unicodes set and glyph maps during cmap generation.
- Also use the above cache to populate the unicodes set in order to make use of recently added set page lookup caching on insert.

Median reduction in subsetting time of 12% for the MPlus 1p and 10,000 codepoint case. Full benchmark diff:

BM_subset_codepoints/subset_roboto/10_median                              +0.0985         +0.0978             0             0             0             0
BM_subset_codepoints/subset_roboto/64_median                              +0.0296         +0.0309             1             1             1             1
BM_subset_codepoints/subset_roboto/512_median                             -0.1443         -0.1432             1             1             1             1
BM_subset_codepoints/subset_roboto/4000_median                            -0.0716         -0.0717             7             7             7             7
BM_subset_codepoints/subset_amiri/10_median                               +0.0776         +0.0771             1             1             1             1
BM_subset_codepoints/subset_amiri/64_median                               +0.0207         +0.0208             1             1             1             1
BM_subset_codepoints/subset_amiri/512_median                              -0.0374         -0.0373             9             8             9             8
BM_subset_codepoints/subset_amiri/4000_median                             -0.0555         -0.0556            13            13            13            13
BM_subset_codepoints/subset_noto_nastaliq_urdu/10_median                  -0.0055         -0.0049             1             1             1             1
BM_subset_codepoints/subset_noto_nastaliq_urdu/64_median                  -0.0250         -0.0240            21            20            21            20
BM_subset_codepoints/subset_noto_nastaliq_urdu/512_median                 -0.0043         -0.0042           166           166           166           166
BM_subset_codepoints/subset_noto_nastaliq_urdu/1000_median                -0.0062         -0.0062           167           166           167           166
BM_subset_codepoints/subset_noto_devangari/10_median                      -0.0140         -0.0140             0             0             0             0
BM_subset_codepoints/subset_noto_devangari/64_median                      -0.0733         -0.0733             0             0             0             0
BM_subset_codepoints/subset_noto_devangari/512_median                     -0.0093         -0.0094             5             5             5             5
BM_subset_codepoints/subset_noto_devangari/1000_median                    -0.0032         -0.0036             6             6             6             6
BM_subset_codepoints/subset_mplus1p/10_median                             -0.0051         -0.0052             0             0             0             0
BM_subset_codepoints/subset_mplus1p/64_median                             +0.0087         +0.0076             1             1             1             1
BM_subset_codepoints/subset_mplus1p/512_median                            -0.0584         -0.0586             1             1             1             1
BM_subset_codepoints/subset_mplus1p/4096_median                           -0.0743         -0.0744             8             8             8             8
BM_subset_codepoints/subset_mplus1p/10000_median                          -0.1212         -0.1212            17            15            17            15