### PR TITLE
[hb-cairo] Fixes for sweep gradients

### DIFF
--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -723,8 +723,9 @@ _hb_cairo_add_sweep_gradient_patches (hb_color_stop_t *stops,
         }
 
       //assert (angles[0] + k * span <= 0 && 0 < angles[n_stops - 1] + k * span);
+      span = fabs (span);
 
-     for (unsigned l = k; 1; l++)
+     for (unsigned l = k; l < 1000; l++)
         {
           for (unsigned i = 1; i < n_stops; i++)
             {


### PR DESCRIPTION
Make reversed angles not infloop, and
cap the number of interval repetitions
at 1000.

Fixes: https://github.com/harfbuzz/harfbuzz/issues/4055