### PR TITLE
[buffer] fix `hb_buffer_t::similar` setting `replacement` to `src.invisible`

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -268,7 +268,7 @@ hb_buffer_t::similar (const hb_buffer_t &src)
   unicode = hb_unicode_funcs_reference (src.unicode);
   flags = src.flags;
   cluster_level = src.cluster_level;
-  replacement = src.invisible;
+  replacement = src.replacement;
   invisible = src.invisible;
   not_found = src.not_found;
 }


### PR DESCRIPTION
```cpp
void
hb_buffer_t::similar (const hb_buffer_t &src)
{
  hb_unicode_funcs_destroy (unicode);
  unicode = hb_unicode_funcs_reference (src.unicode);
  flags = src.flags;
  cluster_level = src.cluster_level;
  replacement = src.invisible; // <- this should be src.replacement
  invisible = src.invisible;
  not_found = src.not_found;
}
```