### PR TITLE
 Add read-only top-level permissions to cifuzz.yml

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,9 @@
 name: CIFuzz
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #4190.

As mentioned in the issue, this PR adds read-only token permissions to the cifuzz.yml workflow, making it compatible with the other workflows (they were fixed in #3639). This reduces the risk of supply-chain attacks on the project.