### PR TITLE
[repacker] fix incorrect coverage table size estimation.

### DIFF
--- a/src/graph/pairpos-graph.hh
+++ b/src/graph/pairpos-graph.hh
@@ -526,10 +526,13 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
     }, hb_second)
     ;
 
+    auto new_coverage = + klass_map | hb_map_retains_sorting (hb_first);
     if (!Coverage::make_coverage (split_context.c,
-                                  + klass_map | hb_map_retains_sorting (hb_first),
+                                  + new_coverage,
                                   coverage.index,
-                                  coverage.vertex->table_size ()))
+                                  // existing ranges my not be kept, worst case size is a format 1
+                                  // coverage table.
+                                  4 + new_coverage.len() * 2))
       return false;
 
     return ClassDef::make_class_def (split_context.c,


### PR DESCRIPTION
During splitting of PairPosFormat2 the code was assuming the maximum size of the generated coverage table would be equal too the current size. This is incorrect size the new coverage table may not preserve the ranges found in the original coverage table (since we are splitting based on class, not coverage) and in the worst case may convert from format2 to format1. So use the size of a format1 table as the max size.