### PR TITLE
Remove extra blank line in hb-outline.cc

### DIFF
--- a/src/hb-outline.cc
+++ b/src/hb-outline.cc
@@ -4,7 +4,6 @@
  * Copyright © 2005  Werner Lemberg
  * Copyright © 2013-2015  Alexei Podtelezhnikov
  *
- *
  *  This is part of HarfBuzz, a text shaping library.
  *
  * Permission is hereby granted, without written agreement and without


### PR DESCRIPTION
This file contains an extra blank line in the copyright header, which is different from other HarfBuzz source files.

Flutter uses a script that parses the source of its dependencies in order to collect licenses.  This inconsistency is causing issues for the script.
