### PR TITLE
[meson] Don’t tamper with paths in amalgam files

### DIFF
--- a/src/gen-harfbuzzcc.py
+++ b/src/gen-harfbuzzcc.py
@@ -14,7 +14,7 @@ CURRENT_SOURCE_DIR = sys.argv[2]
 sources = sorted(set(sys.argv[3:]))
 
 with open (OUTPUT, "wb") as f:
-	f.write ("".join ('#include "{}"\n'.format (os.path.basename (x)) for x in sources if x.endswith (".cc")).encode ())
+	f.write ("".join ('#include "{}"\n'.format (os.path.relpath (os.path.abspath (x), CURRENT_SOURCE_DIR)) for x in sources if x.endswith (".cc")).encode ())
 
 # copy it also to the source tree, but only if it has changed
 baseline_filename = os.path.join (CURRENT_SOURCE_DIR, os.path.basename (OUTPUT))

--- a/src/gen-harfbuzzcc.py
+++ b/src/gen-harfbuzzcc.py
@@ -2,23 +2,24 @@
 
 "This tool is intended to be used from meson"
 
-import os, sys, shutil
+import shutil
+import sys
+
+from pathlib import Path
 
 if len (sys.argv) < 3:
 	sys.exit (__doc__)
 
-OUTPUT = sys.argv[1]
-CURRENT_SOURCE_DIR = sys.argv[2]
+OUTPUT = Path (sys.argv[1])
+CURRENT_SOURCE_DIR = Path (sys.argv[2])
 
 # make sure input files are unique
-sources = sorted(set(sys.argv[3:]))
+sources = [Path(x) for x in sorted(set(sys.argv[3:]))]
 
 with open (OUTPUT, "wb") as f:
-	f.write ("".join ('#include "{}"\n'.format (os.path.relpath (os.path.abspath (x), CURRENT_SOURCE_DIR)) for x in sources if x.endswith (".cc")).encode ())
+	f.write ("".join (f'#include "{p.resolve ().relative_to (CURRENT_SOURCE_DIR)}"\n' for p in sources if p.suffix == ".cc").encode ())
 
 # copy it also to the source tree, but only if it has changed
-baseline_filename = os.path.join (CURRENT_SOURCE_DIR, os.path.basename (OUTPUT))
-with open(baseline_filename, "rb") as baseline:
-	with open(OUTPUT, "rb") as generated:
-		if baseline.read() != generated.read():
-			shutil.copyfile (OUTPUT, baseline_filename)
+baseline = CURRENT_SOURCE_DIR / OUTPUT.name
+if baseline.read_bytes() != OUTPUT.read_bytes():
+	shutil.copyfile (OUTPUT, baseline)

--- a/src/harfbuzz-subset.cc
+++ b/src/harfbuzz-subset.cc
@@ -1,4 +1,4 @@
-#include "gsubgpos-graph.cc"
+#include "graph/gsubgpos-graph.cc"
 #include "hb-aat-layout.cc"
 #include "hb-aat-map.cc"
 #include "hb-blob.cc"


### PR DESCRIPTION
Using `os.path.basename()` breaks files in subdirectories (`gsubgpos-graph.cc` instead of `graph/gsubgpos-graph.cc`). The relative paths that meson returns look a bit ugly but they still work.