### PR TITLE
7.0.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,133 @@
+Overview of changes leading to 7.0.0
+Saturday, February 11, 2023
+====================================
+- New hb-paint API that is designed mainly to paint “COLRv1” glyphs, but can be
+  also used as a unified API to paint any of the glyph representations
+  supported by HarfBuzz (B/W outlines, color layers, or color bitmaps). 
+  (Behdad Esfahbod, Matthias Clasen)
+- New hb-cairo API for integrating with cairo graphics library. This is provided
+  as a separate harfbuzz-cairo library. (Behdad Esfahbod, Matthias Clasen)
+- Support for instancing “CFF2” table. (Behdad Esfahbod)
+- Support font emboldening. (Behdad Esfahbod)
+- Support feature ranges with AAT shaping. (Behdad Esfahbod)
+- Experimental support to cubic curves in “glyf” table, see
+  https://github.com/harfbuzz/boring-expansion-spec/blob/main/glyf1-cubicOutlines.md
+  for spec. (Behdad Esfahbod)
+- Various subsetter improvements. (Garret Rieger, Qunxin Liu, Behdad Esfahbod)
+- Various documentation improvements. 
+  (Behdad Esfahbod, Matthias Clasen, Khaled Hosny)
+- Significantly reduced memory use during shaping. (Behdad Esfahbod)
+- Greatly reduced memory use during subsetting “CFF” table. (Behdad Esfahbod)
+- New command line utility, hb-info, for querying various font information.
+  (Behdad Esfahbod, Matthias Clasen)
+- New hb-shape/hb-view options: --glyphs, --color-palette, --font-bold,
+  --font-grade, and --named-instance. (Behdad Esfahbod)
+- Miscellaneous fixes and improvements.
+  (Amir Masoud Abdol, Andres Salomon, Behdad Esfahbod, Chun-wei Fan,
+  Garret Rieger, Jens Kutilek, Khaled Hosny, Konstantin Käfer, Matthias Clasen,
+  Nirbheek Chauhan, Pedro J. Estébanez, Qunxin Liu, Sergei Trofimovich)
+
+- New API:
++HB_FONT_NO_VAR_NAMED_INSTANCE
++HB_PAINT_IMAGE_FORMAT_BGRA
++HB_PAINT_IMAGE_FORMAT_PNG
++HB_PAINT_IMAGE_FORMAT_SVG
++hb_cairo_font_face_create_for_face
++hb_cairo_font_face_create_for_font
++hb_cairo_font_face_get_face
++hb_cairo_font_face_get_font
++hb_cairo_font_face_get_scale_factor
++hb_cairo_font_face_set_font_init_func
++hb_cairo_font_face_set_scale_factor
++hb_cairo_font_init_func_t
++hb_cairo_glyphs_from_buffer
++hb_cairo_scaled_font_get_font
++hb_color_line_get_color_stops
++hb_color_line_get_color_stops_func_t
++hb_color_line_get_extend
++hb_color_line_get_extend_func_t
++hb_color_line_t
++hb_color_stop_t
++hb_draw_funcs_get_empty
++hb_draw_funcs_get_user_data
++hb_draw_funcs_set_user_data
++hb_face_collect_nominal_glyph_mapping
++hb_font_draw_glyph
++hb_font_draw_glyph_func_t
++hb_font_funcs_set_draw_glyph_func
++hb_font_funcs_set_paint_glyph_func
++hb_font_get_synthetic_bold
++hb_font_get_var_named_instance
++hb_font_paint_glyph
++hb_font_paint_glyph_func_t
++hb_font_set_synthetic_bold
++hb_map_keys
++hb_map_next
++hb_map_update
++hb_map_values
++hb_ot_color_glyph_has_paint
++hb_ot_color_has_paint
++hb_ot_layout_script_select_language2
++hb_ot_name_id_predefined_t
++hb_paint_color
++hb_paint_color_func_t
++hb_paint_composite_mode_t
++hb_paint_custom_palette_color
++hb_paint_custom_palette_color_func_t
++hb_paint_extend_t
++hb_paint_funcs_create
++hb_paint_funcs_destroy
++hb_paint_funcs_get_empty
++hb_paint_funcs_get_user_data
++hb_paint_funcs_is_immutable
++hb_paint_funcs_make_immutable
++hb_paint_funcs_reference
++hb_paint_funcs_set_color_func
++hb_paint_funcs_set_custom_palette_color_func
++hb_paint_funcs_set_image_func
++hb_paint_funcs_set_linear_gradient_func
++hb_paint_funcs_set_pop_clip_func
++hb_paint_funcs_set_pop_group_func
++hb_paint_funcs_set_pop_transform_func
++hb_paint_funcs_set_push_clip_glyph_func
++hb_paint_funcs_set_push_clip_rectangle_func
++hb_paint_funcs_set_push_group_func
++hb_paint_funcs_set_push_transform_func
++hb_paint_funcs_set_radial_gradient_func
++hb_paint_funcs_set_sweep_gradient_func
++hb_paint_funcs_set_user_data
++hb_paint_funcs_t
++hb_paint_image
++hb_paint_image_func_t
++hb_paint_linear_gradient
++hb_paint_linear_gradient_func_t
++hb_paint_pop_clip
++hb_paint_pop_clip_func_t
++hb_paint_pop_group
++hb_paint_pop_group_func_t
++hb_paint_pop_transform
++hb_paint_pop_transform_func_t
++hb_paint_push_clip_glyph
++hb_paint_push_clip_glyph_func_t
++hb_paint_push_clip_rectangle
++hb_paint_push_clip_rectangle_func_t
++hb_paint_push_group
++hb_paint_push_group_func_t
++hb_paint_push_transform
++hb_paint_push_transform_func_t
++hb_paint_radial_gradient
++hb_paint_radial_gradient_func_t
++hb_paint_sweep_gradient
++hb_paint_sweep_gradient_func_t
++hb_set_is_inverted
++hb_subset_input_keep_everything
+
+- Deprecated API:
++hb_font_funcs_set_glyph_shape_func
++hb_font_get_glyph_shape_func_t
++hb_font_get_glyph_shape
+
+
 Overview of changes leading to 6.0.0
 Friday, December 16, 2022
 ====================================

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.64])
 AC_INIT([HarfBuzz],
-        [6.0.0],
+        [7.0.0],
         [https://github.com/harfbuzz/harfbuzz/issues/new],
         [harfbuzz],
         [http://harfbuzz.org/])

--- a/docs/harfbuzz-docs.xml
+++ b/docs/harfbuzz-docs.xml
@@ -120,6 +120,7 @@
       <index id="api-index-full"><title>API Index</title><xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include></index>
       <index id="deprecated-api-index"><title>Index of deprecated API</title><xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include></index>
 
+      <index id="api-index-7-0-0"><title>Index of new symbols in 7.0.0</title><xi:include href="xml/api-index-7.0.0.xml"><xi:fallback /></xi:include></index>
       <index id="api-index-6-0-0"><title>Index of new symbols in 6.0.0</title><xi:include href="xml/api-index-6.0.0.xml"><xi:fallback /></xi:include></index>
       <index id="api-index-5-3-0"><title>Index of new symbols in 5.3.0</title><xi:include href="xml/api-index-5.3.0.xml"><xi:fallback /></xi:include></index>
       <index id="api-index-5-0-0"><title>Index of new symbols in 5.0.0</title><xi:include href="xml/api-index-5.0.0.xml"><xi:fallback /></xi:include></index>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('harfbuzz', 'c', 'cpp',
   meson_version: '>= 0.55.0',
-  version: '6.0.0',
+  version: '7.0.0',
   default_options: [
     'cpp_eh=none',          # Just to support msvc, we are passing -fno-exceptions also anyway
     'cpp_rtti=false',       # Just to support msvc, we are passing -fno-rtti also anyway

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -651,7 +651,7 @@ user_font_face_create (hb_face_t *face)
  *
  * Returns: (transfer full): a newly created #cairo_font_face_t
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 cairo_font_face_t *
 hb_cairo_font_face_create_for_font (hb_font_t *font)
@@ -677,7 +677,7 @@ hb_cairo_font_face_create_for_font (hb_font_t *font)
  *
  * Returns: (nullable) (transfer none): the #hb_font_t that @font_face was created from
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_font_t *
 hb_cairo_font_face_get_font (cairo_font_face_t *font_face)
@@ -695,7 +695,7 @@ hb_cairo_font_face_get_font (cairo_font_face_t *font_face)
  *
  * Returns: (transfer full): a newly created #cairo_font_face_t
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 cairo_font_face_t *
 hb_cairo_font_face_create_for_face (hb_face_t *face)
@@ -713,7 +713,7 @@ hb_cairo_font_face_create_for_face (hb_face_t *face)
  *
  * Returns: (nullable) (transfer none): the #hb_face_t associated with @font_face
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_face_t *
 hb_cairo_font_face_get_face (cairo_font_face_t *font_face)
@@ -733,7 +733,7 @@ hb_cairo_font_face_get_face (cairo_font_face_t *font_face)
  * face created using hb_cairo_font_face_create_for_face()
  * creates an #hb_font_t for a #cairo_scaled_font_t.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_cairo_font_face_set_font_init_func (cairo_font_face_t *font_face,
@@ -766,7 +766,7 @@ hb_cairo_font_face_set_font_init_func (cairo_font_face_t *font_face,
  *
  * Returns: (nullable) (transfer none): the #hb_font_t associated with @scaled_font
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_font_t *
 hb_cairo_scaled_font_get_font (cairo_scaled_font_t *scaled_font)
@@ -814,7 +814,7 @@ hb_cairo_scaled_font_get_font (cairo_scaled_font_t *scaled_font)
  * (because you set the scale of the #hb_font_t yourself), use
  * the conversion rate involved.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_cairo_font_face_set_scale_factor (cairo_font_face_t *font_face,
@@ -835,7 +835,7 @@ hb_cairo_font_face_set_scale_factor (cairo_font_face_t *font_face,
  *
  * Returns: the scale factor of @font_face
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 unsigned int
 hb_cairo_font_face_get_scale_factor (cairo_font_face_t *font_face)
@@ -898,7 +898,7 @@ hb_cairo_font_face_get_scale_factor (cairo_font_face_t *font_face)
  * it and the x,y values of the extra entry at the end add up the advance
  * x,y of all the glyphs in the @buffer.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_cairo_glyphs_from_buffer (hb_buffer_t *buffer,

--- a/src/hb-cairo.h
+++ b/src/hb-cairo.h
@@ -57,7 +57,7 @@ hb_cairo_font_face_get_face (cairo_font_face_t *font_face);
  *
  * Return value: the #hb_font_t value to use; in most cases same as @font
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef hb_font_t * (*hb_cairo_font_init_func_t) (hb_font_t *font,
 						  cairo_scaled_font_t *scaled_font,

--- a/src/hb-draw.cc
+++ b/src/hb-draw.cc
@@ -207,7 +207,7 @@ DEFINE_NULL_INSTANCE (hb_draw_funcs_t) =
  *
  * Return value: (transfer full): The empty draw-functions structure
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 hb_draw_funcs_t *
 hb_draw_funcs_get_empty ()
@@ -276,7 +276,7 @@ hb_draw_funcs_destroy (hb_draw_funcs_t *dfuncs)
  *
  * Return value: `true` if success, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 hb_bool_t
 hb_draw_funcs_set_user_data (hb_draw_funcs_t *dfuncs,
@@ -298,7 +298,7 @@ hb_draw_funcs_set_user_data (hb_draw_funcs_t *dfuncs,
  *
  * Return value: (transfer none): A pointer to the user data
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 void *
 hb_draw_funcs_get_user_data (const hb_draw_funcs_t *dfuncs,

--- a/src/hb-face.cc
+++ b/src/hb-face.cc
@@ -609,7 +609,7 @@ hb_face_collect_unicodes (hb_face_t *face,
  * Collects the mapping from Unicode characters to nominal glyphs of the @face,
  * and optionally all of the Unicode characters covered by @face.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_face_collect_nominal_glyph_mapping (hb_face_t *face,

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -1396,6 +1396,7 @@ hb_font_get_glyph_from_name (hb_font_t      *font,
  * objects, with @draw_data passed to them.
  *
  * Since: 4.0.0
+ * Deprecated: 7.0.0: Use hb_font_draw_glyph() instead
  */
 void
 hb_font_get_glyph_shape (hb_font_t *font,
@@ -1417,7 +1418,7 @@ hb_font_get_glyph_shape (hb_font_t *font,
  * The outline is returned by way of calls to the callbacks of the @dfuncs
  * objects, with @draw_data passed to them.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 void
 hb_font_draw_glyph (hb_font_t *font,
@@ -1446,7 +1447,7 @@ hb_font_draw_glyph (hb_font_t *font,
  * then @palette_index selects the palette to use. If the font only
  * has one palette, this will be 0.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_font_paint_glyph (hb_font_t *font,
@@ -2470,12 +2471,12 @@ hb_font_get_ptem (hb_font_t *font)
  * Synthetic boldness is applied when rendering a glyph via
  * hb_font_draw_glyph().
  *
- * If @in_place is `FALSE`, then glyph advance-widths are also
+ * If @in_place is `false`, then glyph advance-widths are also
  * adjusted, otherwise they are not.  The in-place mode is
  * useful for simulating [font grading](https://fonts.google.com/knowledge/glossary/grade).
  *
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 void
 hb_font_set_synthetic_bold (hb_font_t *font,
@@ -2508,7 +2509,7 @@ hb_font_set_synthetic_bold (hb_font_t *font,
  *
  * Fetches the "synthetic boldness" parameters of a font.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 void
 hb_font_get_synthetic_bold (hb_font_t *font,
@@ -2723,7 +2724,7 @@ hb_font_set_var_named_instance (hb_font_t *font,
  *
  * Return value: Named-instance index or %HB_FONT_NO_VAR_NAMED_INSTANCE.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 unsigned int
 hb_font_get_var_named_instance (hb_font_t *font)

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -497,8 +497,7 @@ typedef hb_bool_t (*hb_font_get_glyph_from_name_func_t) (hb_font_t *font, void *
  * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
  *
  * Since: 4.0.0
- *
- * Deprecated: REPLACEME: Use #hb_font_draw_glyph_func_t instead
+ * Deprecated: 7.0.0: Use #hb_font_draw_glyph_func_t instead
  **/
 typedef void (*hb_font_get_glyph_shape_func_t) (hb_font_t *font, void *font_data,
 						hb_codepoint_t glyph,
@@ -516,7 +515,7 @@ typedef void (*hb_font_get_glyph_shape_func_t) (hb_font_t *font, void *font_data
  *
  * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  *
  **/
 typedef void (*hb_font_draw_glyph_func_t) (hb_font_t *font, void *font_data,
@@ -537,7 +536,7 @@ typedef void (*hb_font_draw_glyph_func_t) (hb_font_t *font, void *font_data,
  *
  * A virtual method for the #hb_font_funcs_t of an #hb_font_t object.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_font_paint_glyph_func_t) (hb_font_t *font, void *font_data,
                                             hb_codepoint_t glyph,
@@ -815,8 +814,7 @@ hb_font_funcs_set_glyph_from_name_func (hb_font_funcs_t *ffuncs,
  * which is the same as #hb_font_draw_glyph_func_t.
  *
  * Since: 4.0.0
- *
- * Deprecated: REPLACEME: Use hb_font_funcs_set_draw_glyph_func() instead
+ * Deprecated: 7.0.0: Use hb_font_funcs_set_draw_glyph_func() instead
  **/
 HB_EXTERN void
 hb_font_funcs_set_glyph_shape_func (hb_font_funcs_t *ffuncs,
@@ -833,7 +831,7 @@ hb_font_funcs_set_glyph_shape_func (hb_font_funcs_t *ffuncs,
  * Sets the implementation function for #hb_font_draw_glyph_func_t,
  * which is the same as #hb_font_get_glyph_shape_func_t.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 HB_EXTERN void
 hb_font_funcs_set_draw_glyph_func (hb_font_funcs_t *ffuncs,
@@ -849,7 +847,7 @@ hb_font_funcs_set_draw_glyph_func (hb_font_funcs_t *ffuncs,
  *
  * Sets the implementation function for #hb_font_paint_glyph_func_t.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_font_funcs_set_paint_glyph_func (hb_font_funcs_t *ffuncs,
@@ -1177,7 +1175,7 @@ hb_font_get_var_coords_normalized (hb_font_t *font,
  * named-instance index set.  This is the default of
  * a font.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 #define HB_FONT_NO_VAR_NAMED_INSTANCE 0xFFFFFFFF
 

--- a/src/hb-map.cc
+++ b/src/hb-map.cc
@@ -349,7 +349,7 @@ hb_map_hash (const hb_map_t *map)
  *
  * Add the contents of @other to @map.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 HB_EXTERN void
 hb_map_update (hb_map_t *map,
@@ -375,7 +375,7 @@ hb_map_update (hb_map_t *map,
  *
  * Return value: `true` if there was a next value, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 hb_bool_t
 hb_map_next (const hb_map_t *map,
@@ -393,7 +393,7 @@ hb_map_next (const hb_map_t *map,
  *
  * Add the keys of @map to @keys.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 void
 hb_map_keys (const hb_map_t *map,
@@ -409,7 +409,7 @@ hb_map_keys (const hb_map_t *map,
  *
  * Add the values of @map to @values.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 void
 hb_map_values (const hb_map_t *map,

--- a/src/hb-ot-color.cc
+++ b/src/hb-ot-color.cc
@@ -216,7 +216,7 @@ hb_ot_color_has_layers (hb_face_t *face)
  *
  * Return value: `true` if data found, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_bool_t
 hb_ot_color_has_paint (hb_face_t *face)
@@ -234,7 +234,7 @@ hb_ot_color_has_paint (hb_face_t *face)
  *
  * Return value: `true` if data found, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_bool_t
 hb_ot_color_glyph_has_paint (hb_face_t      *face,

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -746,7 +746,7 @@ hb_ot_layout_script_find_language (hb_face_t    *face,
  *
  * Return value: `true` if one of the given language tags is found, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 hb_bool_t
 hb_ot_layout_script_select_language2 (hb_face_t      *face,

--- a/src/hb-ot-name.h
+++ b/src/hb-ot-name.h
@@ -69,7 +69,7 @@ HB_BEGIN_DECLS
  * For more information on these fields, see the
  * [OpenType spec](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids).
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 typedef enum
 {

--- a/src/hb-paint.cc
+++ b/src/hb-paint.cc
@@ -216,7 +216,7 @@ HB_PAINT_FUNCS_IMPLEMENT_CALLBACKS
  *
  * Returns value: (transfer full): the paint-functions structure
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_paint_funcs_t *
 hb_paint_funcs_create ()
@@ -248,7 +248,7 @@ DEFINE_NULL_INSTANCE (hb_paint_funcs_t) =
  *
  * Return value: (transfer full): The empty paint-functions structure
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 hb_paint_funcs_t *
 hb_paint_funcs_get_empty ()
@@ -267,7 +267,7 @@ hb_paint_funcs_get_empty ()
  *
  * Return value: The paint-functions structure
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_paint_funcs_t *
 hb_paint_funcs_reference (hb_paint_funcs_t *funcs)
@@ -284,7 +284,7 @@ hb_paint_funcs_reference (hb_paint_funcs_t *funcs)
  * When the reference count reaches zero, the structure
  * is destroyed, freeing all memory.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_funcs_destroy (hb_paint_funcs_t *funcs)
@@ -316,7 +316,7 @@ hb_paint_funcs_destroy (hb_paint_funcs_t *funcs)
  *
  * Return value: `true` if success, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 hb_bool_t
 hb_paint_funcs_set_user_data (hb_paint_funcs_t *funcs,
@@ -338,7 +338,7 @@ hb_paint_funcs_set_user_data (hb_paint_funcs_t *funcs,
  *
  * Return value: (transfer none): A pointer to the user data
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 void *
 hb_paint_funcs_get_user_data (const hb_paint_funcs_t *funcs,
@@ -356,7 +356,7 @@ hb_paint_funcs_get_user_data (const hb_paint_funcs_t *funcs,
  * After this call, all attempts to set one of the callbacks
  * on @funcs will fail.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_funcs_make_immutable (hb_paint_funcs_t *funcs)
@@ -375,7 +375,7 @@ hb_paint_funcs_make_immutable (hb_paint_funcs_t *funcs)
  *
  * Return value: `true` if @funcs is immutable, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_bool_t
 hb_paint_funcs_is_immutable (hb_paint_funcs_t *funcs)
@@ -400,7 +400,7 @@ hb_paint_funcs_is_immutable (hb_paint_funcs_t *funcs)
  *
  * Return value: the total number of color stops in @color_line
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 unsigned int
 hb_color_line_get_color_stops (hb_color_line_t *color_line,
@@ -423,7 +423,7 @@ hb_color_line_get_color_stops (hb_color_line_t *color_line,
  *
  * Return value: the extend mode of @color_line
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_paint_extend_t
 hb_color_line_get_extend (hb_color_line_t *color_line)
@@ -447,7 +447,7 @@ hb_color_line_get_extend (hb_color_line_t *color_line)
  *
  * Perform a "push-transform" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_push_transform (hb_paint_funcs_t *funcs, void *paint_data,
@@ -465,7 +465,7 @@ hb_paint_push_transform (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Perform a "pop-transform" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_pop_transform (hb_paint_funcs_t *funcs, void *paint_data)
@@ -482,7 +482,7 @@ hb_paint_pop_transform (hb_paint_funcs_t *funcs, void *paint_data)
  *
  * Perform a "push-clip-glyph" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_push_clip_glyph (hb_paint_funcs_t *funcs, void *paint_data,
@@ -503,7 +503,7 @@ hb_paint_push_clip_glyph (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Perform a "push-clip-rect" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_push_clip_rectangle (hb_paint_funcs_t *funcs, void *paint_data,
@@ -519,7 +519,7 @@ hb_paint_push_clip_rectangle (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Perform a "pop-clip" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_pop_clip (hb_paint_funcs_t *funcs, void *paint_data)
@@ -536,7 +536,7 @@ hb_paint_pop_clip (hb_paint_funcs_t *funcs, void *paint_data)
  *
  * Perform a "color" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_color (hb_paint_funcs_t *funcs, void *paint_data,
@@ -559,7 +559,7 @@ hb_paint_color (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Perform a "image" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_image (hb_paint_funcs_t *funcs, void *paint_data,
@@ -587,7 +587,7 @@ hb_paint_image (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Perform a "linear-gradient" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_linear_gradient (hb_paint_funcs_t *funcs, void *paint_data,
@@ -613,7 +613,7 @@ hb_paint_linear_gradient (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Perform a "radial-gradient" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_radial_gradient (hb_paint_funcs_t *funcs, void *paint_data,
@@ -636,7 +636,7 @@ hb_paint_radial_gradient (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Perform a "sweep-gradient" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_sweep_gradient (hb_paint_funcs_t *funcs, void *paint_data,
@@ -654,7 +654,7 @@ hb_paint_sweep_gradient (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Perform a "push-group" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_push_group (hb_paint_funcs_t *funcs, void *paint_data)
@@ -670,7 +670,7 @@ hb_paint_push_group (hb_paint_funcs_t *funcs, void *paint_data)
  *
  * Perform a "pop-group" paint operation.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_paint_pop_group (hb_paint_funcs_t *funcs, void *paint_data,
@@ -690,7 +690,7 @@ hb_paint_pop_group (hb_paint_funcs_t *funcs, void *paint_data,
  *
  * Return value: `true` if found, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 hb_bool_t
 hb_paint_custom_palette_color (hb_paint_funcs_t *funcs, void *paint_data,

--- a/src/hb-paint.h
+++ b/src/hb-paint.h
@@ -58,7 +58,7 @@ HB_BEGIN_DECLS
  * you want to override colors from the font palette with
  * custom colors.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 typedef struct hb_paint_funcs_t hb_paint_funcs_t;
 
@@ -111,7 +111,7 @@ hb_paint_funcs_is_immutable (hb_paint_funcs_t *funcs);
  * and remains in effect until a matching call to
  * the #hb_paint_funcs_pop_transform_func_t vfunc.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_push_transform_func_t) (hb_paint_funcs_t *funcs,
                                                 void *paint_data,
@@ -130,7 +130,7 @@ typedef void (*hb_paint_push_transform_func_t) (hb_paint_funcs_t *funcs,
  * the effect of a prior call to the #hb_paint_funcs_push_transform_func_t
  * vfunc.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_pop_transform_func_t) (hb_paint_funcs_t *funcs,
                                                void *paint_data,
@@ -154,7 +154,7 @@ typedef void (*hb_paint_pop_transform_func_t) (hb_paint_funcs_t *funcs,
  * and remains in effect until a matching call to
  * the #hb_paint_funcs_pop_clip_func_t vfunc.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_push_clip_glyph_func_t) (hb_paint_funcs_t *funcs,
                                                  void *paint_data,
@@ -182,7 +182,7 @@ typedef void (*hb_paint_push_clip_glyph_func_t) (hb_paint_funcs_t *funcs,
  * and remains in effect until a matching call to
  * the #hb_paint_funcs_pop_clip_func_t vfunc.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_push_clip_rectangle_func_t) (hb_paint_funcs_t *funcs,
                                                      void *paint_data,
@@ -200,7 +200,7 @@ typedef void (*hb_paint_push_clip_rectangle_func_t) (hb_paint_funcs_t *funcs,
  * the effect of a prior call to the #hb_paint_funcs_push_clip_glyph_func_t
  * or #hb_paint_funcs_push_clip_rectangle_func_t vfuncs.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_pop_clip_func_t) (hb_paint_funcs_t *funcs,
                                           void *paint_data,
@@ -217,7 +217,7 @@ typedef void (*hb_paint_pop_clip_func_t) (hb_paint_funcs_t *funcs,
  * A virtual method for the #hb_paint_funcs_t to paint a
  * color everywhere within the current clip.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_color_func_t) (hb_paint_funcs_t *funcs,
                                        void *paint_data,
@@ -230,7 +230,7 @@ typedef void (*hb_paint_color_func_t) (hb_paint_funcs_t *funcs,
  *
  * Tag identifying PNG images in #hb_paint_image_func_t callbacks.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 #define HB_PAINT_IMAGE_FORMAT_PNG HB_TAG('p','n','g',' ')
 
@@ -239,7 +239,7 @@ typedef void (*hb_paint_color_func_t) (hb_paint_funcs_t *funcs,
  *
  * Tag identifying SVG images in #hb_paint_image_func_t callbacks.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 #define HB_PAINT_IMAGE_FORMAT_SVG HB_TAG('s','v','g',' ')
 
@@ -249,7 +249,7 @@ typedef void (*hb_paint_color_func_t) (hb_paint_funcs_t *funcs,
  * Tag identifying raw pixel-data images in #hb_paint_image_func_t callbacks.
  * The data is in BGRA pre-multiplied sRGBA color-space format.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 #define HB_PAINT_IMAGE_FORMAT_BGRA HB_TAG('B','G','R','A')
 
@@ -277,7 +277,7 @@ typedef void (*hb_paint_color_func_t) (hb_paint_funcs_t *funcs,
  *
  * Return value: Whether the operation was successful.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef hb_bool_t (*hb_paint_image_func_t) (hb_paint_funcs_t *funcs,
 					    void *paint_data,
@@ -305,7 +305,7 @@ typedef hb_bool_t (*hb_paint_image_func_t) (hb_paint_funcs_t *funcs,
  * [COLR](https://learn.microsoft.com/en-us/typography/opentype/spec/colr)
  * section for details.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef struct {
   float offset;
@@ -331,7 +331,7 @@ typedef struct {
  * See the OpenType spec [COLR](https://learn.microsoft.com/en-us/typography/opentype/spec/colr)
  * section for details.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef enum {
   HB_PAINT_EXTEND_PAD,
@@ -355,7 +355,7 @@ typedef struct hb_color_line_t hb_color_line_t;
  *
  * Return value: the total number of color stops in @color_line
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef unsigned int (*hb_color_line_get_color_stops_func_t) (hb_color_line_t *color_line,
 							      void *color_line_data,
@@ -374,7 +374,7 @@ typedef unsigned int (*hb_color_line_get_color_stops_func_t) (hb_color_line_t *c
  *
  * Return value: the extend mode of @color_line
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef hb_paint_extend_t (*hb_color_line_get_extend_func_t) (hb_color_line_t *color_line,
 							      void *color_line_data,
@@ -385,7 +385,7 @@ typedef hb_paint_extend_t (*hb_color_line_get_extend_func_t) (hb_color_line_t *c
  *
  * A struct containing color information for a gradient.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 struct hb_color_line_t {
   void *data;
@@ -441,7 +441,7 @@ hb_color_line_get_extend (hb_color_line_t *color_line);
  * section for details on how the points define the direction
  * of the gradient, and how to interpret the @color_line.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_linear_gradient_func_t) (hb_paint_funcs_t *funcs,
                                                  void *paint_data,
@@ -477,7 +477,7 @@ typedef void (*hb_paint_linear_gradient_func_t) (hb_paint_funcs_t *funcs,
  * section for details on how the points define the direction
  * of the gradient, and how to interpret the @color_line.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_radial_gradient_func_t) (hb_paint_funcs_t *funcs,
                                                  void *paint_data,
@@ -510,7 +510,7 @@ typedef void (*hb_paint_radial_gradient_func_t) (hb_paint_funcs_t *funcs,
  * section for details on how the points define the direction
  * of the gradient, and how to interpret the @color_line.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_sweep_gradient_func_t)  (hb_paint_funcs_t *funcs,
                                                  void *paint_data,
@@ -586,7 +586,7 @@ typedef void (*hb_paint_sweep_gradient_func_t)  (hb_paint_funcs_t *funcs,
  * See the OpenType spec [COLR](https://learn.microsoft.com/en-us/typography/opentype/spec/colr)
  * section for details.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef enum {
   HB_PAINT_COMPOSITE_MODE_CLEAR,
@@ -632,7 +632,7 @@ typedef enum {
  * until a matching call to the #hb_paint_funcs_pop_group_func_t
  * vfunc.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_push_group_func_t) (hb_paint_funcs_t *funcs,
                                             void *paint_data,
@@ -653,7 +653,7 @@ typedef void (*hb_paint_push_group_func_t) (hb_paint_funcs_t *funcs,
  * and then composites it on the previous surface, using the
  * compositing mode passed to this call.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef void (*hb_paint_pop_group_func_t) (hb_paint_funcs_t *funcs,
                                            void *paint_data,
@@ -680,7 +680,7 @@ typedef void (*hb_paint_pop_group_func_t) (hb_paint_funcs_t *funcs,
  *
  * Return value: `true` if found, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 typedef hb_bool_t (*hb_paint_custom_palette_color_func_t) (hb_paint_funcs_t *funcs,
                                                            void *paint_data,
@@ -698,7 +698,7 @@ typedef hb_bool_t (*hb_paint_custom_palette_color_func_t) (hb_paint_funcs_t *fun
  *
  * Sets the push-transform callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_push_transform_func (hb_paint_funcs_t               *funcs,
@@ -715,7 +715,7 @@ hb_paint_funcs_set_push_transform_func (hb_paint_funcs_t               *funcs,
  *
  * Sets the pop-transform callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_pop_transform_func (hb_paint_funcs_t              *funcs,
@@ -732,7 +732,7 @@ hb_paint_funcs_set_pop_transform_func (hb_paint_funcs_t              *funcs,
  *
  * Sets the push-clip-glyph callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_push_clip_glyph_func (hb_paint_funcs_t                *funcs,
@@ -749,7 +749,7 @@ hb_paint_funcs_set_push_clip_glyph_func (hb_paint_funcs_t                *funcs,
  *
  * Sets the push-clip-rect callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_push_clip_rectangle_func (hb_paint_funcs_t                    *funcs,
@@ -766,7 +766,7 @@ hb_paint_funcs_set_push_clip_rectangle_func (hb_paint_funcs_t                   
  *
  * Sets the pop-clip callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_pop_clip_func (hb_paint_funcs_t         *funcs,
@@ -783,7 +783,7 @@ hb_paint_funcs_set_pop_clip_func (hb_paint_funcs_t         *funcs,
  *
  * Sets the paint-color callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_color_func (hb_paint_funcs_t      *funcs,
@@ -800,7 +800,7 @@ hb_paint_funcs_set_color_func (hb_paint_funcs_t      *funcs,
  *
  * Sets the paint-image callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_image_func (hb_paint_funcs_t      *funcs,
@@ -817,7 +817,7 @@ hb_paint_funcs_set_image_func (hb_paint_funcs_t      *funcs,
  *
  * Sets the linear-gradient callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_linear_gradient_func (hb_paint_funcs_t                *funcs,
@@ -834,7 +834,7 @@ hb_paint_funcs_set_linear_gradient_func (hb_paint_funcs_t                *funcs,
  *
  * Sets the radial-gradient callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_radial_gradient_func (hb_paint_funcs_t                *funcs,
@@ -851,7 +851,7 @@ hb_paint_funcs_set_radial_gradient_func (hb_paint_funcs_t                *funcs,
  *
  * Sets the sweep-gradient callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_sweep_gradient_func (hb_paint_funcs_t               *funcs,
@@ -868,7 +868,7 @@ hb_paint_funcs_set_sweep_gradient_func (hb_paint_funcs_t               *funcs,
  *
  * Sets the push-group callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_push_group_func (hb_paint_funcs_t           *funcs,
@@ -885,7 +885,7 @@ hb_paint_funcs_set_push_group_func (hb_paint_funcs_t           *funcs,
  *
  * Sets the pop-group callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_pop_group_func (hb_paint_funcs_t          *funcs,
@@ -902,7 +902,7 @@ hb_paint_funcs_set_pop_group_func (hb_paint_funcs_t          *funcs,
  *
  * Sets the custom-palette-color callback on the paint functions struct.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 HB_EXTERN void
 hb_paint_funcs_set_custom_palette_color_func (hb_paint_funcs_t                     *funcs,

--- a/src/hb-set.cc
+++ b/src/hb-set.cc
@@ -501,7 +501,7 @@ hb_set_invert (hb_set_t *set)
  *
  * Return value: `true` if the set is inverted, `false` otherwise
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  **/
 hb_bool_t
 hb_set_is_inverted (const hb_set_t *set)

--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -385,7 +385,7 @@ hb_subset_input_get_user_data (const hb_subset_input_t *input,
  *
  * The input can be tailored afterwards by the caller.
  *
- * XSince: REPLACEME
+ * Since: 7.0.0
  */
 void
 hb_subset_input_keep_everything (hb_subset_input_t *input)

--- a/src/hb-version.h
+++ b/src/hb-version.h
@@ -41,7 +41,7 @@ HB_BEGIN_DECLS
  *
  * The major component of the library version available at compile-time.
  */
-#define HB_VERSION_MAJOR 6
+#define HB_VERSION_MAJOR 7
 /**
  * HB_VERSION_MINOR:
  *
@@ -60,7 +60,7 @@ HB_BEGIN_DECLS
  *
  * A string literal containing the library version available at compile-time.
  */
-#define HB_VERSION_STRING "6.0.0"
+#define HB_VERSION_STRING "7.0.0"
 
 /**
  * HB_VERSION_ATLEAST:


### PR DESCRIPTION
Fixes #4002 

- [x] Open gitk and review changes since last release.

	- [x] Print all public API changes:
        `git diff $(git describe | sed 's/-.*//').. src/*.h`

    - [x]  Document them in NEWS.
        All API and API semantic changes should be clearly marked as API additions, API changes, or API deletions.

    - [x] Document deprecations.
        Ensure all new API / deprecations are in listed correctly in docs/harfbuzz-sections.txt.
        If release added new API, add entry for new API index at the end of docs/harfbuzz-docs.xml.

     If there's a backward-incompatible API change (including deletions for API used anywhere), that's a release blocker.
     Do NOT release.

- [x] Based on severity of changes, decide whether it's a minor or micro release number bump.

- [x] Search for 'XSince: REPLACEME' on the repository and replace it with the chosen version for the release, e.g. 'Since: 1.4.7'.

- [x] Make sure you have correct date and new version at the top of NEWS file.

- [x] Bump version in line 3 of meson.build and configure.ac.

- [x] Do a `meson test -Cbuild` so it both checks the tests and updates hb-version.h (use `git diff` to see if is really updated).

- [x] Commit NEWS, meson.build, configure.ac, and src/hb-version.h, as well as any REPLACEME changes you made.
        The commit message is simply the release number, e. g. "1.4.7"

- [x] Do a `meson dist -Cbuild` that runs the tests against the latest committed changes.
   If doesn't pass, something fishy is going on, reset the repo and start over.

- [ ] Tag the release and sign it: e.g. `git tag -s 1.4.7 -m 1.4.7`.
	  Enter your GPG password.

- [ ] Push the commit and tag out: `git push --follow-tags`.