### PR TITLE
hb-cairo: Fix handling of foreground color

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -211,6 +211,7 @@ if cairo_dep.found()
   else
     check_funcs += [['cairo_user_font_face_set_render_color_glyph_func', {'deps': cairo_dep}]]
     check_funcs += [['cairo_font_options_get_custom_palette_color', {'deps': cairo_dep}]]
+    check_funcs += [['cairo_user_scaled_font_get_foreground_source', {'deps': cairo_dep}]]
   endif
 endif
 

--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -288,9 +288,14 @@ _hb_cairo_get_color_stops (hb_cairo_context_t *c,
     if ((*stops)[i].is_foreground)
     {
       double r, g, b, a;
-      cairo_user_scaled_font_get_foreground_color (c->scaled_font, &r, &g, &b, &a);
-      (*stops)[i].color = HB_COLOR (round (b * 255.), round (g * 255.), round (r * 255.),
-				    round (a * hb_color_get_alpha ((*stops)[i].color)));
+      cairo_pattern_t *foreground;
+
+      foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
+      if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
+        (*stops)[i].color = HB_COLOR (round (b * 255.), round (g * 255.), round (r * 255.),
+                                      round (a * hb_color_get_alpha ((*stops)[i].color)));
+      else
+        (*stops)[i].color = HB_COLOR (0, 0, 0, hb_color_get_alpha ((*stops)[i].color));
     }
 
   *count = len;

--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -288,9 +288,7 @@ _hb_cairo_get_color_stops (hb_cairo_context_t *c,
     if ((*stops)[i].is_foreground)
     {
       double r, g, b, a;
-      cairo_pattern_t *foreground;
-
-      foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
+      cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
       if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
         (*stops)[i].color = HB_COLOR (round (b * 255.), round (g * 255.), round (r * 255.),
                                       round (a * hb_color_get_alpha ((*stops)[i].color)));

--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -287,12 +287,14 @@ _hb_cairo_get_color_stops (hb_cairo_context_t *c,
   for (unsigned i = 0; i < len; i++)
     if ((*stops)[i].is_foreground)
     {
+#ifdef HAVE_CAIRO_USER_SCALED_FONT_GET_FOREGROUND_SOURCE
       double r, g, b, a;
-      cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
+      cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font, true);
       if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
         (*stops)[i].color = HB_COLOR (round (b * 255.), round (g * 255.), round (r * 255.),
                                       round (a * hb_color_get_alpha ((*stops)[i].color)));
       else
+#endif
         (*stops)[i].color = HB_COLOR (0, 0, 0, hb_color_get_alpha ((*stops)[i].color));
     }
 

--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -289,7 +289,7 @@ _hb_cairo_get_color_stops (hb_cairo_context_t *c,
     {
 #ifdef HAVE_CAIRO_USER_SCALED_FONT_GET_FOREGROUND_SOURCE
       double r, g, b, a;
-      cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font, true);
+      cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
       if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
         (*stops)[i].color = HB_COLOR (round (b * 255.), round (g * 255.), round (r * 255.),
                                       round (a * hb_color_get_alpha ((*stops)[i].color)));

--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -274,7 +274,7 @@ _hb_cairo_normalize_color_line (hb_color_stop_t *stops,
   *omax = max;
 }
 
-static void
+static bool
 _hb_cairo_get_color_stops (hb_cairo_context_t *c,
 			   hb_color_line_t *color_line,
 			   unsigned *count,
@@ -282,7 +282,11 @@ _hb_cairo_get_color_stops (hb_cairo_context_t *c,
 {
   unsigned len = hb_color_line_get_color_stops (color_line, 0, nullptr, nullptr);
   if (len > *count)
+  {
     *stops = (hb_color_stop_t *) hb_malloc (len * sizeof (hb_color_stop_t));
+    if (unlikely (!stops))
+      return false;
+  }
   hb_color_line_get_color_stops (color_line, 0, &len, *stops);
   for (unsigned i = 0; i < len; i++)
     if ((*stops)[i].is_foreground)
@@ -299,6 +303,7 @@ _hb_cairo_get_color_stops (hb_cairo_context_t *c,
     }
 
   *count = len;
+  return true;
 }
 
 void
@@ -318,7 +323,8 @@ _hb_cairo_paint_linear_gradient (hb_cairo_context_t *c,
   float min, max;
   cairo_pattern_t *pattern;
 
-  _hb_cairo_get_color_stops (c, color_line, &len, &stops);
+  if (unlikely (!_hb_cairo_get_color_stops (c, color_line, &len, &stops)))
+    return;
   _hb_cairo_normalize_color_line (stops, len, &min, &max);
 
   _hb_cairo_reduce_anchors (x0, y0, x1, y1, x2, y2, &xx0, &yy0, &xx1, &yy1);
@@ -365,7 +371,8 @@ _hb_cairo_paint_radial_gradient (hb_cairo_context_t *c,
   float rr0, rr1;
   cairo_pattern_t *pattern;
 
-  _hb_cairo_get_color_stops (c, color_line, &len, &stops);
+  if (unlikely (!_hb_cairo_get_color_stops (c, color_line, &len, &stops)))
+    return;
   _hb_cairo_normalize_color_line (stops, len, &min, &max);
 
   xx0 = x0 + min * (x1 - x0);
@@ -626,6 +633,12 @@ _hb_cairo_add_sweep_gradient_patches (hb_color_stop_t *stops,
   {
     angles = (float *) hb_malloc (sizeof (float) * n_stops);
     colors = (hb_cairo_color_t *) hb_malloc (sizeof (hb_cairo_color_t) * n_stops);
+    if (unlikely (!angles || !colors))
+    {
+      hb_free (angles);
+      hb_free (colors);
+      return;
+    }
   }
 
   for (unsigned i = 0; i < n_stops; i++)
@@ -828,7 +841,8 @@ _hb_cairo_paint_sweep_gradient (hb_cairo_context_t *c,
   float max_x, max_y, radius;
   cairo_pattern_t *pattern;
 
-  _hb_cairo_get_color_stops (c, color_line, &len, &stops);
+  if (unlikely (!_hb_cairo_get_color_stops (c, color_line, &len, &stops)))
+    return;
 
   hb_qsort (stops, len, sizeof (hb_color_stop_t), _hb_cairo_cmp_color_stop);
 

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -253,11 +253,14 @@ hb_cairo_paint_color (hb_paint_funcs_t *pfuncs HB_UNUSED,
 
   if (use_foreground)
   {
+    cairo_pattern_t *foreground;
     double r, g, b, a;
-    cairo_user_scaled_font_get_foreground_color (c->scaled_font,
-						 &r, &g, &b, &a);
-    cairo_set_source_rgba (cr, r, g, b,
-			   a * hb_color_get_alpha (color) / 255.);
+
+    foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
+    if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) != CAIRO_STATUS_SUCCESS)
+      cairo_set_source_rgba (cr, r, g, b, a * hb_color_get_alpha (color) / 255.);
+    else
+      cairo_set_source_rgba (cr, 0, 0, 0, hb_color_get_alpha (color) / 255.);
   }
   else
     cairo_set_source_rgba (cr,
@@ -595,7 +598,6 @@ hb_cairo_render_color_glyph (cairo_scaled_font_t  *scaled_font,
 #endif
 
   hb_color_t color = HB_COLOR (0, 0, 0, 255);
-
   hb_position_t x_scale, y_scale;
   hb_font_get_scale (font, &x_scale, &y_scale);
   cairo_scale (cr, +1./x_scale, -1./y_scale);

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -253,10 +253,8 @@ hb_cairo_paint_color (hb_paint_funcs_t *pfuncs HB_UNUSED,
 
   if (use_foreground)
   {
-    cairo_pattern_t *foreground;
     double r, g, b, a;
-
-    foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
+    cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
     if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
       cairo_set_source_rgba (cr, r, g, b, a * hb_color_get_alpha (color) / 255.);
     else

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -585,11 +585,9 @@ hb_cairo_render_color_glyph (cairo_scaled_font_t  *scaled_font,
   cairo_font_options_destroy (options);
 #endif
 
-  hb_color_t color = HB_COLOR (0, 0, 0, 255);
-  cairo_pattern_t *pattern = cairo_get_source (cr);
   double r, g, b, a;
-  if (cairo_pattern_get_rgba (pattern, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
-    color = HB_COLOR (round (b * 255.), round (g * 255.), round (r * 255.), round (a * 255.));
+  cairo_user_scaled_font_get_foreground_color (scaled_font, &r, &g, &b, &a);
+  hb_color_t color = HB_COLOR (round (b * 255.), round (g * 255.), round (r * 255.), round (a * 255.));
 
   hb_position_t x_scale, y_scale;
   hb_font_get_scale (font, &x_scale, &y_scale);

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -253,11 +253,13 @@ hb_cairo_paint_color (hb_paint_funcs_t *pfuncs HB_UNUSED,
 
   if (use_foreground)
   {
+#ifdef HAVE_CAIRO_USER_SCALED_FONT_GET_FOREGROUND_SOURCE
     double r, g, b, a;
-    cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
+    cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font, true);
     if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
       cairo_set_source_rgba (cr, r, g, b, a * hb_color_get_alpha (color) / 255.);
     else
+#endif
       cairo_set_source_rgba (cr, 0, 0, 0, hb_color_get_alpha (color) / 255.);
   }
   else

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -257,7 +257,7 @@ hb_cairo_paint_color (hb_paint_funcs_t *pfuncs HB_UNUSED,
     double r, g, b, a;
 
     foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
-    if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) != CAIRO_STATUS_SUCCESS)
+    if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
       cairo_set_source_rgba (cr, r, g, b, a * hb_color_get_alpha (color) / 255.);
     else
       cairo_set_source_rgba (cr, 0, 0, 0, hb_color_get_alpha (color) / 255.);

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -251,11 +251,20 @@ hb_cairo_paint_color (hb_paint_funcs_t *pfuncs HB_UNUSED,
   hb_cairo_context_t *c = (hb_cairo_context_t *) paint_data;
   cairo_t *cr = c->cr;
 
-  cairo_set_source_rgba (cr,
-                         hb_color_get_red (color) / 255.,
-                         hb_color_get_green (color) / 255.,
-                         hb_color_get_blue (color) / 255.,
-                         hb_color_get_alpha (color) / 255.);
+  if (use_foreground)
+  {
+    double r, g, b, a;
+    cairo_user_scaled_font_get_foreground_color (c->scaled_font,
+						 &r, &g, &b, &a);
+    cairo_set_source_rgba (cr, r, g, b,
+			   a * hb_color_get_alpha (color) / 255.);
+  }
+  else
+    cairo_set_source_rgba (cr,
+			   hb_color_get_red (color) / 255.,
+			   hb_color_get_green (color) / 255.,
+			   hb_color_get_blue (color) / 255.,
+			   hb_color_get_alpha (color) / 255.);
   cairo_paint (cr);
 }
 
@@ -585,9 +594,7 @@ hb_cairo_render_color_glyph (cairo_scaled_font_t  *scaled_font,
   cairo_font_options_destroy (options);
 #endif
 
-  double r, g, b, a;
-  cairo_user_scaled_font_get_foreground_color (scaled_font, &r, &g, &b, &a);
-  hb_color_t color = HB_COLOR (round (b * 255.), round (g * 255.), round (r * 255.), round (a * 255.));
+  hb_color_t color = HB_COLOR (0, 0, 0, 255);
 
   hb_position_t x_scale, y_scale;
   hb_font_get_scale (font, &x_scale, &y_scale);

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -255,7 +255,7 @@ hb_cairo_paint_color (hb_paint_funcs_t *pfuncs HB_UNUSED,
   {
 #ifdef HAVE_CAIRO_USER_SCALED_FONT_GET_FOREGROUND_SOURCE
     double r, g, b, a;
-    cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font, true);
+    cairo_pattern_t *foreground = cairo_user_scaled_font_get_foreground_source (c->scaled_font);
     if (cairo_pattern_get_rgba (foreground, &r, &g, &b, &a) == CAIRO_STATUS_SUCCESS)
       cairo_set_source_rgba (cr, r, g, b, a * hb_color_get_alpha (color) / 255.);
     else


### PR DESCRIPTION
Use the new cairo_user_scaled_font_get_foreground_color to obtain the foreground color, since the cr's source can't be trusted.

Requires https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/420