### PR TITLE
[repacker] Increase max_rounds when called via public api.

### DIFF
--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -157,7 +157,7 @@ template<typename T>
 inline hb_blob_t*
 hb_resolve_overflows (const T& packed,
                       hb_tag_t table_tag,
-                      unsigned max_rounds = 20) {
+                      unsigned max_rounds = 40) {
   graph_t sorted_graph (packed);
   sorted_graph.sort_shortest_distance ();
 

--- a/src/hb-subset-repacker.cc
+++ b/src/hb-subset-repacker.cc
@@ -43,7 +43,7 @@ hb_blob_t* hb_subset_repack_or_fail (hb_object_t* hb_objects, unsigned num_hb_ob
   packed.push (nullptr);
   for (unsigned i = 0 ; i < num_hb_objs ; i++)
     packed.push (&(hb_objects[i]));
+
   return hb_resolve_overflows (packed, HB_OT_TAG_GSUB);
 }
 #endif
-


### PR DESCRIPTION
Fix for https://github.com/fonttools/fonttools/issues/2691