### PR TITLE
Pin Actions by commit SHA

### DIFF
--- a/.github/workflows/arm-ci.yml
+++ b/.github/workflows/arm-ci.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: devkitpro/devkitarm:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Configure CMake
         run: |
           cmake -S . -B build \

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -21,7 +21,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/configs-build.yml
+++ b/.github/workflows/configs-build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - name: install dependencies
       run: sudo apt-get install gcc
     - name: HB_DISABLE_DEPRECATED

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -11,7 +11,7 @@ jobs:
   latest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - run: sudo apt-get install gcc clang wget git curl pkg-config libfreetype6-dev libglib2.0-dev libicu-dev libgraphite2-dev
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - name: Setup Ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
       with:
         key: ${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
     - name: Install Dependencies
@@ -66,6 +66,6 @@ jobs:
     - name: Generate Coverage
       run: ninja -Cbuild coverage-xml
     - name: Upload Coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       with:
         file: build/meson-logs/coverage.xml

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - name: Setup Ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
       with:
         key: ${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
     - name: Install Dependencies
@@ -55,6 +55,6 @@ jobs:
     - name: Generate Coverage
       run: ninja -Cbuild coverage-xml
     - name: Upload Coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       with:
         file: build/meson-logs/coverage.xml

--- a/.github/workflows/msvc-ci.yml
+++ b/.github/workflows/msvc-ci.yml
@@ -28,18 +28,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - name: Setup Ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
       with:
         variant: sccache
         key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.ARCH }}
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4.6.1
       with:
         python-version: '3.x'
     - name: Setup MSVC
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
       with:
         arch : ${{ matrix.ARCH }}
     - name: Install Python Dependencies

--- a/.github/workflows/msys2-ci.yml
+++ b/.github/workflows/msys2-ci.yml
@@ -33,9 +33,9 @@ jobs:
         shell: msys2 {0}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - name: Setup MSYS2
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@cf96e00c0aab3788743aaf63b64146f0d383cee9 # v2
       with:
         msystem: ${{ matrix.MSYSTEM }}
         update: true


### PR DESCRIPTION
See #4273.

This PR hash-pins all Actions in your workflows, transforming `actions/checkout@v3` into `actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2`. This is the commit SHA associated with the most recent version of the Action.

Note that the Actions are called by their commit SHA, but we also have the associated version tag in a comment. Dependabot is already set up to keep Actions up-to-date. It will continue to do so, and it will update both the hash and the version comment. (To see some examples, check out the [pull requests on my fork](https://github.com/pnacht/harfbuzz/pulls), when I hash-pinned some Actions to outdated versions)

So whenever the new version of `hendrikmuhs/ccache-action` comes out, you'll receive a dependabot PR with

```diff
- hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
+ hendrikmuhs/ccache-action@1a2b3c4d3f1a2b3c4d3f1a2b3c4d3f1a2b3c4d3f # v1.2.10
```

It's actually important that you only accept version bumps from automated tools such as dependabot to protect the project from [imposter commits](https://www.chainguard.dev/unchained/what-the-fork-imposter-commits-in-github-actions-and-ci-cd).

The hashes were all found from the respective Action's releases page:

| Action | release |
| - | - |
| actions/checkout | https://github.com/actions/checkout/releases/tag/v3.5.2
| actions/upload-artifact | https://github.com/actions/upload-artifact/releases/tag/v3.1.2
| hendrikmuhs/ccache-action | https://github.com/hendrikmuhs/ccache-action/releases/tag/v1.2.9
| codecov/codecov-action | https://github.com/codecov/codecov-action/releases/tag/v3.1.4
| actions/setup-python | https://github.com/actions/setup-python/releases/tag/v4.6.1
| ilammy/msvc-dev-cmd | https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.12.0
| msys2/setup-msys2 | https://github.com/msys2/setup-msys2/releases/tag/v2*

\* msys2/setup-msys2 doesn't have minor version tags