### PR TITLE
[gsubgpos] Try at caching check_glyph_properties() result

### DIFF
--- a/src/hb-ot-layout-gpos-table.hh
+++ b/src/hb-ot-layout-gpos-table.hh
@@ -63,12 +63,17 @@ inline bool PosLookup::dispatch_recurse_func<hb_ot_apply_context_t> (hb_ot_apply
   c->set_lookup_index (lookup_index);
   c->set_lookup_props (l.get_props ());
 
+  bool saved_props_cached = c->props_cached;
+  if (saved_lookup_props != c->lookup_props)
+    c->props_cached = false;
+
   bool ret = false;
   auto *accel = gpos->get_accel (lookup_index);
   ret = accel && accel->apply (c, l.get_subtable_count (), false);
 
   c->set_lookup_index (saved_lookup_index);
   c->set_lookup_props (saved_lookup_props);
+  c->props_cached = saved_props_cached;
   return ret;
 }
 #endif

--- a/src/hb-ot-layout-gsub-table.hh
+++ b/src/hb-ot-layout-gsub-table.hh
@@ -73,13 +73,21 @@ inline bool SubstLookup::dispatch_recurse_func<hb_ot_apply_context_t> (hb_ot_app
   const SubstLookup &l = gsub->table->get_lookup (lookup_index);
   unsigned int saved_lookup_props = c->lookup_props;
   unsigned int saved_lookup_index = c->lookup_index;
+  unsigned int lookup_props = l.get_props ();
+
+  bool saved_props_cached = c->props_cached;
+  if (saved_lookup_props != lookup_props)
+    c->props_cached = false;
+
   c->set_lookup_index (lookup_index);
-  c->set_lookup_props (l.get_props ());
+  c->set_lookup_props (lookup_props);
+
 
   bool ret = false;
   auto *accel = gsub->get_accel (lookup_index);
   ret = accel && accel->apply (c, l.get_subtable_count (), false);
 
+  c->props_cached = saved_props_cached;
   c->set_lookup_index (saved_lookup_index);
   c->set_lookup_props (saved_lookup_props);
   return ret;

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1857,16 +1857,18 @@ apply_forward (OT::hb_ot_apply_context_t *c,
 	       const OT::hb_ot_layout_lookup_accelerator_t &accel,
 	       unsigned subtable_count)
 {
+  bool use_props_cache = accel.props_cache_enter (c);
   bool use_cache = accel.cache_enter (c);
 
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
+  c->props_cached = use_props_cache;
   while (buffer->idx < buffer->len && buffer->successful)
   {
     bool applied = false;
     if (accel.digest.may_have (buffer->cur().codepoint) &&
 	(buffer->cur().mask & c->lookup_mask) &&
-	c->check_glyph_property (&buffer->cur(), c->lookup_props))
+	c->check_glyph_property (&buffer->cur(), c->lookup_props, use_props_cache))
      {
        applied = accel.apply (c, subtable_count, use_cache);
      }
@@ -1879,6 +1881,8 @@ apply_forward (OT::hb_ot_apply_context_t *c,
 
   if (use_cache)
     accel.cache_leave (c);
+  if (use_props_cache)
+    accel.props_cache_leave (c);
 
   return ret;
 }


### PR DESCRIPTION
I was hoping this would (significantly) speed up Duployan, but it doesn't. Apparently the recursed-to lookups do the heavy lifting and they have different lookup-props, so they cannot share the cache :(.

Recording here for posterity.