### PR TITLE
[repacker] Extension promotion mechanism in the repacker

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -399,7 +399,7 @@ test_priority_queue_SOURCES = test-priority-queue.cc hb-static.cc
 test_priority_queue_CPPFLAGS = $(HBCFLAGS)
 test_priority_queue_LDADD = libharfbuzz.la $(HBLIBS)
 
-test_repacker_SOURCES = test-repacker.cc hb-static.cc
+test_repacker_SOURCES = test-repacker.cc hb-static.cc graph/gsubgpos-graph.cc
 test_repacker_CPPFLAGS = $(HBCFLAGS)
 test_repacker_LDADD = libharfbuzz.la libharfbuzz-subset.la $(HBLIBS)
 

--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -348,6 +348,8 @@ HB_SUBSET_sources = \
 	hb-subset.hh \
 	hb-repacker.hh \
 	graph/graph.hh \
+	graph/gsubgpos-graph.hh \
+	graph/gsubgpos-graph.cc \
 	graph/serialize.hh \
 	$(NULL)
 

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -310,41 +310,6 @@ struct graph_t
     }
   }
 
-
-  /*
-  void promote_extension_lookups (const hb_set_t& subtable_indices)
-  {
-    const OT::GSUBGPOS* gstar = (OT::GSUBGPOS*) root ().obj.head;
-
-    unsigned lookup_list_idx = index_for_offset (root_idx (), &(gstar->lookupList));
-    const OT::LookupList<SmallTypes>* lookupList =
-        (OT::LookupList<SmallTypes>*) object (lookup_list_idx).head;
-
-
-    for (unsigned i = 0; i < lookupList->len; i++)
-    {
-      unsigned lookup_idx = index_for_offset (lookup_list_idx, &(lookupList->arrayZ[i]));
-      const OT::Lookup* lookup = (OT::Lookup*) object (lookup_idx).head;
-
-      // TODO(grieger): use the correct type for GSUB vs GPOS
-      if (lookup->get_type () == 9) continue; // skip extensions
-
-      for (unsigned j = 0; j < lookup->subTable.len; j++)
-      {
-        unsigned subtable_idx = index_for_offset (lookup_idx, &(lookup->subTable.arrayZ[j]));
-        if (subtable_indices.has (subtable_idx))
-          promote_to_extension (lookup_idx);
-      }
-    }
-  }
-
-  void promote_to_extension (unsigned lookup_idx)
-  {
-    DEBUG_MSG (SUBSET_REPACK, nullptr, "Promoting %d to extension lookup.", lookup_idx);
-    // TODO(garretrieger): implement me.
-  }
-  */
-
   unsigned index_for_offset(unsigned node_idx, const void* offset) const
   {
     const auto& node = object (node_idx);
@@ -642,7 +607,6 @@ struct graph_t
   {
     positions_invalid = true;
     distance_invalid = true;
-    parents_invalid = true; // TODO: remove
 
     auto* clone = vertices_.push ();
     if (vertices_.in_error ()) {

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -111,6 +111,10 @@ struct graph_t
       return priority >= 3;
     }
 
+    size_t table_size () const {
+      return obj.tail - obj.head;
+    }
+
     int64_t modified_distance (unsigned order) const
     {
       // TODO(garretrieger): once priority is high enough, should try

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -621,7 +621,6 @@ struct graph_t
     clone->obj.tail = tail;
     clone->distance = 0;
     clone->space = 0;
-    printf("Creating new node from %p to %p\n", head, tail);
 
     unsigned clone_idx = vertices_.length - 2;
 

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -653,6 +653,7 @@ struct graph_t
     clone->obj.tail = tail;
     clone->distance = 0;
     clone->space = 0;
+    printf("Creating new node from %p to %p\n", head, tail);
 
     unsigned clone_idx = vertices_.length - 2;
 

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -484,15 +484,18 @@ struct graph_t
       find_subgraph (link.objidx, subgraph);
   }
 
-  size_t find_subgraph_size (unsigned node_idx, hb_set_t& subgraph)
+  size_t find_subgraph_size (unsigned node_idx, hb_set_t& subgraph, unsigned max_depth = -1)
   {
     if (subgraph.has (node_idx)) return 0;
     subgraph.add (node_idx);
 
     const auto& o = vertices_[node_idx].obj;
     size_t size = o.tail - o.head;
+    if (max_depth == 0)
+      return size;
+
     for (const auto& link : o.all_links ())
-      size += find_subgraph_size (link.objidx, subgraph);
+      size += find_subgraph_size (link.objidx, subgraph, max_depth - 1);
     return size;
   }
 

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -24,9 +24,9 @@
  * Google Author(s): Garret Rieger
  */
 
-#include "hb-set.hh"
-#include "hb-priority-queue.hh"
-#include "hb-serialize.hh"
+#include "../hb-set.hh"
+#include "../hb-priority-queue.hh"
+#include "../hb-serialize.hh"
 
 #ifndef GRAPH_GRAPH_HH
 #define GRAPH_GRAPH_HH

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -480,6 +480,18 @@ struct graph_t
       find_subgraph (link.objidx, subgraph);
   }
 
+  size_t find_subgraph_size (unsigned node_idx, hb_set_t& subgraph)
+  {
+    if (subgraph.has (node_idx)) return 0;
+    subgraph.add (node_idx);
+
+    const auto& o = vertices_[node_idx].obj;
+    size_t size = o.tail - o.head;
+    for (const auto& link : o.all_links ())
+      size += find_subgraph_size (link.objidx, subgraph);
+    return size;
+  }
+
   /*
    * Finds the topmost children of 32bit offsets in the subgraph starting
    * at node_idx. Found indices are placed into 'found'.

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -24,6 +24,10 @@
  * Google Author(s): Garret Rieger
  */
 
+#include "hb-set.hh"
+#include "hb-priority-queue.hh"
+#include "hb-serialize.hh"
+
 #ifndef GRAPH_GRAPH_HH
 #define GRAPH_GRAPH_HH
 

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -310,6 +310,57 @@ struct graph_t
     }
   }
 
