### PR TITLE
[subset/regaingid/glyf] Add a fastpath for empty glyphs

### DIFF
--- a/src/OT/glyf/SubsetGlyph.hh
+++ b/src/OT/glyf/SubsetGlyph.hh
@@ -26,6 +26,23 @@ struct SubsetGlyph
   {
     TRACE_SERIALIZE (this);
 
+    if (length () == 0)
+    {
+      /* Fast path for retain-gid holes. */
+
+      unsigned int pad_length = use_short_loca ? padding () : 0;
+      DEBUG_MSG (SUBSET, nullptr, "serialize empty glyph, pad %u", pad_length);
+
+      HBUINT8 pad;
+      pad = 0;
+      while (pad_length > 0)
+      {
+	c->embed (pad);
+	pad_length--;
+      }
+      return true;
+    }
+
     hb_bytes_t dest_glyph = dest_start.copy (c);
     hb_bytes_t end_copy = dest_end.copy (c);
     if (!end_copy.arrayZ || !dest_glyph.arrayZ) {


### PR DESCRIPTION
Mplus benchmark:
```
Comparing before to after
Benchmark                                                                      Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------------------------------------
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/retaingids/10                   -0.1764         -0.1771             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/retaingids/64                   -0.1394         -0.1394             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/retaingids/512                  -0.0644         -0.0645             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/retaingids/4096                 +0.0132         +0.0131             1             1             1             1
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/retaingids/10000                -0.0029         -0.0034             3             3             3             3
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/10                              +0.0364         +0.0362             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/64                              +0.0346         +0.0343             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/512                             +0.0271         +0.0268             0             0             0             0
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/4096                            +0.0193         +0.0193             1             1             1             1
BM_subset/subset_glyphs/Mplus1p-Regular.ttf/10000                           -0.0240         -0.0243             2             2             2             2
OVERALL_GEOMEAN                                                             -0.0305         -0.0307             0             0             0             0
```