### PR TITLE
[introspection] Fix g-ir-scanner syntax errors on macOS

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -431,6 +431,18 @@ if conf.get('HAVE_FREETYPE', 0) == 1
   hb_features.set('HB_HAS_FREETYPE', 1)
 endif
 
+if conf.get('HAVE_GLIB', 0) == 1
+  hb_sources += hb_glib_sources
+  hb_headers += hb_glib_headers
+  harfbuzz_deps += [glib_dep]
+  hb_features.set('HB_HAS_GLIB', 1)
+endif
+
+# We set those here to not include the sources below that are of no use to
+# GObject Introspection
+gir_sources = hb_sources + hb_gobject_sources
+gir_headers = hb_headers + hb_gobject_headers
+
 if conf.get('HAVE_GDI', 0) == 1
   hb_sources += hb_gdi_sources
   hb_headers += hb_gdi_headers
@@ -443,13 +455,6 @@ if conf.get('HAVE_GRAPHITE2', 0) == 1
   hb_headers += hb_graphite2_headers
   harfbuzz_deps += [graphite2_dep, graphite_dep]
   hb_features.set('HB_HAS_GRAPHITE', 1)
-endif
-
-if conf.get('HAVE_GLIB', 0) == 1
-  hb_sources += hb_glib_sources
-  hb_headers += hb_glib_headers
-  harfbuzz_deps += [glib_dep]
-  hb_features.set('HB_HAS_GLIB', 1)
 endif
 
 if conf.get('HAVE_UNISCRIBE', 0) == 1
