### PR TITLE
Typo in the documentation of hb-ot-math

### DIFF
--- a/src/hb-ot-math.cc
+++ b/src/hb-ot-math.cc
@@ -76,7 +76,7 @@ hb_ot_math_has_data (hb_face_t *face)
  *
  * However, if the requested constant is #HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN,
  * #HB_OT_MATH_CONSTANT_SCRIPT_SCRIPT_PERCENT_SCALE_DOWN or
- * #HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN, then the return value is
+ * #HB_OT_MATH_CONSTANT_RADICAL_DEGREE_BOTTOM_RAISE_PERCENT, then the return value is
  * an integer between 0 and 100 representing that percentage.
  *
  * Return value: the requested constant or zero


### PR DESCRIPTION
Simple typo in the documentation of the hb_ot_math_get_constant() function of hb-ot-math.

The 3rd percent constant is HB_OT_MATH_CONSTANT_RADICAL_DEGREE_BOTTOM_RAISE_PERCENT and not HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN.