### PR TITLE
[ot-font] Try CBDT extents before outline tables

### DIFF
--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -348,14 +348,12 @@ hb_ot_get_glyph_extents (hb_font_t *font,
 
 #if !defined(HB_NO_OT_FONT_BITMAP) && !defined(HB_NO_COLOR)
   if (ot_face->sbix->get_extents (font, glyph, extents)) return true;
+  if (ot_face->CBDT->get_extents (font, glyph, extents)) return true;
 #endif
   if (ot_face->glyf->get_extents (font, glyph, extents)) return true;
 #ifndef HB_NO_OT_FONT_CFF
   if (ot_face->cff1->get_extents (font, glyph, extents)) return true;
   if (ot_face->cff2->get_extents (font, glyph, extents)) return true;
-#endif
-#if !defined(HB_NO_OT_FONT_BITMAP) && !defined(HB_NO_COLOR)
-  if (ot_face->CBDT->get_extents (font, glyph, extents)) return true;
 #endif
 
   // TODO Hook up side-bearings variations.


### PR DESCRIPTION
Like we do for sbix table.

Fixes https://github.com/harfbuzz/harfbuzz/issues/3827