### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives me time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to behdad@behdad.org; and/or
+- send me a [private vulnerability report](https://github.com/harfbuzz/harfbuzz/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is mostly maintained by a single developer, working on a reasonable effort
+basis. As such, I ask that you give me 90 days to work on a fix before public
+disclosure.


### PR DESCRIPTION
Fixes #4193.

As mentioned in the issue, this PR adds a security policy for the project, helping users know how to responsibly disclose vulnerabilities they might've found.

I added the email mentioned in https://github.com/harfbuzz/harfbuzz/discussions/3611. Let me know if you'd rather use another email (or website), and/or if you'd rather use offer just one mode of disclosure.

I mentioned that the project is "mostly maintained" by a single developer since I've noticed that most commits are made by behdad (either directly or merging PRs). If this isn't a correct characterization, let me know and I'll reword!

The 90-day timeline is pretty standard, but I'll happily change if needed.