+
+  /*
+  void promote_extension_lookups (const hb_set_t& subtable_indices)
+  {
+    const OT::GSUBGPOS* gstar = (OT::GSUBGPOS*) root ().obj.head;
+
+    unsigned lookup_list_idx = index_for_offset (root_idx (), &(gstar->lookupList));
+    const OT::LookupList<SmallTypes>* lookupList =
+        (OT::LookupList<SmallTypes>*) object (lookup_list_idx).head;
+
+
+    for (unsigned i = 0; i < lookupList->len; i++)
+    {
+      unsigned lookup_idx = index_for_offset (lookup_list_idx, &(lookupList->arrayZ[i]));
+      const OT::Lookup* lookup = (OT::Lookup*) object (lookup_idx).head;
+
+      // TODO(grieger): use the correct type for GSUB vs GPOS
+      if (lookup->get_type () == 9) continue; // skip extensions
+
+      for (unsigned j = 0; j < lookup->subTable.len; j++)
+      {
+        unsigned subtable_idx = index_for_offset (lookup_idx, &(lookup->subTable.arrayZ[j]));
+        if (subtable_indices.has (subtable_idx))
+          promote_to_extension (lookup_idx);
+      }
+    }
+  }
+
+  void promote_to_extension (unsigned lookup_idx)
+  {
+    DEBUG_MSG (SUBSET_REPACK, nullptr, "Promoting %d to extension lookup.", lookup_idx);
+    // TODO(garretrieger): implement me.
+  }
+  */
+
+  unsigned index_for_offset(unsigned node_idx, const void* offset) const
+  {
+    const auto& node = object (node_idx);
+    if (offset < node.head || offset >= node.tail) return -1;
+
+    for (const auto& link : node.real_links)
+    {
+      if (offset != node.head + link.position)
+        continue;
+      return link.objidx;
+    }
+
+    return -1;
+  }
+
+
   /*
    * Assign unique space numbers to each connected subgraph of 24 bit and/or 32 bit offset(s).
    * Currently, this is implemented specifically tailored to the structure of a GPOS/GSUB

--- a/src/graph/gsubgpos-graph.cc
+++ b/src/graph/gsubgpos-graph.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Garret Rieger
+ */
+
+#include "gsubgpos-graph.hh"
+
+namespace graph {
+
+unsigned make_extension_context_t::num_non_ext_subtables ()  {
+  unsigned count = 0;
+  for (auto l : lookups.values ())
+  {
+    if (l->is_extension (table_tag)) continue;
+    count += l->number_of_subtables ();
+  }
+  return count;
+}
+
+}

