### PR TITLE
hb-info: Print table version where relevant

### DIFF
--- a/util/face-options.hh
+++ b/util/face-options.hh
@@ -28,6 +28,7 @@
 #define FACE_OPTIONS_HH
 
 #include "options.hh"
+#include "hb-open-type.hh"
 
 struct face_options_t
 {
@@ -141,7 +142,15 @@ static G_GNUC_NORETURN void _list_tables (hb_face_t *face)
 
     hb_blob_t *blob = hb_face_reference_table (face, tag);
 
-    printf ("%c%c%c%c: %8u bytes\n", HB_UNTAG (tag), hb_blob_get_length (blob));
+    int version = 0;
+
+    if (tag == HB_TAG('C','P','A','L') ||
+        tag == HB_TAG('C','O','L','R'))
+    {
+      version = (int) *(OT::HBUINT16 *) hb_blob_get_data (blob, NULL);
+    }
+
+    printf ("%c%c%c%c%s %8u bytes\n", HB_UNTAG (tag), version == 1 ? "v1:" : ":  ", hb_blob_get_length (blob));
 
     hb_blob_destroy (blob);
   }


### PR DESCRIPTION
When listing tables with --list-tables, show
the version for CPAL and COLR tables.