### PR TITLE
[subset] Cache has_seac in accelerator

### DIFF
--- a/src/hb-subset-accelerator.hh
+++ b/src/hb-subset-accelerator.hh
@@ -43,10 +43,12 @@ struct hb_subset_accelerator_t
   }
 
   static hb_subset_accelerator_t* create(const hb_map_t& unicode_to_gid_,
-                                         const hb_set_t& unicodes_) {
+                                         const hb_set_t& unicodes_,
+					 bool has_seac_) {
     hb_subset_accelerator_t* accel =
         (hb_subset_accelerator_t*) hb_malloc (sizeof(hb_subset_accelerator_t));
     new (accel) hb_subset_accelerator_t (unicode_to_gid_, unicodes_);
+    accel->has_seac = has_seac_;
     return accel;
   }
 
@@ -64,6 +66,7 @@ struct hb_subset_accelerator_t
 
   const hb_map_t unicode_to_gid;
   const hb_set_t unicodes;
+  bool has_seac;
   // TODO(garretrieger): cumulative glyf checksum map
   // TODO(garretrieger): sanitized table cache.
 

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -194,6 +194,7 @@ struct hb_subset_plan_t
   hb_map_t *axes_old_index_tag_map;
   bool all_axes_pinned;
   bool pinned_at_default;
+  bool has_seac;
 
   //hmtx metrics map: new gid->(advance, lsb)
   hb_hashmap_t<unsigned, hb_pair_t<unsigned, int>> *hmtx_map;

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -504,7 +504,8 @@ static void _attach_accelerator_data (const hb_subset_plan_t* plan,
 {
   hb_subset_accelerator_t* accel =
       hb_subset_accelerator_t::create (*plan->codepoint_to_glyph,
-                                       *plan->unicodes);
+                                       *plan->unicodes,
+				       plan->has_seac);
 
   if (accel->in_error ())
   {


### PR DESCRIPTION
Speeds up SourceHanSans-Regular/10000 benchmark by %25.