### PR TITLE
[instancer] change tuple variations' axis limits

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -532,7 +532,7 @@ test_instancer_solver_SOURCES = test-subset-instancer-solver.cc hb-subset-instan
 test_instancer_solver_CPPFLAGS = $(COMPILED_TESTS_CPPFLAGS)
 test_instancer_solver_LDADD = $(COMPILED_TESTS_LDADD)
 
-test_tuple_varstore_SOURCES = test-tuple-varstore.cc hb-static.cc
+test_tuple_varstore_SOURCES = test-tuple-varstore.cc hb-subset-instancer-solver.cc hb-static.cc
 test_tuple_varstore_CPPFLAGS = $(COMPILED_TESTS_CPPFLAGS)
 test_tuple_varstore_LDADD = $(COMPILED_TESTS_LDADD)
 

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -419,7 +419,7 @@ struct TupleVariationHeader
 struct tuple_delta_t
 {
   public:
-  hb_hashmap_t<unsigned, Triple> axis_tuples;
+  hb_hashmap_t<hb_tag_t, Triple> axis_tuples;
 
   /* indices_length = point_count, indice[i] = 1 means point i is referenced */
   hb_vector_t<bool> indices;

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -646,6 +646,33 @@ struct TupleVariationData
         tuple_vars = std::move (new_vars);
       }
     }
+
+    /* merge tuple variations with overlapping tents */
+    void merge_tuple_variations ()
+    {
+      hb_vector_t<tuple_delta_t> new_vars;
+      hb_hashmap_t<hb_hashmap_t<hb_tag_t, Triple>, unsigned> m;
+      unsigned i = 0;
+      for (const tuple_delta_t& var : tuple_vars)
+      {
+        /* if all axes are pinned, drop the tuple variation */
+        if (var.axis_tuples.is_empty ()) continue;
+
+        unsigned *idx;
+        if (m.has (var.axis_tuples, &idx))
+        {
+          new_vars[*idx] += var;
+        }
+        else
+        {
+          new_vars.push (var);
+          m.set (var.axis_tuples, i);
+          i++;
+        }
+      }
+      tuple_vars.fini ();
+      tuple_vars = std::move (new_vars);
+    }
   };
 
   struct tuple_iterator_t

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -642,7 +642,7 @@ struct TupleVariationData
           if (!out) continue;
           unsigned new_len = new_vars.length + out.length;
 
-          if (unlikely (!new_vars.resize (new_len, false)))
+          if (unlikely (!new_vars.alloc (new_len, false)))
           { fini (); return;}
 
           for (unsigned i = 0; i < out.length; i++)

--- a/src/hb-ot-var-cvar-table.hh
+++ b/src/hb-ot-var-cvar-table.hh
@@ -54,6 +54,7 @@ struct cvar
   bool decompile_tuple_variations (unsigned axis_count,
                                    unsigned point_count,
                                    bool is_gvar,
+                                   const hb_map_t *axes_old_index_tag_map,
                                    TupleVariationData::tuple_variations_t& tuple_variations /* OUT */) const
   {
     hb_vector_t<unsigned> shared_indices;
@@ -65,6 +66,7 @@ struct cvar
       return false;
 
     return tupleVariationData.decompile_tuple_variations (point_count, is_gvar, iterator,
+                                                          axes_old_index_tag_map,
                                                           shared_indices,
                                                           hb_array<const F2DOT14> (),
                                                           tuple_variations);

--- a/src/hb-subset-instancer-solver.hh
+++ b/src/hb-subset-instancer-solver.hh
@@ -42,11 +42,29 @@ struct Triple {
 	   maximum == o.maximum;
   }
 
+  bool operator != (const Triple o) const
+  { return !(*this == o); }
+
   bool is_point () const
   { return minimum == middle && middle == maximum; }
 
   bool contains (float point) const
   { return minimum <= point && point <= maximum; }
+
+  /* from hb_array_t hash ()*/
+  uint32_t hash () const
+  {
+    uint32_t current = /*cbf29ce4*/0x84222325;
+    current = current ^ hb_hash (minimum);
+    current = current * 16777619;
+
+    current = current ^ hb_hash (middle);
+    current = current * 16777619;
+
+    current = current ^ hb_hash (maximum);
+    current = current * 16777619;
+    return current;
+  }
 
   float minimum;
   float middle;

--- a/src/meson.build
+++ b/src/meson.build
@@ -723,7 +723,7 @@ if get_option('tests').enabled()
     'test-vector': ['test-vector.cc', 'hb-static.cc'],
     'test-bimap': ['test-bimap.cc', 'hb-static.cc'],
     'test-instancer-solver': ['test-subset-instancer-solver.cc', 'hb-subset-instancer-solver.cc', 'hb-static.cc'],
-    'test-tuple-varstore': ['test-tuple-varstore.cc', 'hb-static.cc'],
+    'test-tuple-varstore': ['test-tuple-varstore.cc', 'hb-subset-instancer-solver.cc', 'hb-static.cc'],
   }
   foreach name, source : compiled_tests
     if cpp.get_argument_syntax() == 'msvc' and source.contains('hb-static.cc')

--- a/src/test-tuple-varstore.cc
+++ b/src/test-tuple-varstore.cc
@@ -33,8 +33,13 @@ test_decompile_cvar ()
   const OT::cvar* cvar_table = reinterpret_cast<const OT::cvar*> (cvar_data);
   unsigned point_count = 65;
   unsigned axis_count = 1;
