### PR TITLE
[Ligature] Speed up

### DIFF
--- a/src/OT/Layout/GSUB/Ligature.hh
+++ b/src/OT/Layout/GSUB/Ligature.hh
@@ -10,7 +10,7 @@ namespace GSUB_impl {
 template <typename Types>
 struct Ligature
 {
-  protected:
+  public:
   typename Types::HBGlyphID
 		ligGlyph;               /* GlyphID of ligature to substitute */
   HeadlessArrayOf<typename Types::HBGlyphID>


### PR DESCRIPTION
Match the first component of the ligature in the LigatureSet loop.

Speeds up Roboto shaping by 25%. I don't think it breaks anything. The test suite seems happy.