### PR TITLE
[subset] Always output Lookup's even if they are empty.

### DIFF
--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -1388,6 +1388,12 @@ struct Lookup
       outMarkFilteringSet = markFilteringSet;
     }
 
+    // Always keep the lookup even if it's empty. The rest of layout subsetting depends on lookup
+    // indices being consistent with those computed during planning. So if an empty lookup is
+    // discarded during the subset phase it will invalidate all subsequent lookup indices.
+    // Generally we shouldn't end up with an empty lookup as we pre-prune them during the planning
+    // phase, but it can happen in rare cases such as when during closure subtable is considered
+    // degenerate (see: https://github.com/harfbuzz/harfbuzz/issues/3853)
     return true;
   }
 

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -1388,7 +1388,7 @@ struct Lookup
       outMarkFilteringSet = markFilteringSet;
     }
 
-    return_trace (out->subTable.len);
+    return true;
   }
 
   template <typename TSubTable>
@@ -2948,7 +2948,7 @@ struct ConditionSet
 
     // all conditions met
     if (num_kept_cond == 0) return DROP_COND_WITH_VAR;
- 
+
     //check if condition_set is unique with variations
     if (c->conditionset_map->has (p))
       //duplicate found, drop the entire record


### PR DESCRIPTION
The rest of layout subsetting depends on lookup indices being consistent with those computed during planning. So if an empty lookup is discarded during the subset phase it will invalidate all subsequent lookup indices. Generally we shouldn't end up with an empty lookup as we pre-prune them during the planning phase, but it can happen in rare cases such as when a subtable is considered degenerate (eg. #3853)