### PR TITLE
VarC: properly cast int

### DIFF
--- a/src/OT/glyf/VarCompositeGlyph.hh
+++ b/src/OT/glyf/VarCompositeGlyph.hh
@@ -314,7 +314,7 @@ struct VarCompositeGlyphRecord
     unsigned count = numAxes;
     for (unsigned i = 0; i < count; i++)
     {
-      unsigned axis_index = axis_width == 1 ? *p++ : *q++;
+      unsigned axis_index = axis_width == 1 ? (unsigned) *p++ : (unsigned) *q++;
 
       signed v = have_variations ? rec_points[i].x : *a++;
 


### PR DESCRIPTION
msvc is rightfully complaining that the types on the sides of the ternary are not matching:

```
C:\pango\subprojects\harfbuzz\src\OT\glyf\VarCompositeGlyph.hh(317): error C2446: ':': no conversion from 'const OT::HBUINT16' to 'const OT::HBUINT8'
```