### PR TITLE
Fix Windows build warnings

### DIFF
--- a/src/hb-meta.hh
+++ b/src/hb-meta.hh
@@ -188,7 +188,7 @@ template <> struct hb_int_max<signed long long>		: hb_integral_constant<signed l
 template <> struct hb_int_max<unsigned long long>	: hb_integral_constant<unsigned long long,	ULLONG_MAX>	{};
 #define hb_int_max(T) hb_int_max<T>::value
 
-#if __GNUG__ && __GNUC__ < 5
+#if defined(__GNUG__) && __GNUC__ < 5
 #define hb_is_trivially_copyable(T) __has_trivial_copy(T)
 #define hb_is_trivially_copy_assignable(T) __has_trivial_assign(T)
 #define hb_is_trivially_constructible(T) __has_trivial_constructor(T)

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -183,7 +183,7 @@
 #include <cassert>
 #include <cfloat>
 #include <climits>
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_USE_MATH_DEFINES)
 # define _USE_MATH_DEFINES
 #endif
 #include <cmath>


### PR DESCRIPTION
Fixes the following Windows warnings seen in Firefox builds:
```
hb-meta.hh(191,5): warning: '__GNUG__' is not defined, evaluates to 0 [-Wundef]
#if __GNUG__ && __GNUC__ < 5
    ^
```
```
hb.hh(187,10): error: '_USE_MATH_DEFINES' macro redefined [-Werror,-Wmacro-redefined]
# define _USE_MATH_DEFINES
         ^
mozilla-config.h(158,9): note: previous definition is here
#define _USE_MATH_DEFINES 1
        ^
```