### PR TITLE
[subset] Begin implementing a subset accelerator

### DIFF
--- a/perf/benchmark-subset.cc
+++ b/perf/benchmark-subset.cc
@@ -122,6 +122,9 @@ static hb_face_t* preprocess_face(hb_face_t* face)
                                      HB_SUBSET_SETS_NAME_ID));
 
   hb_subset_input_set_flags(input,
+                            HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
+                            HB_SUBSET_FLAGS_GLYPH_NAMES |
+                            HB_SUBSET_FLAGS_RETAIN_GIDS |
                             HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA);
 
   hb_face_t* subset = hb_subset_or_fail (face, input);

--- a/perf/benchmark-subset.cc
+++ b/perf/benchmark-subset.cc
@@ -101,37 +101,9 @@ void AddGlyphs(unsigned num_glyphs_in_font,
 // the subsetting operations.
 static hb_face_t* preprocess_face(hb_face_t* face)
 {
-  hb_subset_input_t* input = hb_subset_input_create_or_fail ();
-
-  hb_set_clear (hb_subset_input_set(input, HB_SUBSET_SETS_UNICODE));
-  hb_set_invert (hb_subset_input_set(input, HB_SUBSET_SETS_UNICODE));
-
-  hb_set_clear (hb_subset_input_set(input,
-                                    HB_SUBSET_SETS_LAYOUT_FEATURE_TAG));
-  hb_set_invert (hb_subset_input_set(input,
-                                     HB_SUBSET_SETS_LAYOUT_FEATURE_TAG));
-
-  hb_set_clear (hb_subset_input_set(input,
-                                    HB_SUBSET_SETS_LAYOUT_SCRIPT_TAG));
-  hb_set_invert (hb_subset_input_set(input,
-                                     HB_SUBSET_SETS_LAYOUT_SCRIPT_TAG));
-
-  hb_set_clear (hb_subset_input_set(input,
-                                    HB_SUBSET_SETS_NAME_ID));
-  hb_set_invert (hb_subset_input_set(input,
-                                     HB_SUBSET_SETS_NAME_ID));
-
-  hb_subset_input_set_flags(input,
-                            HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
-                            HB_SUBSET_FLAGS_GLYPH_NAMES |
-                            HB_SUBSET_FLAGS_RETAIN_GIDS |
-                            HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA);
-
-  hb_face_t* subset = hb_subset_or_fail (face, input);
-  hb_face_destroy (face);
-  hb_subset_input_destroy (input);
-
-  return subset;
+  hb_face_t* new_face = hb_subset_preprocess(face);
+  hb_face_destroy(face);
+  return new_face;
 }
 
 /* benchmark for subsetting a font */

--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -341,6 +341,7 @@ HB_SUBSET_sources = \
 	hb-subset-cff2.hh \
 	hb-subset-input.cc \
 	hb-subset-input.hh \
+	hb-subset-accelerator.hh \
 	hb-subset-plan.cc \
 	hb-subset-plan.hh \
 	hb-subset-repacker.cc \

--- a/src/gen-def.py
+++ b/src/gen-def.py
@@ -21,7 +21,9 @@ if '--experimental-api' not in sys.argv:
 	experimental_symbols = \
 """hb_subset_repack_or_fail
 hb_subset_input_pin_axis_location
-hb_subset_input_pin_axis_to_default""".splitlines ()
+hb_subset_input_pin_axis_to_default
+hb_subset_preprocess
+""".splitlines ()
 	symbols = [x for x in symbols if x not in experimental_symbols]
 symbols = "\n".join (symbols)
 

--- a/src/hb-subset-accelerator.hh
+++ b/src/hb-subset-accelerator.hh
@@ -61,9 +61,10 @@ struct hb_subset_accelerator_t
                           const hb_set_t& unicodes_)
       : unicode_to_gid(unicode_to_gid_), unicodes(unicodes_) {}
 
-  hb_map_t unicode_to_gid;
-  hb_set_t unicodes;
+  const hb_map_t unicode_to_gid;
+  const hb_set_t unicodes;
   // TODO(garretrieger): cumulative glyf checksum map
+  // TODO(garretrieger): sanitized table cache.
 
   bool in_error () const
   {

--- a/src/hb-subset-accelerator.hh
+++ b/src/hb-subset-accelerator.hh
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2022  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Garret Rieger
+ */
+
+#ifndef HB_SUBSET_ACCELERATOR_HH
+#define HB_SUBSET_ACCELERATOR_HH
+
+
+#include "hb.hh"
+
+#include "hb-map.hh"
+#include "hb-set.hh"
+
+struct hb_subset_accelerator_t
+{
+  static hb_user_data_key_t* user_data_key()
+  {
+    static hb_user_data_key_t key;
+    return &key;
+  }
+
+  static hb_subset_accelerator_t* create(const hb_map_t& unicode_to_gid_,
+                                         const hb_set_t& unicodes_) {
+    hb_subset_accelerator_t* accel =
+        (hb_subset_accelerator_t*) hb_malloc (sizeof(hb_subset_accelerator_t));
+    new (accel) hb_subset_accelerator_t (unicode_to_gid_, unicodes_);
+    return accel;
+  }
+
+  static void destroy(void* value) {
+    if (!value) return;
+
+    hb_subset_accelerator_t* accel = (hb_subset_accelerator_t*) value;
+    accel->~hb_subset_accelerator_t ();
+    hb_free (accel);
+  }
+
+  hb_subset_accelerator_t(const hb_map_t& unicode_to_gid_,
+                          const hb_set_t& unicodes_)
+      : unicode_to_gid(unicode_to_gid_), unicodes(unicodes_) {}
+
+  hb_map_t unicode_to_gid;
+  hb_set_t unicodes;
+  // TODO(garretrieger): cumulative glyf checksum map
+
+  bool in_error () const
+  {
+    return unicode_to_gid.in_error() || unicodes.in_error ();
+  }
+};
+
+
+#endif /* HB_SUBSET_ACCELERATOR_HH */

--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -392,7 +392,7 @@ hb_subset_input_get_user_data (const hb_subset_input_t *input,
  *
  * Since: EXPERIMENTAL
  **/
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_subset_input_pin_axis_to_default (hb_subset_input_t  *input,
                                      hb_face_t          *face,
                                      hb_tag_t            axis_tag)
@@ -416,7 +416,7 @@ hb_subset_input_pin_axis_to_default (hb_subset_input_t  *input,
  *
  * Since: EXPERIMENTAL
  **/
-hb_bool_t
+HB_EXTERN hb_bool_t
 hb_subset_input_pin_axis_location (hb_subset_input_t  *input,
                                    hb_face_t          *face,
                                    hb_tag_t            axis_tag,
@@ -430,7 +430,9 @@ hb_subset_input_pin_axis_location (hb_subset_input_t  *input,
   return input->axes_location->set (axis_tag, val);
 }
 #endif
+#endif
 
+#ifdef HB_EXPERIMENTAL_API
 /**
  * hb_subset_preprocess
  * @input: a #hb_face_t object.
@@ -476,6 +478,4 @@ hb_subset_preprocess (hb_face_t *source)
 
   return new_source;
 }
-
-
 #endif

--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -49,7 +49,7 @@ hb_subset_input_create_or_fail (void)
     set = hb_set_create ();
 
   input->axes_location = hb_hashmap_create<hb_tag_t, float> ();
-  
+
   if (!input->axes_location || input->in_error ())
   {
     hb_subset_input_destroy (input);
@@ -430,4 +430,52 @@ hb_subset_input_pin_axis_location (hb_subset_input_t  *input,
   return input->axes_location->set (axis_tag, val);
 }
 #endif
+
+/**
+ * hb_subset_preprocess
+ * @input: a #hb_face_t object.
+ *
+ * Preprocesses the face and attaches data that will be needed by the
+ * subsetter. Future subsetting operations can then use the precomputed data
+ * to speed up the subsetting operation.
+ *
+ * Since: EXPERIMENTAL
+ **/
+
+hb_face_t *
+hb_subset_preprocess (hb_face_t *source)
+{
+  hb_subset_input_t* input = hb_subset_input_create_or_fail ();
+
+  hb_set_clear (hb_subset_input_set(input, HB_SUBSET_SETS_UNICODE));
+  hb_set_invert (hb_subset_input_set(input, HB_SUBSET_SETS_UNICODE));
+
+  hb_set_clear (hb_subset_input_set(input,
+                                    HB_SUBSET_SETS_LAYOUT_FEATURE_TAG));
+  hb_set_invert (hb_subset_input_set(input,
+                                     HB_SUBSET_SETS_LAYOUT_FEATURE_TAG));
+
+  hb_set_clear (hb_subset_input_set(input,
+                                    HB_SUBSET_SETS_LAYOUT_SCRIPT_TAG));
+  hb_set_invert (hb_subset_input_set(input,
+                                     HB_SUBSET_SETS_LAYOUT_SCRIPT_TAG));
+
+  hb_set_clear (hb_subset_input_set(input,
+                                    HB_SUBSET_SETS_NAME_ID));
+  hb_set_invert (hb_subset_input_set(input,
+                                     HB_SUBSET_SETS_NAME_ID));
+
+  hb_subset_input_set_flags(input,
+                            HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
+                            HB_SUBSET_FLAGS_GLYPH_NAMES |
+                            HB_SUBSET_FLAGS_RETAIN_GIDS);
+  input->attach_accelerator_data = true;
+
+  hb_face_t* new_source = hb_subset_or_fail (source, input);
+  hb_subset_input_destroy (input);
+
+  return new_source;
+}
+
+
 #endif

--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -442,7 +442,7 @@ hb_subset_input_pin_axis_location (hb_subset_input_t  *input,
  * Since: EXPERIMENTAL
  **/
 
-hb_face_t *
+HB_EXTERN hb_face_t *
 hb_subset_preprocess (hb_face_t *source)
 {
   hb_subset_input_t* input = hb_subset_input_create_or_fail ();

--- a/src/hb-subset-input.hh
+++ b/src/hb-subset-input.hh
@@ -59,6 +59,7 @@ struct hb_subset_input_t
   };
 
   unsigned flags;
+  bool attach_accelerator_data = false;
   hb_hashmap_t<hb_tag_t, float> *axes_location;
 
   inline unsigned num_sets () const

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -849,6 +849,8 @@ hb_subset_plan_create_or_fail (hb_face_t	 *face,
   plan->check_success (plan->hmtx_map = hb_hashmap_create<unsigned, hb_pair_t<unsigned, int>> ());
 
   void* accel = hb_face_get_user_data(face, hb_subset_accelerator_t::user_data_key());
+
+  plan->attach_accelerator_data = input->attach_accelerator_data;
   if (accel)
     plan->accelerator = (hb_subset_accelerator_t*) accel;
 

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -25,6 +25,7 @@
  */
 
 #include "hb-subset-plan.hh"
+#include "hb-subset-accelerator.hh"
 #include "hb-map.hh"
 #include "hb-set.hh"
 
@@ -456,41 +457,73 @@ _populate_unicodes_to_retain (const hb_set_t *unicodes,
                               hb_subset_plan_t *plan)
 {
   OT::cmap::accelerator_t cmap (plan->source);
-
   unsigned size_threshold = plan->source->get_num_glyphs ();
   if (glyphs->is_empty () && unicodes->get_population () < size_threshold)
   {
+
+    const hb_map_t* unicode_to_gid = nullptr;
+    if (plan->accelerator)
+      unicode_to_gid = &plan->accelerator->unicode_to_gid;
+
     // This is approach to collection is faster, but can only be used  if glyphs
     // are not being explicitly added to the subset and the input unicodes set is
     // not excessively large (eg. an inverted set).
     plan->unicode_to_new_gid_list.alloc (unicodes->get_population ());
-    for (hb_codepoint_t cp : *unicodes)
-    {
-      hb_codepoint_t gid;
-      if (!cmap.get_nominal_glyph (cp, &gid))
+    if (!unicode_to_gid) {
+      for (hb_codepoint_t cp : *unicodes)
       {
-        DEBUG_MSG(SUBSET, nullptr, "Drop U+%04X; no gid", cp);
-        continue;
-      }
+        hb_codepoint_t gid;
+        if (!cmap.get_nominal_glyph (cp, &gid))
+        {
+          DEBUG_MSG(SUBSET, nullptr, "Drop U+%04X; no gid", cp);
+          continue;
+        }
 
-      plan->codepoint_to_glyph->set (cp, gid);
-      plan->unicode_to_new_gid_list.push (hb_pair (cp, gid));
+        plan->codepoint_to_glyph->set (cp, gid);
+        plan->unicode_to_new_gid_list.push (hb_pair (cp, gid));
+      }
+    } else {
+      // Use in memory unicode to gid map it's faster then looking up from
+      // the map. This code is mostly duplicated from above to avoid doing
+      // conditionals on the presence of the unicode_to_gid map each
+      // iteration.
+      for (hb_codepoint_t cp : *unicodes)
+      {
+        hb_codepoint_t gid = unicode_to_gid->get (cp);
+        if (gid == HB_MAP_VALUE_INVALID)
+        {
+          DEBUG_MSG(SUBSET, nullptr, "Drop U+%04X; no gid", cp);
+          continue;
+        }
+
+        plan->codepoint_to_glyph->set (cp, gid);
+        plan->unicode_to_new_gid_list.push (hb_pair (cp, gid));
+      }
     }
   }
   else
   {
     // This approach is slower, but can handle adding in glyphs to the subset and will match
     // them with cmap entries.
-    hb_map_t unicode_glyphid_map;
-    hb_set_t cmap_unicodes;
-    cmap.collect_mapping (&cmap_unicodes, &unicode_glyphid_map);
-    plan->unicode_to_new_gid_list.alloc (hb_min(unicodes->get_population ()
-                                                + glyphs->get_population (),
-                                                cmap_unicodes.get_population ()));
 
-    for (hb_codepoint_t cp : cmap_unicodes)
+    hb_map_t unicode_glyphid_map_storage;
+    hb_set_t cmap_unicodes_storage;
+    const hb_map_t* unicode_glyphid_map = &unicode_glyphid_map_storage;
+    const hb_set_t* cmap_unicodes = &cmap_unicodes_storage;
+
+    if (!plan->accelerator) {
+      cmap.collect_mapping (&cmap_unicodes_storage, &unicode_glyphid_map_storage);
+      plan->unicode_to_new_gid_list.alloc (hb_min(unicodes->get_population ()
+                                                  + glyphs->get_population (),
+                                                  cmap_unicodes->get_population ()));
+    } else {
+      unicode_glyphid_map = &plan->accelerator->unicode_to_gid;
+      cmap_unicodes = &plan->accelerator->unicodes;
+    }
+
+    for (hb_codepoint_t cp : *cmap_unicodes)
     {
-      hb_codepoint_t gid = unicode_glyphid_map[cp];
+      hb_codepoint_t gid = (*unicode_glyphid_map)[cp];
       if (!unicodes->has (cp) && !glyphs->has (gid))
         continue;
 
@@ -729,7 +762,7 @@ _normalize_axes_location (hb_face_t *face, hb_subset_plan_t *plan)
     }
     if (has_avar)
       seg_maps = &StructAfter<OT::SegmentMaps> (*seg_maps);
-    
+
     old_axis_idx++;
   }
   plan->all_axes_pinned = !axis_not_pinned;
@@ -814,6 +847,11 @@ hb_subset_plan_create_or_fail (hb_face_t	 *face,
 
   plan->check_success (plan->vmtx_map = hb_hashmap_create<unsigned, hb_pair_t<unsigned, int>> ());
   plan->check_success (plan->hmtx_map = hb_hashmap_create<unsigned, hb_pair_t<unsigned, int>> ());
+
+  void* accel = hb_face_get_user_data(face, hb_subset_accelerator_t::user_data_key());
+  if (accel)
+    plan->accelerator = (hb_subset_accelerator_t*) accel;
+
 
   if (unlikely (plan->in_error ())) {
     hb_subset_plan_destroy (plan);

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -98,6 +98,7 @@ struct hb_subset_plan_t
 
   bool successful;
   unsigned flags;
+  bool attach_accelerator_data = false;
 
   // For each cp that we'd like to retain maps to the corresponding gid.
   hb_set_t *unicodes;

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -31,6 +31,7 @@
 
 #include "hb-subset.h"
 #include "hb-subset-input.hh"
+#include "hb-subset-accelerator.hh"
 
 #include "hb-map.hh"
 #include "hb-bimap.hh"
@@ -188,6 +189,8 @@ struct hb_subset_plan_t
   hb_hashmap_t<unsigned, hb_pair_t<unsigned, int>> *hmtx_map;
   //vmtx metrics map: new gid->(advance, lsb)
   hb_hashmap_t<unsigned, hb_pair_t<unsigned, int>> *vmtx_map;
+
+  const hb_subset_accelerator_t* accelerator;
 
  public:
 

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -510,7 +510,7 @@ static void _attach_accelerator_data (const hb_subset_plan_t* plan,
 
   if (!hb_face_set_user_data(face,
                              hb_subset_accelerator_t::user_data_key(),
-                             &accel,
+                             accel,
                              hb_subset_accelerator_t::destroy,
                              true))
     hb_subset_accelerator_t::destroy (accel);

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -598,7 +598,7 @@ hb_subset_plan_execute_or_fail (hb_subset_plan_t *plan)
     offset += num_tables;
   }
 
-  if (success && plan->flags & HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA) {
+  if (success && plan->attach_accelerator_data) {
     _attach_accelerator_data (plan, plan->dest);
   }
 

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -56,6 +56,7 @@
 #include "hb-ot-math-table.hh"
 #include "hb-ot-stat-table.hh"
 #include "hb-repacker.hh"
+#include "hb-subset-accelerator.hh"
 
 using OT::Layout::GSUB;
 using OT::Layout::GPOS;
@@ -494,6 +495,27 @@ _subset_table (hb_subset_plan_t *plan,
   }
 }
 
+static void _attach_accelerator_data (const hb_subset_plan_t* plan,
+                                      hb_face_t* face /* IN/OUT */)
+{
+  hb_subset_accelerator_t* accel =
+      hb_subset_accelerator_t::create (*plan->codepoint_to_glyph,
+                                       *plan->unicodes);
+
+  if (accel->in_error ())
+  {
+    hb_subset_accelerator_t::destroy (accel);
+    return;
+  }
+
+  if (!hb_face_set_user_data(face,
+                             hb_subset_accelerator_t::user_data_key(),
+                             &accel,
+                             hb_subset_accelerator_t::destroy,
+                             true))
+    hb_subset_accelerator_t::destroy (accel);
+}
+
 /**
  * hb_subset_or_fail:
  * @source: font face data to be subset.
@@ -574,6 +596,10 @@ hb_subset_plan_execute_or_fail (hb_subset_plan_t *plan)
       revisit_set = revisit_temp;
     }
     offset += num_tables;
+  }
+
+  if (success && plan->flags & HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA) {
+    _attach_accelerator_data (plan, plan->dest);
   }
 
 end:

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -70,9 +70,6 @@ typedef struct hb_subset_plan_t hb_subset_plan_t;
  * in the final subset.
  * @HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES: If set then the unicode ranges in
  * OS/2 will not be recalculated.
- * @HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA: If set the subsetter will append into
- * the output hb_face_t's user data, accelerator data that can be used to speedup
- * further subsetting operations on the face.
  * @HB_SUBSET_FLAGS_PATCH_MODE: If set the subsetter behaviour will be modified
  * to produce a subset that is better suited to patching. For example cmap
  * subtable format will be kept stable.
@@ -97,9 +94,8 @@ typedef enum { /*< flags >*/
   HB_SUBSET_FLAGS_NOTDEF_OUTLINE =	     0x00000040u,
   HB_SUBSET_FLAGS_GLYPH_NAMES =		     0x00000080u,
   HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES =  0x00000100u,
-  HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA =     0x00000200u,
-  // Not supported yet: HB_SUBSET_FLAGS_PATCH_MODE = 0x00000400u,
-  // Not supported yet: HB_SUBSET_FLAGS_OMIT_GLYF =  0x00000800u,
+  // Not supported yet: HB_SUBSET_FLAGS_PATCH_MODE = 0x00000200u,
+  // Not supported yet: HB_SUBSET_FLAGS_OMIT_GLYF =  0x00000400u,
 } hb_subset_flags_t;
 
 /**
@@ -181,6 +177,10 @@ hb_subset_input_pin_axis_location (hb_subset_input_t  *input,
 				   hb_tag_t            axis_tag,
 				   float               axis_value);
 #endif
+
+HB_EXTERN hb_face_t *
+hb_subset_preprocess (hb_face_t *source);
+
 #endif
 
 HB_EXTERN hb_face_t *

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -98,8 +98,8 @@ typedef enum { /*< flags >*/
   HB_SUBSET_FLAGS_GLYPH_NAMES =		     0x00000080u,
   HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES =  0x00000100u,
   HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA =     0x00000200u,
-  HB_SUBSET_FLAGS_PATCH_MODE =               0x00000400u,
-  HB_SUBSET_FLAGS_OMIT_GLYF =                0x00000800u,
+  // Not supported yet: HB_SUBSET_FLAGS_PATCH_MODE = 0x00000400u,
+  // Not supported yet: HB_SUBSET_FLAGS_OMIT_GLYF =  0x00000800u,
 } hb_subset_flags_t;
 
 /**

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -177,6 +177,9 @@ hb_subset_input_pin_axis_location (hb_subset_input_t  *input,
 				   hb_tag_t            axis_tag,
 				   float               axis_value);
 #endif
+#endif
+
+#ifdef HB_EXPERIMENTAL_API
 
 HB_EXTERN hb_face_t *
 hb_subset_preprocess (hb_face_t *source);

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -70,6 +70,17 @@ typedef struct hb_subset_plan_t hb_subset_plan_t;
  * in the final subset.
  * @HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES: If set then the unicode ranges in
  * OS/2 will not be recalculated.
+ * @HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA: If set the subsetter will append into
+ * the output hb_face_t's user data, accelerator data that can be used to speedup
+ * further subsetting operations on the face.
+ * @HB_SUBSET_FLAGS_PATCH_MODE: If set the subsetter behaviour will be modified
+ * to produce a subset that is better suited to patching. For example cmap
+ * subtable format will be kept stable.
+ * @HB_SUBSET_FLAGS_OMIT_GLYF: If set the subsetter won't actually produce the final
+ * glyf table bytes. The table directory will include and entry as if the table was
+ * there but the actual final font blob will be truncated prior to the glyf data. This
+ * is a useful performance optimization when a font aware binary patching algorithm
+ * is being used to diff two subsets.
  *
  * List of boolean properties that can be configured on the subset input.
  *
@@ -86,6 +97,9 @@ typedef enum { /*< flags >*/
   HB_SUBSET_FLAGS_NOTDEF_OUTLINE =	     0x00000040u,
   HB_SUBSET_FLAGS_GLYPH_NAMES =		     0x00000080u,
   HB_SUBSET_FLAGS_NO_PRUNE_UNICODE_RANGES =  0x00000100u,
+  HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA =     0x00000200u,
+  HB_SUBSET_FLAGS_PATCH_MODE =               0x00000400u,
+  HB_SUBSET_FLAGS_OMIT_GLYF =                0x00000800u,
 } hb_subset_flags_t;
 
 /**

--- a/src/meson.build
+++ b/src/meson.build
@@ -334,6 +334,7 @@ hb_subset_sources = files(
   'hb-ot-cff1-table.cc',
   'hb-ot-cff2-table.cc',
   'hb-static.cc',
+  'hb-subset-accelerator.hh',
   'hb-subset-cff-common.cc',
   'hb-subset-cff-common.hh',
   'hb-subset-cff1.cc',

--- a/test/subset/run-tests.py
+++ b/test/subset/run-tests.py
@@ -52,6 +52,7 @@ def run_test (test, should_check_ots):
 	cli_args = ["--font-file=" + test.font_path,
 		    "--output-file=" + out_file,
 		    "--unicodes=%s" % test.unicodes (),
+		    "--preprocess-face",
 		    "--drop-tables+=DSIG",
 		    "--drop-tables-=sbix"]
 	cli_args.extend (test.get_profile_flags ())

--- a/util/hb-subset.cc
+++ b/util/hb-subset.cc
@@ -34,36 +34,11 @@
 
 static hb_face_t* preprocess_face(hb_face_t* face)
 {
-  hb_subset_input_t* input = hb_subset_input_create_or_fail ();
-
-  hb_set_clear (hb_subset_input_set(input, HB_SUBSET_SETS_UNICODE));
-  hb_set_invert (hb_subset_input_set(input, HB_SUBSET_SETS_UNICODE));
-
-  hb_set_clear (hb_subset_input_set(input,
-                                    HB_SUBSET_SETS_LAYOUT_FEATURE_TAG));
-  hb_set_invert (hb_subset_input_set(input,
-                                     HB_SUBSET_SETS_LAYOUT_FEATURE_TAG));
-
-  hb_set_clear (hb_subset_input_set(input,
-                                    HB_SUBSET_SETS_LAYOUT_SCRIPT_TAG));
-  hb_set_invert (hb_subset_input_set(input,
-                                     HB_SUBSET_SETS_LAYOUT_SCRIPT_TAG));
-
-  hb_set_clear (hb_subset_input_set(input,
-                                    HB_SUBSET_SETS_NAME_ID));
-  hb_set_invert (hb_subset_input_set(input,
-                                     HB_SUBSET_SETS_NAME_ID));
-
-  hb_subset_input_set_flags(input,
-                            HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
-                            HB_SUBSET_FLAGS_GLYPH_NAMES |
-                            HB_SUBSET_FLAGS_RETAIN_GIDS |
-                            HB_SUBSET_FLAGS_ADD_ACCELERATOR_DATA);
-
-  hb_face_t* subset = hb_subset_or_fail (face, input);
-  hb_subset_input_destroy (input);
-
-  return subset;
+  #ifdef HB_EXPERIMENTAL_API
+  return hb_subset_preprocess (face);
+  #else
+  return hb_face_reference(face);
+  #endif
 }
 
 /*


### PR DESCRIPTION
The subset accelerator is cached data that can be attached to a hb_face_t and used in subsequent subsetting operations. This allows those subsetting operations to avoid doing things such as collecting the full unicode to gid mapping.

Gives significant speedups of up to 40% in some cases:

BM_subset/subset_glyphs/Roboto-Regular.ttf/10_median                                     -0.2081         -0.2079             0             0             0             0
BM_subset/subset_glyphs/Roboto-Regular.ttf/64_median                                     -0.1231         -0.1226             0             0             0             0
BM_subset/subset_glyphs/Roboto-Regular.ttf/512_median                                    -0.0378         -0.0379             1             1             1             1
BM_subset/subset_glyphs/Roboto-Regular.ttf/4000_median                                   -0.0358         -0.0360             2             2             2             2
BM_subset/subset_glyphs/Amiri-Regular.ttf/10_median                                      -0.1493         -0.1493             1             0             1             0
BM_subset/subset_glyphs/Amiri-Regular.ttf/64_median                                      -0.0943         -0.0943             1             1             1             1
BM_subset/subset_glyphs/Amiri-Regular.ttf/512_median                                     -0.0211         -0.0214             6             6             6             6
BM_subset/subset_glyphs/Amiri-Regular.ttf/4000_median                                    -0.0064         -0.0062             9             9             9             9
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/10_median                           -0.0516         -0.0518             1             1             1             1
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/64_median                           -0.0458         -0.0459             1             1             1             1
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/512_median                          +0.0033         -0.0012            75            75            75            75
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/1000_median                         -0.0085         -0.0085           120           119           120           119
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/10_median                         -0.0742         -0.0742             0             0             0             0
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/64_median                         -0.0362         -0.0362             0             0             0             0
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/512_median                        -0.0149         -0.0151             4             4             4             4
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/1000_median                       -0.0106         -0.0106             3             3             3             3
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/10_median                                    -0.4549         -0.4549             1             1             1             1
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/64_median                                    -0.4073         -0.4073             1             1             1             1
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/512_median                                   -0.3000         -0.2999             2             1             2             1
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/4096_median                                  -0.1162         -0.1163             6             5             6             5
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/10000_median                                 -0.0597         -0.0598            11            11            11            11
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/10_median                       -0.2933         -0.2933             1             1             1             1
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/64_median                       -0.2153         -0.2155             1             1             1             1
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/512_median                      -0.0828         -0.0828             5             4             5             4
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/4096_median                     -0.0376         -0.0377            57            55            57            55
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/10000_median                    -0.0166         -0.0166           142           140           142           140
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/10_median                              -0.0914         -0.0915             0             0             0             0
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/64_median                              -0.0404         -0.0405             1             1             1             1
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/512_median                             -0.0104         -0.0104             4             3             4             3
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/2000_median                            -0.0220         -0.0222            11            11            11            11
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/10_median                                    -0.3857         -0.3858             1             1             1             1
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/64_median                                    -0.3552         -0.3553             1             1             1             1
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/512_median                                   -0.1442         -0.1448             4             3             4             3
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/4096_median                                  -0.0699         -0.0714            10             9            10             9
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/6000_median                                  -0.0205         -0.0207            13            13            13            13
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/10_median                                -0.0794         -0.0795             0             0             0             0
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/64_median                                -0.0282         -0.0283             1             1             1             1
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/512_median                               -0.0157         -0.0158             5             5             5             5
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/900_median                               -0.0249         -0.0251             5             5             5             5
BM_subset/subset_codepoints/Roboto-Regular.ttf/10_median                                 +0.0045         +0.0044             0             0             0             0
BM_subset/subset_codepoints/Roboto-Regular.ttf/64_median                                 +0.0052         +0.0033             0             0             0             0
BM_subset/subset_codepoints/Roboto-Regular.ttf/512_median                                +0.0018         +0.0014             1             1             1             1
BM_subset/subset_codepoints/Roboto-Regular.ttf/4000_median                               -0.0001         -0.0009             1             1             1             1
BM_subset/subset_codepoints/Amiri-Regular.ttf/10_median                                  -0.0030         -0.0030             0             0             0             0
BM_subset/subset_codepoints/Amiri-Regular.ttf/64_median                                  +0.0117         +0.0118             1             1             1             1
BM_subset/subset_codepoints/Amiri-Regular.ttf/512_median                                 -0.0091         -0.0091             6             6             6             6
BM_subset/subset_codepoints/Amiri-Regular.ttf/4000_median                                -0.0069         -0.0069             9             9             9             9
BM_subset/subset_codepoints/NotoNastaliqUrdu-Regular.ttf/10_median                       +0.0022         +0.0022             1             1             1             1
BM_subset/subset_codepoints/NotoNastaliqUrdu-Regular.ttf/64_median                       +0.0035         +0.0035            12            12            12            12
BM_subset/subset_codepoints/NotoNastaliqUrdu-Regular.ttf/512_median                      -0.0081         -0.0081           125           124           125           124
BM_subset/subset_codepoints/NotoNastaliqUrdu-Regular.ttf/1000_median                     -0.0116         -0.0115           125           124           125           124
BM_subset/subset_codepoints/NotoSansDevanagari-Regular.ttf/10_median                     -0.0059         -0.0060             0             0             0             0
BM_subset/subset_codepoints/NotoSansDevanagari-Regular.ttf/64_median                     -0.0102         -0.0101             0             0             0             0
BM_subset/subset_codepoints/NotoSansDevanagari-Regular.ttf/512_median                    -0.0145         -0.0144             4             4             4             4
BM_subset/subset_codepoints/NotoSansDevanagari-Regular.ttf/1000_median                   -0.0170         -0.0170             4             4             4             4
BM_subset/subset_codepoints/Mplus1p-Regular.ttf/10_median                                +0.0063         +0.0063             0             0             0             0
BM_subset/subset_codepoints/Mplus1p-Regular.ttf/64_median                                +0.0007         +0.0007             1             1             1             1
BM_subset/subset_codepoints/Mplus1p-Regular.ttf/512_median                               -0.0031         -0.0030             1             1             1             1
BM_subset/subset_codepoints/Mplus1p-Regular.ttf/4096_median                              -0.0207         -0.0207             5             5             5             5
BM_subset/subset_codepoints/Mplus1p-Regular.ttf/10000_median                             -0.0303         -0.0303            11            10            11            10
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/10_median                   -0.0023         -0.0020             1             1             1             1
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/64_median                   -0.0096         -0.0086             1             1             1             1
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/512_median                  -0.0047         -0.0040             4             4             4             4
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/4096_median                 -0.0186         -0.0180           111           109           111           109
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/10000_median                -0.0170         -0.0171           141           139           141           139
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/10_median                          -0.0021         -0.0021             0             0             0             0
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/64_median                          -0.0108         -0.0108             1             1             1             1
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/512_median                         -0.0067         -0.0066             4             4             4             4
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/2000_median                        -0.0138         -0.0138             9             9             9             9
BM_subset/subset_codepoints/MPLUS1-Variable.ttf/10_median                                -0.0054         -0.0030             1             1             1             1
BM_subset/subset_codepoints/MPLUS1-Variable.ttf/64_median                                -0.0172         -0.0144             1             1             1             1
BM_subset/subset_codepoints/MPLUS1-Variable.ttf/512_median                               -0.0227         -0.0206             4             4             4             4
BM_subset/subset_codepoints/MPLUS1-Variable.ttf/4096_median                              -0.0210         -0.0205            10             9            10             9
BM_subset/subset_codepoints/MPLUS1-Variable.ttf/6000_median                              +0.0177         +0.0179            13            13            13            13
BM_subset/subset_codepoints/RobotoFlex-Variable.ttf/10_median                            +0.0031         +0.0031             0             0             0             0
BM_subset/subset_codepoints/RobotoFlex-Variable.ttf/64_median                            -0.0059         -0.0059             1             1             1             1
BM_subset/subset_codepoints/RobotoFlex-Variable.ttf/512_median                           -0.0195         -0.0193             5             5             5             5
BM_subset/subset_codepoints/RobotoFlex-Variable.ttf/900_median                           -0.0290         -0.0288             5             5             5             5
BM_subset/instance/MPLUS1-Variable.ttf/10_median                                         -0.0060         -0.0059             1             1             1             1
BM_subset/instance/MPLUS1-Variable.ttf/64_median                                         -0.0074         -0.0059             1             1             1             1
BM_subset/instance/MPLUS1-Variable.ttf/512_median                                        -0.0132         -0.0128             4             4             4             4
BM_subset/instance/MPLUS1-Variable.ttf/4096_median                                       -0.0076         -0.0074            37            37            37            37
BM_subset/instance/MPLUS1-Variable.ttf/6000_median                                       -0.0067         -0.0060            58            58            58            58
BM_subset/instance/RobotoFlex-Variable.ttf/10_median                                     -0.0050         -0.0043             1             1             1             1
BM_subset/instance/RobotoFlex-Variable.ttf/64_median                                     -0.0056         -0.0055             2             2             2             2
BM_subset/instance/RobotoFlex-Variable.ttf/512_median                                    -0.0115         -0.0114            13            13            13            13
BM_subset/instance/RobotoFlex-Variable.ttf/900_median                                    -0.0096         -0.0095            21            21            21            21