### PR TITLE
[meta] Fix warning with emscripten

### DIFF
--- a/src/hb-meta.hh
+++ b/src/hb-meta.hh
@@ -188,7 +188,7 @@ template <> struct hb_int_max<signed long long>		: hb_integral_constant<signed l
 template <> struct hb_int_max<unsigned long long>	: hb_integral_constant<unsigned long long,	ULLONG_MAX>	{};
 #define hb_int_max(T) hb_int_max<T>::value
 
-#if defined(__GNUC__) && __GNUC__ < 5
+#if defined(__GNUC__) && __GNUC__ < 5 && !defined(__clang__)
 #define hb_is_trivially_copyable(T) __has_trivial_copy(T)
 #define hb_is_trivially_copy_assignable(T) __has_trivial_assign(T)
 #define hb_is_trivially_constructible(T) __has_trivial_constructor(T)


### PR DESCRIPTION
For whatever reason, em++ takes the first branch and spouts a gazillion warnings like:

```
./harfbuzz/src/hb-vector.hh:229:20: warning: builtin __has_trivial_assign is deprecated; use __is_trivially_assignable instead [-Wdeprecated-builtins]
            hb_enable_if (hb_is_trivially_copy_assignable(T))>
                          ^
./harfbuzz/src/hb-meta.hh:193:44: note: expanded from macro 'hb_is_trivially_copy_assignable'
```