### PR TITLE
test-paint: Limit the precision of clip boxes

### DIFF
--- a/test/api/results/bad-20-0-154
+++ b/test/api/results/bad-20-0-154
@@ -1,5 +1,9 @@
+# random seed: R02S0c7c227b697c55fc8a404d1a07eefa13
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 0.000000 500.000000 500.000000 1000.000000
+  start clip rectangle 0.000 500.000 500.000 1000.000
     push group
     pop group mode 3
     push group

--- a/test/api/results/hand-20-0-10
+++ b/test/api/results/hand-20-0-10
@@ -1,5 +1,9 @@
+# random seed: R02Sd5438917343eb7947eecc7c286375174
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.019531 0.000000 0.000000 0.019531 0.000000 0.000000
-  start clip rectangle 64.000000 -224.000000 1216.000000 928.000000
+  start clip rectangle 64.000 -224.000 1216.000 928.000
     push group
       start transform 51.200001 0.000000 -0.000000 51.200001 0.000000 0.000000
         start clip glyph 13

--- a/test/api/results/hand-20-0.2-10
+++ b/test/api/results/hand-20-0.2-10
@@ -1,5 +1,9 @@
+# random seed: R02Sdc93669d47479c1ae75ca4eb9acfc094
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.019531 0.000000 0.003906 0.019531 0.000000 0.000000
-  start clip rectangle 64.000000 -224.000000 1216.000000 928.000000
+  start clip rectangle 64.000 -224.000 1216.000 928.000
     push group
       start transform 51.200001 0.000000 -10.240000 51.200001 0.000000 0.000000
         start clip glyph 13

--- a/test/api/results/test-20-0-10
+++ b/test/api/results/test-20-0-10
@@ -1,5 +1,9 @@
+# random seed: R02S0b6d4d806c672d59da4f38bc9dfb80c5
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 0.000000 0.000000 1000.000000 1000.000000
+  start clip rectangle 0.000 0.000 1000.000 1000.000
     start transform 50.000000 0.000000 -0.000000 50.000000 0.000000 0.000000
       start clip glyph 174
         start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000

--- a/test/api/results/test-20-0-106
+++ b/test/api/results/test-20-0-106
@@ -1,9 +1,9 @@
-# random seed: R02Sd8ba8572df09a4a1a751e54c8e409ff5
+# random seed: R02Saa7f2ea6879605eb31c0637bd0aaa441
 # Start of hb tests
 # Start of paint tests
 # Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 250.000000 250.000000 882.212341 1022.905273
+  start clip rectangle 250.000 250.000 882.212 1022.905
     start transform 50.000000 0.000000 -0.000000 50.000000 0.000000 0.000000
       start clip glyph 3
         start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000

--- a/test/api/results/test-20-0-116
+++ b/test/api/results/test-20-0-116
@@ -1,9 +1,9 @@
-# random seed: R02S98754cbb43cad9f7002e3016c43558c6
+# random seed: R02S9a46a04ee5fc4b533c3546a718582661
 # Start of hb tests
 # Start of paint tests
 # Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 250.000000 250.000000 950.000000 950.000000
+  start clip rectangle 250.000 250.000 950.000 950.000
     start transform 50.000000 0.000000 -0.000000 50.000000 0.000000 0.000000
       start clip glyph 3
         start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000

--- a/test/api/results/test-20-0-123
+++ b/test/api/results/test-20-0-123
@@ -1,5 +1,9 @@
+# random seed: R02Sfe87285ffd48bfb962003fac6c5f609f
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 0.000000 0.000000 1000.000000 1000.000000
+  start clip rectangle 0.000 0.000 1000.000 1000.000
     push group
       start transform 50.000000 0.000000 -0.000000 50.000000 0.000000 0.000000
         start clip glyph 3

--- a/test/api/results/test-20-0-165
+++ b/test/api/results/test-20-0-165
@@ -1,5 +1,9 @@
+# random seed: R02S3011486c07bf6e93538aa69228a5b23d
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 100.000000 250.000000 1200.000000 950.000000
+  start clip rectangle 100.000 250.000 1200.000 950.000
     start transform 50.000000 0.000000 -0.000000 50.000000 0.000000 0.000000
       start clip glyph 165
         start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000

--- a/test/api/results/test-20-0-175
+++ b/test/api/results/test-20-0-175
@@ -1,5 +1,9 @@
+# random seed: R02Sc0912bbd8819573b3782e05cfc8874f9
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 0.000000 0.000000 1000.000000 1000.000000
+  start clip rectangle 0.000 0.000 1000.000 1000.000
     push group
       start transform 1.000000 0.000000 0.000000 1.000000 150.000000 0.000000
         start transform 50.000000 0.000000 -0.000000 50.000000 0.000000 0.000000

--- a/test/api/results/test-20-0-6
+++ b/test/api/results/test-20-0-6
@@ -1,5 +1,9 @@
+# random seed: R02S7ce54ccd8f8e58916e959bd580aec603
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 100.000000 250.000000 900.000000 950.000000
+  start clip rectangle 100.000 250.000 900.000 950.000
     start transform 50.000000 0.000000 -0.000000 50.000000 0.000000 0.000000
       start clip glyph 6
         start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000

--- a/test/api/results/test-20-0-92
+++ b/test/api/results/test-20-0-92
@@ -1,5 +1,9 @@
+# random seed: R02S26929ce222d63c24c49dac8cfca51b99
+# Start of hb tests
+# Start of paint tests
+# Start of ot tests
 start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000
-  start clip rectangle 0.000000 0.000000 1000.000000 1000.000000
+  start clip rectangle 0.000 0.000 1000.000 1000.000
     start transform 50.000000 0.000000 -0.000000 50.000000 0.000000 0.000000
       start clip glyph 2
         start transform 0.020000 0.000000 0.000000 0.020000 0.000000 0.000000

--- a/test/api/test-paint.c
+++ b/test/api/test-paint.c
@@ -106,7 +106,7 @@ push_clip_rectangle (hb_paint_funcs_t *funcs,
 {
   paint_data_t *data = user_data;
 
-  print (data, "start clip rectangle %f %f %f %f", xmin, ymin, xmax, ymax);
+  print (data, "start clip rectangle %.3f %.3f %.3f %.3f", xmin, ymin, xmax, ymax);
   data->level++;
 }
 


### PR DESCRIPTION
This is an attempt to work around rounding differences seen in some of the ci runs, for clipboxes.