### PR TITLE
Update freetype subproject to 2.12.1

### DIFF
--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory=freetype
 url=https://gitlab.freedesktop.org/freetype/freetype.git
-revision=VER-2-11-0
+revision=VER-2-12-1
 
 [provide]
 freetype2 = freetype_dep


### PR DESCRIPTION
Freetype is now at `2.12.1` as per https://gitlab.freedesktop.org/freetype/freetype/-/tags