### PR TITLE
docs: Fix a typo

### DIFF
--- a/src/hb-face.cc
+++ b/src/hb-face.cc
@@ -600,7 +600,7 @@ hb_face_collect_unicodes (hb_face_t *face,
  * @unicodes: (nullable) (out): The set to add Unicode characters to, or %NULL
  *
  * Collects the mapping from Unicode characters to nominal glyphs of the @face,
- * and optionall all of the Unicode characters covered by @face.
+ * and optionally all of the Unicode characters covered by @face.
  *
  * Since: REPLACEME
  */


### PR DESCRIPTION
Here's a typo noticed in passing.

And a question: Should you not empty out that static_unicodes set to avoid accumulating memory there?