### PR TITLE
[ci/msys] Don't install freetype

### DIFF
--- a/.github/workflows/msys2-ci.yml
+++ b/.github/workflows/msys2-ci.yml
@@ -54,6 +54,9 @@ jobs:
           mingw-w64-${{ matrix.MSYS2_ARCH }}-pkg-config
           mingw-w64-${{ matrix.MSYS2_ARCH }}-python
           mingw-w64-${{ matrix.MSYS2_ARCH }}-python-pip
+    - name: Remove installed HarfBuzz dll
+      run: |
+        rm -f -v C:\\mingw*\\bin\\libharfbuzz-*.dll
     - name: Install Python Dependencies
       run: |
         pip3 install -r .ci/requirements-fonttools.txt --require-hashes

--- a/.github/workflows/msys2-ci.yml
+++ b/.github/workflows/msys2-ci.yml
@@ -54,9 +54,9 @@ jobs:
           mingw-w64-${{ matrix.MSYS2_ARCH }}-pkg-config
           mingw-w64-${{ matrix.MSYS2_ARCH }}-python
           mingw-w64-${{ matrix.MSYS2_ARCH }}-python-pip
-    - name: Remove installed HarfBuzz dll
+    - name: Remove installed HarfBuzz DLLs
       run: |
-        rm -f -v C:\\mingw*\\bin\\libharfbuzz-*.dll
+        rm -f -v /ming*/bin/libharfbuzz-*.dll
     - name: Install Python Dependencies
       run: |
         pip3 install -r .ci/requirements-fonttools.txt --require-hashes
@@ -74,9 +74,9 @@ jobs:
       run: meson compile -Cbuild
     - name: Test
       run: meson test --print-errorlogs --suite=harfbuzz -Cbuild
-    - name: Upload DLL
+    - name: Upload DLLs
       if: always()
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: libharfbuzz-0.dll-${{ matrix.MSYS2_ARCH }}
-        path: ./build/src/libharfbuzz-0.dll
+        name: libharfbuzz-${{ matrix.MSYS2_ARCH }}
+        path: ./build/src/libharfbuzz-*.dll


### PR DESCRIPTION
FreeType pulls in HarfBuzz package, and the linker seems to get confused and sometimes pick that up instead of the build HarfBuzz DLL. This causes random failures in the bots.

See eg.:
https://github.com/harfbuzz/harfbuzz/pull/4350
https://github.com/harfbuzz/harfbuzz/pull/4353