### PR TITLE
[layout] Use NEON SIMD instructions for apply_forward()

### DIFF
--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -3824,7 +3824,8 @@ struct hb_ot_layout_lookup_accelerator_t
   }
   void fini () { subtables.fini (); }
 
-  bool may_have (hb_codepoint_t g) const
+  template <typename T>
+  bool may_have (const T &g) const
   { return digest.may_have (g); }
 
   bool apply (hb_ot_apply_context_t *c, bool use_cache) const

--- a/src/hb-set-digest.hh
+++ b/src/hb-set-digest.hh
@@ -29,6 +29,8 @@
 
 #include "hb.hh"
 
+#include <arm_neon.h>
+
 /*
  * The set-digests here implement various "filters" that support
  * "approximate member query".  Conceptually these are like Bloom
@@ -116,10 +118,34 @@ struct hb_set_digest_bits_pattern_t
   bool may_have (hb_codepoint_t g) const
   { return mask & mask_for (g); }
 
+  static inline bool uint32x4_is_not_zero(uint32x4_t v)
+  {
+    // https://stackoverflow.com/questions/15389539/fastest-way-to-test-a-128-bit-neon-register-for-a-value-of-0-using-intrinsics
+    uint32x2_t tmp = vorr_u32(vget_low_u32(v), vget_high_u32(v));
+    return vget_lane_u32(vpmax_u32(tmp, tmp), 0);
+  }
+
+  bool may_have (const uint32x4_t &g) const
+  { return uint32x4_is_not_zero (vandq_u32 (vdupq_n_u32 (mask), mask_for (g))); }
+
   private:
 
   static mask_t mask_for (hb_codepoint_t g)
   { return ((mask_t) 1) << ((g >> shift) & (mask_bits - 1)); }
+
+  template <int u = shift,
+	    hb_enable_if (u == 0)>
+  static uint32x4_t shifted (uint32x4_t v) { return v; }
+  template <int u = shift,
+	    hb_enable_if (u != 0)>
+  static uint32x4_t shifted (uint32x4_t v) { return vshrq_n_u32 (v, shift); }
+
+  static uint32x4_t mask_for (const uint32x4_t &g)
+  {
+    uint32x4_t a = vandq_u32 (shifted (g), vdupq_n_u32 (mask_bits - 1));
+    return vshlq_u32 (vdupq_n_u32 (1), a);
+  }
+
   mask_t mask;
 };
 
@@ -162,7 +188,8 @@ struct hb_set_digest_combiner_t
   template <typename T>
   bool add_sorted_array (const hb_sorted_array_t<const T>& arr) { return add_sorted_array (&arr, arr.len ()); }
 
-  bool may_have (hb_codepoint_t g) const
+  template <typename T>
+  bool may_have (const T &g) const
   {
     return head.may_have (g) && tail.may_have (g);
   }
@@ -183,11 +210,11 @@ struct hb_set_digest_combiner_t
 using hb_set_digest_t =
   hb_set_digest_combiner_t
   <
-    hb_set_digest_bits_pattern_t<unsigned long, 4>,
+    hb_set_digest_bits_pattern_t<uint32_t, 4>,
     hb_set_digest_combiner_t
     <
-      hb_set_digest_bits_pattern_t<unsigned long, 0>,
-      hb_set_digest_bits_pattern_t<unsigned long, 9>
+      hb_set_digest_bits_pattern_t<uint32_t, 0>,
+      hb_set_digest_bits_pattern_t<uint32_t, 9>
     >
   >
 ;


### PR DESCRIPTION
    [layout] Use NEON SIMD instructions for apply_forward()
    
    To skip four glyphs at a time.
    
    Unfortunately slows down benchmark-shape by up to 25% for Amiri, instead of
    speeding anything up. This is due to the overhead of switching back and forth
    between the ARM and NEON processors.
    
    To be experimented with: Same architecture but with AVX on x86_64 to skip 8
    glyphs at a time.
    
    https://github.com/harfbuzz/harfbuzz/issues/566

Posting for posterity.