### PR TITLE
docs: Clarify 0xFFFF as palette index

### DIFF
--- a/src/hb-ot-color.h
+++ b/src/hb-ot-color.h
@@ -102,6 +102,10 @@ hb_ot_color_has_layers (hb_face_t *face);
  *
  * Pairs of glyph and color index.
  *
+ * A color index of 0xFFFF does not refer to a palette
+ * color, but indicates that the foreground color should
+ * be used.
+ *
  * Since: 2.1.0
  **/
 typedef struct hb_ot_color_layer_t {


### PR DESCRIPTION
Mention that a palette index of 0xFFFF
means to use the foreground color.