### PR TITLE
Make hb-features.h usable standalone

### DIFF
--- a/src/hb-features.h.in
+++ b/src/hb-features.h.in
@@ -22,14 +22,8 @@
  * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
  */
 
-#if !defined(HB_H_IN) && !defined(HB_NO_SINGLE_HEADER_ERROR)
-#error "Include <hb.h> instead."
-#endif
-
 #ifndef HB_FEATURES_H
 #define HB_FEATURES_H
-
-#include "hb-common.h"
 
 HB_BEGIN_DECLS
 


### PR DESCRIPTION
The intended use for hb-features.h is to
be included standalone, so we can't put
the single-include guards in here.