### PR TITLE
COLRv1: use ClipBoxes for extents

### DIFF
--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -1048,6 +1048,7 @@ struct ClipList
   bool sanitize (hb_sanitize_context_t *c) const
   {
     TRACE_SANITIZE (this);
+    // TODO Make a formatted struct!
     return_trace (c->check_struct (this) && clips.sanitize (c, this));
   }
 

--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -930,6 +930,7 @@ struct ClipBox
   }
 
   bool get_extents (hb_glyph_extents_t *extents,
+		    const DeltaSetIndexMap &varIdxMap,
 		    const VariationStore &varStore,
 		    hb_array_t<int> coords) const
   {
@@ -944,10 +945,10 @@ struct ClipBox
       if (u.format == 2 && coords && u.format2.varIdxBase != HB_OT_LAYOUT_NO_VARIATIONS_INDEX)
       {
 	uint32_t varIdx = u.format2.varIdxBase;
-	extents->x_bearing += _hb_roundf (varStore.get_delta (varIdx  , coords));
-	extents->y_bearing += _hb_roundf (varStore.get_delta (varIdx+1, coords));
-	extents->width     += _hb_roundf (varStore.get_delta (varIdx+2, coords));
-	extents->height    += _hb_roundf (varStore.get_delta (varIdx+3, coords));
+	extents->x_bearing += _hb_roundf (varStore.get_delta (varIdxMap.map (varIdx+0), coords));
+	extents->y_bearing += _hb_roundf (varStore.get_delta (varIdxMap.map (varIdx+1), coords));
+	extents->width     += _hb_roundf (varStore.get_delta (varIdxMap.map (varIdx+2), coords));
+	extents->height    += _hb_roundf (varStore.get_delta (varIdxMap.map (varIdx+3), coords));
       }
 
       return true;
@@ -986,10 +987,11 @@ struct ClipRecord
 
   bool get_extents (hb_glyph_extents_t *extents,
 		    const void *base,
+		    const DeltaSetIndexMap &varIdxMap,
 		    const VariationStore &varStore,
 		    hb_array_t<int> coords) const
   {
-    return (base+clipBox).get_extents (extents, varStore, coords);
+    return (base+clipBox).get_extents (extents, varIdxMap, varStore, coords);
   }
 
   public:
@@ -1095,13 +1097,14 @@ struct ClipList
   bool
   get_extents (hb_codepoint_t gid,
 	       hb_glyph_extents_t *extents,
+	       const DeltaSetIndexMap &varIdxMap,
 	       const VariationStore &varStore,
 	       hb_array_t<int> coords) const
   {
     auto *rec = clips.as_array ().bsearch (gid);
     if (rec)
     {
-      rec->get_extents (extents, this, varStore, coords);
+      rec->get_extents (extents, this, varIdxMap, varStore, coords);
       return true;
     }
     return false;
@@ -1575,6 +1578,7 @@ struct COLR
       return false;
     if ((this+clipList).get_extents (glyph,
 				     extents,
+				     this+varIdxMap,
 				     this+varStore,
 				     hb_array (font->coords, font->num_coords)))
     {

--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -1547,6 +1547,8 @@ struct COLR
   bool
   get_extents (hb_font_t *font, hb_codepoint_t glyph, hb_glyph_extents_t *extents) const
   {
+    if (version != 1)
+      return false;
     if ((this+clipList).get_extents (glyph, extents))
     {
       extents->x_bearing = font->em_scale_x (extents->x_bearing);

--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -932,16 +932,13 @@ struct ClipBox
   {
     switch (u.format) {
     case 1:
+    case 2: // TODO variations
       extents->x_bearing = u.format1.xMin;
       extents->y_bearing = u.format1.yMax;
       extents->width = u.format1.xMax - u.format1.xMin;
       extents->height = u.format1.yMin - u.format1.yMax;
       return true;
-    case 2:
-      // TODO
-      return false;
     default:
-      // This shouldn't happen
       return false;
     }
   }
@@ -1078,7 +1075,7 @@ struct ClipList
   bool
   get_extents (hb_codepoint_t gid, hb_glyph_extents_t *extents) const
   {
-    for (const ClipRecord& record : clips.iter ())
+    for (auto& record : clips)
     {
       if (record.startGlyphID <= gid && gid <= record.endGlyphID)
         return record.get_extents (extents, this);
@@ -1551,13 +1548,13 @@ struct COLR
   get_extents (hb_font_t *font, hb_codepoint_t glyph, hb_glyph_extents_t *extents) const
   {
     if ((this+clipList).get_extents (glyph, extents))
-      {
-        extents->x_bearing = font->em_scale_x (extents->x_bearing);
-        extents->y_bearing = font->em_scale_x (extents->y_bearing);
-        extents->width = font->em_scale_x (extents->width);
-        extents->height = font->em_scale_x (extents->height);
-        return true;
-      }
+    {
+      extents->x_bearing = font->em_scale_x (extents->x_bearing);
+      extents->y_bearing = font->em_scale_x (extents->y_bearing);
+      extents->width = font->em_scale_x (extents->width);
+      extents->height = font->em_scale_x (extents->height);
+      return true;
+    }
 
     return false;
   }

--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -953,6 +953,9 @@ struct ClipBox
 
 struct ClipRecord
 {
+  int cmp (hb_codepoint_t g) const
+  { return g < startGlyphID ? -1 : g <= endGlyphID ? 0 : +1; }
+
   ClipRecord* copy (hb_serialize_context_t *c, const void *base) const
   {
     TRACE_SERIALIZE (this);
@@ -980,6 +983,7 @@ struct ClipRecord
   public:
   DEFINE_SIZE_STATIC (7);
 };
+DECLARE_NULL_NAMESPACE_BYTES (OT, ClipRecord);
 
 struct ClipList
 {
@@ -1075,10 +1079,11 @@ struct ClipList
   bool
   get_extents (hb_codepoint_t gid, hb_glyph_extents_t *extents) const
   {
-    for (auto& record : clips)
+    auto *rec = clips.as_array ().bsearch (gid);
+    if (rec)
     {
-      if (record.startGlyphID <= gid && gid <= record.endGlyphID)
-        return record.get_extents (extents, this);
+      rec->get_extents (extents, this);
+      return true;
     }
     return false;
   }

--- a/src/hb-ot-color-colr-table.hh
+++ b/src/hb-ot-color-colr-table.hh
@@ -941,7 +941,7 @@ struct ClipBox
       extents->width = u.format1.xMax - u.format1.xMin;
       extents->height = u.format1.yMin - u.format1.yMax;
 
-      if (u.format == 2 && coords)
+      if (u.format == 2 && coords && u.format2.varIdxBase != HB_OT_LAYOUT_NO_VARIATIONS_INDEX)
       {
 	uint32_t varIdx = u.format2.varIdxBase;
 	extents->x_bearing += _hb_roundf (varStore.get_delta (varIdx  , coords));

--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -45,6 +45,7 @@
 #include "hb-ot-vorg-table.hh"
 #include "hb-ot-color-cbdt-table.hh"
 #include "hb-ot-color-sbix-table.hh"
+#include "hb-ot-color-colr-table.hh"
 
 
 /**
@@ -349,6 +350,9 @@ hb_ot_get_glyph_extents (hb_font_t *font,
 #if !defined(HB_NO_OT_FONT_BITMAP) && !defined(HB_NO_COLOR)
   if (ot_face->sbix->get_extents (font, glyph, extents)) return true;
   if (ot_face->CBDT->get_extents (font, glyph, extents)) return true;
+#endif
+#if !defined(HB_NO_COLOR)
+  if (ot_face->COLR->get_extents (font, glyph, extents)) return true;
 #endif
   if (ot_face->glyf->get_extents (font, glyph, extents)) return true;
 #ifndef HB_NO_OT_FONT_CFF

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -2715,6 +2715,14 @@ struct VariationStore
     unsigned int inner = index & 0xFFFF;
     return get_delta (outer, inner, coords, coord_count, cache);
   }
+  float get_delta (unsigned int index,
+		   hb_array_t<int> coords,
+		   VarRegionList::cache_t *cache = nullptr) const
+  {
+    return get_delta (index,
+		      coords.arrayZ, coords.length,
+		      cache);
+  }
 
   bool sanitize (hb_sanitize_context_t *c) const
   {

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -219,6 +219,23 @@ struct DeltaSetIndexMap
   DEFINE_SIZE_UNION (1, format);
 };
 
+
+struct VarStoreInstancer
+{
+  VarStoreInstancer (const VariationStore &varStore,
+		     const DeltaSetIndexMap &varIdxMap,
+		     hb_array_t<int> coords) :
+    varStore (varStore), varIdxMap (varIdxMap), coords (coords) {}
+
+  float operator() (uint32_t varIdx) const
+  { return varStore.get_delta (varIdxMap.map (varIdx), coords); }
+
+  const VariationStore &varStore;
+  const DeltaSetIndexMap &varIdxMap;
+  hb_array_t<int> coords;
+};
+
+
 } /* namespace OT */
 
 

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -227,6 +227,8 @@ struct VarStoreInstancer
 		     hb_array_t<int> coords) :
     varStore (varStore), varIdxMap (varIdxMap), coords (coords) {}
 
+  operator bool () const { return bool (coords); }
+
   float operator() (uint32_t varIdx) const
   { return varStore.get_delta (varIdxMap.map (varIdx), coords); }
 

--- a/src/hb-static.cc
+++ b/src/hb-static.cc
@@ -33,6 +33,7 @@
 #include "hb-aat-layout-feat-table.hh"
 #include "hb-ot-layout-common.hh"
 #include "hb-ot-cmap-table.hh"
+#include "hb-ot-color-colr-table.hh"
 #include "hb-ot-glyf-table.hh"
 #include "hb-ot-head-table.hh"
 #include "hb-ot-maxp-table.hh"
@@ -47,6 +48,7 @@ DEFINE_NULL_NAMESPACE_BYTES (OT, Index) =  {0xFF,0xFF};
 DEFINE_NULL_NAMESPACE_BYTES (OT, VarIdx) =  {0xFF,0xFF,0xFF,0xFF};
 DEFINE_NULL_NAMESPACE_BYTES (OT, LangSys) = {0x00,0x00, 0xFF,0xFF, 0x00,0x00};
 DEFINE_NULL_NAMESPACE_BYTES (OT, RangeRecord) = {0x01};
+DEFINE_NULL_NAMESPACE_BYTES (OT, ClipRecord) = {0x01};
 DEFINE_NULL_NAMESPACE_BYTES (OT, CmapSubtableLongGroup) = {0x00,0x00,0x00,0x01, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00};
 DEFINE_NULL_NAMESPACE_BYTES (AAT, SettingName) = {0xFF,0xFF, 0xFF,0xFF};
 DEFINE_NULL_NAMESPACE_BYTES (AAT, Lookup) = {0xFF,0xFF};


### PR DESCRIPTION
This is a first step; ultimatively, we should compute the extents is ClipBoxes are missing.