### PR TITLE
hb-view: Detect WezTerm and use iterm2 image protocol

### DIFF
--- a/util/helper-cairo.hh
+++ b/util/helper-cairo.hh
@@ -410,7 +410,7 @@ helper_cairo_create_context (double w, double h,
 	extension = "png";
 	protocol = image_protocol_t::ITERM2;
       }
-      if ((name = getenv ("TERM_PROGRAM")) != nullptr &&
+      else if ((name = getenv ("TERM_PROGRAM")) != nullptr &&
 	  0 == g_ascii_strcasecmp (name, "WezTerm"))
       {
 	extension = "png";

--- a/util/helper-cairo.hh
+++ b/util/helper-cairo.hh
@@ -410,6 +410,12 @@ helper_cairo_create_context (double w, double h,
 	extension = "png";
 	protocol = image_protocol_t::ITERM2;
       }
+      if ((name = getenv ("TERM_PROGRAM")) != nullptr &&
+	  0 == g_ascii_strcasecmp (name, "WezTerm"))
+      {
+	extension = "png";
+	protocol = image_protocol_t::ITERM2;
+      }
       else if ((name = getenv ("TERM")) != nullptr &&
 	       0 == g_ascii_strcasecmp (name, "xterm-kitty"))
       {


### PR DESCRIPTION
Similar to the logic that detects iterm2, but look for
TERM_PROGRAM=WezTerm which identifies wezterm is present.

This allows hb-view to output an image directly to the terminal.