### PR TITLE
[subset-cff] Compact parsed strings if using accelerator

### DIFF
--- a/src/hb-array.hh
+++ b/src/hb-array.hh
@@ -267,7 +267,7 @@ struct hb_array_t : hb_iter_with_fallback_t<hb_array_t<Type>, Type&>
 
   template <typename hb_serialize_context_t,
 	    typename U = Type,
-	    hb_enable_if (!(sizeof (U) < sizeof (long long) && hb_is_trivially_copy_assignable(Type)))>
+	    hb_enable_if (!(sizeof (U) < sizeof (long long) && hb_is_trivially_copy_assignable(hb_decay<Type>)))>
   hb_array_t copy (hb_serialize_context_t *c) const
   {
     TRACE_SERIALIZE (this);
@@ -280,7 +280,7 @@ struct hb_array_t : hb_iter_with_fallback_t<hb_array_t<Type>, Type&>
 
   template <typename hb_serialize_context_t,
 	    typename U = Type,
-	    hb_enable_if (sizeof (U) < sizeof (long long) && hb_is_trivially_copy_assignable(Type))>
+	    hb_enable_if (sizeof (U) < sizeof (long long) && hb_is_trivially_copy_assignable(hb_decay<Type>))>
   hb_array_t copy (hb_serialize_context_t *c) const
   {
     TRACE_SERIALIZE (this);

--- a/src/hb-array.hh
+++ b/src/hb-array.hh
@@ -286,7 +286,7 @@ struct hb_array_t : hb_iter_with_fallback_t<hb_array_t<Type>, Type&>
     TRACE_SERIALIZE (this);
     auto* out = c->start_embed (arrayZ);
     if (unlikely (!c->extend_size (out, get_size (), false))) return_trace (hb_array_t ());
-    hb_memcpy (out, arrayZ, length);
+    hb_memcpy (out, arrayZ, get_size ());
     return_trace (hb_array_t (out, length));
   }
 

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -973,7 +973,6 @@ struct subr_subsetter_t
     unsigned count = str.get_count ();
     str_encoder_t  encoder (buff);
     encoder.reset ();
-    buff.alloc (count * 2);
     bool hinting = !(plan->flags & HB_SUBSET_FLAGS_NO_HINTING);
     /* if a prefix (CFF1 width or CFF2 vsindex) has been removed along with hints,
      * re-insert it at the beginning of charstreing */
@@ -984,6 +983,12 @@ struct subr_subsetter_t
 	encoder.encode_op (str.prefix_op ());
     }
     auto *arr = str.values.arrayZ;
+
+    unsigned size = 0;
+    for (unsigned int i = 0; i < count; i++)
+      size += arr[i].length;
+    buff.alloc (size);
+
     for (unsigned int i = 0; i < count; i++)
     {
       const parsed_cs_op_t  &opstr = arr[i];

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -981,7 +981,7 @@ struct subr_subsetter_t
       if (opstr.op == OpCode_callsubr || opstr.op == OpCode_callgsubr)
         size += 3;
     }
-    if (!buff.alloc (size))
+    if (!buff.alloc (buff.length + size))
       return false;
 
     for (auto &opstr : str.values)

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -936,24 +936,21 @@ struct subr_subsetter_t
     if (!str.has_calls ())
       return;
 
