### PR TITLE
[meson] add source fallback URL to freetype2 wrap

### DIFF
--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,6 +1,7 @@
 [wrap-file]
 directory = freetype-2.13.0
 source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.13.0.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.13.0-1/freetype-2.13.0.tar.xz
 source_filename = freetype-2.13.0.tar.xz
 source_hash = 5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c
 


### PR DESCRIPTION
Since downloading from savannah can be pretty flaky.