### PR TITLE
[subset] Cache parsed char strings in CFF accelerator

### DIFF
--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -1295,10 +1295,10 @@ struct cff1
     }
 
     protected:
-    hb_blob_t	           *blob = nullptr;
     hb_sanitize_context_t   sc;
 
     public:
+    hb_blob_t               *blob = nullptr;
     const Encoding	    *encoding = nullptr;
     const Charset	    *charset = nullptr;
     const CFF1NameIndex     *nameIndex = nullptr;

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -486,10 +486,10 @@ struct cff2
     bool is_valid () const { return blob; }
 
     protected:
-    hb_blob_t			*blob = nullptr;
     hb_sanitize_context_t	sc;
 
     public:
+    hb_blob_t			*blob = nullptr;
     cff2_top_dict_values_t	topDict;
     const CFF2Subrs		*globalSubrs = nullptr;
     const CFF2VariationStore	*varStore = nullptr;

--- a/src/hb-subset-accelerator.hh
+++ b/src/hb-subset-accelerator.hh
@@ -35,6 +35,10 @@
 
 extern HB_INTERNAL hb_user_data_key_t _hb_subset_accelerator_user_data_key;
 
+namespace CFF {
+struct cff_subset_accelerator_t;
+}
+
 struct hb_subset_accelerator_t
 {
   static hb_user_data_key_t* user_data_key()
@@ -62,11 +66,17 @@ struct hb_subset_accelerator_t
 
   hb_subset_accelerator_t(const hb_map_t& unicode_to_gid_,
                           const hb_set_t& unicodes_)
-      : unicode_to_gid(unicode_to_gid_), unicodes(unicodes_) {}
+      : unicode_to_gid(unicode_to_gid_), unicodes(unicodes_),
+        has_seac(false), cff_accelerator(nullptr) {}
 
+  // Generic
   const hb_map_t unicode_to_gid;
   const hb_set_t unicodes;
+
+  // CFF
   bool has_seac;
+  CFF::cff_subset_accelerator_t* cff_accelerator;
+
   // TODO(garretrieger): cumulative glyf checksum map
   // TODO(garretrieger): sanitized table cache.
 

--- a/src/hb-subset-accelerator.hh
+++ b/src/hb-subset-accelerator.hh
@@ -60,6 +60,10 @@ struct hb_subset_accelerator_t
     if (!value) return;
 
     hb_subset_accelerator_t* accel = (hb_subset_accelerator_t*) value;
+
+    if (accel->cff_accelerator && accel->destroy_cff_accelerator)
+      accel->destroy_cff_accelerator ((void*) accel->cff_accelerator);
+
     accel->~hb_subset_accelerator_t ();
     hb_free (accel);
   }
@@ -67,7 +71,7 @@ struct hb_subset_accelerator_t
   hb_subset_accelerator_t(const hb_map_t& unicode_to_gid_,
                           const hb_set_t& unicodes_)
       : unicode_to_gid(unicode_to_gid_), unicodes(unicodes_),
-        has_seac(false), cff_accelerator(nullptr) {}
+        has_seac(false), cff_accelerator(nullptr), destroy_cff_accelerator(nullptr) {}
 
   // Generic
   const hb_map_t unicode_to_gid;
@@ -76,6 +80,7 @@ struct hb_subset_accelerator_t
   // CFF
   bool has_seac;
   CFF::cff_subset_accelerator_t* cff_accelerator;
+  hb_destroy_func_t destroy_cff_accelerator;
 
   // TODO(garretrieger): cumulative glyf checksum map
   // TODO(garretrieger): sanitized table cache.

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -402,6 +402,28 @@ struct parsed_cs_str_vec_t : hb_vector_t<parsed_cs_str_t>
   typedef hb_vector_t<parsed_cs_str_t> SUPER;
 };
 
+struct cff_subset_accelerator_t
+{
+  static cff_subset_accelerator_t* create() {
+    cff_subset_accelerator_t* accel =
+        (cff_subset_accelerator_t*) hb_malloc (sizeof(cff_subset_accelerator_t));
+    new (accel) cff_subset_accelerator_t ();
+    return accel;
+  }
+
+  static void destroy(void* value) {
+    if (!value) return;
+
+    cff_subset_accelerator_t* accel = (cff_subset_accelerator_t*) value;
+    accel->~cff_subset_accelerator_t ();
+    hb_free (accel);
+  }
+
+  parsed_cs_str_t parsed_charstring;
+  parsed_cs_str_vec_t parsed_global_subrs;
+  parsed_cs_str_vec_t parsed_local_subrs;
+};
+
 struct subr_subset_param_t
 {
   subr_subset_param_t (parsed_cs_str_t *parsed_charstring_,

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -404,7 +404,7 @@ struct parsed_cs_str_vec_t : hb_vector_t<parsed_cs_str_t>
 
 struct cff_subset_accelerator_t
 {
-  static cff_subset_accelerator_t* create(
+  static cff_subset_accelerator_t* create (
       hb_face_t* original_face,
       const parsed_cs_str_vec_t& parsed_charstrings,
       const parsed_cs_str_vec_t& parsed_global_subrs,
@@ -418,7 +418,7 @@ struct cff_subset_accelerator_t
     return accel;
   }
 
-  static void destroy(void* value) {
+  static void destroy (void* value) {
     if (!value) return;
 
     cff_subset_accelerator_t* accel = (cff_subset_accelerator_t*) value;
@@ -1025,6 +1025,8 @@ struct subr_subsetter_t
                                          parsed_charstrings,
                                          parsed_global_subrs,
                                          parsed_local_subrs);
+    plan->inprogress_accelerator->destroy_cff_accelerator =
+        cff_subset_accelerator_t::destroy;
 
   }
 


### PR DESCRIPTION
Gives speed ups across the CFF subsetting benchmarks (up to 45% at large subset sizes):

BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/10_median | -3%
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/64_median | -11%
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/512_median | -27%
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/4096_median | -40%
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/10000_median | -44%
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/10_median | -3%
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/64_median | -13%
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/512_median | -35%
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/2000_median | -33%
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/10_median | -1%
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/64_median | -5%
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/512_median | -24%
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/4096_median | -44%
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/10000_median | -45%
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/10_median | -2%
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/64_median | -6%
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/512_median | -22%
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/2000_median | -28%

