### PR TITLE
[instancer] bug fix

### DIFF
--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -238,7 +238,7 @@ _GSUBGPOS_find_duplicate_features (const OT::GSUBGPOS &g,
 
       const OT::Feature* other_f = &(g.get_feature (other_f_index));
       if (feature_substitutes_map->has (other_f_index, &p))
-        f = *p;
+        other_f = *p;
 
       auto f_iter =
       + hb_iter (f->lookupIndex)


### PR DESCRIPTION
Fixed a bug caused by typo. When finding duplicate features, we should use feature substitutes if they exist.
I'll see if I can generate a small test for it. Current file is too large, but once I subset it down, the issue disappeared.