### PR TITLE
[math] Improve fuzzing coverage

### DIFF
--- a/test/api/test-ot-face.c
+++ b/test/api/test-ot-face.c
@@ -127,20 +127,19 @@ test_font (hb_font_t *font, hb_codepoint_t cp)
 
   hb_ot_math_has_data (face);
   for (unsigned constant = HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN; constant <= HB_OT_MATH_CONSTANT_RADICAL_DEGREE_BOTTOM_RAISE_PERCENT; constant++) {
-    hb_ot_math_get_constant (font, constant);
+    hb_ot_math_get_constant (font, (hb_ot_math_constant_t)constant);
   }
-  hb_ot_math_get_constant (font, -1);
 
   hb_ot_math_get_glyph_italics_correction (font, cp);
   hb_ot_math_get_glyph_top_accent_attachment (font, cp);
   hb_ot_math_is_glyph_extended_shape (face, cp);
 
-  for (unsigned kern = HB_OT_MATH_KERN_TOP_RIGHT; kern <= HB_OT_MATH_KERN_BOTTOM_LEFT; kern++) {
-    hb_ot_math_get_glyph_kerning (font, cp, kern, 0);
-    hb_ot_math_get_glyph_kernings (font, cp, kern, 0, NULL, NULL);
+  {
+    hb_ot_math_get_glyph_kerning (font, cp, HB_OT_MATH_KERN_BOTTOM_RIGHT, 0);
+    hb_ot_math_get_glyph_kernings (font, cp, HB_OT_MATH_KERN_BOTTOM_RIGHT, 0, NULL, NULL);
     hb_ot_math_kern_entry_t entries[5];
     unsigned count = sizeof (entries) / sizeof (entries[0]);
-    hb_ot_math_get_glyph_kernings (font, cp, kern, 0, &count, entries);
+    hb_ot_math_get_glyph_kernings (font, cp, HB_OT_MATH_KERN_BOTTOM_RIGHT, 0, &count, entries);
   }
 
   {

--- a/test/api/test-ot-face.c
+++ b/test/api/test-ot-face.c
@@ -126,15 +126,40 @@ test_font (hb_font_t *font, hb_codepoint_t cp)
   }
 
   hb_ot_math_has_data (face);
-  hb_ot_math_get_constant (font, HB_OT_MATH_CONSTANT_MATH_LEADING);
+  for (unsigned constant = HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN; constant <= HB_OT_MATH_CONSTANT_RADICAL_DEGREE_BOTTOM_RAISE_PERCENT; constant++) {
+    hb_ot_math_get_constant (font, constant);
+  }
+  hb_ot_math_get_constant (font, -1);
+
   hb_ot_math_get_glyph_italics_correction (font, cp);
   hb_ot_math_get_glyph_top_accent_attachment (font, cp);
   hb_ot_math_is_glyph_extended_shape (face, cp);
-  hb_ot_math_get_glyph_kerning (font, cp, HB_OT_MATH_KERN_BOTTOM_RIGHT, 0);
-  hb_ot_math_get_glyph_kernings (font, cp, HB_OT_MATH_KERN_BOTTOM_RIGHT, 0, NULL, NULL);
-  hb_ot_math_get_glyph_variants (font, cp, HB_DIRECTION_TTB, 0, NULL, NULL);
-  hb_ot_math_get_min_connector_overlap (font, HB_DIRECTION_RTL);
-  hb_ot_math_get_glyph_assembly (font, cp, HB_DIRECTION_BTT, 0, NULL, NULL, NULL);
+
+  for (unsigned kern = HB_OT_MATH_KERN_TOP_RIGHT; kern <= HB_OT_MATH_KERN_BOTTOM_LEFT; kern++) {
+    hb_ot_math_get_glyph_kerning (font, cp, kern, 0);
+    hb_ot_math_get_glyph_kernings (font, cp, kern, 0, NULL, NULL);
+    hb_ot_math_kern_entry_t entries[5];
+    unsigned count = sizeof (entries) / sizeof (entries[0]);
+    hb_ot_math_get_glyph_kernings (font, cp, kern, 0, &count, entries);
+  }
+
+  {
+    hb_ot_math_get_glyph_variants (font, cp, HB_DIRECTION_LTR, 0, NULL, NULL);
+    hb_ot_math_get_glyph_variants (font, cp, HB_DIRECTION_TTB, 0, NULL, NULL);
+    hb_ot_math_glyph_variant_t entries[5];
+    unsigned count = sizeof (entries) / sizeof (entries[0]);
+    hb_ot_math_get_glyph_variants (font, cp, HB_DIRECTION_LTR, 0, &count, entries);
+  }
+
+  {
+    hb_ot_math_get_min_connector_overlap (font, HB_DIRECTION_LTR);
+    hb_ot_math_get_glyph_assembly (font, cp, HB_DIRECTION_LTR, 0, NULL, NULL, NULL);
+    hb_ot_math_get_glyph_assembly (font, cp, HB_DIRECTION_TTB, 0, NULL, NULL, NULL);
+    hb_ot_math_glyph_part_t entries[5];
+    unsigned count = sizeof (entries) / sizeof (entries[0]);
+    hb_position_t corr;
+    hb_ot_math_get_glyph_assembly (font, cp, HB_DIRECTION_LTR, 0, &count, entries, &corr);
+  }
 
   hb_ot_meta_get_entry_tags (face, 0, NULL, NULL);
   hb_blob_destroy (hb_ot_meta_reference_entry (face, HB_OT_META_TAG_DESIGN_LANGUAGES));


### PR DESCRIPTION
Extend testing to cover parts that are missing according to the recent
oss-fuzz-coverage report:
- Retriving all constants from MathConstants.
- Retrieving entries from MathKern, MathGlyphPartRecord and
  MathGlyphAssembly.
- Retrieving italic correction from MathGlyphAssembly.
- Choosing between horizontal/vertical offset in MathVariants.

https://storage.googleapis.com/oss-fuzz-coverage/harfbuzz/reports/20220627/linux/src/harfbuzz/src/hb-ot-math-table.hh.html
https://github.com/harfbuzz/harfbuzz/issues/3688