### PR TITLE
[subset] begin implementing omit-glyf mode.

### DIFF
--- a/src/OT/glyf/SubsetGlyph.hh
+++ b/src/OT/glyf/SubsetGlyph.hh
@@ -31,7 +31,7 @@ struct SubsetGlyph
 
     if (do_copy)
     {
-      hb_bytes_t dest_glyph = dest_start.copy (c);
+      dest_glyph = dest_start.copy (c);
       hb_bytes_t end_copy = dest_end.copy (c);
       if (!end_copy.arrayZ || !dest_glyph.arrayZ) {
         return false;
@@ -164,7 +164,7 @@ struct SubsetGlyph
 
   uint32_t checksum (bool use_short_loca,
                      uint8_t   remainder[4],
-                     unsigned *remainder_length)
+                     unsigned *remainder_length) const
   {
     // TODO(garretrieger): remove assertion.
     assert (!dest_end); // we don't handle hint removal.

--- a/src/OT/glyf/glyf.hh
+++ b/src/OT/glyf/glyf.hh
@@ -65,11 +65,20 @@ struct glyf
       uint8_t remainder[4];
       unsigned remainder_length = 0;
 
+      uint32_t total_length = 0;
       uint32_t checksum = 0;
       for (auto &_ : it)
+      {
+        total_length += _.length();
+        total_length += use_short_loca ? _.padding() : 0;
         checksum += _.checksum (use_short_loca, remainder, &remainder_length);
+      }
 
       checksum += *((HBUINT32*) remainder);
+
+      HBUINT32 length (total_length);
+      if (unlikely (!c->embed (length)))
+        return_trace (false);
 
       HBUINT32 checksum_storage (checksum);
       if (unlikely (!c->embed (checksum_storage)))

--- a/src/hb-face-builder.cc
+++ b/src/hb-face-builder.cc
@@ -128,7 +128,7 @@ _hb_face_builder_data_reference_blob (hb_face_builder_data_t *data)
                                   sfnt_tag,
                                   + sorted_entries.iter()
                                   | hb_map ([&] (hb_pair_t<hb_tag_t, face_table_info_t> _) {
-                                    return hb_pair_t<hb_tag_t, hb_blob_t*> (_.first, _.second.data);
+                                    return OT::TableInfo(_.first, _.second.data);
                                   }));
 
   c.end_serialize ();

--- a/src/hb-face-builder.cc
+++ b/src/hb-face-builder.cc
@@ -210,6 +210,19 @@ hb_face_builder_add_table (hb_face_t *face, hb_tag_t tag, hb_blob_t *blob)
 }
 
 /**
+ * TODO(grieger): write me.
+ **/
+hb_bool_t
+hb_face_builder_add_phantom_table (hb_face_t *face,
+			           hb_tag_t   tag,
+                                   unsigned   length,
+                                   uint32_t   checksum)
+{
+  // TODO(grieger): implement me.
+  return true;
+}
+
+/**
  * hb_face_builder_sort_tables:
  * @face: A face object created with hb_face_builder_create()
  * @tags: (array zero-terminated=1): ordered list of table tags terminated by

--- a/src/hb-face-builder.cc
+++ b/src/hb-face-builder.cc
@@ -211,6 +211,10 @@ hb_face_builder_add_table (hb_face_t *face, hb_tag_t tag, hb_blob_t *blob)
 
 /**
  * TODO(grieger): write me.
+ * - adds a table directory entry, but doesn't include the table bytes in the
+*    final file.
+ * - phantom tables are always the last entries in the directory. Regardless
+ *   of any user provided sort order.
  **/
 hb_bool_t
 hb_face_builder_add_phantom_table (hb_face_t *face,

--- a/src/hb-face.h
+++ b/src/hb-face.h
@@ -177,6 +177,12 @@ hb_face_builder_add_table (hb_face_t *face,
 			   hb_tag_t   tag,
 			   hb_blob_t *blob);
 
+HB_EXTERN hb_bool_t
+hb_face_builder_add_phantom_table (hb_face_t *face,
+			           hb_tag_t   tag,
+                                   unsigned   length,
+                                   uint32_t   checksum);
+
 HB_EXTERN void
 hb_face_builder_sort_tables (hb_face_t *face,
                              const hb_tag_t  *tags);

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -274,6 +274,8 @@ struct hb_subset_plan_t
 
     if (tag == HB_TAG('g', 'l', 'y', 'f') && should_omit_glyf_bytes())
     {
+      // TODO(garretrieger): add a struct to handle this instead of manually
+      //                     encoding/decoding.
       unsigned blob_length = 0;
       const uint8_t* data = (const uint8_t*) hb_blob_get_data (contents, &blob_length);
       if (blob_length == 8)
@@ -302,6 +304,7 @@ struct hb_subset_plan_t
   {
     return
         flags & HB_SUBSET_FLAGS_OMIT_GLYF &&
+        // TODO(garretrieger): can we support without retain gids?
         flags & HB_SUBSET_FLAGS_RETAIN_GIDS &&
         !(flags & HB_SUBSET_FLAGS_NO_HINTING) &&
         !(flags & HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG) &&

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -271,6 +271,30 @@ struct hb_subset_plan_t
 		hb_blob_get_length (source_blob));
       hb_blob_destroy (source_blob);
     }
+
+    if (tag == HB_TAG('g', 'l', 'y', 'f') && should_omit_glyf_bytes())
+    {
+      unsigned blob_length = 0;
+      const uint8_t* data = (const uint8_t*) hb_blob_get_data (contents, &blob_length);
+      if (blob_length == 8)
+      {
+        uint32_t length =
+          ((uint32_t) data[0]) << 24 |
+          ((uint32_t) data[1]) << 16 |
+          ((uint32_t) data[2]) << 8  |
+          (uint32_t) data[3];
+
+        uint32_t checksum =
+          ((uint32_t) data[4]) << 24 |
+          ((uint32_t) data[5]) << 16 |
+          ((uint32_t) data[6]) << 8  |
+          (uint32_t) data[7];
+
+        printf("##### fake glyf length = %u, checksum=%#010x\n", length, checksum);
+        return hb_face_builder_add_phantom_table (dest, tag, length, checksum);
+      }
+    }
+
     return hb_face_builder_add_table (dest, tag, contents);
   }
 

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -273,6 +273,16 @@ struct hb_subset_plan_t
     }
     return hb_face_builder_add_table (dest, tag, contents);
   }
