### PR TITLE
[gi] Add freetype2-2.0 for g-i-r includes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -465,7 +465,7 @@ INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir)
 INTROSPECTION_SCANNER_ENV = CC="$(CC)"
 
 HarfBuzz-0.0.gir: libharfbuzz.la libharfbuzz-gobject.la
-HarfBuzz_0_0_gir_INCLUDES = GObject-2.0
+HarfBuzz_0_0_gir_INCLUDES = GObject-2.0 freetype2-2.0
 HarfBuzz_0_0_gir_CFLAGS = \
 	$(INCLUDES) \
 	$(HBCFLAGS) \

--- a/src/meson.build
+++ b/src/meson.build
@@ -674,7 +674,7 @@ if have_gobject
       nsversion: '0.0',
       identifier_prefix: 'hb_',
       symbol_prefix: ['hb', 'hb_gobject'],
-      includes: ['GObject-2.0'],
+      includes: ['GObject-2.0', 'freetype2-2.0'],
       export_packages: ['harfbuzz-gobject'],
       header: 'hb-gobject.h',
       install: true,


### PR DESCRIPTION
Fixes the warnings:
../src/hb-ft.cc:810: Warning: HarfBuzz: hb_ft_face_create: argument ft_face: Unresolved type: 'FT_Face'
../src/hb-ft.cc:886: Warning: HarfBuzz: hb_ft_face_create_cached: argument ft_face: Unresolved type: 'FT_Face'
../src/hb-ft.cc:855: Warning: HarfBuzz: hb_ft_face_create_referenced: argument ft_face: Unresolved type: 'FT_Face'
../src/hb-ft.cc:920: Warning: HarfBuzz: hb_ft_font_create: argument ft_face: Unresolved type: 'FT_Face'
../src/hb-ft.cc:1029: Warning: HarfBuzz: hb_ft_font_create_referenced: argument ft_face: Unresolved type: 'FT_Face'
../src/hb-ft.cc:240: Warning: HarfBuzz: hb_ft_font_get_face: return value: Unresolved type: 'FT_Face'
../src/hb-ft.cc:262: Warning: HarfBuzz: hb_ft_font_lock_face: return value: Unresolved type: 'FT_Face'