### PR TITLE
Fix the annotation for hb_blob_get_data

### DIFF
--- a/src/hb-blob.cc
+++ b/src/hb-blob.cc
@@ -369,7 +369,7 @@ hb_blob_get_length (hb_blob_t *blob)
  *
  * Fetches the data from a blob.
  *
- * Returns: (transfer none) (array length=length): the byte data of @blob.
+ * Returns: (nullable) (transfer none) (array length=length): the byte data of @blob.
  *
  * Since: 0.9.2
  **/


### PR DESCRIPTION
This function will return NULL for the the
empty blob. That is important information for
bindings that treat nullability as a type trait.