### PR TITLE
[subset-cff1] Cache glyph-to-sid-map in the accelerator

### DIFF
--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -483,6 +483,11 @@ struct cff2
       blob = nullptr;
     }
 
+    hb_map_t *create_glyph_to_sid_map () const
+    {
+      return nullptr;
+    }
+
     bool is_valid () const { return blob; }
 
     protected:

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -433,11 +433,13 @@ struct cff_subset_accelerator_t
 
   ~cff_subset_accelerator_t() {
     hb_blob_destroy (original_blob);
+    hb_map_destroy (glyph_to_sid_map.get_relaxed ());
   }
 
   parsed_cs_str_vec_t parsed_charstrings;
   parsed_cs_str_vec_t parsed_global_subrs;
   hb_vector_t<parsed_cs_str_vec_t> parsed_local_subrs;
+  mutable hb_atomic_ptr_t<hb_map_t> glyph_to_sid_map = nullptr;
 
  private:
   hb_blob_t* original_blob;


### PR DESCRIPTION
Benchmark                                                                                      Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/nohinting/10                   -0.0841         -0.0843             0             0             0             0
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/nohinting/64                   -0.1305         -0.1305             0             0             0             0
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/nohinting/512                  -0.1398         -0.1401             1             1             1             1
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/nohinting/4096                 +0.0382         +0.0380             9             9             9             9
BM_subset/subset_codepoints/SourceHanSans-Regular_subset.otf/nohinting/10000                +0.0213         +0.0211            11            11            11            11