### PR TITLE
meson: Override dependencies to improve usage as a subproject

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -535,6 +535,7 @@ libharfbuzz_dep = declare_dependency(
   link_with: libharfbuzz,
   include_directories: incsrc,
   dependencies: harfbuzz_deps)
+meson.override_dependency('harfbuzz', libharfbuzz_dep)
 
 # harfbuzz-subset
 harfbuzz_subset_def = custom_target('harfbuzz-subset.def',
@@ -567,6 +568,7 @@ libharfbuzz_subset_dep = declare_dependency(
   link_with: libharfbuzz_subset,
   include_directories: incsrc,
   dependencies: [m_dep])
+meson.override_dependency('harfbuzz-subset', libharfbuzz_subset_dep)
 
 if get_option('tests').enabled()
   # TODO: MSVC gives the following,
@@ -663,6 +665,7 @@ if have_icu and not have_icu_builtin
     link_with: libharfbuzz_icu,
     include_directories: incsrc,
     dependencies: icu_dep)
+  meson.override_dependency('harfbuzz-icu', libharfbuzz_icu_dep)
 
   pkgmod.generate(libharfbuzz_icu,
     description: 'HarfBuzz text shaping library ICU integration',
@@ -776,6 +779,7 @@ if have_gobject
     include_directories: incsrc,
     sources: build_gir ? hb_gen_files_gir : hb_gobject_sources,
     dependencies: [glib_dep, gobject_dep])
+  meson.override_dependency('harfbuzz-gobject', libharfbuzz_gobject_dep)
 
   pkgmod.generate(libharfbuzz_gobject,
     description: 'HarfBuzz text shaping library GObject integration',

--- a/util/meson.build
+++ b/util/meson.build
@@ -25,6 +25,7 @@ if conf.get('HAVE_GLIB', 0) == 1
       link_with: [libharfbuzz],
       install: true,
     )
+    meson.override_find_program('hb-view', hb_view)
   endif
 
   hb_shape = executable('hb-shape', hb_shape_sources,
@@ -34,6 +35,7 @@ if conf.get('HAVE_GLIB', 0) == 1
     link_with: [libharfbuzz],
     install: true,
   )
+  meson.override_find_program('hb-shape', hb_shape)
 
   hb_subset = executable('hb-subset', hb_subset_cli_sources,
     cpp_args: cpp_args,
@@ -42,6 +44,7 @@ if conf.get('HAVE_GLIB', 0) == 1
     link_with: [libharfbuzz, libharfbuzz_subset],
     install: true,
   )
+  meson.override_find_program('hb-subset', hb_subset)
 
   hb_ot_shape_closure = executable('hb-ot-shape-closure', hb_ot_shape_closure_sources,
     cpp_args: cpp_args,
@@ -50,6 +53,7 @@ if conf.get('HAVE_GLIB', 0) == 1
     link_with: [libharfbuzz],
     install: true,
   )
+  meson.override_find_program('hb-ot-shape-closure', hb_ot_shape_closure)
 else
   # Disable tests that use this
   hb_shape = disabler()


### PR DESCRIPTION
With this change, harfbuzz can be consumed as a subproject without making any changes to the build files of a project. All you need to do is provide a wrap file with a `[provide]` section:

https://mesonbuild.com/Wrap-dependency-system-manual.html#provide-section

This is also necessary because otherwise projects need to hard-code the subproject name, which might be `harfbuzz` when using `wrap-git` or `harfbuzz-6.0.0` when using `wrap-file` (to build from a release tarball). This can cause conflicts between different subprojects that consume harfbuzz differently.

Other projects like glib, cairo, pango, etc already do this.