### PR TITLE
build fix for HB_NO_VAR in hb-subset-plan.cc

### DIFF
--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -589,7 +589,7 @@ _nameid_closure (hb_face_t *face,
 #endif
 }
 
-
+#ifndef HB_NO_VAR
 static void
 _normalize_axes_location (hb_face_t *face,
 			  const hb_hashmap_t<hb_tag_t, float> *user_axes_location,
@@ -631,6 +631,7 @@ _normalize_axes_location (hb_face_t *face,
   }
   all_axes_pinned = !axis_not_pinned;
 }
+#endif
 /**
  * hb_subset_plan_create_or_fail:
  * @face: font face to create the plan for.
@@ -730,10 +731,12 @@ hb_subset_plan_create_or_fail (hb_face_t	 *face,
         plan->glyph_map->get(plan->unicode_to_new_gid_list.arrayZ[i].second);
   }
 
+#ifndef HB_NO_VAR
   _normalize_axes_location (face,
                             input->axes_location,
                             plan->axes_location,
                             plan->all_axes_pinned);
+#endif
 
   _nameid_closure (face, plan->name_ids, plan->all_axes_pinned, plan->user_axes_location);
   if (unlikely (plan->in_error ())) {


### PR DESCRIPTION
So this just fixed issues in subset_plan.cc, the build is not fine yet. 

I see there're still build issues in hb-shape:
```
FAILED: util/hb-ot-shape-closure 
c++  -o util/hb-ot-shape-closure util/hb-ot-shape-closure.p/hb-ot-shape-closure.cc.o -Wl,--as-needed -Wl,--no-undefined -DHB_NO_VAR=1 '-Wl,-rpath,$ORIGIN/../src' -Wl,-rpath-link,/usr/local/google/home/qxliu/harfbuzz/build/src -Wl,--start-group src/libharfbuzz.so.0.40401.0 /usr/lib/x86_64-linux-gnu/libfreetype.so /usr/lib/x86_64-linux-gnu/libcairo.so /usr/lib/x86_64-linux-gnu/libglib-2.0.so -Wl,--end-group
/usr/bin/ld: util/hb-ot-shape-closure.p/hb-ot-shape-closure.cc.o: in function `font_options_t::post_parse(_GError**)':
/usr/local/google/home/qxliu/harfbuzz/build/../util/font-options.hh:105: undefined reference to `hb_font_set_variations'
collect2: error: ld returned 1 exit status
[208/279] Linking target util/hb-view
FAILED: util/hb-view 
c++  -o util/hb-view util/hb-view.p/hb-view.cc.o -Wl,--as-needed -Wl,--no-undefined -DHB_NO_VAR=1 '-Wl,-rpath,$ORIGIN/../src' -Wl,-rpath-link,/usr/local/google/home/qxliu/harfbuzz/build/src -Wl,--start-group src/libharfbuzz.so.0.40401.0 /usr/lib/x86_64-linux-gnu/libfreetype.so /usr/lib/x86_64-linux-gnu/libcairo.so /usr/lib/x86_64-linux-gnu/libglib-2.0.so -Wl,--end-group
/usr/bin/ld: util/hb-view.p/hb-view.cc.o: in function `font_options_t::post_parse(_GError**)':
/usr/local/google/home/qxliu/harfbuzz/build/../util/font-options.hh:105: undefined reference to `hb_font_set_variations'
/usr/bin/ld: util/hb-view.p/hb-view.cc.o: in function `helper_cairo_create_ft_font_face(font_options_t const*)':
/usr/local/google/home/qxliu/harfbuzz/build/../util/helper-cairo-ft.hh:85: undefined reference to `hb_font_get_var_coords_normalized'
collect2: error: ld returned 1 exit status
[209/279] Linking target util/hb-shape
FAILED: util/hb-shape 
c++  -o util/hb-shape util/hb-shape.p/hb-shape.cc.o -Wl,--as-needed -Wl,--no-undefined -DHB_NO_VAR=1 '-Wl,-rpath,$ORIGIN/../src' -Wl,-rpath-link,/usr/local/google/home/qxliu/harfbuzz/build/src -Wl,--start-group src/libharfbuzz.so.0.40401.0 /usr/lib/x86_64-linux-gnu/libfreetype.so /usr/lib/x86_64-linux-gnu/libcairo.so /usr/lib/x86_64-linux-gnu/libglib-2.0.so -Wl,--end-group
/usr/bin/ld: util/hb-shape.p/hb-shape.cc.o: in function `font_options_t::post_parse(_GError**)':
/usr/local/google/home/qxliu/harfbuzz/build/../util/font-options.hh:105: undefined reference to `hb_font_set_variations'
collect2: error: ld returned 1 exit status
[211/279] Linking target test/threads/hb-shape-threads
FAILED: test/threads/hb-shape-threads 
c++  -o test/threads/hb-shape-threads test/threads/hb-shape-threads.p/hb-shape-threads.cc.o -Wl,--as-needed -Wl,--no-undefined -DHB_NO_VAR=1 '-Wl,-rpath,$ORIGIN/../../src' -Wl,-rpath-link,/usr/local/google/home/qxliu/harfbuzz/build/src -Wl,--start-group src/libharfbuzz.so.0.40401.0 /usr/lib/x86_64-linux-gnu/libfreetype.so -Wl,--end-group -pthread
/usr/bin/ld: test/threads/hb-shape-threads.p/hb-shape-threads.cc.o: in function `test_backend(backend_t, char const*, bool, test_input_t const&)':
/usr/local/google/home/qxliu/harfbuzz/build/../test/threads/hb-shape-threads.cc:138: undefined reference to `hb_font_set_variations'
collect2: error: ld returned 1 exit status
[214/279] Compiling C++ object src/libharfbuzz-subset.so.0.40401.0.p/hb-subset.cc.o
ninja: build stopped: subcommand failed.
```
As I fixed those, more issues popped up in other files. I'm not familiar with hb-shape and hb-draw, not sure what is the best solution for them.
