### PR TITLE
[subset] switch out the specialized hb_bytes hash function with fasth…

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -491,11 +491,11 @@ test_priority_queue_SOURCES = test-priority-queue.cc hb-static.cc
 test_priority_queue_CPPFLAGS = $(HBCFLAGS)
 test_priority_queue_LDADD = libharfbuzz.la $(HBLIBS)
 
-test_repacker_SOURCES = test-repacker.cc hb-static.cc graph/gsubgpos-context.cc
+test_repacker_SOURCES = test-repacker.cc hb-static.cc graph/gsubgpos-context.cc fasthash/fasthash.cc
 test_repacker_CPPFLAGS = $(HBCFLAGS)
 test_repacker_LDADD = libharfbuzz.la libharfbuzz-subset.la $(HBLIBS)
 
-test_classdef_graph_SOURCES = graph/test-classdef-graph.cc hb-static.cc graph/gsubgpos-context.cc
+test_classdef_graph_SOURCES = graph/test-classdef-graph.cc hb-static.cc graph/gsubgpos-context.cc fasthash/fasthash.cc
 test_classdef_graph_CPPFLAGS = $(HBCFLAGS)
 test_classdef_graph_LDADD = libharfbuzz.la libharfbuzz-subset.la $(HBLIBS)
 
@@ -503,7 +503,7 @@ test_set_SOURCES = test-set.cc hb-static.cc
 test_set_CPPFLAGS = $(COMPILED_TESTS_CPPFLAGS)
 test_set_LDADD = $(COMPILED_TESTS_LDADD)
 
-test_serialize_SOURCES = test-serialize.cc hb-static.cc
+test_serialize_SOURCES = test-serialize.cc hb-static.cc fasthash/fasthash.cc
 test_serialize_CPPFLAGS = $(COMPILED_TESTS_CPPFLAGS)
 test_serialize_LDADD = $(COMPILED_TESTS_LDADD)
 

--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -1,6 +1,7 @@
 # Base and default-included sources and headers
 
 HB_BASE_sources = \
+        fasthash/fasthash.cc \
 	hb-aat-layout-ankr-table.hh \
 	hb-aat-layout-bsln-table.hh \
 	hb-aat-layout-common.hh \
@@ -344,6 +345,7 @@ HB_ICU_headers = hb-icu.h
 
 # Sources for libharfbuzz-subset
 HB_SUBSET_sources = \
+        fasthash/fasthash.cc \
 	hb-number.cc \
 	hb-number.hh \
 	hb-ot-cff1-table.cc \

--- a/src/fasthash/fasthash.cc
+++ b/src/fasthash/fasthash.cc
@@ -1,0 +1,77 @@
+/* The MIT License
+
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#include "hb.hh"
+#include <stdint.h>
+#include <stdio.h>
+
+// Compression function for Merkle-Damgard construction.
+// This function is generated using the framework provided.
+#define mix(h) ({                                       \
+                        (h) ^= (h) >> 23;               \
+                        (h) *= 0x2127599bf4325c37ULL;   \
+                        (h) ^= (h) >> 47; })
+
+uint64_t _fasthash64(const void *buf, size_t len, uint64_t seed)
+{
+        const uint64_t    m = 0x880355f21e6d1965ULL;
+        const uint64_t *pos = (const uint64_t *)buf;
+        const uint64_t *end = pos + (len / 8);
+        const unsigned char *pos2;
+        uint64_t h = seed ^ (len * m);
+        uint64_t v;
+
+        while (pos != end) {
+                v  = *pos++;
+                h ^= mix(v);
+                h *= m;
+        }
+
+        pos2 = (const unsigned char*)pos;
+        v = 0;
+
+        switch (len & 7) {
+        case 7: v ^= (uint64_t)pos2[6] << 48;
+        case 6: v ^= (uint64_t)pos2[5] << 40;
+        case 5: v ^= (uint64_t)pos2[4] << 32;
+        case 4: v ^= (uint64_t)pos2[3] << 24;
+        case 3: v ^= (uint64_t)pos2[2] << 16;
+        case 2: v ^= (uint64_t)pos2[1] << 8;
+        case 1: v ^= (uint64_t)pos2[0];
+                h ^= mix(v);
+                h *= m;
+        }
+
+        return mix(h);
+}
+
+uint32_t _fasthash32(const void *buf, size_t len, uint32_t seed)
+{
+        // the following trick converts the 64-bit hashcode to Fermat
+        // residue, which shall retain information from both the higher
+        // and lower parts of hashcode.
+        uint64_t h = _fasthash64(buf, len, seed);
+        return h - (h >> 32);
+}

--- a/src/hb-array.hh
+++ b/src/hb-array.hh
@@ -32,7 +32,6 @@
 #include "hb-iter.hh"
 #include "hb-null.hh"
 
-
 template <typename Type>
 struct hb_sorted_array_t;
 
@@ -43,6 +42,21 @@ enum hb_not_found_t
   HB_NOT_FOUND_STORE_CLOSEST,
 };
 
+/**
+ * fasthash32 - 32-bit implementation of fasthash
+ * @buf:  data buffer
+ * @len:  data size
+ * @seed: the seed
+ */
+HB_INTERNAL uint32_t _fasthash32(const void *buf, size_t len, uint32_t seed);
+
+/**
+ * fasthash64 - 64-bit implementation of fasthash
+ * @buf:  data buffer
+ * @len:  data size
+ * @seed: the seed
+ */
+HB_INTERNAL uint64_t _fasthash64(const void *buf, size_t len, uint64_t seed);
 
 template <typename Type>
 struct hb_array_t : hb_iter_with_fallback_t<hb_array_t<Type>, Type&>
