### PR TITLE
[repacker] Add a second repacker api method which takes a table tag.

### DIFF
--- a/src/hb-subset-repacker.cc
+++ b/src/hb-subset-repacker.cc
@@ -25,18 +25,24 @@
 #include "hb-repacker.hh"
 
 #ifdef HB_EXPERIMENTAL_API
+
 /**
  * hb_subset_repack_or_fail:
+ * @table_tag: tag of the table being packed, needed to allow table specific optimizations.
  * @hb_objects: raw array of struct hb_object_t, which provides
  * object graph info
  * @num_hb_objs: number of hb_object_t in the hb_objects array.
  *
  * Given the input object graph info, repack a table to eliminate
  * offset overflows. A nullptr is returned if the repacking attempt fails.
+ * Table specific optimizations (eg. extension promotion in GSUB/GPOS) may be performed.
+ * Passing HB_TAG_NONE will disable table specific optimizations.
  *
  * Since: EXPERIMENTAL
  **/
-hb_blob_t* hb_subset_repack_or_fail (hb_object_t* hb_objects, unsigned num_hb_objs)
+hb_blob_t* hb_subset_repack_or_fail (hb_tag_t table_tag,
+                                     hb_object_t* hb_objects,
+                                     unsigned num_hb_objs)
 {
   hb_vector_t<const hb_object_t *> packed;
   packed.alloc (num_hb_objs + 1);
@@ -45,7 +51,7 @@ hb_blob_t* hb_subset_repack_or_fail (hb_object_t* hb_objects, unsigned num_hb_ob
     packed.push (&(hb_objects[i]));
 
   return hb_resolve_overflows (packed,
-                               HB_OT_TAG_GSUB,
+                               table_tag,
                                20,
                                true);
 }

--- a/src/hb-subset-repacker.h
+++ b/src/hb-subset-repacker.h
@@ -70,7 +70,8 @@ struct hb_object_t
 typedef struct hb_object_t hb_object_t;
 
 HB_EXTERN hb_blob_t*
-hb_subset_repack_or_fail (hb_object_t* hb_objects,
+hb_subset_repack_or_fail (hb_tag_t table_tag,
+                          hb_object_t* hb_objects,
                           unsigned num_hb_objs);
 
 #endif

--- a/test/api/test-subset-repacker.c
+++ b/test/api/test-subset-repacker.c
@@ -184,12 +184,12 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[14].real_links[2].objidx = 14;
   hb_objs[14].virtual_links = NULL;
 
-  hb_blob_t *result = hb_subset_repack_or_fail (hb_objs, 15);
-  
+  hb_blob_t *result = hb_subset_repack_or_fail (HB_TAG_NONE, hb_objs, 15);
+
   hb_face_t *face_expected = hb_test_open_font_file ("fonts/repacker_expected.otf");
   hb_blob_t *expected_blob = hb_face_reference_table (face_expected, HB_TAG ('G','S','U','B'));
   fprintf(stderr, "expected %d bytes, actual %d bytes\n", hb_blob_get_length(expected_blob), hb_blob_get_length (result));
-  
+
   if (hb_blob_get_length (expected_blob) != 0 ||
       hb_blob_get_length (result) != 0)
     hb_test_assert_blobs_equal (expected_blob, result);


### PR DESCRIPTION
This is needed to allow table specific optimizations to be performed during repacking.