### PR TITLE
Require numerators and denominators in automatic fractions

### DIFF
--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -765,6 +765,8 @@ hb_ot_shape_setup_masks_fraction (const hb_ot_shape_context_t *c)
 	     _hb_glyph_info_get_general_category (&info[end]) ==
 	     HB_UNICODE_GENERAL_CATEGORY_DECIMAL_NUMBER)
 	end++;
+      if (start == i || end == i + 1)
+	continue;
 
       buffer->unsafe_to_break (start, end);
 

--- a/test/shape/data/in-house/tests/automatic-fractions.tests
+++ b/test/shape/data/in-house/tests/automatic-fractions.tests
@@ -1,3 +1,7 @@
 ../fonts/15dfc433a135a658b9f4b1a861b5cdd9658ccbb9.ttf;;U+0031,U+0032,U+0033,U+2044,U+0034,U+0035,U+0036;[one.numr=0+600|two.numr=1+600|three.numr=2+600|fraction=3+252|four.small=4+600|five.small=5+600|six.small=6+600]
 ../fonts/15dfc433a135a658b9f4b1a861b5cdd9658ccbb9.ttf;--direction=l --script=arab;U+0031,U+0032,U+0033,U+2044,U+0034,U+0035,U+0036;[one.numr=0+600|two.numr=1+600|three.numr=2+600|fraction=3+252|four.small=4+600|five.small=5+600|six.small=6+600]
 ../fonts/15dfc433a135a658b9f4b1a861b5cdd9658ccbb9.ttf;--direction=l;U+0661,U+0662,U+0663,U+2044,U+0664,U+0665,U+0666;[uni0661.numr=0+600|uni0662.numr=1+600|uni0663.numr=2+600|fraction=3+252|uni0664.small=4+600|uni0665.small=5+600|uni0666.small=6+600]
+../fonts/15dfc433a135a658b9f4b1a861b5cdd9658ccbb9.ttf;;U+0031,U+0032,U+0033,U+2044;[one=0+1090|two=1+1090|three=2+1090|fraction=3+252]
+../fonts/15dfc433a135a658b9f4b1a861b5cdd9658ccbb9.ttf;--direction=l;U+0661,U+0662,U+0663,U+2044;[uni0661=0+1200|uni0662=1+1200|uni0663=2+1200|fraction=3+252]
+../fonts/15dfc433a135a658b9f4b1a861b5cdd9658ccbb9.ttf;;U+2044,U+0034,U+0035,U+0036;[fraction=0+252|four=1+1090|five=2+1090|six=3+1090]
+../fonts/15dfc433a135a658b9f4b1a861b5cdd9658ccbb9.ttf;--direction=l;U+2044,U+0664,U+0665,U+0666;[fraction=0+252|uni0664=1+1200|uni0665=2+1200|uni0666=3+1200]


### PR DESCRIPTION
HarfBuzz automatically applies fraction features to any instance of U+2044 plus any decimal digits that precede or follow it. However, [_The Unicode Standard_, version 15.0, chapter 6](https://www.unicode.org/versions/Unicode15.0.0/ch06.pdf#page=21) says “The standard form of a fraction built using the fraction slash is defined as follows: any sequence of one or more decimal digits (General Category = Nd), followed by the fraction slash, followed by any sequence of one or more decimal digits.” That is, there must be at least one digit in the numerator and at least one digit in the denominator.