### PR TITLE
fix meson install tag for `harfbuzz-config.cmake`

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -39,7 +39,7 @@ jobs:
           python3 \
           python3-setuptools
     - name: Install Python Dependencies
-      run: sudo pip3 install fonttools meson==0.56.0 gcovr==5.0
+      run: sudo pip3 install fonttools meson==0.60.0 gcovr==5.0
     - name: Setup Meson
       run: |
         ccache --version

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('harfbuzz', 'c', 'cpp',
-  meson_version: '>= 0.55.0',
+  meson_version: '>= 0.60.0',
   version: '6.0.0',
   default_options: [
     'cpp_eh=none',          # Just to support msvc, we are passing -fno-exceptions also anyway

--- a/src/meson.build
+++ b/src/meson.build
@@ -770,6 +770,7 @@ configure_file(input: 'harfbuzz-config.cmake.in',
   output: 'harfbuzz-config.cmake',
   configuration: cmake_config,
   install_dir: get_option('libdir') / 'cmake' / 'harfbuzz',
+  install_tag: 'devel',
 )
 
 gobject_enums_c = []

--- a/src/meson.build
+++ b/src/meson.build
@@ -890,7 +890,7 @@ if get_option('tests').enabled()
 
   env = environment()
   env.set('srcdir', meson.current_source_dir())
-  env.set('base_srcdir', meson.source_root())
+  env.set('base_srcdir', meson.project_source_root())
   env.set('builddir', meson.current_build_dir())
   env.set('libs', meson.current_build_dir()) # TODO: Merge this with builddir after autotools removal
   HBSOURCES = []


### PR DESCRIPTION
So it does not get installed when filtering out `devel` stuff, e.g. by using `meson install --tags runtime`.

Note: [installation tags](https://mesonbuild.com/Installing.html#installation-tags) support is available starting with meson version 0.60.0, released Nov 2, 2021.