### PR TITLE
fix bug in hb_hashmap_t has() interface

### DIFF
--- a/src/hb-map.hh
+++ b/src/hb-map.hh
@@ -221,7 +221,7 @@ struct hb_hashmap_t
     unsigned int i = bucket_for (key);
     if (items[i].is_real () && items[i] == key)
     {
-      if (vp) *vp = &items[i].value;
+      if (vp) *vp = std::addressof (items[i].value);
       return true;
     }
     else

--- a/src/test-map.cc
+++ b/src/test-map.cc
@@ -240,5 +240,15 @@ main (int argc, char **argv)
     m1->set (2,4);
     assert (!m.has (p2));
   }
+  /* Test value type with hb_bytes_t. */
+  {
+    hb_hashmap_t<int, hb_bytes_t> m;
+    char c_str[] = "Test";
+    hb_bytes_t bytes (c_str, 4);
+
+    m.set (1, bytes);
+    assert (m.has (1));
+  }
+
   return 0;
 }


### PR DESCRIPTION
It was not working when the value type is hb_bytes_t because hb_array_t overloaded operator &