### PR TITLE
[ot-tags] Fix `min_subtag_len` calculations

### DIFF
--- a/src/gen-tag-table.py
+++ b/src/gen-tag-table.py
@@ -1019,14 +1019,12 @@ for initial, items in sorted (complex_tags.items ()):
 		if not tags:
 			continue
 		subtag_len = 0
-		subtag_len += len(lt.script) if lt.script is not None else 0
-		subtag_len += len(lt.region) if lt.region is not None else 0
-		subtag_len += len(lt.variant) if lt.variant is not None else 0
+		subtag_len += 1 + len (lt.script) if lt.script is not None else 0
+		subtag_len += 1 + len (lt.region) if lt.region is not None else 0
+		subtag_len += 1 + len (lt.variant) if lt.variant is not None else 0
 		min_subtag_len = min(subtag_len, min_subtag_len)
-min_subtag_len += 1 # For initial '-'
 
-print ('  if (limit - lang_str > %d ||' % min_subtag_len)
-print ("      (limit - lang_str == %d && *lang_str == '-'))" % min_subtag_len)
+print ('  if (limit - lang_str >= %d)' % (min_subtag_len + 2))
 print ('  {')
 print ("    const char *p = strchr (lang_str, '-');")
 print ("    if (!p || p >= limit || limit - p < %i) goto out;" % min_subtag_len)
@@ -1058,7 +1056,7 @@ for initial, items in sorted (complex_tags.items ()):
 				print ()
 			print ('      };')
 			print ('      for (i = 0; i < %s && i < *count; i++)' % len (tags))
-			print ('        tags[i] = possible_tags[i];')
+			print ('\ttags[i] = possible_tags[i];')
 			print ('      *count = i;')
 		print ('      return true;')
 		print ('    }')

--- a/src/hb-ot-tag-table.hh
+++ b/src/hb-ot-tag-table.hh
@@ -1642,8 +1642,7 @@ hb_ot_tags_from_complex_language (const char   *lang_str,
 				  unsigned int *count /* IN/OUT */,
 				  hb_tag_t     *tags /* OUT */)
 {
-  if (limit - lang_str > 5 ||
-      (limit - lang_str == 5 && *lang_str == '-'))
+  if (limit - lang_str >= 7)
   {
     const char *p = strchr (lang_str, '-');
     if (!p || p >= limit || limit - p < 5) goto out;


### PR DESCRIPTION
`hb_ot_tags_from_complex_language` had two conditions guarding the sequence of checks that don’t check the language subtag.

The first condition was `limit - lang_str > 5`. I modified it to `limit - lang_str >= 7`. This is because 5 is the minimum length of a relevant language tag excluding the language subtag. The minimum language subtag length is 2. Therefore, the minimum total language tag length is 7. The practical effect is minimal: 6-character tags like `zh-cmn` no longer pass into that block.

The second condition was `(limit - lang_str == 5 && *lang_str == '-')`. That accepts language tags like `-geok`. However, language tags can’t begin with hyphens, so no valid input would ever pass this condition, so I removed it.

I also fixed gen-tag-table.py to add 1 for each subtag’s hyphen, instead 1 for just the first subtag’s hyphen. It currently makes no difference because none of these special cases check multiple subtags.