### PR TITLE
[subset] fix fuzzer found underflow when heap push fails.

### DIFF
--- a/src/hb-priority-queue.hh
+++ b/src/hb-priority-queue.hh
@@ -51,6 +51,7 @@ struct hb_priority_queue_t
   void insert (int64_t priority, unsigned value)
   {
     heap.push (item_t (priority, value));
+    if (unlikely (heap.in_error ())) return;
     bubble_up (heap.length - 1);
   }
 


### PR DESCRIPTION
Fixes https://oss-fuzz.com/testcase-detail/5148625505746944.