### PR TITLE
harfbuzz-config.cmake.in: Support Windows usage

### DIFF
--- a/src/harfbuzz-config.cmake.in
+++ b/src/harfbuzz-config.cmake.in
@@ -13,12 +13,18 @@ list(GET _harfbuzz_version_info 2
 unset(_harfbuzz_version_info)
 
 if ("@default_library@" MATCHES "static")
+  set(_harfbuzz_lib_prefix "lib")
   set(_harfbuzz_lib_suffix ".a")
 else ()
   if (APPLE)
+    set(_harfbuzz_lib_prefix "${CMAKE_SHARED_LIBRARY_PREFIX}")
     set(_harfbuzz_lib_suffix ".0${CMAKE_SHARED_LIBRARY_SUFFIX}")
   elseif (UNIX)
+    set(_harfbuzz_lib_prefix "${CMAKE_SHARED_LIBRARY_PREFIX}")
     set(_harfbuzz_lib_suffix "${CMAKE_SHARED_LIBRARY_SUFFIX}.0.${_harfbuzz_current}.${_harfbuzz_revision}")
+  elseif (WIN32)
+    set(_harfbuzz_lib_prefix "${CMAKE_IMPORT_LIBRARY_PREFIX}")
+    set(_harfbuzz_lib_suffix "${CMAKE_IMPORT_LIBRARY_SUFFIX}")
   else ()
     # Unsupported.
     set(harfbuzz_FOUND 0)
@@ -29,19 +35,19 @@ endif ()
 add_library(harfbuzz::harfbuzz SHARED IMPORTED)
 set_target_properties(harfbuzz::harfbuzz PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_includedir}/harfbuzz"
-  IMPORTED_LOCATION "${_harfbuzz_libdir}/libharfbuzz${_harfbuzz_lib_suffix}")
+  IMPORTED_LOCATION "${_harfbuzz_libdir}/${_harfbuzz_lib_prefix}harfbuzz${_harfbuzz_lib_suffix}")
 
 add_library(harfbuzz::icu SHARED IMPORTED)
 set_target_properties(harfbuzz::icu PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_includedir}/harfbuzz"
   INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
-  IMPORTED_LOCATION "${_harfbuzz_libdir}/libharfbuzz-icu${_harfbuzz_lib_suffix}")
+  IMPORTED_LOCATION "${_harfbuzz_libdir}/${_harfbuzz_lib_prefix}harfbuzz-icu${_harfbuzz_lib_suffix}")
 
 add_library(harfbuzz::subset SHARED IMPORTED)
 set_target_properties(harfbuzz::subset PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_includedir}/harfbuzz"
   INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
-  IMPORTED_LOCATION "${_harfbuzz_libdir}/libharfbuzz-subset${_harfbuzz_lib_suffix}")
+  IMPORTED_LOCATION "${_harfbuzz_libdir}/${_harfbuzz_lib_prefix}harfbuzz-subset${_harfbuzz_lib_suffix}")
 
 # Only add the gobject library if it was built.
 set(_harfbuzz_have_gobject "@have_gobject@")
@@ -50,10 +56,11 @@ if (_harfbuzz_have_gobject)
   set_target_properties(harfbuzz::gobject PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${_harfbuzz_includedir}/harfbuzz"
     INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
-    IMPORTED_LOCATION "${_harfbuzz_libdir}/libharfbuzz-gobject${_harfbuzz_lib_suffix}")
+    IMPORTED_LOCATION "${_harfbuzz_libdir}/${_harfbuzz_lib_prefix}harfbuzz-gobject${_harfbuzz_lib_suffix}")
 endif ()
 
 # Clean out variables we used in our scope.
+unset(_harfbuzz_lib_prefix)
 unset(_harfbuzz_lib_suffix)
 unset(_harfbuzz_current)
 unset(_harfbuzz_revision)


### PR DESCRIPTION
Hi,

This attempts to improve the CMake config file that is generated during the autotools/Meson builds so that the CMake config file is usable under Windows as well, with the appropriate library prefixes and suffixes.

Note: Sadly I lost access to my former account `fanc999`.

With blessings, thank you!