### PR TITLE
[subset] In the preprocess subset call always use long loca.

### DIFF
--- a/src/OT/glyf/glyf.hh
+++ b/src/OT/glyf/glyf.hh
@@ -85,9 +85,12 @@ struct glyf
     | hb_map (&glyf_impl::SubsetGlyph::padded_size)
     ;
 
-    unsigned max_offset = + padded_offsets | hb_reduce (hb_add, 0);
-    bool use_short_loca = max_offset < 0x1FFFF;
-
+    bool use_short_loca = false;
+    if (likely (!c->plan->force_long_loca))
+    {
+      unsigned max_offset = + padded_offsets | hb_reduce (hb_add, 0);
+      use_short_loca = max_offset < 0x1FFFF;
+    }
 
     glyf_prime->serialize (c->serializer, hb_iter (glyphs), use_short_loca, c->plan);
     if (!use_short_loca) {

--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -489,6 +489,11 @@ hb_subset_preprocess (hb_face_t *source)
                             HB_SUBSET_FLAGS_RETAIN_GIDS);
   input->attach_accelerator_data = true;
 
+  // Always use long loca in the preprocessed version. This allows
+  // us to store the glyph bytes unpadded which allows the future subset
+  // operation to run faster by skipping the trim padding step.
+  input->force_long_loca = true;
+
   hb_face_t* new_source = hb_subset_or_fail (source, input);
   hb_subset_input_destroy (input);
 

--- a/src/hb-subset-input.hh
+++ b/src/hb-subset-input.hh
@@ -60,6 +60,10 @@ struct hb_subset_input_t
 
   unsigned flags;
   bool attach_accelerator_data = false;
+
+  // If set loca format will always be the long version.
+  bool force_long_loca = false;
+
   hb_hashmap_t<hb_tag_t, float> *axes_location;
 #ifdef HB_EXPERIMENTAL_API
   hb_hashmap_t<unsigned, hb_bytes_t> *name_table_overrides;

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -883,6 +883,7 @@ hb_subset_plan_create_or_fail (hb_face_t	 *face,
   void* accel = hb_face_get_user_data(face, hb_subset_accelerator_t::user_data_key());
 
   plan->attach_accelerator_data = input->attach_accelerator_data;
+  plan->force_long_loca = input->force_long_loca;
   if (accel)
     plan->accelerator = (hb_subset_accelerator_t*) accel;
 

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -108,6 +108,7 @@ struct hb_subset_plan_t
   bool successful;
   unsigned flags;
   bool attach_accelerator_data = false;
+  bool force_long_loca = false;
 
   // For each cp that we'd like to retain maps to the corresponding gid.
   hb_set_t *unicodes;


### PR DESCRIPTION
Long loca is needed so that we can store the trimmed glyph bytes to allow us to safely skip trimming in the later subset.