### PR TITLE
[subset] Use vector instead of map for glyph bounds

### DIFF
--- a/src/OT/glyf/Glyph.hh
+++ b/src/OT/glyf/Glyph.hh
@@ -112,12 +112,10 @@ struct Glyph
     if (!plan->new_gid_for_old_gid (gid, &new_gid))
       return;
 
-    uint32_t hash = hb_hash (new_gid);
-
     if (type != EMPTY)
     {
-      plan->bounds_width_map.set_with_hash (new_gid, hash, xMax - xMin);
-      plan->bounds_height_map.set_with_hash (new_gid, hash, yMax - yMin);
+      plan->bounds_width_vec[new_gid] = xMax - xMin;
+      plan->bounds_height_vec[new_gid] = yMax - yMin;
     }
 
     unsigned len = all_points.length;
@@ -125,6 +123,8 @@ struct Glyph
     float rightSideX = all_points[len - 3].x;
     float topSideY = all_points[len - 2].y;
     float bottomSideY = all_points[len - 1].y;
+
+    uint32_t hash = hb_hash (new_gid);
 
     signed hori_aw = roundf (rightSideX - leftSideX);
     if (hori_aw < 0) hori_aw = 0;

--- a/src/hb-ot-hmtx-table.hh
+++ b/src/hb-ot-hmtx-table.hh
@@ -83,7 +83,7 @@ struct hmtxvmtx
   bool subset_update_header (hb_subset_context_t *c,
 			     unsigned int num_hmetrics,
 			     const hb_hashmap_t<hb_codepoint_t, hb_pair_t<unsigned, int>> *mtx_map,
-			     const hb_map_t *bounds_map) const
+			     const hb_vector_t<unsigned> &bounds_vec) const
   {
     hb_blob_t *src_blob = hb_sanitize_context_t ().reference_table<H> (c->plan->source, H::tableTag);
     hb_blob_t *dest_blob = hb_blob_copy_writable_or_fail (src_blob);
@@ -114,6 +114,7 @@ struct hmtxvmtx
 	HB_ADD_MVAR_VAR (HB_OT_METRICS_TAG_VERTICAL_CARET_OFFSET,   caretOffset);
       }
 
+      bool empty = true;
       int min_lsb = 0x7FFF;
       int min_rsb = 0x7FFF;
       int max_extent = -0x7FFF;
@@ -125,9 +126,10 @@ struct hmtxvmtx
         int lsb = _.second.second;
         max_adv = hb_max (max_adv, adv);
 
-        if (bounds_map->has (gid))
+        if (bounds_vec[gid])
         {
-          unsigned bound_width = bounds_map->get (gid);
+	  empty = false;
+          unsigned bound_width = bounds_vec[gid];
           int rsb = adv - lsb - bound_width;
           int extent = lsb + bound_width;
           min_lsb = hb_min (min_lsb, lsb);
@@ -137,7 +139,7 @@ struct hmtxvmtx
       }
 
       table->advanceMax = max_adv;
-      if (!bounds_map->is_empty ())
+      if (!empty)
       {
         table->minLeadingBearing = min_lsb;
         table->minTrailingBearing = min_rsb;
@@ -233,7 +235,7 @@ struct hmtxvmtx
 
     // Amend header num hmetrics
     if (unlikely (!subset_update_header (c, num_long_metrics, mtx_map,
-                                         T::is_horizontal ? &c->plan->bounds_width_map : &c->plan->bounds_height_map)))
+                                         T::is_horizontal ? c->plan->bounds_width_vec : c->plan->bounds_height_vec)))
       return_trace (false);
 
     return_trace (true);

--- a/src/hb-ot-hmtx-table.hh
+++ b/src/hb-ot-hmtx-table.hh
@@ -126,7 +126,7 @@ struct hmtxvmtx
         int lsb = _.second.second;
         max_adv = hb_max (max_adv, adv);
 
-        if (bounds_vec[gid])
+        if (bounds_vec[gid] != 0xFFFFFFFF)
         {
 	  empty = false;
           unsigned bound_width = bounds_vec[gid];

--- a/src/hb-subset-plan-member-list.hh
+++ b/src/hb-subset-plan-member-list.hh
@@ -115,9 +115,9 @@ HB_SUBSET_PLAN_MEMBER (mutable hb_hashmap_t E(<hb_codepoint_t, hb_pair_t E(<unsi
 //vmtx metrics map: new gid->(advance, lsb)
 HB_SUBSET_PLAN_MEMBER (mutable hb_hashmap_t E(<hb_codepoint_t, hb_pair_t E(<unsigned, int>)>), vmtx_map)
 //boundsWidth map: new gid->boundsWidth, boundWidth=xMax - xMin
-HB_SUBSET_PLAN_MEMBER (mutable hb_map_t, bounds_width_map)
+HB_SUBSET_PLAN_MEMBER (mutable hb_vector_t<unsigned>, bounds_width_vec)
 //boundsHeight map: new gid->boundsHeight, boundsHeight=yMax - yMin
-HB_SUBSET_PLAN_MEMBER (mutable hb_map_t, bounds_height_map)
+HB_SUBSET_PLAN_MEMBER (mutable hb_vector_t<unsigned>, bounds_height_vec)
 
 #ifdef HB_EXPERIMENTAL_API
 // name table overrides map: hb_ot_name_record_ids_t-> name string new value or

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -987,7 +987,7 @@ _update_instance_metrics_map_from_cff2 (hb_subset_plan_t *plan)
           continue;
       }
       plan->hmtx_map.set (new_gid, hb_pair ((unsigned) hori_aw, lsb));
-      plan->bounds_width_map.set (new_gid, extents.width);
+      plan->bounds_width_vec[new_gid] = extents.width;
     }
 
     if (_vmtx.has_data ())
@@ -1004,7 +1004,7 @@ _update_instance_metrics_map_from_cff2 (hb_subset_plan_t *plan)
           continue;
       }
       plan->vmtx_map.set (new_gid, hb_pair ((unsigned) vert_aw, tsb));
-      plan->bounds_height_map.set (new_gid, extents.height);
+      plan->bounds_height_vec[new_gid] = extents.height;
     }
   }
   hb_font_destroy (font);
@@ -1102,6 +1102,9 @@ hb_subset_plan_t::hb_subset_plan_t (hb_face_t *face,
     unicode_to_new_gid_list.arrayZ[i].second =
         glyph_map->get(unicode_to_new_gid_list.arrayZ[i].second);
   }
+
+  bounds_width_vec.resize (_num_output_glyphs);
+  bounds_height_vec.resize (_num_output_glyphs);
 
   if (unlikely (in_error ()))
     return;

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -1103,8 +1103,12 @@ hb_subset_plan_t::hb_subset_plan_t (hb_face_t *face,
         glyph_map->get(unicode_to_new_gid_list.arrayZ[i].second);
   }
 
-  bounds_width_vec.resize (_num_output_glyphs);
-  bounds_height_vec.resize (_num_output_glyphs);
+  bounds_width_vec.resize (_num_output_glyphs, false);
+  for (auto &v : bounds_width_vec)
+    v = 0xFFFFFFFF;
+  bounds_height_vec.resize (_num_output_glyphs, false);
+  for (auto &v : bounds_height_vec)
+    v = 0xFFFFFFFF;
 
   if (unlikely (in_error ()))
     return;


### PR DESCRIPTION
Is faster.

Part of https://github.com/harfbuzz/harfbuzz/issues/4231