### PR TITLE
[repacker] fix case of failing repacker.

### DIFF
--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -474,6 +474,18 @@ struct graph_t
     return root ().equals (other.root (), *this, other, 0);
   }
 
+  void print () const {
+    for (int i = vertices_.length - 1; i >= 0; i--)
+    {
+      const auto& v = vertices_[i];
+      printf("%d: %lu [", i, v.table_size());
+      for (const auto &l : v.obj.real_links) {
+        printf("%u, ", l.objidx);
+      }
+      printf("]\n");
+    }
+  }
+
   // Sorts links of all objects in a consistent manner and zeroes all offsets.
   void normalize ()
   {

--- a/src/graph/gsubgpos-context.hh
+++ b/src/graph/gsubgpos-context.hh
@@ -40,8 +40,7 @@ struct gsubgpos_graph_context_t
   graph_t& graph;
   unsigned lookup_list_index;
   hb_hashmap_t<unsigned, graph::Lookup*> lookups;
-  hb_map_t subtable_to_extension;
-
+  hb_hashmap_t<unsigned, unsigned> subtable_to_extension;
 
   HB_INTERNAL gsubgpos_graph_context_t (hb_tag_t table_tag_,
                                         graph_t& graph_);

--- a/src/graph/gsubgpos-context.hh
+++ b/src/graph/gsubgpos-context.hh
@@ -40,6 +40,7 @@ struct gsubgpos_graph_context_t
   graph_t& graph;
   unsigned lookup_list_index;
   hb_hashmap_t<unsigned, graph::Lookup*> lookups;
+  hb_map_t subtable_to_extension;
 
 
   HB_INTERNAL gsubgpos_graph_context_t (hb_tag_t table_tag_,

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -299,24 +299,35 @@ struct Lookup : public OT::Lookup
                                 unsigned subtable_index)
   {
     unsigned type = lookupType;
+    unsigned ext_index = -1;
+    unsigned* existing_ext_index = nullptr;
+    if (c.subtable_to_extension.has(subtable_index, &existing_ext_index)) {
+      ext_index = *existing_ext_index;
+    } else {    
+      ext_index = create_extension_subtable(c, subtable_index, type);
+      c.subtable_to_extension.set(subtable_index, ext_index);
+    }
 
-    unsigned ext_index = create_extension_subtable(c, subtable_index, type);
     if (ext_index == (unsigned) -1)
       return false;
 
+    auto& subtable_vertex = c.graph.vertices_[subtable_index];
     auto& lookup_vertex = c.graph.vertices_[lookup_index];
     for (auto& l : lookup_vertex.obj.real_links.writer ())
     {
-      if (l.objidx == subtable_index)
+      if (l.objidx == subtable_index) {
         // Change lookup to point at the extension.
         l.objidx = ext_index;
+        if (existing_ext_index)
+          subtable_vertex.remove_parent(lookup_index);
+      }
     }
 
     // Make extension point at the subtable.
     auto& ext_vertex = c.graph.vertices_[ext_index];
-    auto& subtable_vertex = c.graph.vertices_[subtable_index];
     ext_vertex.add_parent (lookup_index);
-    subtable_vertex.remap_parent (lookup_index, ext_index);
+    if (!existing_ext_index)
+      subtable_vertex.remap_parent (lookup_index, ext_index);
 
     return true;
   }

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -114,11 +114,15 @@ bool _promote_extensions_if_needed (graph::gsubgpos_graph_context_t& ext_context
   // TODO(grieger): skip this for the 24 bit case.
   if (!ext_context.lookups) return true;
 
+  unsigned total_lookup_table_sizes = 0;
   hb_vector_t<lookup_size_t> lookup_sizes;
   lookup_sizes.alloc (ext_context.lookups.get_population (), true);
 
   for (unsigned lookup_index : ext_context.lookups.keys ())
   {
+    const auto& lookup_v = ext_context.graph.vertices_[lookup_index];
+    total_lookup_table_sizes += lookup_v.table_size ();
+
     const graph::Lookup* lookup = ext_context.lookups.get(lookup_index);
     hb_set_t visited;
     lookup_sizes.push (lookup_size_t {
@@ -131,14 +135,16 @@ bool _promote_extensions_if_needed (graph::gsubgpos_graph_context_t& ext_context
   lookup_sizes.qsort ();
 
   size_t lookup_list_size = ext_context.graph.vertices_[ext_context.lookup_list_index].table_size ();
-  size_t l2_l3_size = lookup_list_size; // Lookup List + Lookups
-  size_t l3_l4_size = 0; // Lookups + SubTables
+  size_t l2_l3_size = lookup_list_size + total_lookup_table_sizes; // Lookup List + Lookups
+  size_t l3_l4_size = total_lookup_table_sizes; // Lookups + SubTables
   size_t l4_plus_size = 0; // SubTables + their descendants
 
   // Start by assuming all lookups are using extension subtables, this size will be removed later
   // if it's decided to not make a lookup extension.
   for (auto p : lookup_sizes)
   {
+    // TODO(garretrieger): this overestimates the extension subtables size because some extension subtables may be
+    //                     reused. However, we can't correct this until we have connected component analysis in place.
     unsigned subtables_size = p.num_subtables * 8;
     l3_l4_size += subtables_size;
     l4_plus_size += subtables_size;
@@ -159,8 +165,7 @@ bool _promote_extensions_if_needed (graph::gsubgpos_graph_context_t& ext_context
       size_t subtables_size = ext_context.graph.find_subgraph_size (p.lookup_index, visited, 1) - lookup_size;
       size_t remaining_size = p.size - subtables_size - lookup_size;
 
-      l2_l3_size   += lookup_size;
-      l3_l4_size   += lookup_size + subtables_size;
+      l3_l4_size   += subtables_size;
       l3_l4_size   -= p.num_subtables * 8;
       l4_plus_size += subtables_size + remaining_size;
 

--- a/src/test-repacker.cc
+++ b/src/test-repacker.cc
@@ -448,6 +448,7 @@ static void run_resolve_overflow_test (const char* name,
           name);
 
   graph_t graph (overflowing.object_graph ());
+
   graph_t expected_graph (expected.object_graph ());
   if (graph::will_overflow (expected_graph))
   {
@@ -473,6 +474,12 @@ static void run_resolve_overflow_test (const char* name,
   // Check the graphs are equivalent
   graph.normalize ();
   expected_graph.normalize ();
+  if (!(graph == expected_graph)) {
+    printf("## Expected:\n");
+    expected_graph.print();
+    printf("## Result:\n");
+    graph.print();
+  }
   assert (graph == expected_graph);
 }
 
@@ -1239,7 +1246,8 @@ populate_serializer_with_24_and_32_bit_offsets (hb_serialize_context_t* c)
 
 static void
 populate_serializer_with_extension_promotion (hb_serialize_context_t* c,
-                                              int num_extensions = 0)
+                                              int num_extensions = 0,
+                                              bool shared_subtables = false)
 {
   constexpr int num_lookups = 5;
   constexpr int num_subtables = num_lookups * 2;
@@ -1252,15 +1260,13 @@ populate_serializer_with_extension_promotion (hb_serialize_context_t* c,
 
 
   for (int i = num_subtables - 1; i >= 0; i--)
-    subtables[i] = add_object(large_string.c_str (), 15000, c);
+    subtables[i] = add_object(large_string.c_str (), 15000 + i, c);
 
   for (int i = num_subtables - 1;
        i >= (num_lookups - num_extensions) * 2;
        i--)
   {
-    unsigned ext_index = i - (num_lookups - num_extensions) * 2;
-    unsigned subtable_index = num_subtables - ext_index - 1;
-    extensions[i] = add_extension (subtables[subtable_index], 5, c);
+    extensions[i] = add_extension (subtables[i], 5, c);
   }
 
   for (int i = num_lookups - 1; i >= 0; i--)
@@ -1268,13 +1274,19 @@ populate_serializer_with_extension_promotion (hb_serialize_context_t* c,
     bool is_ext = (i >= (num_lookups - num_extensions));
 
     start_lookup (is_ext ? (char) 7 : (char) 5,
-                  2,
+                  shared_subtables && i > 2 ? 3 : 2,
                   c);
 
     if (is_ext) {
+      if (shared_subtables && i > 2) {
+        add_offset (extensions[i * 2 - 1], c);
+      }
       add_offset (extensions[i * 2], c);
       add_offset (extensions[i * 2 + 1], c);
     } else {
+      if (shared_subtables && i > 2) {
+        add_offset (subtables[i * 2 - 1], c);
+      }
       add_offset (subtables[i * 2], c);
       add_offset (subtables[i * 2 + 1], c);
     }
@@ -1837,6 +1849,28 @@ static void test_resolve_with_extension_promotion ()
   free (expected_buffer);
 }
 
+static void test_resolve_with_shared_extension_promotion ()
+{
+  size_t buffer_size = 200000;
+  void* buffer = malloc (buffer_size);
+  assert (buffer);
+  hb_serialize_context_t c (buffer, buffer_size);
+  populate_serializer_with_extension_promotion (&c, 0, true);
+
+  void* expected_buffer = malloc (buffer_size);
+  assert (expected_buffer);
+  hb_serialize_context_t e (expected_buffer, buffer_size);
+  populate_serializer_with_extension_promotion (&e, 3, true);
+
+  run_resolve_overflow_test ("test_resolve_with_extension_promotion",
+                             c,
+                             e,
+                             20,
+                             true);
+  free (buffer);
+  free (expected_buffer);
+}
+
 static void test_resolve_with_basic_pair_pos_1_split ()
 {
   size_t buffer_size = 200000;
@@ -2122,6 +2156,7 @@ main (int argc, char **argv)
   test_virtual_link ();
   test_shared_node_with_virtual_links ();
   test_resolve_with_extension_promotion ();
+  test_resolve_with_shared_extension_promotion ();
   test_resolve_with_basic_pair_pos_1_split ();
   test_resolve_with_extension_pair_pos_1_split ();
   test_resolve_with_basic_pair_pos_2_split ();


### PR DESCRIPTION
See: https://github.com/fonttools/fonttools/issues/3260

This font has huge number of subtables, but many are de-dupped. This fixes the repacking failure by ensuring that created extension subtables are shared where possible.