### PR TITLE
[subset] make cff accelerator and cmap cache const

### DIFF
--- a/src/hb-subset-accelerator.hh
+++ b/src/hb-subset-accelerator.hh
@@ -99,7 +99,7 @@ struct hb_subset_accelerator_t
 
   // CFF
   bool has_seac;
-  CFF::cff_subset_accelerator_t* cff_accelerator;
+  const CFF::cff_subset_accelerator_t* cff_accelerator;
   hb_destroy_func_t destroy_cff_accelerator;
 
   // TODO(garretrieger): see if we can make the cff_accelerator and cmap_cache const

--- a/src/hb-subset-accelerator.hh
+++ b/src/hb-subset-accelerator.hh
@@ -94,7 +94,7 @@ struct hb_subset_accelerator_t
   const hb_set_t unicodes;
 
   // cmap
-  OT::SubtableUnicodesCache* cmap_cache;
+  const OT::SubtableUnicodesCache* cmap_cache;
   hb_destroy_func_t destroy_cmap_cache;
 
   // CFF
@@ -102,9 +102,7 @@ struct hb_subset_accelerator_t
   const CFF::cff_subset_accelerator_t* cff_accelerator;
   hb_destroy_func_t destroy_cff_accelerator;
 
-  // TODO(garretrieger): see if we can make the cff_accelerator and cmap_cache const
   // TODO(garretrieger): cumulative glyf checksum map
-  // TODO(garretrieger): sanitized table cache.
 
   bool in_error () const
   {


### PR DESCRIPTION
To prevent unintentional modification while they are used in subsetting operations.