@@ -816,7 +821,7 @@ if have_gobject
   if build_gir
     conf.set('HAVE_INTROSPECTION', 1)
     hb_gen_files_gir = gnome.generate_gir(libharfbuzz_gobject,
-      sources: [hb_headers, hb_sources, hb_gobject_headers, hb_gobject_sources, enum_h],
+      sources: [gir_headers, gir_sources, enum_h],
       dependencies: libharfbuzz_dep,
       namespace: 'HarfBuzz',
       nsversion: '0.0',


### PR DESCRIPTION
Similar to: https://github.com/harfbuzz/harfbuzz/pull/2853

This time, g-ir-scanner is trying to parse system headers for some reason and is giving a gazillion of gibberish warnings. This hack is to prevent it from including macOS system headers:

```
[6/6] Generating src/HarfBuzz-0.0.gir with a custom command (wrapped by meson to set env)
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os/clock.h:14: syntax error, unexpected ':', expecting identifier or typedef-name or '{' in 'typedef enum : uint32_t { OS_CLOCK_MACH_ABSOLUTE_TIME = 32, } os_clockid_t;' at ':'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dispatch/queue.h:816: syntax error, unexpected ':', expecting identifier or typedef-name or '{' in 'typedef enum : unsigned long { DISPATCH_AUTORELEASE_FREQUENCY_INHERIT __attribute__((availability(macos,introduced=10.12))) __attribute__((availability(ios,introduced=10.0))) __attribute__((availability(tvos,introduced=10.0))) __attribute__((availability(watchos,introduced=3.0))) = 0, DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM __attribute__((availability(macos,introduced=10.12))) __attribute__((availability(ios,introduced=10.0))) __attribute__((availability(tvos,introduced=10.0))) __attribute__((availability(watchos,introduced=3.0))) = 1, DISPATCH_AUTORELEASE_FREQUENCY_NEVER __attribute__((availability(macos,introduced=10.12))) __attribute__((availability(ios,introduced=10.0))) __attribute__((availability(tvos,introduced=10.0))) __attribute__((availability(watchos,introduced=3.0))) = 2, } __attribute__((__enum_extensibility__(open))) dispatch_autorelease_frequency_t;' at ':'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dispatch/queue.h:867: syntax error, unexpected identifier in '  dispatch_autorelease_frequency_t frequency);' at 'dispatch_autorelease_frequency_t'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dispatch/workloop.h:133: syntax error, unexpected identifier in '  dispatch_autorelease_frequency_t frequency);' at 'dispatch_autorelease_frequency_t'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:1288: syntax error, unexpected '{' in '    return __extension__ (__m64){ 0LL };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:1688: syntax error, unexpected '{' in '  return __extension__ (__m128){ __u, 0, 0, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:1710: syntax error, unexpected '{' in '  return __extension__ (__m128){ __u, __u, __u, __u };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:1802: syntax error, unexpected '{' in '  return __extension__ (__m128){ __w, 0, 0, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:1820: syntax error, unexpected '{' in '  return __extension__ (__m128){ __w, __w, __w, __w };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:1866: syntax error, unexpected '{' in '  return __extension__ (__m128){ __w, __x, __y, __z };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:1894: syntax error, unexpected '{' in '  return __extension__ (__m128){ __z, __y, __x, __w };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:1909: syntax error, unexpected '{' in '  return __extension__ (__m128){ 0, 0, 0, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:233: syntax error, unexpected '{' in '  return __extension__ (__m128d) { __c[0], __a[1] };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:766: syntax error, unexpected '{' in '  return __extension__ (__m128d) { __c[0], __a[1] };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:792: syntax error, unexpected '{' in '  return __extension__ (__m128d) { __c[0], __a[1] };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:948: syntax error, unexpected '{' in '  return __extension__ (__m128d) { __c[0], __a[1] };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:974: syntax error, unexpected '{' in '  return __extension__ (__m128d) { __c[0], __a[1] };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1322: syntax error, unexpected typedef-name in '      __builtin_shufflevector((__v4sf)__a, (__v4sf)__a, 0, 1), __v2df);' at '__v2df'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1345: syntax error, unexpected typedef-name in '      __builtin_shufflevector((__v4si)__a, (__v4si)__a, 0, 1), __v2df);' at '__v2df'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1607: syntax error, unexpected '{' in '  return __extension__ (__m128d){ __u, __u };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1671: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v2di){__u, 0LL};' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1692: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v4si){__u, 0, 0, 0};' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1713: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v8hi){__u, 0, 0, 0, 0, 0, 0, 0};' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1734: syntax error, unexpected '{' in '  return __extension__ (__m128d){ __u, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1761: syntax error, unexpected '{' in '  return __extension__ (__m128d){ __a[0], __u };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1788: syntax error, unexpected '{' in '  return __extension__ (__m128d){ __u, __a[1] };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1825: syntax error, unexpected '{' in '  return __extension__ (__m128d){ __w, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1843: syntax error, unexpected '{' in '  return __extension__ (__m128d){ __w, __w };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1881: syntax error, unexpected '{' in '  return __extension__ (__m128d){ __x, __w };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1902: syntax error, unexpected '{' in '  return __extension__ (__m128d){ __w, __x };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:1917: syntax error, unexpected '{' in '  return __extension__ (__m128d){ 0, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3418: syntax error, unexpected typedef-name in '  return (__m128)__builtin_convertvector((__v4si)__a, __v4sf);' at '__v4sf'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3467: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v4si){ __a, 0, 0, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3484: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v2di){ __a, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3578: syntax error, unexpected '{' in '  return __extension__ (__m128i) { ((const struct __mm_loadl_epi64_struct*)__p)->__u, 0};' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3578: syntax error, unexpected ')', expecting identifier or '(' in '  return __extension__ (__m128i) { ((const struct __mm_loadl_epi64_struct*)__p)->__u, 0};' at ')'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3615: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v2di){ __q0, __q1 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3665: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v4si){ __i0, __i1, __i2, __i3};' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3705: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v8hi){ __w0, __w1, __w2, __w3, __w4, __w5, __w6, __w7 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3753: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v16qi){ __b0, __b1, __b2, __b3, __b4, __b5, __b6, __b7, __b8, __b9, __b10, __b11, __b12, __b13, __b14, __b15 };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:3983: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v2di){ 0LL, 0LL };' at '{'
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:4743: syntax error, unexpected '{' in '  return __extension__ (__m128i)(__v2di){ (long long)__a, 0 };' at '{'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGColorSpace.h:318: syntax error, unexpected typedef-name, expecting identifier or '(' in 'typedef const struct __attribute__((objc_bridge(id))) ColorSyncProfile* ColorSyncProfileRef;' at 'ColorSyncProfileRef'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPath.h:392: syntax error, unexpected '^', expecting identifier or '(' or '*' in 'typedef void (^CGPathApplyBlock)(const CGPathElement * element);' at '^'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPath.h:392: syntax error, unexpected ')', expecting ',' or ';' in 'typedef void (^CGPathApplyBlock)(const CGPathElement * element);' at ')'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPath.h:394: syntax error, unexpected identifier in 'extern __attribute__((visibility("default"))) void CGPathApplyWithBlock(CGPathRef path, CGPathApplyBlock __attribute__((noescape)) block)' at 'CGPathApplyBlock'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFArray.h:103: syntax error, unexpected '^', expecting identifier or '(' or '*' in 'typedef _Bool (^CGPDFArrayApplierBlock)(size_t index,' at '^'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFArray.h:104: syntax error, unexpected typedef-name, expecting identifier or '(' or '*' in '    CGPDFObjectRef value, void * _Nullable info);' at 'CGPDFObjectRef'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFArray.h:104: syntax error, unexpected VOID, expecting identifier or '(' or '*' in '    CGPDFObjectRef value, void * _Nullable info);' at 'void'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFArray.h:104: syntax error, unexpected ')', expecting ',' or ';' in '    CGPDFObjectRef value, void * _Nullable info);' at ')'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFArray.h:113: syntax error, unexpected identifier in '    CGPDFArrayApplierBlock _Nullable block, void * _Nullable info)' at 'CGPDFArrayApplierBlock'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFArray.h:113: syntax error, unexpected ')', expecting ',' or ';' in '    CGPDFArrayApplierBlock _Nullable block, void * _Nullable info)' at ')'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFDictionary.h:116: syntax error, unexpected '^', expecting identifier or '(' or '*' in 'typedef _Bool (^CGPDFDictionaryApplierBlock)(const char * key,' at '^'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFDictionary.h:117: syntax error, unexpected typedef-name, expecting identifier or '(' or '*' in '    CGPDFObjectRef value, void * _Nullable info);' at 'CGPDFObjectRef'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFDictionary.h:117: syntax error, unexpected VOID, expecting identifier or '(' or '*' in '    CGPDFObjectRef value, void * _Nullable info);' at 'void'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFDictionary.h:117: syntax error, unexpected ')', expecting ',' or ';' in '    CGPDFObjectRef value, void * _Nullable info);' at ')'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFDictionary.h:126: syntax error, unexpected identifier in '    CGPDFDictionaryApplierBlock _Nullable block, void * _Nullable info)' at 'CGPDFDictionaryApplierBlock'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Versions/A/Headers/CGPDFDictionary.h:126: syntax error, unexpected ')', expecting ',' or ';' in '    CGPDFDictionaryApplierBlock _Nullable block, void * _Nullable info)' at ')'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageIO.framework/Versions/A/Headers/CGImageAnimation.h:42: syntax error, unexpected '^', expecting identifier or '(' or '*' in 'typedef void (^CGImageSourceAnimationBlock)(size_t index, CGImageRef image, _Bool* stop);' at '^'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageIO.framework/Versions/A/Headers/CGImageAnimation.h:42: syntax error, unexpected typedef-name, expecting identifier or '(' or '*' in 'typedef void (^CGImageSourceAnimationBlock)(size_t index, CGImageRef image, _Bool* stop);' at 'CGImageRef'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageIO.framework/Versions/A/Headers/CGImageAnimation.h:42: syntax error, unexpected BASIC_TYPE, expecting identifier or '(' or '*' in 'typedef void (^CGImageSourceAnimationBlock)(size_t index, CGImageRef image, _Bool* stop);' at '_Bool'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageIO.framework/Versions/A/Headers/CGImageAnimation.h:42: syntax error, unexpected ')', expecting ',' or ';' in 'typedef void (^CGImageSourceAnimationBlock)(size_t index, CGImageRef image, _Bool* stop);' at ')'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageIO.framework/Versions/A/Headers/CGImageAnimation.h:50: syntax error, unexpected identifier in 'extern __attribute__((visibility("default"))) OSStatus CGAnimateImageAtURLWithBlock(CFURLRef url, CFDictionaryRef _Nullable options, CGImageSourceAnimationBlock block) __attribute__((availability(macos,introduced=10.15))) __attribute__((availability(ios,introduced=13.0)));' at 'CGImageSourceAnimationBlock'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageIO.framework/Versions/A/Headers/CGImageAnimation.h:58: syntax error, unexpected identifier in 'extern __attribute__((visibility("default"))) OSStatus CGAnimateImageDataWithBlock(CFDataRef data, CFDictionaryRef _Nullable options, CGImageSourceAnimationBlock block) __attribute__((availability(macos,introduced=10.15))) __attribute__((availability(ios,introduced=13.0)));' at 'CGImageSourceAnimationBlock'
```