### PR TITLE
[ot-font] Use the cmap cache more

### DIFF
--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -31,6 +31,7 @@
 #include "hb-ot-shaper-arabic-pua.hh"
 #include "hb-open-type.hh"
 #include "hb-set.hh"
+#include "hb-cache.hh"
 
 /*
  * cmap -- Character to Glyph Index Mapping
@@ -1841,6 +1842,8 @@ struct cmap
 
   struct accelerator_t
   {
+    using cache_t = hb_cache_t<21, 16, 8, true>;
+
     accelerator_t (hb_face_t *face)
     {
       this->table = hb_sanitize_context_t ().reference_table<cmap> (face);
@@ -1895,15 +1898,6 @@ struct cmap
     }
     ~accelerator_t () { this->table.destroy (); }
 
-    bool get_nominal_glyph (hb_codepoint_t  unicode,
-                            hb_codepoint_t *glyph) const
-    {
-      if (unlikely (!this->get_glyph_funcZ)) return false;
-
-      return this->get_glyph_funcZ (this->get_glyph_data, unicode, glyph);
-    }
-
-    template <typename cache_t = void>
     inline bool _cached_get (hb_codepoint_t unicode,
 			     hb_codepoint_t *glyph,
 			     cache_t *cache) const
@@ -1914,21 +1908,21 @@ struct cmap
         *glyph = v;
 	return true;
       }
-      bool ret  = get_nominal_glyph (unicode, glyph);
+      bool ret  = this->get_glyph_funcZ (this->get_glyph_data, unicode, glyph);
+
       if (cache && ret)
         cache->set (unicode, *glyph);
       return ret;
     }
 
-    template <typename cache_t = void>
     bool get_nominal_glyph (hb_codepoint_t  unicode,
 			    hb_codepoint_t *glyph,
 			    cache_t *cache = nullptr) const
     {
+      if (unlikely (!this->get_glyph_funcZ)) return 0;
       return _cached_get (unicode, glyph, cache);
     }
 
-    template <typename cache_t = void>
     unsigned int get_nominal_glyphs (unsigned int count,
 				     const hb_codepoint_t *first_unicode,
 				     unsigned int unicode_stride,
@@ -1949,7 +1943,6 @@ struct cmap
       return done;
     }
 
-    template <typename cache_t = void>
     bool get_variation_glyph (hb_codepoint_t  unicode,
 			      hb_codepoint_t  variation_selector,
 			      hb_codepoint_t *glyph,

--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -1896,9 +1896,8 @@ struct cmap
     ~accelerator_t () { this->table.destroy (); }
 
     bool get_nominal_glyph (hb_codepoint_t  unicode,
-			    hb_codepoint_t *glyph) const
+                            hb_codepoint_t *glyph) const
     {
-      if (unlikely (!this->get_glyph_funcZ)) return false;
       return this->get_glyph_funcZ (this->get_glyph_data, unicode, glyph);
     }
 
@@ -1913,10 +1912,18 @@ struct cmap
         *glyph = v;
 	return true;
       }
-      bool ret = this->get_glyph_funcZ (this->get_glyph_data, unicode, glyph);
+      bool ret  = get_nominal_glyph (unicode, glyph);
       if (cache && ret)
-	cache->set (unicode, *glyph);
+        cache->set (unicode, *glyph);
       return ret;
+    }
+
+    template <typename cache_t = void>
+    bool get_nominal_glyph (hb_codepoint_t  unicode,
+			    hb_codepoint_t *glyph,
+			    cache_t *cache = nullptr) const
+    {
+      return _cached_get (unicode, glyph, cache);
     }
 
     template <typename cache_t = void>
@@ -1940,9 +1947,11 @@ struct cmap
       return done;
     }
 
+    template <typename cache_t = void>
     bool get_variation_glyph (hb_codepoint_t  unicode,
 			      hb_codepoint_t  variation_selector,
-			      hb_codepoint_t *glyph) const
+			      hb_codepoint_t *glyph,
+			      cache_t *cache = nullptr) const
     {
       switch (this->subtable_uvs->get_glyph_variant (unicode,
 						     variation_selector,
@@ -1953,7 +1962,7 @@ struct cmap
 	case GLYPH_VARIANT_USE_DEFAULT:	break;
       }
 
-      return get_nominal_glyph (unicode, glyph);
+      return get_nominal_glyph (unicode, glyph, cache);
     }
 
     void collect_unicodes (hb_set_t *out, unsigned int num_glyphs) const

--- a/src/hb-ot-cmap-table.hh
+++ b/src/hb-ot-cmap-table.hh
@@ -1898,6 +1898,8 @@ struct cmap
     bool get_nominal_glyph (hb_codepoint_t  unicode,
                             hb_codepoint_t *glyph) const
     {
+      if (unlikely (!this->get_glyph_funcZ)) return false;
+
       return this->get_glyph_funcZ (this->get_glyph_data, unicode, glyph);
     }
 

--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -136,7 +136,7 @@ hb_ot_get_nominal_glyph (hb_font_t *font HB_UNUSED,
 {
   const hb_ot_font_t *ot_font = (const hb_ot_font_t *) font_data;
   const hb_ot_face_t *ot_face = ot_font->ot_face;
-  return ot_face->cmap->get_nominal_glyph (unicode, glyph);
+  return ot_face->cmap->get_nominal_glyph (unicode, glyph, ot_font->cmap_cache);
 }
 
 static unsigned int
@@ -167,7 +167,9 @@ hb_ot_get_variation_glyph (hb_font_t *font HB_UNUSED,
 {
   const hb_ot_font_t *ot_font = (const hb_ot_font_t *) font_data;
   const hb_ot_face_t *ot_face = ot_font->ot_face;
-  return ot_face->cmap->get_variation_glyph (unicode, variation_selector, glyph);
+  return ot_face->cmap->get_variation_glyph (unicode,
+                                             variation_selector, glyph,
+                                             ot_font->cmap_cache);
 }
 
 static void


### PR DESCRIPTION
Use the cmap cache for get_nominal_glyph and
get_variation_glyph as well. The first of these
is used a lot in pango.