### PR TITLE
[subset] Fix issue in hb_subset_input_override_name_table()

### DIFF
--- a/src/hb-ot-name-table.hh
+++ b/src/hb-ot-name-table.hh
@@ -422,6 +422,16 @@ struct name
     ;
 
 #ifdef HB_EXPERIMENTAL_API
+    hb_hashmap_t<hb_ot_name_record_ids_t, unsigned> retained_name_record_ids;
+    for (const NameRecord& rec : it)
+    {
+      hb_ot_name_record_ids_t rec_ids (rec.platformID,
+                                       rec.encodingID,
+                                       rec.languageID,
+                                       rec.nameID);
+      retained_name_record_ids.set (rec_ids, 1);
+    }
+
     hb_vector_t<hb_ot_name_record_ids_t> insert_name_records;
     if (!name_table_overrides->is_empty ())
     {
@@ -431,7 +441,7 @@ struct name
       {
         if (name_table_overrides->get (record_ids).length == 0)
           continue;
-        if (has_name_record_with_ids (record_ids))
+        if (retained_name_record_ids.has (record_ids))
           continue;
         insert_name_records.push (record_ids);
       }
@@ -553,22 +563,6 @@ struct name
     hb_blob_ptr_t<name> table;
     hb_vector_t<hb_ot_name_entry_t> names;
   };
-
-  private:
-  // sometimes NameRecords are not sorted in the font file, so use linear search
-  // here
-  bool has_name_record_with_ids (const hb_ot_name_record_ids_t& record_ids) const
-  {
-    for (const auto& record : nameRecordZ.as_array (count))
-    {
-      if (record.platformID == record_ids.platform_id &&
-          record.encodingID == record_ids.encoding_id &&
-          record.languageID == record_ids.language_id &&
-          record.nameID == record_ids.name_id)
-        return true;
-    }
-    return false;
-  }
 
   public:
   /* We only implement format 0 for now. */

--- a/test/api/test-subset-nameids.c
+++ b/test/api/test-subset-nameids.c
@@ -83,7 +83,7 @@ test_subset_name_overrides (void)
  
   hb_set_t *name_ids = hb_set_create();
   hb_face_t *face_subset;
-  hb_set_add_range (name_ids, 0, 15);
+  hb_set_add_range (name_ids, 0, 13);
 
   hb_subset_input_t *subset_input = hb_subset_test_create_input_from_nameids (name_ids);
   hb_subset_input_override_name_table (subset_input, 1, 1, 0, 0, str1, -1);


### PR DESCRIPTION
If a nameRecord with provided name_id/platform_id/encoding_id/lang_id is not retained after subsetting, create it and insert it to the name table. So we need to check against retained name_records rather than name_record in the original name table.