### PR TITLE
[sanitize] Only check trailing edge of ranges

### DIFF
--- a/src/hb-sanitize.hh
+++ b/src/hb-sanitize.hh
@@ -268,8 +268,7 @@ struct hb_sanitize_context_t :
 		    unsigned int len) const
   {
     const char *p = (const char *) base;
-    bool ok = (uintptr_t) (p - this->start) <= this->length &&
-	      (unsigned int) (this->end - p) >= len &&
+    bool ok = (intptr_t) (this->end - p) >= (intptr_t) len &&
 	      ((this->max_ops -= len) > 0);
 
     DEBUG_MSG_LEVEL (SANITIZE, p, this->debug_depth+1, 0,
@@ -288,8 +287,7 @@ struct hb_sanitize_context_t :
 			 unsigned int len) const
   {
     const char *p = (const char *) base;
-    bool ok = ((uintptr_t) (p - this->start) <= this->length &&
-	       (unsigned int) (this->end - p) >= len);
+    bool ok = (intptr_t) (this->end - p) >= (intptr_t) len;
 
     DEBUG_MSG_LEVEL (SANITIZE, p, this->debug_depth+1, 0,
 		     "check_range_fast [%p..%p]"


### PR DESCRIPTION
Assumptions...

Speeds up Gulzar load_face_and_shape benchmark by 7%.