### PR TITLE
Change vsnprintf for C++11

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -2212,7 +2212,7 @@ hb_buffer_t::message_impl (hb_font_t *font, const char *fmt, va_list ap)
   message_depth++;
 
   char buf[100];
-  vsnprintf (buf, sizeof (buf), fmt, ap);
+  vsnprintf_s (buf, sizeof (buf), fmt, ap);
   bool ret = (bool) this->message_func (this, font, buf, this->message_data);
 
   message_depth--;

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -2212,7 +2212,7 @@ hb_buffer_t::message_impl (hb_font_t *font, const char *fmt, va_list ap)
   message_depth++;
 
   char buf[100];
-#if defined(_MSC_VER) || defined(__GNUC__)
+#if defined(__GNUC__)
   vsnprintf_s (buf, sizeof (buf), fmt, ap);
 #else
   vsnprintf (buf, sizeof (buf), fmt, ap);

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -2212,7 +2212,11 @@ hb_buffer_t::message_impl (hb_font_t *font, const char *fmt, va_list ap)
   message_depth++;
 
   char buf[100];
+#if defined(_MSC_VER) || defined(__GNUC__)
   vsnprintf_s (buf, sizeof (buf), fmt, ap);
+#else
+  vsnprintf (buf, sizeof (buf), fmt, ap);
+#endif
   bool ret = (bool) this->message_func (this, font, buf, this->message_data);
 
   message_depth--;


### PR DESCRIPTION
```
hb-buffer.cc: In member function 'bool hb_buffer_t::message_impl(hb_font_t*, const char*, va_list)':
hb-buffer.cc:2215:13: warning: function 'bool hb_buffer_t::message_impl(hb_font_t*, const char*, va_list)' might be a candidate for 'gnu_printf' format attribute [-Wsuggest-attribute=format]
 2215 |   vsnprintf (buf, sizeof (buf), fmt, ap);
      |   ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```