### PR TITLE
Added !defined(HB_NO_MT) to conditional compilation that does '#include <atomic>'

### DIFF
--- a/src/hb-atomic.hh
+++ b/src/hb-atomic.hh
@@ -114,7 +114,7 @@ _hb_atomic_ptr_impl_cmplexch (const void **P, const void *O_, const void *N)
 #ifndef _hb_compiler_memory_r_barrier
 /* This we always use std::atomic for; and should never be disabled...
  * except that MSVC gives me an internal compiler error on it. */
-#if !defined(_MSC_VER)
+#if !defined(HB_NO_MT) && !defined(_MSC_VER)
 #include <atomic>
 #define _hb_compiler_memory_r_barrier() std::atomic_signal_fence (std::memory_order_acquire)
 #else


### PR DESCRIPTION
The `#include <atomic>` declaration causes problems for WebAssembler, a single threaded platform.  HarfBuzz already has a preexisting macro to disable multithreading, so we're using that.