### PR TITLE
[instancer] compile tuple variations

### DIFF
--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -1189,6 +1189,34 @@ struct TupleVariationData
       return res;
     }
 
+    void instantiate (const hb_hashmap_t<hb_tag_t, Triple>& normalized_axes_location)
+    {
+      change_tuple_variations_axis_limits (&normalized_axes_location);
+      merge_tuple_variations ();
+    }
+
+    bool compile_bytes (const hb_map_t& axes_index_map,
+                        const hb_map_t& axes_old_index_tag_map)
+    {
+      // compile points set and store data in hashmap
+      if (!compile_all_point_sets ())
+        return false;
+      // compile delta and tuple var header for each tuple variation
+      for (auto& tuple: tuple_vars)
+      {
+        const hb_vector_t<bool>* points_set = &(tuple.indices);
+        byte_data_t *points_data;
+        if (unlikely (!point_data_map.has (points_set, &points_data)))
+          return false;
+
+        if (!tuple.compile_deltas ())
+          return false;
+
+        if (!tuple.compile_tuple_var_header (axes_index_map, points_data->length, axes_old_index_tag_map))
+          return false;
+      }
+      return true;
+    }
   };
 
   struct tuple_iterator_t

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -591,7 +591,8 @@ struct TupleVariationData
         { fini (); return false; }
 
         const hb_vector_t<unsigned> &indices = has_private_points ? private_indices : shared_indices;
-        unsigned num_deltas = indices.length;
+        bool apply_to_all = (indices.length == 0);
+        unsigned num_deltas = apply_to_all ? point_count : indices.length;
 
         hb_vector_t<int> deltas_x;
 
@@ -618,7 +619,8 @@ struct TupleVariationData
 
         for (unsigned i = 0; i < num_deltas; i++)
         {
-          unsigned idx = indices[i];
+          unsigned idx = apply_to_all ? i : indices[i];
+          if (idx >= point_count) continue;
           var.indices[idx] = true;
           var.deltas_x[idx] = static_cast<float> (deltas_x[i]);
           if (is_gvar)

--- a/src/hb-ot-var-cvar-table.hh
+++ b/src/hb-ot-var-cvar-table.hh
@@ -27,6 +27,7 @@
 #define HB_OT_VAR_CVAR_TABLE_HH
 
 #include "hb-ot-var-common.hh"
+#include "hb-ot-var-fvar-table.hh"
 
 
 namespace OT {
@@ -138,12 +139,21 @@ struct cvar
   bool subset (hb_subset_context_t *c) const
   {
     TRACE_SUBSET (this);
+    if (c->plan->all_axes_pinned)
+      return_trace (false);
+
     /* subset() for cvar is called by partial instancing only, we always pass
      * through cvar table in other cases */
-    if (unlikely (!c->plan->normalized_coords ||
-                  c->plan->pinned_at_default ||
-                  c->plan->all_axes_pinned))
-      return_trace (false);
+    if (!c->plan->normalized_coords)
+    {
+      unsigned axis_count = c->plan->source->table.fvar->get_axis_count ();
+      unsigned total_size = min_size + tupleVariationData.get_size (axis_count);
+      char *out = c->serializer->allocate_size<char> (total_size);
+      if (unlikely (!out)) return_trace (false);
+
+      hb_memcpy (out, this, total_size);
+      return_trace (true);
+    }
 
     OT::TupleVariationData::tuple_variations_t tuple_variations;
     unsigned axis_count = c->plan->axes_old_index_tag_map.get_population ();

--- a/src/test-tuple-varstore.cc
+++ b/src/test-tuple-varstore.cc
@@ -117,22 +117,22 @@ test_decompile_cvar ()
   assert (tuple_variations.tuple_vars[0].compiled_tuple_header.length == 6);
   const char tuple_var_header_1[] = "\x0\x51\xa0\x0\xc0\x0";
   for (unsigned i = 0; i < 6; i++)
-    assert(tuple_variations.tuple_vars[0].compiled_tuple_header.p[i] == tuple_var_header_1[i]);
+    assert(tuple_variations.tuple_vars[0].compiled_tuple_header.arrayZ[i] == tuple_var_header_1[i]);
 
   assert (tuple_variations.tuple_vars[1].compiled_tuple_header.length == 6);
   const char tuple_var_header_2[] = "\x0\x54\xa0\x0\x40\x0";
   for (unsigned i = 0; i < 6; i++)
-    assert(tuple_variations.tuple_vars[1].compiled_tuple_header.p[i] == tuple_var_header_2[i]);
+    assert(tuple_variations.tuple_vars[1].compiled_tuple_header.arrayZ[i] == tuple_var_header_2[i]);
 
   assert (tuple_variations.tuple_vars[0].compiled_deltas.length == 37);
   assert (tuple_variations.tuple_vars[1].compiled_deltas.length == 40);
   const char compiled_deltas_1[] = "\x0d\xff\x00\xfe\x01\x00\xff\x00\xfe\x01\x00\xed\xed\xf3\xf3\x82\x00\xfe\x84\x06\xfe\x00\x01\xf1\xf1\xf6\xf6\x82\x04\x01\xf1\xf1\xf6\xf6\x82\x00\x01";
   for (unsigned i = 0; i < 37; i++)
-    assert (tuple_variations.tuple_vars[0].compiled_deltas.p[i] == compiled_deltas_1[i]);
+    assert (tuple_variations.tuple_vars[0].compiled_deltas.arrayZ[i] == compiled_deltas_1[i]);
 
   const char compiled_deltas_2[] = "\x0d\x01\x00\x04\xfe\x00\x01\x00\x04\xfe\x00\x44\x44\x30\x30\x82\x00\x04\x81\x09\x01\xff\x01\x05\xff\xfc\x33\x33\x25\x25\x82\x04\xff\x33\x33\x25\x25\x82\x00\xff";
   for (unsigned i = 0; i < 40; i++)
-    assert (tuple_variations.tuple_vars[1].compiled_deltas.p[i] == compiled_deltas_2[i]);
+    assert (tuple_variations.tuple_vars[1].compiled_deltas.arrayZ[i] == compiled_deltas_2[i]);
 }
 
 int

--- a/src/test-tuple-varstore.cc
+++ b/src/test-tuple-varstore.cc
@@ -110,6 +110,29 @@ test_decompile_cvar ()
     }
   }
 
