### PR TITLE
hb-info: Only build if we have hb-gobject

### DIFF
--- a/util/meson.build
+++ b/util/meson.build
@@ -20,7 +20,7 @@ hb_subset_cli_sources = [
 
 util_deps = [freetype_dep, cairo_dep, cairo_ft_dep, glib_dep]
 
-if conf.get('HAVE_GLIB', 0) == 1
+if conf.get('HAVE_GOBJECT', 0) == 1
   if conf.get('HAVE_CAIRO', 0) == 1
     hb_view = executable('hb-view', hb_view_sources,
       cpp_args: cpp_args,


### PR DESCRIPTION
This was using the wrong condition.