--- a/src/graph/gsubgpos-graph.cc
+++ b/src/graph/gsubgpos-graph.cc
@@ -34,11 +34,14 @@ make_extension_context_t::make_extension_context_t (hb_tag_t table_tag_,
     : table_tag (table_tag_),
       graph (graph_),
       buffer (buffer_),
+      lookup_list_index (0),
       lookups ()
 {
   GSTAR* gstar = graph::GSTAR::graph_to_gstar (graph_);
-  if (gstar)
+  if (gstar) {
     gstar->find_lookups (graph, lookups);
+    lookup_list_index = gstar->get_lookup_list_index (graph_);
+  }
 
   unsigned extension_size = OT::ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>::static_size;
   buffer.alloc (num_non_ext_subtables () * extension_size);

--- a/src/graph/gsubgpos-graph.cc
+++ b/src/graph/gsubgpos-graph.cc
@@ -28,6 +28,22 @@
 
 namespace graph {
 
+make_extension_context_t::make_extension_context_t (hb_tag_t table_tag_,
+                                                    graph_t& graph_,
+                                                    hb_vector_t<char>& buffer_)
+    : table_tag (table_tag_),
+      graph (graph_),
+      buffer (buffer_),
+      lookups ()
+{
+  GSTAR* gstar = graph::GSTAR::graph_to_gstar (graph_);
+  if (gstar)
+    gstar->find_lookups (graph, lookups);
+
+  unsigned extension_size = OT::ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>::static_size;
+  buffer.alloc (num_non_ext_subtables () * extension_size);
+}
+
 unsigned make_extension_context_t::num_non_ext_subtables ()  {
   unsigned count = 0;
   for (auto l : lookups.values ())

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -39,7 +39,7 @@ struct make_extension_context_t
 {
   hb_tag_t table_tag;
   graph_t& graph;
-  hb_vector_t<char> buffer;
+  hb_vector_t<char>& buffer;
   hb_hashmap_t<unsigned, graph::Lookup*> lookups;
 
   HB_INTERNAL make_extension_context_t (hb_tag_t table_tag_,

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -40,6 +40,7 @@ struct make_extension_context_t
   hb_tag_t table_tag;
   graph_t& graph;
   hb_vector_t<char>& buffer;
+  unsigned lookup_list_index;
   hb_hashmap_t<unsigned, graph::Lookup*> lookups;
 
   HB_INTERNAL make_extension_context_t (hb_tag_t table_tag_,
@@ -224,12 +225,17 @@ struct GSTAR : public OT::GSUBGPOS
     }
   }
 
+  unsigned get_lookup_list_index (graph_t& graph)
+  {
+    return graph.index_for_offset (graph.root_idx (),
+                                   get_lookup_list_field_offset());
+  }
+
   template<typename Types>
   void find_lookups (graph_t& graph,
                      hb_hashmap_t<unsigned, Lookup*>& lookups /* OUT */)
   {
-    unsigned lookup_list_idx = graph.index_for_offset (graph.root_idx (),
-                                                       get_lookup_list_field_offset());
+    unsigned lookup_list_idx = get_lookup_list_index (graph);
 
     const LookupList<Types>* lookupList =
         (const LookupList<Types>*) graph.object (lookup_list_idx).head;

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -25,8 +25,8 @@
  */
 
 #include "graph.hh"
-#include "hb-ot-layout-gsubgpos.hh"
-#include "OT/Layout/GSUB/ExtensionSubst.hh"
+#include "../hb-ot-layout-gsubgpos.hh"
+#include "../OT/Layout/GSUB/ExtensionSubst.hh"
 
 #ifndef GRAPH_GSUBGPOS_GRAPH_HH
 #define GRAPH_GSUBGPOS_GRAPH_HH

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -104,8 +104,9 @@ struct Lookup : public OT::Lookup
     unsigned type = lookupType;
     unsigned extension_size = OT::ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>::static_size;
     unsigned start = buffer.length;
-    unsigned end = start + extension_size;
+    unsigned end = start + extension_size - 1;
     if (!buffer.resize (buffer.length + extension_size))
+      // TODO: resizing potentially invalidates existing head/tail pointers.
       return false;
 
     OT::ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>* extension =

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2022  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Garret Rieger
+ */
+
+#ifndef GRAPH_GSUBGPOS_GRAPH_HH
+#define GRAPH_GSUBGPOS_GRAPH_HH
+
+#include "graph.hh"
+#include "hb-ot-layout-gsubgpos.hh"
+#include "OT/Layout/GSUB/ExtensionSubst.hh"
+
+namespace graph {
+
+struct GSTAR : public OT::GSUBGPOS
+{
+  const void* get_lookup_list_field_offset () const
+  {
+    switch (u.version.major) {
+    case 1: return &(u.version1.lookupList);
+#ifndef HB_NO_BORING_EXPANSION
+    case 2: return &(u.version2.lookupList);
+#endif
+    default: return 0;
+    }
+  }
+
+};
+
+struct Lookup : public OT::Lookup
+{
+  unsigned extension_type (hb_tag_t table_tag)
+  {
+    switch (table_tag)
+    {
+    case HB_OT_TAG_GPOS: return 9;
+    case HB_OT_TAG_GSUB: return 7;
+    default: return 0;
+    }
+  }
+
+  bool make_extension (hb_tag_t table_tag,
+                       graph_t& graph,
+                       unsigned this_index,
+                       hb_vector_t<char>& buffer)
+  {
+    // TODO: use a context_t?
+    unsigned ext_type = extension_type (table_tag);
+    unsigned type = lookupType;
+    if (!ext_type || type == ext_type)
+    {
+      // NOOP
+      printf("Already extension (obj %u).\n", this_index);
+      return true;
+    }
+
+    printf("Promoting lookup type %u (obj %u) to extension.\n",
+           type,
+           this_index);
+
+
+    for (unsigned i = 0; i < subTable.len; i++)
+    {
+      unsigned subtable_index = graph.index_for_offset (this_index, &subTable[i]);
+      if (!make_subtable_extension (graph,
+                                    this_index,
+                                    subtable_index,
+                                    buffer))
+        return false;
+    }
+
+    lookupType = ext_type;
+    return true;
+  }
+
+  bool make_subtable_extension (graph_t& graph,
+                                unsigned lookup_index,
+                                unsigned subtable_index,
+                                hb_vector_t<char>& buffer)
+  {
+    printf("  Promoting subtable %u in lookup %u to extension.\n", subtable_index, lookup_index);
+
+    unsigned type = lookupType;
+    unsigned extension_size = OT::ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>::static_size;
+    unsigned start = buffer.length;
+    unsigned end = start + extension_size;
+    if (!buffer.resize (buffer.length + extension_size))
+      return false;
+
+    OT::ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>* extension =
+        (OT::ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>*) &buffer[start];
+    extension->format = 1;
+    extension->extensionLookupType = type;
+    extension->extensionOffset = 0;
+
+    unsigned ext_index = graph.new_node (&buffer[start], &buffer[end]);
+    if (ext_index == (unsigned) -1) return false;
+
+    auto& lookup_vertex = graph.vertices_[lookup_index];
+    for (auto& l : lookup_vertex.obj.real_links.writer ())
+    {
+      if (l.objidx == subtable_index)
+      {
+        // Change lookup to point at the extension.
+        printf("  Changing %d to %d\n", l.objidx, ext_index);
+        l.objidx = ext_index;
+      }
+    }
+
+    // Make extension point at the subtable.
+    // TODO: update extension parents array.
+    auto& ext_vertex = graph.vertices_[ext_index];
+    auto& subtable_vertex = graph.vertices_[subtable_index];
+    auto* l = ext_vertex.obj.real_links.push ();
+
+    l->width = 4;
+    l->objidx = subtable_index;
+    l->is_signed = 0;
+    l->whence = 0;
+    l->position = 4;
+    l->bias = 0;
+
+    subtable_vertex.remap_parent (lookup_index, ext_index);
+
+    return true;
+  }
+};
+
+static inline void
+find_lookups (graph_t& graph,
+              hb_hashmap_t<unsigned, Lookup*>& lookups /* OUT */)
+{
+  // TODO: move this into GSTAR?
+  // TODO: template on types, based on gstar version.
+  const GSTAR* gstar = (const GSTAR*) graph.root ().obj.head;
+
+  unsigned lookup_list_idx = graph.index_for_offset (graph.root_idx (),
+                                                     gstar->get_lookup_list_field_offset());
+
+  const OT::LookupList<SmallTypes>* lookupList =
+      (const OT::LookupList<SmallTypes>*) graph.object (lookup_list_idx).head;
+
+  for (unsigned i = 0; i < lookupList->len; i++)
+  {
+    unsigned lookup_idx = graph.index_for_offset (lookup_list_idx, &(lookupList->arrayZ[i]));
+    Lookup* lookup = (Lookup*) graph.object (lookup_idx).head;
+    lookups.set (lookup_idx, lookup);
+  }
+}
+
+}
+
+#endif  /* GRAPH_GSUBGPOS_GRAPH_HH */

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -200,8 +200,8 @@ struct GSTAR : public OT::GSUBGPOS
   bool sanitize (const graph_t::vertex_t& vertex)
   {
     int64_t len = vertex.obj.tail - vertex.obj.head;
-    // Only need access to fields in min_size
-    return len >= OT::GSUBGPOS::min_size;
+    if (len < OT::GSUBGPOS::min_size) return false;
+    return len >= get_size ();
   }
 
   void find_lookups (graph_t& graph,

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -104,7 +104,7 @@ struct Lookup : public OT::Lookup
     unsigned type = lookupType;
     unsigned extension_size = OT::ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>::static_size;
     unsigned start = buffer.length;
-    unsigned end = start + extension_size - 1;
+    unsigned end = start + extension_size;
     if (!buffer.resize (buffer.length + extension_size))
       // TODO: resizing potentially invalidates existing head/tail pointers.
       return false;
@@ -115,7 +115,11 @@ struct Lookup : public OT::Lookup
     extension->extensionLookupType = type;
     extension->extensionOffset = 0;
 
-    unsigned ext_index = graph.new_node (&buffer[start], &buffer[end]);
+    unsigned type_prime = extension->extensionLookupType;
+    printf("Assigned type %d to extension\n", type_prime);
+
+    unsigned ext_index = graph.new_node (&buffer.arrayZ[start],
+                                         &buffer.arrayZ[end]);
     if (ext_index == (unsigned) -1) return false;
 
     auto& lookup_vertex = graph.vertices_[lookup_index];
@@ -142,6 +146,7 @@ struct Lookup : public OT::Lookup
     l->position = 4;
     l->bias = 0;
 
+    ext_vertex.parents.push (lookup_index);
     subtable_vertex.remap_parent (lookup_index, ext_index);
 
     return true;

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -86,7 +86,7 @@ struct Lookup : public OT::Lookup
     }
 
     DEBUG_MSG (SUBSET_REPACK, nullptr,
-               "Promoting lookup type %u (obj %u) to extension.\n",
+               "Promoting lookup type %u (obj %u) to extension.",
                type,
                this_index);
 

--- a/src/graph/serialize.hh
+++ b/src/graph/serialize.hh
@@ -205,6 +205,7 @@ inline hb_blob_t* serialize (const graph_t& graph)
 {
   hb_vector_t<char> buffer;
   size_t size = graph.total_size_in_bytes ();
+  printf("Expected graph size: %lu.\n", size);
   if (!buffer.alloc (size)) {
     DEBUG_MSG (SUBSET_REPACK, nullptr, "Unable to allocate output buffer.");
     return nullptr;

--- a/src/graph/serialize.hh
+++ b/src/graph/serialize.hh
@@ -205,7 +205,6 @@ inline hb_blob_t* serialize (const graph_t& graph)
 {
   hb_vector_t<char> buffer;
   size_t size = graph.total_size_in_bytes ();
-  printf("Expected graph size: %lu.\n", size);
   if (!buffer.alloc (size)) {
     DEBUG_MSG (SUBSET_REPACK, nullptr, "Unable to allocate output buffer.");
     return nullptr;

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -1337,7 +1337,7 @@ struct Lookup
     return_trace (true);
   }
 
-  private:
+  protected:
   HBUINT16	lookupType;		/* Different enumerations for GSUB and GPOS */
   HBUINT16	lookupFlag;		/* Lookup qualifiers */
   Array16Of<Offset16>

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -3850,7 +3850,7 @@ struct ExtensionFormat1
     return_trace (dest_offset.serialize_subset (c, src_offset, this, get_type ()));
   }
 
-  public: // TODO
+  protected:
   HBUINT16	format;			/* Format identifier. Set to 1. */
   HBUINT16	extensionLookupType;	/* Lookup type of subtable referenced
 					 * by ExtensionOffset (i.e. the
@@ -3988,7 +3988,7 @@ struct GSUBGPOSVersion1_2
 {
   friend struct GSUBGPOS;
 
-  public: // TODO
+  protected:
   FixedVersion<>version;	/* Version of the GSUB/GPOS table--initially set
 				 * to 0x00010000u */
   typename Types:: template OffsetTo<ScriptList>
@@ -4009,6 +4009,11 @@ struct GSUBGPOSVersion1_2
   {
     return min_size +
 	   (version.to_int () >= 0x00010001u ? featureVars.static_size : 0);
+  }
+
+  const typename Types::template OffsetTo<LookupList<Types>>* get_lookup_list_offset () const
+  {
+    return &lookupList;
   }
 
   template <typename TLookup>

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -3850,7 +3850,7 @@ struct ExtensionFormat1
     return_trace (dest_offset.serialize_subset (c, src_offset, this, get_type ()));
   }
 
-  protected:
+  public: // TODO
   HBUINT16	format;			/* Format identifier. Set to 1. */
   HBUINT16	extensionLookupType;	/* Lookup type of subtable referenced
 					 * by ExtensionOffset (i.e. the

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -3988,7 +3988,7 @@ struct GSUBGPOSVersion1_2
 {
   friend struct GSUBGPOS;
 
-  protected:
+  public: // TODO
   FixedVersion<>version;	/* Version of the GSUB/GPOS table--initially set
 				 * to 0x00010000u */
   typename Types:: template OffsetTo<ScriptList>

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -74,6 +74,8 @@ bool _promote_extensions_if_needed (graph::make_extension_context_t& ext_context
   // TODO(garretrieger): also support extension promotion during iterative resolution phase, then
   //                     we can use a less conservative threshold here.
 
+  if (!ext_context.lookups) return true;
+
   hb_vector_t<hb_pair_t<unsigned, size_t>> lookup_sizes;
   lookup_sizes.alloc (ext_context.lookups.get_population ());
 
@@ -88,7 +90,9 @@ bool _promote_extensions_if_needed (graph::make_extension_context_t& ext_context
 
   lookup_sizes.qsort (compare_sizes);
 
-  size_t accumlated_bytes = 0;
+  size_t accumlated_bytes =
+      ext_context.graph.vertices_[ext_context.lookup_list_index].table_size ();
+
   for (auto p : lookup_sizes)
   {
     unsigned lookup_index = p.first;

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -193,7 +193,7 @@ hb_resolve_overflows (const T& packed,
     if (ext_context.in_error ())
       return nullptr;
 
-    if (1 && !_promote_extensions_if_needed (ext_context)) {
+    if (0 && !_promote_extensions_if_needed (ext_context)) {
       DEBUG_MSG (SUBSET_REPACK, nullptr, "Extensions promotion failed.");
       return nullptr;
     }

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -68,6 +68,8 @@ bool _promote_extensions_if_needed (graph::make_extension_context_t& ext_context
   // 4. Promote the rest.
 
   // TODO(garretrieger): support extension demotion, then consider all lookups. Requires advanced algo.
+  // TODO(garretrieger): also support extension promotion during iterative resolution phase, then
+  //                     we can use a less conservative threshold here.
 
   hb_vector_t<hb_pair_t<unsigned, size_t>> lookup_sizes;
   lookup_sizes.alloc (ext_context.lookups.get_population ());

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -57,7 +57,7 @@ inline int compare_sizes (const void* a, const void* b)
   double subtables_per_byte_b = (double) size_b->num_subtables / (double) size_b->size;
 
   if (subtables_per_byte_a == subtables_per_byte_b) {
-    return size_b->lookup_index - size_b->lookup_index;
+    return size_b->lookup_index - size_a->lookup_index;
 
   }
   double cmp = subtables_per_byte_b - subtables_per_byte_a;

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -45,6 +45,9 @@ inline int compare_sizes (const void* a, const void* b)
 {
   hb_pair_t<unsigned, size_t>* size_a = (hb_pair_t<unsigned, size_t>*) a;
   hb_pair_t<unsigned, size_t>* size_b = (hb_pair_t<unsigned, size_t>*) b;
+  if (size_a->second == size_b->second) {
+    return size_b->first - size_a->first;
+  }
   return size_a->second - size_b->second;
 }
 

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -44,7 +44,7 @@ using graph::graph_t;
  */
 
 static inline
-void _make_extensions (graph_t& sorted_graph)
+void _make_extensions (hb_tag_t table_tag, graph_t& sorted_graph, hb_vector_t<char>& buffer)
 {
   // TODO: Move this into graph or gsubgpos graph?
   hb_hashmap_t<unsigned, graph::Lookup*> lookups;
@@ -52,7 +52,7 @@ void _make_extensions (graph_t& sorted_graph)
 
   for (auto p : lookups.iter ())
   {
-    p.second->make_extension (sorted_graph, p.first);
+    p.second->make_extension (table_tag, sorted_graph, p.first, buffer);
   }
 }
 
@@ -182,12 +182,13 @@ hb_resolve_overflows (const T& packed,
     return graph::serialize (sorted_graph);
   }
 
+  hb_vector_t<char> extension_buffer;
   if ((table_tag == HB_OT_TAG_GPOS
        ||  table_tag == HB_OT_TAG_GSUB)
       && will_overflow)
   {
+    _make_extensions (table_tag, sorted_graph, extension_buffer);
     DEBUG_MSG (SUBSET_REPACK, nullptr, "Assigning spaces to 32 bit subgraphs.");
-    _make_extensions (sorted_graph);
     if (sorted_graph.assign_spaces ())
       sorted_graph.sort_shortest_distance ();
   }

--- a/src/hb-subset-repacker.cc
+++ b/src/hb-subset-repacker.cc
@@ -44,6 +44,9 @@ hb_blob_t* hb_subset_repack_or_fail (hb_object_t* hb_objects, unsigned num_hb_ob
   for (unsigned i = 0 ; i < num_hb_objs ; i++)
     packed.push (&(hb_objects[i]));
 
-  return hb_resolve_overflows (packed, HB_OT_TAG_GSUB);
+  return hb_resolve_overflows (packed,
+                               HB_OT_TAG_GSUB,
+                               20,
+                               true);
 }
 #endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -345,6 +345,7 @@ hb_subset_sources = files(
   'hb-subset-plan.cc',
   'hb-subset-plan.hh',
   'hb-subset-repacker.cc',
+  'graph/gsubgpos-graph.cc',
   'hb-subset.cc',
   'hb-subset.hh',
 )
@@ -565,7 +566,7 @@ if get_option('tests').enabled()
     'test-number': ['test-number.cc', 'hb-number.cc'],
     'test-ot-tag': ['hb-ot-tag.cc'],
     'test-priority-queue': ['test-priority-queue.cc', 'hb-static.cc'],
-    'test-repacker': ['test-repacker.cc', 'hb-static.cc'],
+    'test-repacker': ['test-repacker.cc', 'hb-static.cc', 'graph/gsubgpos-graph.cc'],
     'test-set': ['test-set.cc', 'hb-static.cc'],
     'test-serialize': ['test-serialize.cc', 'hb-static.cc'],
     'test-unicode-ranges': ['test-unicode-ranges.cc'],

--- a/src/test-repacker.cc
+++ b/src/test-repacker.cc
@@ -1485,4 +1485,5 @@ main (int argc, char **argv)
   test_resolve_with_extension_promotion ();
   // TODO(grieger): test with extensions already mixed in as well.
   // TODO(grieger): test two layer ext promotion setup.
+  // TODO(grieger): test sorting by subtables per byte in ext. promotion.
 }

--- a/src/test-repacker.cc
+++ b/src/test-repacker.cc
@@ -1483,4 +1483,6 @@ main (int argc, char **argv)
   test_virtual_link ();
   test_shared_node_with_virtual_links ();
   test_resolve_with_extension_promotion ();
+  // TODO(grieger): test with extensions already mixed in as well.
+  // TODO(grieger): test two layer ext promotion setup.
 }


### PR DESCRIPTION
When enabled analyzes the non-extension lookups within a GSUB/GPOS table and decides if any need to be promoted into extensions prior to space assignemnt.

This is v1 of the algorithm which doesn't factor in shared nodes between lookups.