-    auto *values = str.values.arrayZ;
-    unsigned count = str.values.length;
-    for (unsigned i = 0; i < count; i++)
+    for (auto &opstr : str.values)
     {
-      auto &value = values[i];
-      if (hinting || !value.is_hinting ())
+      if (hinting || !opstr.is_hinting ())
       {
-	switch (value.op)
+	switch (opstr.op)
 	{
 	  case OpCode_callsubr:
 	    collect_subr_refs_in_subr (hinting,
-				       value.subr_num, *param.parsed_local_subrs,
+				       opstr.subr_num, *param.parsed_local_subrs,
 				       param.local_closure, param);
 	    break;
 
 	  case OpCode_callgsubr:
 	    collect_subr_refs_in_subr (hinting,
-				       value.subr_num, *param.parsed_global_subrs,
+				       opstr.subr_num, *param.parsed_global_subrs,
 				       param.global_closure, param);
 	    break;
 
@@ -965,7 +962,6 @@ struct subr_subsetter_t
 
   bool encode_str (const parsed_cs_str_t &str, const unsigned int fd, str_buff_t &buff) const
   {
-    unsigned count = str.get_count ();
     str_encoder_t  encoder (buff);
     encoder.reset ();
     bool hinting = !(plan->flags & HB_SUBSET_FLAGS_NO_HINTING);
@@ -977,21 +973,19 @@ struct subr_subsetter_t
       if (str.prefix_op () != OpCode_Invalid)
 	encoder.encode_op (str.prefix_op ());
     }
-    auto *arr = str.values.arrayZ;
 
     unsigned size = 0;
-    for (unsigned int i = 0; i < count; i++)
+    for (auto &opstr : str.values)
     {
-      size += arr[i].length;
-      if (arr[i].op == OpCode_callsubr || arr[i].op == OpCode_callgsubr)
+      size += opstr.length;
+      if (opstr.op == OpCode_callsubr || opstr.op == OpCode_callgsubr)
         size += 3;
     }
     if (!buff.alloc (size))
       return false;
 
-    for (unsigned int i = 0; i < count; i++)
+    for (auto &opstr : str.values)
     {
-      const parsed_cs_op_t  &opstr = arr[i];
       if (hinting || !opstr.is_hinting ())
       {
 	switch (opstr.op)

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -718,13 +718,13 @@ struct subr_subsetter_t
       if (!plan->old_gid_for_new_gid (i, &glyph))
       {
 	/* add an endchar only charstring for a missing glyph if CFF1 */
-	if (endchar_op != OpCode_Invalid) buffArray[i].push (endchar_op);
+	if (endchar_op != OpCode_Invalid) buffArray.arrayZ[i].push (endchar_op);
 	continue;
       }
       unsigned int  fd = acc.fdSelect->get_fd (glyph);
       if (unlikely (fd >= acc.fdCount))
 	return false;
-      if (unlikely (!encode_str (get_parsed_charstring (i), fd, buffArray[i])))
+      if (unlikely (!encode_str (get_parsed_charstring (i), fd, buffArray.arrayZ[i])))
 	return false;
     }
     return true;

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -998,12 +998,12 @@ struct subr_subsetter_t
 	{
 	  case OpCode_callsubr:
 	    encoder.encode_int (remaps.local_remaps[fd].biased_num (opstr.subr_num));
-	    encoder.encode_op (OpCode_callsubr);
+	    encoder.copy_str (opstr.ptr, opstr.length);
 	    break;
 
 	  case OpCode_callgsubr:
 	    encoder.encode_int (remaps.global_remap.biased_num (opstr.subr_num));
-	    encoder.encode_op (OpCode_callgsubr);
+	    encoder.copy_str (opstr.ptr, opstr.length);
 	    break;
 
 	  default:

--- a/src/hb-vector.hh
+++ b/src/hb-vector.hh
@@ -254,6 +254,16 @@ struct hb_vector_t
     return new_array;
   }
 
+  template <typename T = Type,
+	    hb_enable_if (hb_is_trivially_constructible(T))>
+  void
+  grow_vector (unsigned size)
+  {
+    memset (arrayZ + length, 0, (size - length) * sizeof (*arrayZ));
+    length = size;
+  }
+  template <typename T = Type,
+	    hb_enable_if (!hb_is_trivially_constructible(T))>
   void
   grow_vector (unsigned size)
   {


### PR DESCRIPTION
Saves 32% on SourceHanSans/10000 benchmark!

Also, use memcmp now for writing out strings since now that our ops are not super short, that's faster.

This makes cff-japanese test takes super long though; that needs inspection.