### PR TITLE
[COPYING] Another update

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,21 +2,23 @@ HarfBuzz is licensed under the so-called "Old MIT" license.  Details follow.
 For parts of HarfBuzz that are licensed under different licenses see individual
 files names COPYING in subdirectories where applicable.
 
-Copyright © 2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020  Google, Inc.
-Copyright © 2018,2019,2020  Ebrahim Byagowi
+Copyright © 2010-2022  Google, Inc.
+Copyright © 2015-2020  Ebrahim Byagowi
 Copyright © 2019,2020  Facebook, Inc.
-Copyright © 2012  Mozilla Foundation
+Copyright © 2012,2015  Mozilla Foundation
 Copyright © 2011  Codethink Limited
 Copyright © 2008,2010  Nokia Corporation and/or its subsidiary(-ies)
 Copyright © 2009  Keith Stribley
-Copyright © 2009  Martin Hosken and SIL International
+Copyright © 2011  Martin Hosken and SIL International
 Copyright © 2007  Chris Wilson
 Copyright © 2005,2006,2020,2021,2022,2023  Behdad Esfahbod
 Copyright © 2005  David Turner
-Copyright © 2004,2007,2008,2009,2010  Red Hat, Inc.
+Copyright © 2004,2007,2008,2009,2010,2013,2021,2022,2023  Red Hat, Inc.
 Copyright © 1998-2004  David Turner and Werner Lemberg
+Copyright © 2016  Igalia S.L.
 Copyright © 2022  Matthias Clasen
 Copyright © 2018,2021  Khaled Hosny
+Copyright © 2018,2019,2020  Adobe, Inc
 
 For full copyright notices consult the individual files in the package.
 


### PR DESCRIPTION
This brings the COPYRIGHT file up to date, looking more like what I ended up filling out in Debian's debian/copyright file (the main difference being that the decopy script put names into alphabetical order, which I'm happy to do for harfbuzz if you'd like).

Adobe, Inc has copyright in src/hb-subset-cff*, test/api/test-subset*, and misc other places.

Ebrahim Byagowi has copyright as far back as 2015 in places like src/hb-directwrite.cc.

Google, Inc has newer copyright into 2022 in places like src/graph/test-classdef-graph.cc. Also, listing every year was getting a bit unwieldy, so just do 2010-2022.

Igalia S.L. contributed the stuff in src/hb-ot-math*.

The only references I could find to Martin Hosken & SIL were in src/hb-graphite2*, and they were 2011, not 2009.

Mozilla's got a bunch of 2015 code in src/hb-ot-shaper-*.

Red Hat has copyright up to 2023 (eg, test/api/test-glyph-names.c).