### PR TITLE
[gpos] in PairPos, always advance next-glyph by one only

### DIFF
--- a/src/OT/Layout/GPOS/PairPosFormat2.hh
+++ b/src/OT/Layout/GPOS/PairPosFormat2.hh
@@ -243,8 +243,6 @@ struct PairPosFormat2_4
 
 
     buffer->idx = skippy_iter.idx;
-    if (len2)
-      buffer->idx++;
 
     return_trace (true);
   }

--- a/src/OT/Layout/GPOS/PairSet.hh
+++ b/src/OT/Layout/GPOS/PairSet.hh
@@ -128,8 +128,6 @@ struct PairSet
 
       if (applied_first || applied_second)
         buffer->unsafe_to_break (buffer->idx, pos + 1);
-      if (len2)
-        pos++;
 
       buffer->idx = pos;
       return_trace (true);


### PR DESCRIPTION
This goes against the spec.

WIP. Needs comments at least.

https://github.com/harfbuzz/harfbuzz/issues/3824