### PR TITLE
[justify] Set var_value when expanding/shrinking to max

### DIFF
--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -355,6 +355,7 @@ hb_shape_justify (hb_font_t          *font,
      * there's nothing to solve for. Just return it. */
     if (yb <= (double) max_target_advance)
     {
+      *var_value = (float) b;
       *advance = (float) yb;
       return true;
     }
@@ -379,6 +380,7 @@ hb_shape_justify (hb_font_t          *font,
      * there's nothing to solve for. Just return it. */
     if (ya >= (double) min_target_advance)
     {
+      *var_value = (float) a;
       *advance = (float) ya;
       return true;
     }


### PR DESCRIPTION
When expanding/shrinking the buffer to max (and still not fitting), we need to also set var_value to the axis max/min otherwise client not have the correct axis value to draw with.