### PR TITLE
[subset] Accelerate sanitize-table-cache

### DIFF
--- a/src/hb-mutex.hh
+++ b/src/hb-mutex.hh
@@ -108,10 +108,11 @@ struct hb_mutex_t
 
 struct hb_lock_t
 {
-  hb_lock_t (hb_mutex_t &mutex_) : mutex (mutex_) { mutex.lock (); }
-  ~hb_lock_t () { mutex.unlock (); }
+  hb_lock_t (hb_mutex_t &mutex_) : mutex (&mutex_) { mutex->lock (); }
+  hb_lock_t (hb_mutex_t *mutex_) : mutex (mutex_) { if (mutex) mutex->lock (); }
+  ~hb_lock_t () { if (mutex) mutex->unlock (); }
   private:
-  hb_mutex_t &mutex;
+  hb_mutex_t *mutex;
 };
 
 

--- a/src/hb-subset-accelerator.hh
+++ b/src/hb-subset-accelerator.hh
@@ -75,17 +75,25 @@ struct hb_subset_accelerator_t
     hb_free (accel);
   }
 
-  hb_subset_accelerator_t(const hb_map_t& unicode_to_gid_,
+  hb_subset_accelerator_t (const hb_map_t& unicode_to_gid_,
                           const hb_set_t& unicodes_)
       : unicode_to_gid(unicode_to_gid_), unicodes(unicodes_),
         cmap_cache(nullptr), destroy_cmap_cache(nullptr),
         has_seac(false), cff_accelerator(nullptr), destroy_cff_accelerator(nullptr)
+  { sanitized_table_cache_lock.init (); }
 
-  {}
+  ~hb_subset_accelerator_t ()
+  { sanitized_table_cache_lock.fini (); }
 
   // Generic
+
+  mutable hb_mutex_t sanitized_table_cache_lock;
+  mutable hb_hashmap_t<hb_tag_t, hb::unique_ptr<hb_blob_t>> sanitized_table_cache;
+
   const hb_map_t unicode_to_gid;
   const hb_set_t unicodes;
+
+  // cmap
   OT::SubtableUnicodesCache* cmap_cache;
   hb_destroy_func_t destroy_cmap_cache;
 


### PR DESCRIPTION
Big wins all across small subsets

BM_subset/subset_codepoints/Roboto-Regular.ttf/nohinting/10                              -0.1140         -0.1129             0             0             0             0
BM_subset/subset_codepoints/Amiri-Regular.ttf/nohinting/10                               -0.4717         -0.4714             0             0             0             0
BM_subset/subset_codepoints/NotoNastaliqUrdu-Regular.ttf/nohinting/10                    -0.8147         -0.8146             0             0             0             0
BM_subset/subset_codepoints/NotoSansDevanagari-Regular.ttf/nohinting/10                  -0.3248         -0.3242             0             0             0             0
BM_subset/subset_codepoints/Mplus1p-Regular.ttf/nohinting/10                             -0.1262         -0.1260             0             0             0             0
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/nohinting/10                -0.0308         -0.0309             0             0             0             0
BM_subset/subset_codepoints/SourceSansPro-Regular.otf/nohinting/10                       -0.1374         -0.1373             0             0             0             0
BM_subset/subset_codepoints/AdobeVFPrototype.otf/nohinting/10                            -0.4555         -0.4555             0             0             0             0
BM_subset/subset_codepoints/MPLUS1-Variable.ttf/nohinting/10                             -0.4175         -0.4174             0             0             0             0
BM_subset/subset_codepoints/RobotoFlex-Variable.ttf/nohinting/10                         -0.4214         -0.4214             0             0             0 
