### PR TITLE
Glyph to sid cache

### DIFF
--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -110,6 +110,7 @@ struct Encoding1 {
 
   hb_codepoint_t get_code (hb_codepoint_t glyph) const
   {
+    /* TODO: Add cache like get_sid. */
     assert (glyph > 0);
     glyph--;
     for (unsigned int i = 0; i < nRanges (); i++)

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -389,12 +389,17 @@ struct Charset1_2 {
   {
     if (unlikely (glyph >= num_glyphs)) return 0;
     if (unlikely (glyph == 0)) return 0;
-    hb_codepoint_t start_glyph = 1;
-    unsigned i = 0;
+    unsigned i;
+    hb_codepoint_t start_glyph;
     if (cache && likely (cache->glyph <= glyph))
     {
       i = cache->code;
       start_glyph = cache->glyph;
+    }
+    else
+    {
+      i = 0;
+      start_glyph = 1;
     }
     glyph -= start_glyph;
     for (;; i++)

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -329,12 +329,6 @@ struct Charset0
       return sids[glyph - 1];
   }
 
-  void collect_glyph_to_sid_map (hb_map_t *mapping, unsigned int num_glyphs) const
-  {
-    for (hb_codepoint_t gid = 1; gid < num_glyphs; gid++)
-      mapping->set (gid, sids[gid - 1]);
-  }
-
   hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
   {
     if (sid == 0)
@@ -390,36 +384,34 @@ struct Charset1_2 {
     return_trace (true);
   }
 
-  hb_codepoint_t get_sid (hb_codepoint_t glyph, unsigned num_glyphs) const
+  hb_codepoint_t get_sid (hb_codepoint_t glyph, unsigned num_glyphs,
+			  code_pair_t *cache = nullptr) const
   {
     if (unlikely (glyph >= num_glyphs)) return 0;
     if (unlikely (glyph == 0)) return 0;
-    glyph--;
-    for (unsigned int i = 0;; i++)
+    hb_codepoint_t start_glyph = 1;
+    unsigned i = 0;
+    if (cache && likely (cache->glyph <= glyph))
     {
-      if (glyph <= ranges[i].nLeft)
-	return (hb_codepoint_t) ranges[i].first + glyph;
-      glyph -= (ranges[i].nLeft + 1);
+      i = cache->code;
+      start_glyph = cache->glyph;
+    }
+    glyph -= start_glyph;
+    for (;; i++)
+    {
+      unsigned count = ranges[i].nLeft;
+      if (glyph <= count)
+      {
+        if (cache)
+	  *cache = {i, start_glyph};
+	return ranges[i].first + glyph;
+      }
+      count++;
+      start_glyph += count;
+      glyph -= count;
     }
 
     return 0;
-  }
-
-  void collect_glyph_to_sid_map (hb_map_t *mapping, unsigned int num_glyphs) const
-  {
-    hb_codepoint_t gid = 1;
-    if (gid >= num_glyphs)
-      return;
-    for (unsigned i = 0;; i++)
-    {
-      hb_codepoint_t sid = ranges[i].first;
-      unsigned count = ranges[i].nLeft + 1;
-      for (unsigned j = 0; j < count; j++)
-	mapping->set (gid++, sid++);
-
-      if (gid >= num_glyphs)
-        break;
-    }
   }
 
   hb_codepoint_t get_glyph (hb_codepoint_t sid, unsigned int num_glyphs) const
@@ -551,25 +543,15 @@ struct Charset
     }
   }
 
-  hb_codepoint_t get_sid (hb_codepoint_t glyph, unsigned int num_glyphs) const
+  hb_codepoint_t get_sid (hb_codepoint_t glyph, unsigned int num_glyphs,
+			  code_pair_t *cache = nullptr) const
   {
     switch (format)
     {
     case 0: return u.format0.get_sid (glyph, num_glyphs);
-    case 1: return u.format1.get_sid (glyph, num_glyphs);
-    case 2: return u.format2.get_sid (glyph, num_glyphs);
+    case 1: return u.format1.get_sid (glyph, num_glyphs, cache);
+    case 2: return u.format2.get_sid (glyph, num_glyphs, cache);
     default:return 0;
-    }
-  }
-
-  void collect_glyph_to_sid_map (hb_map_t *mapping, unsigned int num_glyphs) const
-  {
-    switch (format)
-    {
-    case 0: u.format0.collect_glyph_to_sid_map (mapping, num_glyphs); return;
-    case 1: u.format1.collect_glyph_to_sid_map (mapping, num_glyphs); return;
-    case 2: u.format2.collect_glyph_to_sid_map (mapping, num_glyphs); return;
-    default:return;
     }
   }
 
@@ -1209,13 +1191,14 @@ struct cff1
 
     bool is_predef_encoding () const { return topDict.EncodingOffset <= ExpertEncoding; }
 
-    hb_codepoint_t glyph_to_code (hb_codepoint_t glyph) const
+    hb_codepoint_t glyph_to_code (hb_codepoint_t glyph,
+				  code_pair_t *glyph_to_sid_cache = nullptr) const
     {
       if (encoding != &Null (Encoding))
 	return encoding->get_code (glyph);
       else
       {
-	hb_codepoint_t sid = glyph_to_sid (glyph);
+	hb_codepoint_t sid = glyph_to_sid (glyph, glyph_to_sid_cache);
 	if (sid == 0) return 0;
 	hb_codepoint_t code = 0;
 	switch (topDict.EncodingOffset)
@@ -1233,23 +1216,11 @@ struct cff1
       }
     }
 
-    hb_map_t *create_glyph_to_sid_map () const
+    hb_codepoint_t glyph_to_sid (hb_codepoint_t glyph,
+				 code_pair_t *cache = nullptr) const
     {
       if (charset != &Null (Charset))
-      {
-	hb_map_t *mapping = hb_map_create ();
-	mapping->set (0, 0);
-	charset->collect_glyph_to_sid_map (mapping, num_glyphs);
-	return mapping;
-      }
-      else
-	return nullptr;
-    }
-
-    hb_codepoint_t glyph_to_sid (hb_codepoint_t glyph) const
-    {
-      if (charset != &Null (Charset))
-	return charset->get_sid (glyph, num_glyphs);
+	return charset->get_sid (glyph, num_glyphs, cache);
       else
       {
 	hb_codepoint_t sid = 0;
@@ -1392,9 +1363,10 @@ struct cff1
 	  /* TODO */
 
 	  /* fill glyph names */
+	  code_pair_t glyph_to_sid_cache {0, HB_CODEPOINT_INVALID};
 	  for (hb_codepoint_t gid = 0; gid < num_glyphs; gid++)
 	  {
-	    hb_codepoint_t	sid = glyph_to_sid (gid);
+	    hb_codepoint_t	sid = glyph_to_sid (gid, &glyph_to_sid_cache);
 	    gname_t	gname;
 	    gname.sid = sid;
 	    if (sid < cff1_std_strings_length)

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -388,7 +388,6 @@ struct Charset1_2 {
 			  code_pair_t *cache = nullptr) const
   {
     if (unlikely (glyph >= num_glyphs)) return 0;
-    if (unlikely (glyph == 0)) return 0;
     unsigned i;
     hb_codepoint_t start_glyph;
     if (cache && likely (cache->glyph <= glyph))
@@ -398,6 +397,7 @@ struct Charset1_2 {
     }
     else
     {
+      if (unlikely (glyph == 0)) return 0;
       i = 0;
       start_glyph = 1;
     }

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -389,30 +389,28 @@ struct Charset1_2 {
   {
     if (unlikely (glyph >= num_glyphs)) return 0;
     unsigned i;
-    hb_codepoint_t start_glyph;
+    hb_codepoint_t orig_glyph = glyph;
     if (cache && likely (cache->glyph <= glyph))
     {
       i = cache->code;
-      start_glyph = cache->glyph;
+      glyph -= cache->glyph;
     }
     else
     {
       if (unlikely (glyph == 0)) return 0;
       i = 0;
-      start_glyph = 1;
+      glyph -= 1;
     }
-    glyph -= start_glyph;
     for (;; i++)
     {
       unsigned count = ranges[i].nLeft;
       if (glyph <= count)
       {
         if (cache)
-	  *cache = {i, start_glyph};
+	  *cache = {i, orig_glyph - glyph};
 	return ranges[i].first + glyph;
       }
       count++;
-      start_glyph += count;
       glyph -= count;
     }
 

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -389,28 +389,30 @@ struct Charset1_2 {
   {
     if (unlikely (glyph >= num_glyphs)) return 0;
     unsigned i;
-    hb_codepoint_t orig_glyph = glyph;
+    hb_codepoint_t start_glyph;
     if (cache && likely (cache->glyph <= glyph))
     {
       i = cache->code;
-      glyph -= cache->glyph;
+      start_glyph = cache->glyph;
     }
     else
     {
       if (unlikely (glyph == 0)) return 0;
       i = 0;
-      glyph -= 1;
+      start_glyph = 1;
     }
+    glyph -= start_glyph;
     for (;; i++)
     {
       unsigned count = ranges[i].nLeft;
       if (glyph <= count)
       {
         if (cache)
-	  *cache = {i, orig_glyph - glyph};
+	  *cache = {i, start_glyph};
 	return ranges[i].first + glyph;
       }
       count++;
+      start_glyph += count;
       glyph -= count;
     }
 

--- a/src/hb-ot-cff2-table.hh
+++ b/src/hb-ot-cff2-table.hh
@@ -481,11 +481,6 @@ struct cff2
       blob = nullptr;
     }
 
-    hb_map_t *create_glyph_to_sid_map () const
-    {
-      return nullptr;
-    }
-
     bool is_valid () const { return blob; }
 
     protected:

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -512,13 +512,11 @@ struct cff_subset_accelerator_t
 
   ~cff_subset_accelerator_t() {
     hb_blob_destroy (original_blob);
-    hb_map_destroy (glyph_to_sid_map.get_relaxed ());
   }
 
   parsed_cs_str_vec_t parsed_charstrings;
   parsed_cs_str_vec_t parsed_global_subrs;
   hb_vector_t<parsed_cs_str_vec_t> parsed_local_subrs;
-  mutable hb_atomic_ptr_t<hb_map_t> glyph_to_sid_map = nullptr;
 
  private:
   hb_blob_t* original_blob;

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -413,6 +413,7 @@ struct cff_subset_plan {
 
     supp_codes.init ();
 
+    code_pair_t glyph_to_sid_cache {0, HB_CODEPOINT_INVALID};
     subset_enc_num_codes = plan->num_output_glyphs () - 1;
     unsigned int glyph;
     auto it = hb_iter (plan->new_to_old_gid_list);
@@ -431,7 +432,7 @@ struct cff_subset_plan {
 	/* Retain the SID for the old missing glyph ID */
 	old_glyph = glyph;
       }
-      code = acc.glyph_to_code (old_glyph);
+      code = acc.glyph_to_code (old_glyph, &glyph_to_sid_cache);
       if (code == CFF_UNDEF_CODE)
       {
 	subset_enc_num_codes = glyph - 1;
@@ -447,7 +448,7 @@ struct cff_subset_plan {
 
       if (encoding != &Null (Encoding))
       {
-	hb_codepoint_t  sid = acc.glyph_to_sid (old_glyph);
+	hb_codepoint_t  sid = acc.glyph_to_sid (old_glyph, &glyph_to_sid_cache);
 	encoding->get_supplement_codes (sid, supp_codes);
 	for (unsigned int i = 0; i < supp_codes.length; i++)
 	{
@@ -473,7 +474,7 @@ struct cff_subset_plan {
   void plan_subset_charset (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
   {
     unsigned int  size0, size_ranges;
-    unsigned sid, last_sid = CFF_UNDEF_CODE - 1;
+    unsigned last_sid = CFF_UNDEF_CODE - 1;
 
     if (unlikely (!subset_charset_ranges.resize (0)))
     {
@@ -481,18 +482,7 @@ struct cff_subset_plan {
       return;
     }
 
-    hb_map_t *glyph_to_sid_map = (plan->accelerator && plan->accelerator->cff_accelerator) ?
-				  plan->accelerator->cff_accelerator->glyph_to_sid_map :
-				  nullptr;
-    bool created_map = false;
-    if (!glyph_to_sid_map &&
-	((plan->accelerator && plan->accelerator->cff_accelerator) ||
-	 plan->num_output_glyphs () > plan->source->get_num_glyphs () / 8.))
-    {
-      created_map = true;
-      glyph_to_sid_map = acc.create_glyph_to_sid_map ();
-    }
-
+    code_pair_t glyph_to_sid_cache {0, HB_CODEPOINT_INVALID};
     unsigned int glyph;
     unsigned num_glyphs = plan->num_output_glyphs ();
     auto it = hb_iter (plan->new_to_old_gid_list);
@@ -512,7 +502,7 @@ struct cff_subset_plan {
 	/* Retain the SID for the old missing glyph ID */
 	old_glyph = glyph;
       }
-      sid = glyph_to_sid_map ? glyph_to_sid_map->get (old_glyph) : acc.glyph_to_sid (old_glyph);
+      unsigned sid = acc.glyph_to_sid (old_glyph, &glyph_to_sid_cache);
 
       if (not_is_cid)
 	sid = sidmap.add (sid);
@@ -523,13 +513,6 @@ struct cff_subset_plan {
 	subset_charset_ranges.push (pair);
       }
       last_sid = sid;
-    }
-
-    if (created_map)
-    {
-      if (!(plan->accelerator && plan->accelerator->cff_accelerator) ||
-	  !plan->accelerator->cff_accelerator->glyph_to_sid_map.cmpexch (nullptr, glyph_to_sid_map))
-	hb_map_destroy (glyph_to_sid_map);
     }
 
     bool two_byte = subset_charset_ranges.complete (glyph);


### PR DESCRIPTION
This speeds up small CFF CJK retaingids subsets, but mysteriously slows down large CFF CJK retaingids subsets by 20%. My profiling doesn't show why. @garretrieger can you take a look please?