### PR TITLE
Disable `hb_paint_extents_*` functions if `HB_NO_PAINT` is defined

### DIFF
--- a/src/hb-paint-extents.cc
+++ b/src/hb-paint-extents.cc
@@ -23,6 +23,9 @@
  */
 
 #include "hb.hh"
+
+#ifndef HB_NO_PAINT
+
 #include "hb-paint-extents.hh"
 
 #include "hb-draw.h"
@@ -322,3 +325,6 @@ hb_paint_extents_get_funcs ()
 {
   return static_paint_extents_funcs.get_unconst ();
 }
+
+
+#endif


### PR DESCRIPTION
Without these functions excluded from the build, setting `HB_NO_PAINT` will result in these linking errors:

```
  "_hb_paint_funcs_create", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_destroy", referenced from:
      hb_paint_extents_get_funcs() in libharfbuzz.a(harfbuzz.cc.o)
      free_static_paint_extents_funcs() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_get_empty", referenced from:
      hb_paint_extents_get_funcs() in libharfbuzz.a(harfbuzz.cc.o)
      free_static_paint_extents_funcs() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_make_immutable", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_color_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_image_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_linear_gradient_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_pop_clip_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_pop_group_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_pop_transform_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_push_clip_glyph_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_push_clip_rectangle_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_push_group_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_push_transform_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_radial_gradient_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
  "_hb_paint_funcs_set_sweep_gradient_func", referenced from:
      hb_paint_extents_funcs_lazy_loader_t::create() in libharfbuzz.a(harfbuzz.cc.o)
```