### PR TITLE
Fix target_link_libraries signatures mixing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,7 +434,7 @@ target_include_directories(harfbuzz PUBLIC
                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/harfbuzz>")
 if (HB_HAVE_FREETYPE AND TARGET freetype)
-  target_link_libraries(harfbuzz PUBLIC freetype)
+  target_link_libraries(harfbuzz freetype)
 endif ()
 
 


### PR DESCRIPTION
Fixing CMake configuration error introduced in https://github.com/harfbuzz/harfbuzz/pull/3361:

```
CMake Error at libs/harfbuzz/CMakeLists.txt:437 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "harfbuzz".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * libs/harfbuzz/CMakeLists.txt:432 (target_link_libraries)
```

According to https://cmake.org/cmake/help/v3.9/policy/CMP0023.html:

> Plain and keyword target_link_libraries signatures cannot be mixed.