### PR TITLE
Coverage cache

### DIFF
--- a/src/hb-cache.hh
+++ b/src/hb-cache.hh
@@ -75,6 +75,7 @@ struct hb_cache_t
 
 typedef hb_cache_t<21, 16, 8> hb_cmap_cache_t;
 typedef hb_cache_t<16, 24, 8> hb_advance_cache_t;
+typedef hb_cache_t<16, 16, 8> hb_coverage_cache_t;
 
 
 #endif /* HB_CACHE_HH */

--- a/src/hb-cache.hh
+++ b/src/hb-cache.hh
@@ -75,7 +75,7 @@ struct hb_cache_t
 
 typedef hb_cache_t<21, 16, 8> hb_cmap_cache_t;
 typedef hb_cache_t<16, 24, 8> hb_advance_cache_t;
-typedef hb_cache_t<16, 16, 8> hb_coverage_cache_t;
+typedef hb_cache_t<16, 16, 6> hb_coverage_cache_t;
 
 
 #endif /* HB_CACHE_HH */

--- a/src/hb-ot-layout-gpos-table.hh
+++ b/src/hb-ot-layout-gpos-table.hh
@@ -794,7 +794,7 @@ struct SinglePosFormat1
   {
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
-    unsigned int index = (this+coverage).get_coverage  (buffer->cur().codepoint);
+    unsigned int index = (this+coverage).get_coverage  (buffer->cur().codepoint, c->coverage_cache);
     if (likely (index == NOT_COVERED)) return_trace (false);
 
     valueFormat.apply_value (c, this, values, buffer->cur_pos());
@@ -910,7 +910,7 @@ struct SinglePosFormat2
   {
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
-    unsigned int index = (this+coverage).get_coverage  (buffer->cur().codepoint);
+    unsigned int index = (this+coverage).get_coverage  (buffer->cur().codepoint, c->coverage_cache);
     if (likely (index == NOT_COVERED)) return_trace (false);
 
     if (likely (index >= valueCount)) return_trace (false);
@@ -1359,7 +1359,7 @@ struct PairPosFormat1
   {
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
-    unsigned int index = (this+coverage).get_coverage  (buffer->cur().codepoint);
+    unsigned int index = (this+coverage).get_coverage  (buffer->cur().codepoint, c->coverage_cache);
     if (likely (index == NOT_COVERED)) return_trace (false);
 
     hb_ot_apply_context_t::skipping_iterator_t &skippy_iter = c->iter_input;
@@ -1557,7 +1557,7 @@ struct PairPosFormat2
   {
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
-    unsigned int index = (this+coverage).get_coverage  (buffer->cur().codepoint);
+    unsigned int index = (this+coverage).get_coverage  (buffer->cur().codepoint, c->coverage_cache);
     if (likely (index == NOT_COVERED)) return_trace (false);
 
     hb_ot_apply_context_t::skipping_iterator_t &skippy_iter = c->iter_input;
@@ -1882,7 +1882,7 @@ struct CursivePosFormat1
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
 
-    const EntryExitRecord &this_record = entryExitRecord[(this+coverage).get_coverage  (buffer->cur().codepoint)];
+    const EntryExitRecord &this_record = entryExitRecord[(this+coverage).get_coverage  (buffer->cur().codepoint, c->coverage_cache)];
     if (!this_record.entryAnchor) return_trace (false);
 
     hb_ot_apply_context_t::skipping_iterator_t &skippy_iter = c->iter_input;
@@ -1894,7 +1894,7 @@ struct CursivePosFormat1
       return_trace (false);
     }
 
-    const EntryExitRecord &prev_record = entryExitRecord[(this+coverage).get_coverage  (buffer->info[skippy_iter.idx].codepoint)];
+    const EntryExitRecord &prev_record = entryExitRecord[(this+coverage).get_coverage  (buffer->info[skippy_iter.idx].codepoint, c->coverage_cache)];
     if (!prev_record.exitAnchor)
     {
       buffer->unsafe_to_concat_from_outbuffer (skippy_iter.idx, buffer->idx + 1);
@@ -2155,7 +2155,7 @@ struct MarkBasePosFormat1
   {
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
-    unsigned int mark_index = (this+markCoverage).get_coverage  (buffer->cur().codepoint);
+    unsigned int mark_index = (this+markCoverage).get_coverage  (buffer->cur().codepoint, c->coverage_cache);
     if (likely (mark_index == NOT_COVERED)) return_trace (false);
 
     /* Now we search backwards for a non-mark glyph */
@@ -2420,7 +2420,7 @@ struct MarkLigPosFormat1
   {
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
-    unsigned int mark_index = (this+markCoverage).get_coverage  (buffer->cur().codepoint);
+    unsigned int mark_index = (this+markCoverage).get_coverage  (buffer->cur().codepoint, c->coverage_cache);
     if (likely (mark_index == NOT_COVERED)) return_trace (false);
 
     /* Now we search backwards for a non-mark glyph */
@@ -2630,7 +2630,7 @@ struct MarkMarkPosFormat1
   {
     TRACE_APPLY (this);
     hb_buffer_t *buffer = c->buffer;
-    unsigned int mark1_index = (this+mark1Coverage).get_coverage  (buffer->cur().codepoint);
+    unsigned int mark1_index = (this+mark1Coverage).get_coverage  (buffer->cur().codepoint, c->coverage_cache);
     if (likely (mark1_index == NOT_COVERED)) return_trace (false);
 
     /* now we search backwards for a suitable mark glyph until a non-mark glyph */

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -623,6 +623,7 @@ struct hb_ot_apply_context_t :
   hb_buffer_t *buffer;
   recurse_func_t recurse_func = nullptr;
   const GDEF &gdef;
+  hb_coverage_cache_t *coverage_cache = nullptr;
   const VariationStore &var_store;
   VariationStore::cache_t *var_store_cache;
 
@@ -639,6 +640,8 @@ struct hb_ot_apply_context_t :
   bool random = false;
   uint32_t random_state = 1;
   unsigned new_syllables = (unsigned) -1;
+
+  hb_coverage_cache_t coverage_cache_static;
 
   hb_ot_apply_context_t (unsigned int table_index_,
 			 hb_font_t *font_,

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1891,12 +1891,23 @@ apply_string (OT::hb_ot_apply_context_t *c,
     /* in/out forward substitution/positioning */
     if (!Proxy::always_inplace)
       buffer->clear_output ();
+    else
+    if (lookup.get_subtable_count () == 1 && buffer->len >= 32)
+    {
+      c->coverage_cache = &c->coverage_cache_static;
+      c->coverage_cache->clear ();
+    }
 
     buffer->idx = 0;
     apply_forward (c, accel);
 
     if (!Proxy::always_inplace)
       buffer->sync ();
+    else
+    if (lookup.get_subtable_count () == 1)
+    {
+      c->coverage_cache = nullptr;
+    }
   }
   else
   {


### PR DESCRIPTION
A PR to use a cache in coverage checking of GPOS (GSUB can be done as well).

Slows things down, so abandoning. Posting for posterity.