+
+  inline bool should_omit_glyf_bytes () const
+  {
+    return
+        flags & HB_SUBSET_FLAGS_OMIT_GLYF &&
+        flags & HB_SUBSET_FLAGS_RETAIN_GIDS &&
+        !(flags & HB_SUBSET_FLAGS_NO_HINTING) &&
+        !(flags & HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG) &&
+        pinned_at_default;
+  }
 };
 
 

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -76,6 +76,14 @@ typedef struct hb_subset_plan_t hb_subset_plan_t;
  * @HB_SUBSET_FLAGS_IFTB_REQUIREMENTS: If set enforce requirements on the output subset
  * to allow it to be used with incremental font transfer IFTB patches. Primarily,
  * this forces all outline data to use long (32 bit) offsets. Since: EXPERIMENTAL
+ * @HB_SUBSET_FLAGS_OMIT_GLYF: If set the subsetter won't actually produce the final
+ * glyf table bytes. The table directory will include and entry as if the table was
+ * there but the actual final font blob will be truncated prior to the glyf data. This
+ * is a useful performance optimization when a font aware binary patching algorithm
+ * is being used to diff two subsets.
+ * @HB_SUBSET_FLAGS_PATCH_MODE: If set the subsetter behaviour will be modified
+ * to produce a subset that is better suited to patching. For example cmap
+ * subtable format will be kept stable.
  *
  * List of boolean properties that can be configured on the subset input.
  *
@@ -96,6 +104,8 @@ typedef enum { /*< flags >*/
 #ifdef HB_EXPERIMENTAL_API
   HB_SUBSET_FLAGS_IFTB_REQUIREMENTS       =  0x00000400u,
 #endif
+  HB_SUBSET_FLAGS_OMIT_GLYF =                0x00000800u,
+  // Not supported yet: HB_SUBSET_FLAGS_PATCH_MODE = 0x00001000u,
 } hb_subset_flags_t;
 
 /**

--- a/util/hb-subset.cc
+++ b/util/hb-subset.cc
@@ -949,6 +949,7 @@ subset_main_t::add_options ()
      "Keep everything by default. Options after this can override the operation.", nullptr},
     {"no-hinting",		0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_NO_HINTING>,		"Whether to drop hints", nullptr},
     {"retain-gids",		0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_RETAIN_GIDS>,		"If set don't renumber glyph ids in the subset.", nullptr},
+    {"omit-glyf",		0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_OMIT_GLYF>,		"If set don't renumber glyph ids in the subset.", nullptr},
     {"desubroutinize",		0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_DESUBROUTINIZE>,		"Remove CFF/CFF2 use of subroutines", nullptr},
     {"name-legacy",		0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_NAME_LEGACY>,		"Keep legacy (non-Unicode) 'name' table entries", nullptr},
     {"set-overlaps-flag",	0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, (gpointer) &set_flag<HB_SUBSET_FLAGS_SET_OVERLAPS_FLAG>,	"Set the overlaps flag on each glyph.", nullptr},


### PR DESCRIPTION
When omit glyf is enabled the subsetter won't actually output glyf table bytes. However, it will still have an entry for the glyf table in the table directory as if the glyf table was there, including the correct checksum and length. This is intended for use with patch subset incxfer where a custom diffing implementation will source the glyph bytes as needed from the original font.

Currently this computes the checksum by inspecting the glyph bytes. However, we could popuate a data structure in the accelerator to significantly accelerate the checksum computation (may require forcing 4 byte alignments of glyphs).

Not yet fully implemented.