### PR TITLE
[graph] Use a hb_map_t to keep parents, instead of hb_vector_t

### DIFF
--- a/src/graph/classdef-graph.hh
+++ b/src/graph/classdef-graph.hh
@@ -72,7 +72,7 @@ struct ClassDef : public OT::ClassDef
     class_def_link->width = SmallTypes::size;
     class_def_link->objidx = class_def_prime_id;
     class_def_link->position = link_position;
-    class_def_prime_vertex.parents.push (parent_id);
+    class_def_prime_vertex.add_parent (parent_id);
 
     return true;
   }

--- a/src/graph/coverage-graph.hh
+++ b/src/graph/coverage-graph.hh
@@ -96,7 +96,7 @@ struct Coverage : public OT::Layout::Common::Coverage
     coverage_link->width = SmallTypes::size;
     coverage_link->objidx = coverage_prime_id;
     coverage_link->position = link_position;
-    coverage_prime_vertex.parents.push (parent_id);
+    coverage_prime_vertex.add_parent (parent_id);
 
     return (Coverage*) coverage_prime_vertex.obj.head;
   }

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -53,7 +53,7 @@ struct graph_t
     hb_hashmap_t<unsigned, unsigned> parents;
     public:
 
-    const auto parents_iter () const HB_AUTO_RETURN
+    auto parents_iter () const HB_AUTO_RETURN
     (
       hb_concat (
 	hb_iter (&single_parent, single_parent != (unsigned) -1),
@@ -266,7 +266,7 @@ struct graph_t
 	return;
       }
 
-      hb_map_t new_parents;
+      hb_hashmap_t<unsigned, unsigned> new_parents;
       new_parents.alloc (parents.get_population ());
       for (auto _ : parents)
         new_parents.set (id_map[_.first], _.second);

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -225,7 +225,7 @@ struct Lookup : public OT::Lookup
         if (is_ext)
         {
           unsigned ext_id = create_extension_subtable (c, subtable_id, type);
-          c.graph.vertices_[subtable_id].parents.push (ext_id);
+          c.graph.vertices_[subtable_id].add_parent (ext_id);
           subtable_id = ext_id;
         }
 
@@ -234,7 +234,7 @@ struct Lookup : public OT::Lookup
         link->objidx = subtable_id;
         link->position = (char*) &new_lookup->subTable[offset_index++] -
                          (char*) new_lookup;
-        c.graph.vertices_[subtable_id].parents.push (this_index);
+        c.graph.vertices_[subtable_id].add_parent (this_index);
       }
     }
 
@@ -315,7 +315,7 @@ struct Lookup : public OT::Lookup
     // Make extension point at the subtable.
     auto& ext_vertex = c.graph.vertices_[ext_index];
     auto& subtable_vertex = c.graph.vertices_[subtable_index];
-    ext_vertex.parents.push (lookup_index);
+    ext_vertex.add_parent (lookup_index);
     subtable_vertex.remap_parent (lookup_index, ext_index);
 
     return true;

--- a/src/graph/pairpos-graph.hh
+++ b/src/graph/pairpos-graph.hh
@@ -419,7 +419,7 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
     class_def_link->width = SmallTypes::size;
     class_def_link->objidx = class_def_2_id;
     class_def_link->position = 10;
-    graph.vertices_[class_def_2_id].parents.push (pair_pos_prime_id);
+    graph.vertices_[class_def_2_id].add_parent (pair_pos_prime_id);
     graph.duplicate (pair_pos_prime_id, class_def_2_id);
 
     return pair_pos_prime_id;


### PR DESCRIPTION
In some fonts, for example Noto Duployan-Regular, nodes can have over a thousand parents... Speed up.