### PR TITLE
Add Tifinagh to list of both-directions scripts

### DIFF
--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -632,6 +632,7 @@ hb_script_get_horizontal_direction (hb_script_t script)
     case HB_SCRIPT_OLD_HUNGARIAN:
     case HB_SCRIPT_OLD_ITALIC:
     case HB_SCRIPT_RUNIC:
+    case HB_SCRIPT_TIFINAGH:
 
       return HB_DIRECTION_INVALID;
   }


### PR DESCRIPTION
Tifinagh can be written RTL as well as LTR. Without support from Harfbuzz this causes weird reordering problems (see https://github.com/notofonts/tifinagh/issues/17).