+
+  hb_tag_t axis_tag = HB_TAG ('w', 'g', 'h', 't');
+  hb_map_t axis_idx_tag_map;
+  axis_idx_tag_map.set (0, axis_tag);
+
   OT::TupleVariationData::tuple_variations_t tuple_variations;
-  bool result = cvar_table->decompile_tuple_variations (axis_count, point_count, false, tuple_variations);
+  bool result = cvar_table->decompile_tuple_variations (axis_count, point_count, false, &axis_idx_tag_map, tuple_variations);
   assert (result);
   assert (tuple_variations.tuple_vars.length == 2);
   for (unsigned i = 0; i < 2; i++)
@@ -44,8 +49,8 @@ test_decompile_cvar ()
     assert (tuple_variations.tuple_vars[i].indices.length == 65);
     assert (tuple_variations.tuple_vars[i].indices.length == tuple_variations.tuple_vars[i].deltas_x.length);
   }
-  assert (tuple_variations.tuple_vars[0].axis_tuples.get (0) == Triple (-1.f, -1.f, 0.f));
-  assert (tuple_variations.tuple_vars[1].axis_tuples.get (0) == Triple (0.f, 1.f, 1.f));
+  assert (tuple_variations.tuple_vars[0].axis_tuples.get (axis_tag) == Triple (-1.f, -1.f, 0.f));
+  assert (tuple_variations.tuple_vars[1].axis_tuples.get (axis_tag) == Triple (0.f, 1.f, 1.f));
   
   hb_vector_t<float> deltas_1 {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, -1.f, 0.f, -3.f, 1.f, 0.f, -1.f, 0.f, -3.f, 1.f, 0.f, -37.f, -37.f, -26.f, -26.f, 0.f, 0.f, 0.f, -3.f, 0.f, 0.f, 0.f, 0.f, 0.f, -3.f, 0.f, 2.f, -29.f, -29.f, -20.f, -20.f, 0.f, 0.f, 0.f, 1.f, -29.f, -29.f, -20.f, -20.f, 0.f, 0.f, 0.f, 1.f};
   for (unsigned i = 0; i < 65; i++)

--- a/src/test-tuple-varstore.cc
+++ b/src/test-tuple-varstore.cc
@@ -75,6 +75,41 @@ test_decompile_cvar ()
       assert (tuple_variations.tuple_vars[1].deltas_x[i] == deltas_2[i]);
     }
   }
+
+  /* partial instancing wght=300:800 */
+  hb_hashmap_t<hb_tag_t, Triple> normalized_axes_location;
+  normalized_axes_location.set (axis_tag, Triple (-0.512817f, 0.f, 0.700012f));
+
+  tuple_variations.change_tuple_variations_axis_limits (&normalized_axes_location);
+  tuple_variations.merge_tuple_variations ();
+
+  assert (tuple_variations.tuple_vars[0].indices.length == 65);
+  assert (tuple_variations.tuple_vars[1].indices.length == 65);
+  assert (!tuple_variations.tuple_vars[0].deltas_y);
+  assert (!tuple_variations.tuple_vars[1].deltas_y);
+  assert (tuple_variations.tuple_vars[0].axis_tuples.get (axis_tag) == Triple (-1.f, -1.f, 0.f));
+  assert (tuple_variations.tuple_vars[1].axis_tuples.get (axis_tag) == Triple (0.f, 1.f, 1.f));
+
+  hb_vector_t<float> rounded_deltas_1 {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, -1, 0.f, -2, 1, 0.f, -1, 0.f, -2, 1, 0.f, -19, -19, -13, -13, 0.f, 0.f, 0.f, -2, 0.f, 0.f, 0.f, 0.f, 0.f, -2, 0.f, 1, -15, -15, -10.f, -10.f, 0.f, 0.f, 0.f, 1, -15, -15, -10.f, -10.f, 0.f, 0.f, 0.f, 1};
+
+  hb_vector_t<float> rounded_deltas_2 {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1, 0.f, 4, -2, 0.f, 1, 0.f, 4, -2, 0.f, 68, 68, 48, 48, 0.f, 0.f, 0.f, 4, 0.f, 0.f, 1, -1, 1, 5, -1, -4, 51, 51, 37, 37, 0.f, 0.f, 0.f, -1, 51, 51, 37, 37, 0.f, 0.f, 0.f, -1};
+
+  for (unsigned i = 0; i < 65; i++)
+  {
+    if (i < 23)
+    {
+      assert (tuple_variations.tuple_vars[0].indices[i] == 0);
+      assert (tuple_variations.tuple_vars[1].indices[i] == 0);
+    }
+    else
+    {
+      assert (tuple_variations.tuple_vars[0].indices[i] == 1);
+      assert (tuple_variations.tuple_vars[1].indices[i] == 1);
+      assert (roundf (tuple_variations.tuple_vars[0].deltas_x[i]) == rounded_deltas_1[i]);
+      assert (roundf (tuple_variations.tuple_vars[1].deltas_x[i]) == rounded_deltas_2[i]);
+    }
+  }
+
 }
 
 int


### PR DESCRIPTION
- add merge_tuple_variations (), this is not covered by unit test yet.
- fix the issue in hashmap usage: use axis tag as the hashmap key instead of axis index, this makes remove_axis and set_tent faster
- add unit test for change_tuple_variation_axis_limits (). Test is still cvar only,  currently gvar is not supported cause we don't have code to unpack shared_tuples yet. will work on it later.