+  hb_map_t axes_index_map;
+  axes_index_map.set (0, 0);
+  bool res = tuple_variations.compile_bytes (axes_index_map, axis_idx_tag_map);
+  assert (res);
+  assert (tuple_variations.tuple_vars[0].compiled_tuple_header.length == 6);
+  const char tuple_var_header_1[] = "\x0\x51\xa0\x0\xc0\x0";
+  for (unsigned i = 0; i < 6; i++)
+    assert(tuple_variations.tuple_vars[0].compiled_tuple_header.p[i] == tuple_var_header_1[i]);
+
+  assert (tuple_variations.tuple_vars[1].compiled_tuple_header.length == 6);
+  const char tuple_var_header_2[] = "\x0\x54\xa0\x0\x40\x0";
+  for (unsigned i = 0; i < 6; i++)
+    assert(tuple_variations.tuple_vars[1].compiled_tuple_header.p[i] == tuple_var_header_2[i]);
+
+  assert (tuple_variations.tuple_vars[0].compiled_deltas.length == 37);
+  assert (tuple_variations.tuple_vars[1].compiled_deltas.length == 40);
+  const char compiled_deltas_1[] = "\x0d\xff\x00\xfe\x01\x00\xff\x00\xfe\x01\x00\xed\xed\xf3\xf3\x82\x00\xfe\x84\x06\xfe\x00\x01\xf1\xf1\xf6\xf6\x82\x04\x01\xf1\xf1\xf6\xf6\x82\x00\x01";
+  for (unsigned i = 0; i < 37; i++)
+    assert (tuple_variations.tuple_vars[0].compiled_deltas.p[i] == compiled_deltas_1[i]);
+
+  const char compiled_deltas_2[] = "\x0d\x01\x00\x04\xfe\x00\x01\x00\x04\xfe\x00\x44\x44\x30\x30\x82\x00\x04\x81\x09\x01\xff\x01\x05\xff\xfc\x33\x33\x25\x25\x82\x04\xff\x33\x33\x25\x25\x82\x00\xff";
+  for (unsigned i = 0; i < 40; i++)
+    assert (tuple_variations.tuple_vars[1].compiled_deltas.p[i] == compiled_deltas_2[i]);
 }
 
 int


### PR DESCRIPTION
1. Added code to compile tuple_variations_t into bytes, also added unit testing code for it.
    - compile all points_set and store the bytes data in a hashmap in tuple_variations_t, cause some points_set could be reused
    - compile deltas and tuple variation header for each tuple_delta_t, bytes stored within each tuple
    - shared_tuples not supported yet
2. Added subset()/serialize() method in TupleVariationData and cvar for instantiating cvar table, this is not covered by test yet, I'll add a full test once gvar is supported.