### PR TITLE
Fix the generated gobject headers

### DIFF
--- a/src/hb-gobject-enums.h.tmpl
+++ b/src/hb-gobject-enums.h.tmpl
@@ -43,7 +43,7 @@ HB_BEGIN_DECLS
 
 /*** BEGIN value-header ***/
 HB_EXTERN GType
-@enum_name@_get_type () G_GNUC_CONST;
+@enum_name@_get_type (void) G_GNUC_CONST;
 #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
 
 /*** END value-header ***/


### PR DESCRIPTION
These headers are not acceptable to modern compilers.
gcc says things like:

/usr/include/harfbuzz/hb-gobject-enums.h:100:1: warning:
  function declaration isn’t a prototype [-Wstrict-prototypes]
  100 | hb_gobject_ot_metrics_tag_get_type () G_GNUC_CONST;