### PR TITLE
bug fix in VarData get_delta ()

### DIFF
--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -2284,19 +2284,19 @@ struct VarData
    unsigned int lcount = is_long ? word_count : 0;
 
    const HBUINT8 *bytes = get_delta_bytes ();
-   const HBUINT8 *row = bytes + inner * (scount + count);
+   const HBUINT8 *row = bytes + inner * get_row_size ();
 
    float delta = 0.;
    unsigned int i = 0;
 
-   const HBINT16 *lcursor = reinterpret_cast<const HBINT16 *> (row);
+   const HBINT32 *lcursor = reinterpret_cast<const HBINT32 *> (row);
    for (; i < lcount; i++)
    {
      float scalar = regions.evaluate (regionIndices.arrayZ[i], coords, coord_count, cache);
      delta += scalar * *lcursor++;
    }
    const HBINT16 *scursor = reinterpret_cast<const HBINT16 *> (lcursor);
-   for (; i < scount; i++)
+   for (; i < lcount + scount; i++)
    {
      float scalar = regions.evaluate (regionIndices.arrayZ[i], coords, coord_count, cache);
      delta += scalar * *scursor++;


### PR DESCRIPTION
I think this is a bug that needs a fix when LONG_WORDS flag is set. Correct me if I'm wrong cause I tried to understand the code according to the spec.

Given below variables defined in the function:
lcount: num of INT 32 deltas
scount: num of INT16 deltas
count: total num of deltas

when LONG_WORDS flag is set, this get_delta() was not working correctly
- the "row" is not computed correctly
- lcursor should be interpreted as INT32

I don't have a testcase for this, but existing tests don't seem to catch this.

