### PR TITLE
[subset] when subsetting preprocessor fails, reference the returned face.

### DIFF
--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -480,7 +480,7 @@ hb_subset_preprocess (hb_face_t *source)
 {
   hb_subset_input_t* input = hb_subset_input_create_or_fail ();
   if (!input)
-    return source;
+    return hb_face_reference (source);
 
   hb_set_clear (hb_subset_input_set(input, HB_SUBSET_SETS_UNICODE));
   hb_set_invert (hb_subset_input_set(input, HB_SUBSET_SETS_UNICODE));
@@ -525,7 +525,7 @@ hb_subset_preprocess (hb_face_t *source)
 
   if (!new_source) {
     DEBUG_MSG (SUBSET, nullptr, "Preprocessing failed due to subset failure.");
-    return source;
+    return hb_face_reference (source);
   }
 
   return new_source;


### PR DESCRIPTION
The caller of the method is expected to destroy the returned result.