### PR TITLE
[ci] Fix fedora-valgrind job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
 
   fedora-valgrind:
     docker:
-      - image: fedora:33
+      - image: fedora:36
     steps:
       - checkout
       - run: dnf install -y pkg-config ragel valgrind gcc gcc-c++ meson git glib2-devel freetype-devel cairo-devel libicu-devel gobject-introspection-devel graphite2-devel redhat-rpm-config python python-pip || true


### PR DESCRIPTION
Fedora 33 is EOL since 2021-11-30, try the latest Fedora release (36).