### PR TITLE
[use] Allow multiple CMAbv glyphs on subjoined

### DIFF
--- a/src/hb-ot-shaper-use-machine.rl
+++ b/src/hb-ot-shaper-use-machine.rl
@@ -110,7 +110,7 @@ export FMPst	= 47; # CONS_FINAL_MOD	UIPC = Not_Applicable
 
 h = H | HVM | IS | Sk;
 
-consonant_modifiers = CMAbv* CMBlw* ((h B | SUB) CMAbv? CMBlw*)*;
+consonant_modifiers = CMAbv* CMBlw* ((h B | SUB) CMAbv* CMBlw*)*;
 medial_consonants = MPre? MAbv? MBlw? MPst?;
 dependent_vowels = VPre* VAbv* VBlw* VPst* | H;
 vowel_modifiers = HVM? VMPre* VMAbv* VMBlw* VMPst*;


### PR DESCRIPTION
The part of the USE spec corresponding to hb-ot-shaper-use-machine.rl’s `consonant_modifiers` is `(CMAbv)* (CMBlw)* (< H B [VS] | SUB > (CMAbv)* (CMBlw)*)*`, so multiple CMAbv glyphs should be allowed after a subjoined glyph.