### PR TITLE
[lao] Decompose and reorder U+0EB3 around U+0EBB

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -857,6 +857,11 @@ hb_in_ranges (T u, T lo1, T hi1, T lo2, T hi2, T lo3, T hi3)
 {
   return hb_in_range (u, lo1, hi1) || hb_in_range (u, lo2, hi2) || hb_in_range (u, lo3, hi3);
 }
+template <typename T> static inline bool
+hb_in_ranges (T u, T lo1, T hi1, T lo2, T hi2, T lo3, T hi3, T lo4, T hi4)
+{
+  return hb_in_range (u, lo1, hi1) || hb_in_range (u, lo2, hi2) || hb_in_range (u, lo3, hi3) || hb_in_range (u, lo4, hi4);
+}
 
 
 /*

--- a/src/hb-ot-shaper-thai.cc
+++ b/src/hb-ot-shaper-thai.cc
@@ -279,7 +279,7 @@ preprocess_text_thai (const hb_ot_shape_plan_t *plan,
    * to be what Uniscribe and other engines implement.  According to Eric Muller:
    *
    * When you have a SARA AM, decompose it in NIKHAHIT + SARA AA, *and* move the
-   * NIKHAHIT backwards over any above-base marks (0E31, 0E34-0E37, 0E47-0E4E).
+   * NIKHAHIT backwards over any above-base marks.
    *
    * <0E14, 0E4B, 0E33> -> <0E14, 0E4D, 0E4B, 0E32>
    *
@@ -308,8 +308,8 @@ preprocess_text_thai (const hb_ot_shape_plan_t *plan,
    * Nikhahit:		U+0E4D	U+0ECD
    *
    * Testing shows that Uniscribe reorder the following marks:
-   * Thai:	<0E31,0E34..0E37,0E47..0E4E>
-   * Lao:	<0EB1,0EB4..0EB7,0EC7..0ECE>
+   * Thai:	<0E31,0E34..0E37,     0E47..0E4E>
+   * Lao:	<0EB1,0EB4..0EB7,0EBB,0EC8..0ECD>
    *
    * Note how the Lao versions are the same as Thai + 0x80.
    */
@@ -319,7 +319,7 @@ preprocess_text_thai (const hb_ot_shape_plan_t *plan,
 #define IS_SARA_AM(x) (((x) & ~0x0080u) == 0x0E33u)
 #define NIKHAHIT_FROM_SARA_AM(x) ((x) - 0x0E33u + 0x0E4Du)
 #define SARA_AA_FROM_SARA_AM(x) ((x) - 1)
-#define IS_ABOVE_BASE_MARK(x) (hb_in_ranges<hb_codepoint_t> ((x) & ~0x0080u, 0x0E34u, 0x0E37u, 0x0E47u, 0x0E4Eu, 0x0E31u, 0x0E31u))
+#define IS_ABOVE_BASE_MARK(x) (hb_in_ranges<hb_codepoint_t> ((x) & ~0x0080u, 0x0E34u, 0x0E37u, 0x0E47u, 0x0E4Eu, 0x0E31u, 0x0E31u, 0x0E3Bu, 0x0E3Bu))
 
   buffer->clear_output ();
   unsigned int count = buffer->len;


### PR DESCRIPTION
U+0EBB LAO VOWEL SIGN MAI KON behaves like other above-base marks in the context of U+0EB3 LAO VOWEL SIGN AM in Notepad in Windows Server 2019. I changed HarfBuzz to match.

U+0EBB has no Thai counterpart. There are multiple marks that only exist in one block or the other, and the existing code did not try to detect reserved code points, so I didn’t do anything to prevent U+0E33 THAI CHARACTER SARA AM from reordering around the reserved U+0E3B. This does not match Uniscribe, but I guess reserved code points don’t matter.