### PR TITLE
Fix transform

### DIFF
--- a/src/OT/glyf/CompositeGlyph.hh
+++ b/src/OT/glyf/CompositeGlyph.hh
@@ -96,7 +96,7 @@ struct CompositeGlyphRecord
     if (matrix[0] != 1.f || matrix[1] != 0.f ||
 	matrix[2] != 0.f || matrix[3] != 1.f)
       for (unsigned i = 0; i < count; i++)
-        arrayZ[i].transform (matrix);
+        arrayZ[i].transform (matrix, points);
   }
 
   static void translate (const contour_point_t &trans,


### PR DESCRIPTION
```
In file included from OT/glyf/Glyph.hh:9,
                 from OT/glyf/glyf.hh:13,
                 from hb-ot-glyf-table.hh:33,
                 from hb-ot-face.cc:30,
                 from harfbuzz.cc:24:
OT/glyf/CompositeGlyph.hh: In static member function 'static void OT::glyf_impl::CompositeGlyphRecord::transform(const float (&)[4], hb_array_t<OT::contour_point_t>)':
OT/glyf/CompositeGlyph.hh:99:19: error: 'struct OT::contour_point_t' has no member named 'transform'
   99 |         arrayZ[i].transform (matrix, points);
      |                   ^~~~~~~~~
In file included from OT/glyf/Glyph.hh:10:
OT/glyf/VarCompositeGlyph.hh: In member function 'void OT::glyf_impl::VarCompositeGlyphRecord::transform_points(hb_array_t<const OT::contour_point_t>, hb_array_t<OT::contour_point_t>) const':
OT/glyf/VarCompositeGlyph.hh:119:19: error: 'struct OT::contour_point_t' has no member named 'transform'
  119 |         arrayZ[i].transform (matrix);
```