### PR TITLE
[subset] Include instancing tests in distribution.

### DIFF
--- a/test/subset/data/Makefile.am
+++ b/test/subset/data/Makefile.am
@@ -7,6 +7,7 @@ SUBDIRS = repack_tests
 
 EXTRA_DIST += \
 	$(TESTS) \
+	$(DISABLED_TESTS) \
 	expected/32bit_var_store \
 	expected/basics \
 	expected/full-font \
@@ -55,6 +56,10 @@ EXTRA_DIST += \
 	expected/math \
 	expected/math_coverage_offset \
 	expected/post \
+	expected/full_instance \
+	expected/instance_feature_variations \
+	expected/instantiate_glyf \
+	expected/pin_all_at_default \
 	fonts \
 	profiles \
 	$(NULL)

--- a/test/subset/data/Makefile.sources
+++ b/test/subset/data/Makefile.sources
@@ -57,5 +57,10 @@ TESTS = \
 XFAIL_TESTS = \
 	$(NULL)
 
+# Disabled because instancing is only available w/ experimental API on.
 DISABLED_TESTS = \
+	tests/full_instance.tests \
+	tests/instance_feature_variations.tests \
+	tests/instantiate_glyf.tests \
+	tests/pin_all_at_default.tests \
 	$(NULL)

--- a/test/subset/meson.build
+++ b/test/subset/meson.build
@@ -40,8 +40,8 @@ tests = [
   'colr_glyphs',
   'math',
   'math_coverage_offset',
-# TODO: re-enable once colrv1 subsetting is stabilized.
-# 'colrv1.notoemoji',
+  # TODO: re-enable once colrv1 subsetting is stabilized.
+  # 'colrv1.notoemoji',
   'colrv1',
   'colr_with_components',
   'cbdt',
@@ -49,12 +49,17 @@ tests = [
   'glyph_names',
   'post',
   '32bit_var_store',
-# instacing tests, enable when --instance is not experimental
-# 'pin_all_at_default',
-# 'instantiate_glyf',
-# 'full_instance',
-# 'instance_feature_variations',
 ]
+
+if get_option('experimental_api')
+  # instacing tests, only supported in experimental api
+  tests += [
+    'pin_all_at_default',
+    'instantiate_glyf',
+    'full_instance',
+    'instance_feature_variations',
+  ]
+endif
 
 repack_tests = [
   'basic',


### PR DESCRIPTION
Automatically enable them when the experimental api is enabled.