@@ -456,53 +470,14 @@ inline bool hb_array_t<const unsigned char>::operator == (const hb_array_t<const
 template <>
 inline uint32_t hb_array_t<const char>::hash () const
 {
-  // FNV-1a hash function
-  uint32_t current = /*cbf29ce4*/0x84222325;
-  unsigned i = 0;
-
-#if defined(__OPTIMIZE__) && !defined(HB_NO_PACKED) && \
-    ((defined(__GNUC__) && __GNUC__ >= 5) || defined(__clang__))
-  struct __attribute__((packed)) packed_uint32_t { uint32_t v; };
-  for (; i + 4 <= this->length; i += 4)
-  {
-    current = current ^ hb_hash ((uint32_t) ((const packed_uint32_t *) &this->arrayZ[i])->v);
-    current = current * 16777619;
-  }
-#endif
-
-  for (; i < this->length; i++)
-  {
-    current = current ^ hb_hash (this->arrayZ[i]);
-    current = current * 16777619;
-  }
-  return current;
+  return _fasthash32(arrayZ, length, 0xf437ffe6);
 }
 
 template <>
 inline uint32_t hb_array_t<const unsigned char>::hash () const
 {
-  // FNV-1a hash function
-  uint32_t current = /*cbf29ce4*/0x84222325;
-  unsigned i = 0;
-
-#if defined(__OPTIMIZE__) && !defined(HB_NO_PACKED) && \
-    ((defined(__GNUC__) && __GNUC__ >= 5) || defined(__clang__))
-  struct __attribute__((packed)) packed_uint32_t { uint32_t v; };
-  for (; i + 4 <= this->length; i += 4)
-  {
-    current = current ^ hb_hash ((uint32_t) ((const packed_uint32_t *) &this->arrayZ[i])->v);
-    current = current * 16777619;
-  }
-#endif
-
-  for (; i < this->length; i++)
-  {
-    current = current ^ hb_hash (this->arrayZ[i]);
-    current = current * 16777619;
-  }
-  return current;
+  return _fasthash32(arrayZ, length, 0xf437ffe6);
 }
-
 
 typedef hb_array_t<const char> hb_bytes_t;
 typedef hb_array_t<const unsigned char> hb_ubytes_t;

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ hb_version_h = configure_file(
 
 # Base and default-included sources and headers
 hb_base_sources = files(
+  'fasthash/fasthash.cc',
   'hb-aat-layout-ankr-table.hh',
   'hb-aat-layout-bsln-table.hh',
   'hb-aat-layout-common.hh',
@@ -344,6 +345,7 @@ hb_icu_headers = files('hb-icu.h')
 
 # Sources for libharfbuzz-subset
 hb_subset_sources = files(
+  'fasthash/fasthash.cc',
   'hb-number.cc',
   'hb-number.hh',
   'hb-ot-cff1-table.cc',
@@ -693,10 +695,10 @@ if get_option('tests').enabled()
     'test-number': ['test-number.cc', 'hb-number.cc'],
     'test-ot-tag': ['hb-ot-tag.cc'],
     'test-priority-queue': ['test-priority-queue.cc', 'hb-static.cc'],
-    'test-repacker': ['test-repacker.cc', 'hb-static.cc', 'graph/gsubgpos-context.cc'],
-    'test-classdef-graph': ['graph/test-classdef-graph.cc', 'hb-static.cc', 'graph/gsubgpos-context.cc'],
+    'test-repacker': ['test-repacker.cc', 'hb-static.cc', 'graph/gsubgpos-context.cc', 'fasthash/fasthash.cc'],
+    'test-classdef-graph': ['graph/test-classdef-graph.cc', 'hb-static.cc', 'graph/gsubgpos-context.cc', 'fasthash/fasthash.cc'],
     'test-set': ['test-set.cc', 'hb-static.cc'],
-    'test-serialize': ['test-serialize.cc', 'hb-static.cc'],
+    'test-serialize': ['test-serialize.cc', 'hb-static.cc', 'fasthash/fasthash.cc'],
     'test-unicode-ranges': ['test-unicode-ranges.cc'],
     'test-vector': ['test-vector.cc', 'hb-static.cc'],
     'test-bimap': ['test-bimap.cc', 'hb-static.cc'],


### PR DESCRIPTION
…ash32.

From https://github.com/ztanml/fast-hash/tree/master

Benchmark results:

BM_subset/subset_glyphs/Roboto-Regular.ttf/10_median                                           +0.0362         +0.0364             0             0             0             0
BM_subset/subset_glyphs/Roboto-Regular.ttf/64_median                                           +0.0194         +0.0194             0             0             0             0
BM_subset/subset_glyphs/Roboto-Regular.ttf/512_median                                          -0.0057         -0.0058             1             1             1             1
BM_subset/subset_glyphs/Roboto-Regular.ttf/1000_median                                         -0.1150         -0.1152             1             1             1             1
BM_subset/subset_glyphs/Roboto-Regular.ttf/nohinting/10_median                                 -0.0360         -0.0360             0             0             0             0
BM_subset/subset_glyphs/Roboto-Regular.ttf/nohinting/64_median                                 -0.0418         -0.0416             0             0             0             0
BM_subset/subset_glyphs/Roboto-Regular.ttf/nohinting/512_median                                -0.0348         -0.0347             1             1             1             1
BM_subset/subset_glyphs/Roboto-Regular.ttf/nohinting/1000_median                               -0.0392         -0.0391             1             1             1             1
BM_subset/subset_glyphs/Amiri-Regular.ttf/10_median                                            -0.0430         -0.0431             0             0             0             0
BM_subset/subset_glyphs/Amiri-Regular.ttf/64_median                                            -0.0263         -0.0263             0             0             0             0
BM_subset/subset_glyphs/Amiri-Regular.ttf/512_median                                           -0.0196         -0.0194             6             6             6             6
BM_subset/subset_glyphs/Amiri-Regular.ttf/4096_median                                          +0.0419         +0.0419             9             9             9             9
BM_subset/subset_glyphs/Amiri-Regular.ttf/nohinting/10_median                                  -0.0108         -0.0109             0             0             0             0
BM_subset/subset_glyphs/Amiri-Regular.ttf/nohinting/64_median                                  -0.0374         -0.0374             0             0             0             0
BM_subset/subset_glyphs/Amiri-Regular.ttf/nohinting/512_median                                 -0.0232         -0.0232             6             6             6             6
BM_subset/subset_glyphs/Amiri-Regular.ttf/nohinting/4096_median                                +0.0315         +0.0315             9            10             9            10
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/10_median                                 -0.0440         -0.0442             0             0             0             0
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/64_median                                 -0.0325         -0.0325             0             0             0             0
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/512_median                                -0.0486         -0.0489            41            39            41            39
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/1400_median                               -0.0159         -0.0158            48            48            48            48
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/nohinting/10_median                       -0.0497         -0.0496             0             0             0             0
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/nohinting/64_median                       -0.0405         -0.0404             0             0             0             0
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/nohinting/512_median                      -0.0441         -0.0440            41            39            41            39
BM_subset/subset_glyphs/NotoNastaliqUrdu-Regular.ttf/nohinting/1400_median                     +0.0115         +0.0116            49            49            49            49
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/10_median                               -0.0338         -0.0341             0             0             0             0
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/64_median                               -0.0381         -0.0381             0             0             0             0
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/512_median                              -0.0012         -0.0011             3             3             3             3
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/1000_median                             +0.0083         +0.0086             2             2             2             2
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/nohinting/10_median                     -0.0172         -0.0173             0             0             0             0
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/nohinting/64_median                     -0.0154         -0.0155             0             0             0             0
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/nohinting/512_median                    -0.0100         -0.0101             3             3             3             3
BM_subset/subset_glyphs/NotoSansDevanagari-Regular.ttf/nohinting/1000_median                   -0.0058         -0.0057             2             2             2             2
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/10_median                                          -0.0123         -0.0122             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/64_median                                          +0.0252         +0.0250             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/512_median                                         -0.0363         -0.0366             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/4096_median                                        -0.0186         -0.0185             3             3             3             3
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/10000_median                                       -0.0200         -0.0200             5             5             5             5
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/nohinting/10_median                                -0.0055         -0.0056             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/nohinting/64_median                                -0.0200         -0.0201             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/nohinting/512_median                               -0.0230         -0.0230             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/nohinting/4096_median                              -0.0159         -0.0160             3             3             3             3
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/nohinting/10000_median                             -0.0190         -0.0191             5             5             5             5
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/10_median                             -0.0064         -0.0063             0             0             0             0
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/64_median                             -0.0205         -0.0206             0             0             0             0
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/512_median                            -0.0428         -0.0428             1             1             1             1
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/4096_median                           -0.0313         -0.0314             8             7             8             7
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/10000_median                          -0.0351         -0.0351            16            16            16            16
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/nohinting/10_median                   -0.0294         -0.0294             0             0             0             0
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/nohinting/64_median                   -0.0209         -0.0209             0             0             0             0
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/nohinting/512_median                  -0.0260         -0.0257             1             1             1             1
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/nohinting/4096_median                 +0.0006         +0.0006             7             7             7             7
BM_subset/subset_glyphs/SourceHanSans-Regular_subset.otf/nohinting/10000_median                -0.0391         -0.0391            16            15            16            15
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/10_median                                    -0.0122         -0.0121             0             0             0             0
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/64_median                                    -0.0249         -0.0248             0             0             0             0
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/512_median                                   -0.0150         -0.0149             1             1             1             1
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/2000_median                                  -0.0305         -0.0305             3             3             3             3
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/nohinting/10_median                          -0.0077         -0.0077             0             0             0             0
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/nohinting/64_median                          -0.0259         -0.0258             0             0             0             0
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/nohinting/512_median                         -0.0195         -0.0196             1             1             1             1
BM_subset/subset_glyphs/SourceSansPro-Regular.otf/nohinting/2000_median                        -0.0182         -0.0182             3             3             3             3
BM_subset/subset_glyphs/AdobeVFPrototype.otf/10_median                                         -0.0184         -0.0186             0             0             0             0
BM_subset/subset_glyphs/AdobeVFPrototype.otf/64_median                                         -0.0148         -0.0149             1             1             1             1
BM_subset/subset_glyphs/AdobeVFPrototype.otf/300_median                                        -0.0246         -0.0247             2             2             2             2
BM_subset/subset_glyphs/AdobeVFPrototype.otf/nohinting/10_median                               -0.0358         -0.0358             0             0             0             0
BM_subset/subset_glyphs/AdobeVFPrototype.otf/nohinting/64_median                               -0.0298         -0.0299             1             1             1             1
BM_subset/subset_glyphs/AdobeVFPrototype.otf/nohinting/300_median                              -0.0357         -0.0355             2             2             2             2
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/10_median                                          -0.0196         -0.0197             0             0             0             0
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/64_median                                          -0.0542         -0.0541             0             0             0             0
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/512_median                                         -0.0173         -0.0173             2             2             2             2
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/4096_median                                        -0.0788         -0.0787             6             5             6             5
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/6000_median                                        -0.0207         -0.0207             8             8             8             8
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/nohinting/10_median                                -0.0129         -0.0130             0             0             0             0
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/nohinting/64_median                                -0.0429         -0.0428             0             0             0             0
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/nohinting/512_median                               -0.0180         -0.0181             2             2             2             2
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/nohinting/4096_median                              -0.0806         -0.0805             6             5             6             5
BM_subset/subset_glyphs/MPLUS1-Variable.ttf/nohinting/6000_median                              -0.0119         -0.0119             8             8             8             8
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/10_median                                      +0.0134         +0.0135             0             0             0             0
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/64_median                                      +0.0098         +0.0097             1             1             1             1
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/512_median                                     -0.0314         -0.0312             4             4             4             4
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/900_median                                     -0.0370         -0.0370             4             4             4             4
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/nohinting/10_median                            -0.0230         -0.0231             0             0             0             0
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/nohinting/64_median                            -0.0258         -0.0258             1             1             1             1
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/nohinting/512_median                           -0.0417         -0.0413             4             4             4             4
BM_subset/subset_glyphs/RobotoFlex-Variable.ttf/nohinting/900_median                           -0.0444         -0.0443             4             4             4             4