### PR TITLE
[ot-tags] Support the language system tag 'ZHP '

### DIFF
--- a/src/hb-buffer-deserialize-json.hh
+++ b/src/hb-buffer-deserialize-json.hh
@@ -32,7 +32,7 @@
 #include "hb.hh"
 
 
-#line 33 "hb-buffer-deserialize-json.hh"
+#line 36 "hb-buffer-deserialize-json.hh"
 static const unsigned char _deserialize_json_trans_keys[] = {
 	0u, 0u, 9u, 123u, 9u, 34u, 97u, 117u, 120u, 121u, 34u, 34u, 9u, 58u, 9u, 57u, 
 	48u, 57u, 9u, 125u, 9u, 125u, 9u, 125u, 34u, 34u, 9u, 58u, 9u, 57u, 48u, 57u, 
@@ -557,12 +557,12 @@ _hb_buffer_deserialize_json (hb_buffer_t *buffer,
   hb_glyph_info_t info = {0};
   hb_glyph_position_t pos = {0};
   
-#line 554 "hb-buffer-deserialize-json.hh"
+#line 561 "hb-buffer-deserialize-json.hh"
 	{
 	cs = deserialize_json_start;
 	}
 
-#line 557 "hb-buffer-deserialize-json.hh"
+#line 566 "hb-buffer-deserialize-json.hh"
 	{
 	int _slen;
 	int _trans;
@@ -774,7 +774,7 @@ _resume:
 	*end_ptr = p;
 }
 	break;
-#line 735 "hb-buffer-deserialize-json.hh"
+#line 778 "hb-buffer-deserialize-json.hh"
 	}
 
 _again:

--- a/src/hb-buffer-deserialize-text.hh
+++ b/src/hb-buffer-deserialize-text.hh
@@ -32,7 +32,7 @@
 #include "hb.hh"
 
 
-#line 33 "hb-buffer-deserialize-text.hh"
+#line 36 "hb-buffer-deserialize-text.hh"
 static const unsigned char _deserialize_text_trans_keys[] = {
 	0u, 0u, 9u, 91u, 85u, 85u, 43u, 43u, 48u, 102u, 9u, 85u, 48u, 57u, 45u, 57u, 
 	48u, 57u, 48u, 57u, 48u, 57u, 45u, 57u, 48u, 57u, 44u, 44u, 45u, 57u, 48u, 57u, 
@@ -509,12 +509,12 @@ _hb_buffer_deserialize_text (hb_buffer_t *buffer,
   hb_glyph_info_t info = {0};
   hb_glyph_position_t pos = {0};
   
-#line 506 "hb-buffer-deserialize-text.hh"
+#line 513 "hb-buffer-deserialize-text.hh"
 	{
 	cs = deserialize_text_start;
 	}
 
-#line 509 "hb-buffer-deserialize-text.hh"
+#line 518 "hb-buffer-deserialize-text.hh"
 	{
 	int _slen;
 	int _trans;
@@ -894,7 +894,7 @@ _resume:
 	*end_ptr = p;
 }
 	break;
-#line 826 "hb-buffer-deserialize-text.hh"
+#line 898 "hb-buffer-deserialize-text.hh"
 	}
 
 _again:
@@ -1043,7 +1043,7 @@ _again:
 	*end_ptr = p;
 }
 	break;
-#line 953 "hb-buffer-deserialize-text.hh"
+#line 1047 "hb-buffer-deserialize-text.hh"
 	}
 	}
 

--- a/src/hb-number-parser.hh
+++ b/src/hb-number-parser.hh
@@ -31,7 +31,7 @@
 #include "hb.hh"
 
 
-#line 32 "hb-number-parser.hh"
+#line 35 "hb-number-parser.hh"
 static const unsigned char _double_parser_trans_keys[] = {
 	0u, 0u, 43u, 57u, 46u, 57u, 48u, 57u, 43u, 57u, 48u, 57u, 48u, 101u, 48u, 57u, 
 	46u, 101u, 0
@@ -135,12 +135,12 @@ strtod_rl (const char *p, const char **end_ptr /* IN/OUT */)
 
   int cs;
   
-#line 132 "hb-number-parser.hh"
+#line 139 "hb-number-parser.hh"
 	{
 	cs = double_parser_start;
 	}
 
-#line 135 "hb-number-parser.hh"
+#line 144 "hb-number-parser.hh"
 	{
 	int _slen;
 	int _trans;
@@ -198,7 +198,7 @@ _resume:
 	  exp_overflow = true;
 }
 	break;
-#line 187 "hb-number-parser.hh"
+#line 202 "hb-number-parser.hh"
 	}
 
 _again:

--- a/src/hb-ot-shaper-indic-machine.hh
+++ b/src/hb-ot-shaper-indic-machine.hh
@@ -53,7 +53,7 @@ enum indic_syllable_type_t {
 };
 
 
-#line 54 "hb-ot-shaper-indic-machine.hh"
+#line 57 "hb-ot-shaper-indic-machine.hh"
 #define indic_syllable_machine_ex_A 9u
 #define indic_syllable_machine_ex_C 1u
 #define indic_syllable_machine_ex_CM 16u
@@ -75,7 +75,7 @@ enum indic_syllable_type_t {
 #define indic_syllable_machine_ex_ZWNJ 5u
 
 
-#line 74 "hb-ot-shaper-indic-machine.hh"
+#line 79 "hb-ot-shaper-indic-machine.hh"
 static const unsigned char _indic_syllable_machine_trans_keys[] = {
 	8u, 8u, 4u, 8u, 5u, 7u, 5u, 8u, 4u, 8u, 4u, 12u, 4u, 8u, 8u, 8u, 
 	5u, 7u, 5u, 8u, 4u, 8u, 4u, 12u, 4u, 12u, 4u, 12u, 8u, 8u, 5u, 7u, 
@@ -422,7 +422,7 @@ find_syllables_indic (hb_buffer_t *buffer)
   int cs;
   hb_glyph_info_t *info = buffer->info;
   
-#line 415 "hb-ot-shaper-indic-machine.hh"
+#line 426 "hb-ot-shaper-indic-machine.hh"
 	{
 	cs = indic_syllable_machine_start;
 	ts = 0;
@@ -438,7 +438,7 @@ find_syllables_indic (hb_buffer_t *buffer)
 
   unsigned int syllable_serial = 1;
   
-#line 427 "hb-ot-shaper-indic-machine.hh"
+#line 442 "hb-ot-shaper-indic-machine.hh"
 	{
 	int _slen;
 	int _trans;
@@ -452,7 +452,7 @@ _resume:
 #line 1 "NONE"
 	{ts = p;}
 	break;
-#line 439 "hb-ot-shaper-indic-machine.hh"
+#line 456 "hb-ot-shaper-indic-machine.hh"
 	}
 
 	_keys = _indic_syllable_machine_trans_keys + (cs<<1);
@@ -555,7 +555,7 @@ _eof_trans:
 #line 113 "hb-ot-shaper-indic-machine.rl"
 	{act = 6;}
 	break;
-#line 521 "hb-ot-shaper-indic-machine.hh"
+#line 559 "hb-ot-shaper-indic-machine.hh"
 	}
 
 _again:
@@ -564,7 +564,7 @@ _again:
 #line 1 "NONE"
 	{ts = 0;}
 	break;
-#line 528 "hb-ot-shaper-indic-machine.hh"
+#line 568 "hb-ot-shaper-indic-machine.hh"
 	}
 
 	if ( ++p != pe )

--- a/src/hb-ot-shaper-khmer-machine.hh
+++ b/src/hb-ot-shaper-khmer-machine.hh
@@ -48,7 +48,7 @@ enum khmer_syllable_type_t {
 };
 
 
-#line 49 "hb-ot-shaper-khmer-machine.hh"
+#line 52 "hb-ot-shaper-khmer-machine.hh"
 #define khmer_syllable_machine_ex_C 1u
 #define khmer_syllable_machine_ex_DOTTEDCIRCLE 11u
 #define khmer_syllable_machine_ex_H 4u
@@ -66,7 +66,7 @@ enum khmer_syllable_type_t {
 #define khmer_syllable_machine_ex_ZWNJ 5u
 
 
-#line 65 "hb-ot-shaper-khmer-machine.hh"
+#line 70 "hb-ot-shaper-khmer-machine.hh"
 static const unsigned char _khmer_syllable_machine_trans_keys[] = {
 	5u, 26u, 5u, 26u, 1u, 15u, 5u, 26u, 5u, 26u, 5u, 26u, 5u, 26u, 5u, 26u, 
 	5u, 26u, 5u, 26u, 5u, 26u, 5u, 26u, 5u, 26u, 1u, 15u, 5u, 26u, 5u, 26u, 
@@ -294,7 +294,7 @@ find_syllables_khmer (hb_buffer_t *buffer)
   int cs;
   hb_glyph_info_t *info = buffer->info;
   
-#line 287 "hb-ot-shaper-khmer-machine.hh"
+#line 298 "hb-ot-shaper-khmer-machine.hh"
 	{
 	cs = khmer_syllable_machine_start;
 	ts = 0;
@@ -310,7 +310,7 @@ find_syllables_khmer (hb_buffer_t *buffer)
 
   unsigned int syllable_serial = 1;
   
-#line 299 "hb-ot-shaper-khmer-machine.hh"
+#line 314 "hb-ot-shaper-khmer-machine.hh"
 	{
 	int _slen;
 	int _trans;
@@ -324,7 +324,7 @@ _resume:
 #line 1 "NONE"
 	{ts = p;}
 	break;
-#line 311 "hb-ot-shaper-khmer-machine.hh"
+#line 328 "hb-ot-shaper-khmer-machine.hh"
 	}
 
 	_keys = _khmer_syllable_machine_trans_keys + (cs<<1);
@@ -394,7 +394,7 @@ _eof_trans:
 #line 98 "hb-ot-shaper-khmer-machine.rl"
 	{act = 3;}
 	break;
-#line 368 "hb-ot-shaper-khmer-machine.hh"
+#line 398 "hb-ot-shaper-khmer-machine.hh"
 	}
 
 _again:
@@ -403,7 +403,7 @@ _again:
 #line 1 "NONE"
 	{ts = 0;}
 	break;
-#line 375 "hb-ot-shaper-khmer-machine.hh"
+#line 407 "hb-ot-shaper-khmer-machine.hh"
 	}
 
 	if ( ++p != pe )

--- a/src/hb-ot-shaper-myanmar-machine.hh
+++ b/src/hb-ot-shaper-myanmar-machine.hh
@@ -50,7 +50,7 @@ enum myanmar_syllable_type_t {
 };
 
 
-#line 51 "hb-ot-shaper-myanmar-machine.hh"
+#line 54 "hb-ot-shaper-myanmar-machine.hh"
 #define myanmar_syllable_machine_ex_A 9u
 #define myanmar_syllable_machine_ex_As 32u
 #define myanmar_syllable_machine_ex_C 1u
@@ -77,7 +77,7 @@ enum myanmar_syllable_type_t {
 #define myanmar_syllable_machine_ex_ZWNJ 5u
 
 
-#line 76 "hb-ot-shaper-myanmar-machine.hh"
+#line 81 "hb-ot-shaper-myanmar-machine.hh"
 static const unsigned char _myanmar_syllable_machine_trans_keys[] = {
 	1u, 41u, 3u, 41u, 5u, 39u, 5u, 8u, 3u, 41u, 3u, 39u, 3u, 39u, 5u, 39u, 
 	5u, 39u, 3u, 39u, 3u, 39u, 3u, 41u, 5u, 39u, 1u, 15u, 3u, 39u, 3u, 39u, 
@@ -443,7 +443,7 @@ find_syllables_myanmar (hb_buffer_t *buffer)
   int cs;
   hb_glyph_info_t *info = buffer->info;
   
-#line 436 "hb-ot-shaper-myanmar-machine.hh"
+#line 447 "hb-ot-shaper-myanmar-machine.hh"
 	{
 	cs = myanmar_syllable_machine_start;
 	ts = 0;
@@ -459,7 +459,7 @@ find_syllables_myanmar (hb_buffer_t *buffer)
 
   unsigned int syllable_serial = 1;
   
-#line 448 "hb-ot-shaper-myanmar-machine.hh"
+#line 463 "hb-ot-shaper-myanmar-machine.hh"
 	{
 	int _slen;
 	int _trans;
@@ -473,7 +473,7 @@ _resume:
 #line 1 "NONE"
 	{ts = p;}
 	break;
-#line 460 "hb-ot-shaper-myanmar-machine.hh"
+#line 477 "hb-ot-shaper-myanmar-machine.hh"
 	}
 
 	_keys = _myanmar_syllable_machine_trans_keys + (cs<<1);
@@ -519,7 +519,7 @@ _eof_trans:
 #line 113 "hb-ot-shaper-myanmar-machine.rl"
 	{te = p;p--;{ found_syllable (myanmar_non_myanmar_cluster); }}
 	break;
-#line 498 "hb-ot-shaper-myanmar-machine.hh"
+#line 523 "hb-ot-shaper-myanmar-machine.hh"
 	}
 
 _again:
@@ -528,7 +528,7 @@ _again:
 #line 1 "NONE"
 	{ts = 0;}
 	break;
-#line 505 "hb-ot-shaper-myanmar-machine.hh"
+#line 532 "hb-ot-shaper-myanmar-machine.hh"
 	}
 
 	if ( ++p != pe )

--- a/src/hb-ot-shaper-use-machine.hh
+++ b/src/hb-ot-shaper-use-machine.hh
@@ -53,7 +53,7 @@ enum use_syllable_type_t {
 };
 
 
-#line 54 "hb-ot-shaper-use-machine.hh"
+#line 57 "hb-ot-shaper-use-machine.hh"
 #define use_syllable_machine_ex_B 1u
 #define use_syllable_machine_ex_CGJ 6u
 #define use_syllable_machine_ex_CMAbv 31u
@@ -97,7 +97,7 @@ enum use_syllable_type_t {
 #define use_syllable_machine_ex_ZWNJ 14u
 
 
-#line 96 "hb-ot-shaper-use-machine.hh"
+#line 101 "hb-ot-shaper-use-machine.hh"
 static const unsigned char _use_syllable_machine_trans_keys[] = {
 	0u, 53u, 11u, 53u, 11u, 53u, 1u, 53u, 23u, 48u, 24u, 47u, 25u, 47u, 26u, 47u, 
 	45u, 46u, 46u, 46u, 24u, 48u, 24u, 48u, 24u, 48u, 1u, 1u, 24u, 48u, 22u, 53u, 
@@ -780,7 +780,7 @@ find_syllables_use (hb_buffer_t *buffer)
   unsigned int act HB_UNUSED;
   int cs;
   
-#line 773 "hb-ot-shaper-use-machine.hh"
+#line 784 "hb-ot-shaper-use-machine.hh"
 	{
 	cs = use_syllable_machine_start;
 	ts = 0;
@@ -793,7 +793,7 @@ find_syllables_use (hb_buffer_t *buffer)
 
   unsigned int syllable_serial = 1;
   
-#line 782 "hb-ot-shaper-use-machine.hh"
+#line 797 "hb-ot-shaper-use-machine.hh"
 	{
 	int _slen;
 	int _trans;
@@ -807,7 +807,7 @@ _resume:
 #line 1 "NONE"
 	{ts = p;}
 	break;
-#line 794 "hb-ot-shaper-use-machine.hh"
+#line 811 "hb-ot-shaper-use-machine.hh"
 	}
 
 	_keys = _use_syllable_machine_trans_keys + (cs<<1);
@@ -897,7 +897,7 @@ _eof_trans:
 #line 171 "hb-ot-shaper-use-machine.rl"
 	{act = 2;}
 	break;
-#line 866 "hb-ot-shaper-use-machine.hh"
+#line 901 "hb-ot-shaper-use-machine.hh"
 	}
 
 _again:
@@ -906,7 +906,7 @@ _again:
 #line 1 "NONE"
 	{ts = 0;}
 	break;
-#line 873 "hb-ot-shaper-use-machine.hh"
+#line 910 "hb-ot-shaper-use-machine.hh"
 	}
 
 	if ( ++p != pe )

--- a/src/hb-ot-tag-table.hh
+++ b/src/hb-ot-tag-table.hh
@@ -7,7 +7,7 @@
  * on files with these headers:
  *
  * <meta name="updated_at" content="2022-01-28 10:00 PM" />
- * File-Date: 2022-03-02
+ * File-Date: 2022-06-28
  */
 
 #ifndef HB_OT_TAG_TABLE_HH
@@ -1655,6 +1655,20 @@ hb_ot_tags_from_complex_language (const char   *lang_str,
       *count = 1;
       return true;
     }
+    if (subtag_matches (p, limit, "-tongyong", 9))
+    {
+      /* Chinese [macrolanguage]; Tongyong Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (subtag_matches (p, limit, "-wadegile", 9))
+    {
+      /* Chinese [macrolanguage]; Wade-Giles romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
     if (subtag_matches (p, limit, "-polyton", 8))
     {
       /* Modern Greek (1453-); Polytonic Greek */
@@ -1883,6 +1897,70 @@ out:
       for (i = 0; i < 2 && i < *count; i++)
 	tags[i] = possible_tags[i];
       *count = i;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "do-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Min Dong Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "jy-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Jinyu Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "mn-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Mandarin Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "np-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Northern Ping Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "px-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Pu-Xian Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "sp-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Southern Ping Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "zh-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Huizhou Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "zo-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Min Zhong Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
       return true;
     }
     if (lang_matches (&lang_str[1], limit, "do-hans", 7))
@@ -2259,6 +2337,14 @@ out:
       *count = i;
       return true;
     }
+    if (0 == strncmp (&lang_str[1], "an-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Gan Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
     if (lang_matches (&lang_str[1], limit, "an-hans", 7))
     {
       /* Gan Chinese; Han (Simplified variant) */
@@ -2350,6 +2436,22 @@ out:
       for (i = 0; i < 2 && i < *count; i++)
 	tags[i] = possible_tags[i];
       *count = i;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "ak-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Hakka Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "sn-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Xiang Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
       return true;
     }
     if (lang_matches (&lang_str[1], limit, "ak-hans", 7))
@@ -2500,6 +2602,14 @@ out:
       *count = i;
       return true;
     }
+    if (0 == strncmp (&lang_str[1], "np-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Min Bei Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
     if (lang_matches (&lang_str[1], limit, "np-hans", 7))
     {
       /* Min Bei Chinese; Han (Simplified variant) */
@@ -2572,6 +2682,14 @@ out:
       for (i = 0; i < 2 && i < *count; i++)
 	tags[i] = possible_tags[i];
       *count = i;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "an-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Min Nan Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
       return true;
     }
     if (lang_matches (&lang_str[1], limit, "an-hans", 7))
@@ -2670,6 +2788,14 @@ out:
       *count = i;
       return true;
     }
+    if (0 == strncmp (&lang_str[1], "uu-", 3)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Wu Chinese; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
+      *count = 1;
+      return true;
+    }
     if (lang_matches (&lang_str[1], limit, "uu-hans", 7))
     {
       /* Wu Chinese; Han (Simplified variant) */
@@ -2749,6 +2875,14 @@ out:
     {
       /* Minnan, Hokkien, Amoy, Taiwanese, Southern Min, Southern Fujian, Hoklo, Southern Fukien, Ho-lo (retired code) */
       tags[0] = HB_TAG('Z','H','S',' ');  /* Chinese, Simplified */
+      *count = 1;
+      return true;
+    }
+    if (0 == strncmp (&lang_str[1], "h-", 2)
+	&& subtag_matches (lang_str, limit, "-pinyin", 7))
+    {
+      /* Chinese [macrolanguage]; Pinyin romanization */
+      tags[0] = HB_TAG('Z','H','P',' ');  /* Chinese, Phonetic */
       *count = 1;
       return true;
     }
@@ -2975,6 +3109,8 @@ hb_ot_ambiguous_tag_to_language (hb_tag_t tag)
     return hb_language_from_string ("xwo", -1);  /* Written Oirat */
   case HB_TAG('Z','H','H',' '):  /* Chinese, Traditional, Hong Kong SAR */
     return hb_language_from_string ("zh-HK", -1);  /* Chinese [macrolanguage]; Hong Kong */
+  case HB_TAG('Z','H','P',' '):  /* Chinese, Phonetic */
+    return hb_language_from_string ("zh-Latn-pinyin", -1);  /* Chinese [macrolanguage]; Latin; Pinyin romanization */
   case HB_TAG('Z','H','S',' '):  /* Chinese, Simplified */
     return hb_language_from_string ("zh-Hans", -1);  /* Chinese [macrolanguage]; Han (Simplified variant) */
   case HB_TAG('Z','H','T',' '):  /* Chinese, Traditional */


### PR DESCRIPTION
This is the practical part of the solution for #2650. 'ZHP ' now corresponds to the three romanizations of Chinese that have BCP 47 variant subtags: Pinyin, Tongyong Pinyin, and Wade–Giles. The full solution would be to recognize any romanization of Chinese, even without an explicitly tagged variant, based on the script of the buffer, but that would be too big an architectural change for the benefit of a single language system tag whose original intent no one remembers and which almost no fonts use.