### PR TITLE
test/threads/hb-subset-threads.cc: add missing <cstdio> include

### DIFF
--- a/test/threads/hb-subset-threads.cc
+++ b/test/threads/hb-subset-threads.cc
@@ -1,4 +1,6 @@
 #include <cassert>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <thread>
 #include <condition_variable>


### PR DESCRIPTION
This week's `gcc-13` snapshot cleaned further up it's standard headers and exposed missing declaration as a build failure:

    ../test/threads/hb-subset-threads.cc: In function 'void test_operation(operation_t, const char*, const test_input_t&)':
    ../test/threads/hb-subset-threads.cc:127:3: error: 'printf' was not declared in this scope

    ../test/threads/hb-subset-threads.cc: In function 'int main(int, char**)':
    ../test/threads/hb-subset-threads.cc:157:19: error: 'atoi' was not declared in this scope