### PR TITLE
[docs] Disable gtdoc-check by default

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -49,6 +49,7 @@ jobs:
           -Dgraphite=enabled \
           -Doptimization=2 \
           -Db_coverage=true \
+          -Ddoc_tests=true \
           -Dragel_subproject=true
     - name: Build
       run: meson compile -Cbuild

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -60,5 +60,5 @@ gnome.gtkdoc('harfbuzz',
   ignore_headers: ignore_headers,
   dependencies: [libharfbuzz_dep],
   install: true,
-  check: true,
+  check: get_option('doc_tests'),
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -29,6 +29,8 @@ option('introspection', type: 'feature', value: 'auto', yield: true,
   description: 'Generate gobject-introspection bindings (.gir/.typelib files)')
 option('docs', type: 'feature', value: 'auto', yield: true,
   description: 'Generate documentation with gtk-doc')
+option('doc_tests', type: 'boolean', value: false,
+  description: 'Run gtkdoc-check tests')
 
 option('benchmark', type: 'feature', value: 'disabled',
   description: 'Enable benchmark tests')


### PR DESCRIPTION
It slows build as it causes documentation to be always rebuilt. We now disable it by default and enable it on relevant CI jobs.