### PR TITLE
[meson] Try to make MSVC build less spammy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,8 @@ project('harfbuzz', 'c', 'cpp',
   meson_version: '>= 0.55.0',
   version: '6.0.0',
   default_options: [
-    'cpp_rtti=false',       # Just to support msvc, we are passing -fno-exceptions also anyway
+    'cpp_eh=none',          # Just to support msvc, we are passing -fno-exceptions also anyway
+    'cpp_rtti=false',       # Just to support msvc, we are passing -fno-rtti also anyway
     'cpp_std=c++11',
     'wrap_mode=nofallback', # Use --wrap-mode=default to revert, https://github.com/harfbuzz/harfbuzz/pull/2548
   ],
@@ -36,8 +37,6 @@ if cpp.get_argument_syntax() == 'msvc'
   add_project_arguments(msvc_args, language: ['c', 'cpp'])
   # Disable SAFESEH with MSVC for libs that use external deps that are built with MinGW
   # noseh_link_args = ['/SAFESEH:NO']
-  # disable exception handling
-  add_project_arguments(['/EHs-', '/EHc-'], language: 'cpp')
 endif
 
 add_project_link_arguments(cpp.get_supported_link_arguments([

--- a/meson.build
+++ b/meson.build
@@ -28,10 +28,7 @@ if cpp.get_argument_syntax() == 'msvc'
   # If a warning is harmless but hard to fix, use '/woXXXX' so it's shown once
   # NOTE: Only add warnings here if you are sure they're spurious
   msvc_args = [
-    '/wd4018', # implicit signed/unsigned conversion
-    '/wd4146', # unary minus on unsigned (beware INT_MIN)
     '/wd4244', # lossy type conversion (e.g. double -> int)
-    '/wd4305', # truncating type conversion (e.g. double -> float)
     cpp.get_supported_arguments(['/utf-8']), # set the input encoding to utf-8
   ]
   add_project_arguments(msvc_args, language: ['c', 'cpp'])

--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -526,8 +526,8 @@ _hb_cairo_add_sweep_gradient_patches1 (float cx, float cy, float radius,
       C0 = _hb_cairo_sum (A, _hb_cairo_scale (U, _hb_cairo_dot (_hb_cairo_difference (p0, A), p0) / _hb_cairo_dot (U, p0)));
       C1 = _hb_cairo_sum (A, _hb_cairo_scale (U, _hb_cairo_dot (_hb_cairo_difference (p1, A), p1) / _hb_cairo_dot (U, p1)));
 
-      patch.c0 = _hb_cairo_sum (center, _hb_cairo_scale (_hb_cairo_sum (C0, _hb_cairo_scale (_hb_cairo_difference (C0, p0), 0.33333)), radius));
-      patch.c1 = _hb_cairo_sum (center, _hb_cairo_scale (_hb_cairo_sum (C1, _hb_cairo_scale (_hb_cairo_difference (C1, p1), 0.33333)), radius));
+      patch.c0 = _hb_cairo_sum (center, _hb_cairo_scale (_hb_cairo_sum (C0, _hb_cairo_scale (_hb_cairo_difference (C0, p0), 0.33333f)), radius));
+      patch.c1 = _hb_cairo_sum (center, _hb_cairo_scale (_hb_cairo_sum (C1, _hb_cairo_scale (_hb_cairo_difference (C1, p1), 0.33333f)), radius));
 
       _hb_cairo_add_patch (pattern, &center, &patch);
 

--- a/subprojects/packagefiles/ragel/meson.build
+++ b/subprojects/packagefiles/ragel/meson.build
@@ -1,6 +1,14 @@
 project('ragel', 'c', 'cpp',
-  version : '6.10'
+  version : '6.10',
+  default_options: [
+    'cpp_eh=default',
+  ],
 )
+
+cpp = meson.get_compiler('cpp')
+add_project_arguments(cpp.get_supported_arguments([
+  '-fexceptions',
+]), language: 'cpp')
 
 conf = configuration_data()
 conf.set_quoted('PACKAGE', meson.project_name())

--- a/test/api/test-paint.c
+++ b/test/api/test-paint.c
@@ -326,7 +326,7 @@ typedef struct {
 static paint_test_t paint_tests[] = {
   /* COLRv1 */
   { NOTO_HAND,   0.,  10,   0, "hand-10" },
-  { NOTO_HAND,   0.2, 10,   0, "hand-10.2" },
+  { NOTO_HAND,   0.2f,10,   0, "hand-10.2" },
 
   { TEST_GLYPHS, 0,    6,   0, "test-6" },   // linear gradient
   { TEST_GLYPHS, 0,   10,   0, "test-10" },  // sweep gradient
@@ -351,8 +351,8 @@ static paint_test_t paint_tests[] = {
   { BAD_COLRV1,  0,  154,   0, "bad-154" },  // recursion
 
   /* COLRv0 */
-  { ROCHER_ABC, 0.3,  1,   0, "rocher-1" },
-  { ROCHER_ABC, 0.3,  2,   2, "rocher-2" },
+  { ROCHER_ABC, 0.3f, 1,   0, "rocher-1" },
+  { ROCHER_ABC, 0.3f, 2,   2, "rocher-2" },
   { ROCHER_ABC, 0,    3, 200, "rocher-3" },
 };
 

--- a/util/ansi-print.hh
+++ b/util/ansi-print.hh
@@ -395,7 +395,7 @@ ansi_print_image_rgb24 (const uint32_t *data,
       {
 	if (last_bg != bi.bg)
 	{
-	  char buf[] = "\e[40m";
+	  char buf[] = "\033[40m";
 	  buf[3] += bi.bg;
 	  write_func (closure, (unsigned char *) buf, 5);
 	  last_bg = bi.bg;
@@ -411,7 +411,7 @@ ansi_print_image_rgb24 (const uint32_t *data,
 	{
 	  if (last_bg != bi.fg || last_fg != bi.bg)
 	  {
-	    char buf[] = "\e[30;40m";
+	    char buf[] = "\033[30;40m";
 	    buf[3] += bi.bg;
 	    buf[6] += bi.fg;
 	    write_func (closure, (unsigned char *) buf, 8);
@@ -423,7 +423,7 @@ ansi_print_image_rgb24 (const uint32_t *data,
 	{
 	  if (last_bg != bi.bg || last_fg != bi.fg)
 	  {
-	    char buf[] = "\e[40;30m";
+	    char buf[] = "\033[40;30m";
 	    buf[3] += bi.bg;
 	    buf[6] += bi.fg;
 	    write_func (closure, (unsigned char *) buf, 8);
@@ -434,7 +434,7 @@ ansi_print_image_rgb24 (const uint32_t *data,
 	write_func (closure, (unsigned char *) c, strlen (c));
       }
     }
-    write_func (closure, (unsigned char *) "\e[0m\n", 5); /* Reset */
+    write_func (closure, (unsigned char *) "\033[0m\n", 5); /* Reset */
     last_bg = last_fg = -1;
   }
 }


### PR DESCRIPTION
Revert the exceptions part of:

```
commit 22cbd038d3578c344e265a098fc98ef168f8d18b
Author: Khaled Hosny <khaled@aliftype.com>
Date:   Tue Sep 14 12:34:25 2021 +0200

    [meson] Add ragel subproject
```
To get ride of the following warnings:
```
cl : Command line warning D9025 : overriding '/EHs' with '/EHs-'
```