### PR TITLE
[hb-info] Fix output for CPAL

### DIFF
--- a/util/hb-info.cc
+++ b/util/hb-info.cc
@@ -964,19 +964,26 @@ struct info_t
 
 	char name[64];
 	unsigned name_len = sizeof name;
+
 	hb_ot_name_get_utf8 (face, name_id,
 			     language,
 			     &name_len, name);
-
-	printf ("%u	", i);
+        const char *type = "";
 	if (flags)
 	{
 	  if (flags & HB_OT_COLOR_PALETTE_FLAG_USABLE_WITH_LIGHT_BACKGROUND)
-	    printf ("Light");
-	  if (flags & HB_OT_COLOR_PALETTE_FLAG_USABLE_WITH_DARK_BACKGROUND)
-	    printf ("Dark");
+          {
+	    if (flags & HB_OT_COLOR_PALETTE_FLAG_USABLE_WITH_DARK_BACKGROUND)
+	      type = "Both";
+            else
+	      type = "Light";
+          }
+          else {
+	    type = "Dark";
+          }
 	}
-	printf ("%s\n", name);
+
+	printf ("%u	%-*s   %s\n", i, (int)strlen ("Light"), type, name);
       }
     }
 


### PR DESCRIPTION
The output for palette names was mangled.
This commit makes things come out ok.

For flags, we use "Both" when both LIGHT
and DARK are set.

Output before:
```
Index	Flags	Name
---------------------
0	Default palette
1	DarkFirst non-default palette
2	LightSunny colors

Colors:

Index	Name
------------
0	The first color
1	The second color
2	Out of color names
[...]
```

Output after:
```
Index	Flags	Name
---------------------
0	        Default palette
1	Dark    First non-default palette
2	Light   Sunny colors

Colors:

Index	Name
------------
0	The first color
1	The second color
2	Out of color names
[...]
```