### PR TITLE
meson: add an option to disable utilities building

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -373,7 +373,10 @@ foreach check : check_funcs
 endforeach
 
 subdir('src')
-subdir('util')
+
+if not get_option('utilities').disabled()
+  subdir('util')
+endif
 
 if not get_option('tests').disabled()
   subdir('test')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -31,6 +31,8 @@ option('docs', type: 'feature', value: 'auto', yield: true,
   description: 'Generate documentation with gtk-doc')
 option('doc_tests', type: 'boolean', value: false,
   description: 'Run gtkdoc-check tests')
+option('utilities', type: 'feature', value: 'enabled', yield: true,
+  description: 'Build harfbuzz utils')
 
 option('benchmark', type: 'feature', value: 'disabled',
   description: 'Enable benchmark tests')


### PR DESCRIPTION
Adds the missing utilities option to meson builds for parity with CMake builds

See also: https://github.com/harfbuzz/harfbuzz/blob/main/CMakeLists.txt#L53