### PR TITLE
meson: fix regression in detecting freetype2/icu-uc when explicitly disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,20 +83,35 @@ check_funcs = [
 
 m_dep = cpp.find_library('m', required: false)
 
-
-# Try pkgconfig name
-freetype_dep = dependency('freetype2', required: false)
-if not freetype_dep.found()
-  # Try cmake name
-  freetype_dep = dependency('freetype', required: false)
-endif
-if not freetype_dep.found()
-  # Subproject fallback, `allow_fallback: true` means the fallback will be
-  # tried even if the freetype option is set to `auto`.
-  freetype_dep = dependency('freetype2',
+if meson.version().version_compare('>=0.60.0')
+  # pkg-config: freetype2, cmake: Freetype
+  freetype_dep = dependency('freetype2', 'Freetype',
                             required: get_option('freetype'),
                             default_options: ['harfbuzz=disabled'],
                             allow_fallback: true)
+else
+  # painful hack to handle multiple dependencies but also respect options
+  freetype_opt = get_option('freetype')
+  # we want to handle enabled manually after fallbacks, but also handle disabled normally
+  if freetype_opt.enabled()
+    freetype_opt = false
+  endif
+  # try pkg-config name
+  freetype_dep = dependency('freetype2', method: 'pkg-config', required: freetype_opt)
+  # when disabled, leave it not-found
+  if not freetype_dep.found() and not get_option('freetype').disabled()
+    # Try cmake name
+    freetype_dep = dependency('Freetype', method: 'cmake', required: false)
+    # Subproject fallback, `allow_fallback: true` means the fallback will be
+    # tried even if the freetype option is set to `auto`.
+    if not freetype_dep.found()
+      freetype_dep = dependency('freetype2',
+                                method: 'pkg-config',
+                                required: get_option('freetype'),
+                                default_options: ['harfbuzz=disabled'],
+                                allow_fallback: true)
+    endif
+  endif
 endif
 
 glib_dep = dependency('glib-2.0', required: get_option('glib'))
@@ -104,18 +119,36 @@ gobject_dep = dependency('gobject-2.0', required: get_option('gobject'))
 graphite2_dep = dependency('graphite2', required: get_option('graphite2'))
 graphite_dep = dependency('graphite2', required: get_option('graphite'))
 
-# Try pkgconfig name
-icu_dep = dependency('icu-uc', required: false)
-if not icu_dep.found()
-  # Try cmake name
-  icu_dep = dependency('ICU',
-                       required: false,
-                       components: 'uc',
-                       method: 'cmake')
-endif
-if not icu_dep.found()
-  # Subproject fallback if icu option is enabled
-  icu_dep = dependency('icu-uc', required: get_option('icu'))
+if meson.version().version_compare('>=0.60.0')
+  # pkg-config: icu-uc, cmake: ICU but with components
+  icu_dep = dependency('icu-uc', 'ICU',
+                            components: 'uc',
+                            required: get_option('icu'),
+                            default_options: ['harfbuzz=disabled'],
+                            allow_fallback: true)
+else
+  # painful hack to handle multiple dependencies but also respect options
+  icu_opt = get_option('icu')
+  # we want to handle enabled manually after fallbacks, but also handle disabled normally
+  if icu_opt.enabled()
+    icu_opt = false
+  endif
+  # try pkg-config name
+  icu_dep = dependency('icu-uc', method: 'pkg-config', required: icu_opt)
+  # when disabled, leave it not-found
+  if not icu_dep.found() and not get_option('icu').disabled()
+    # Try cmake name
+    icu_dep = dependency('ICU', method: 'cmake', components: 'uc', required: false)
+    # Try again with subproject fallback. `allow_fallback: true` means the
+    # fallback will be tried even if the icu option is set to `auto`, but
+    # we cannot pass this option until Meson 0.59.0, because no wrap file
+    # is checked into git.
+    if not icu_dep.found()
+      icu_dep = dependency('icu-uc',
+                           method: 'pkg-config',
+                           required: get_option('icu'))
+    endif
+  endif
 endif
 
 if icu_dep.found() and icu_dep.type_name() == 'pkgconfig'


### PR DESCRIPTION
In #3811 / commit 53a194aa3f5f7de0b40e879e41fcbe0de6e9fefe a broken and half-implemented approach to kind of sort of handling the detection of both pkg-config and cmake names for dependencies, was implemented. It just checked for both versions with required: false, but when the build was configured with *disabled* options, it was still found because it was treated as auto.

Really, the problem here is trying to outsmart Meson, which handles a lot of edge cases correctly. But it's possible, albeit very wordy, to manually implement Meson's internal logic via if/else fallbacks. Do so here.

Fixes failure to build on Gentoo, /cc @thesamesam

Fixes:
https://bugs.gentoo.org/880405
https://bugs.gentoo.org/880479