### PR TITLE
Specify tuple_variations_t special member functions

### DIFF
--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -1076,6 +1076,11 @@ struct TupleVariationData
     unsigned compiled_byte_size = 4;
 
     public:
+    tuple_variations_t () = default;
+    tuple_variations_t (const tuple_variations_t&) = delete;
+    tuple_variations_t& operator=(const tuple_variations_t&) = delete;
+    tuple_variations_t (tuple_variations_t&&) = default;
+    tuple_variations_t& operator=(tuple_variations_t&&) = default;
     ~tuple_variations_t () { fini (); }
     void fini ()
     {

--- a/src/hb-vector.hh
+++ b/src/hb-vector.hh
@@ -208,25 +208,7 @@ struct hb_vector_t
       return std::addressof (Crap (Type));
     return std::addressof (arrayZ[length - 1]);
   }
-  template <typename T,
-	    typename T2 = Type,
-	    hb_enable_if (!std::is_copy_constructible<T2>::value &&
-			  std::is_copy_assignable<T>::value)>
-  Type *push (T&& v)
-  {
-    Type *p = push ();
-    if (p == std::addressof (Crap (Type)))
-      // If push failed to allocate then don't copy v, since this may cause
-      // the created copy to leak memory since we won't have stored a
-      // reference to it.
-      return p;
-    *p = std::forward<T> (v);
-    return p;
-  }
-  template <typename T,
-	    typename T2 = Type,
-	    hb_enable_if (std::is_copy_constructible<T2>::value)>
-  Type *push (T&& v)
+  template <typename... Args> Type *push (Args&&... args)
   {
     if (unlikely ((int) length >= allocated && !alloc (length + 1)))
       // If push failed to allocate then don't copy v, since this may cause
@@ -236,7 +218,7 @@ struct hb_vector_t
 
     /* Emplace. */
     Type *p = std::addressof (arrayZ[length++]);
-    return new (p) Type (std::forward<T> (v));
+    return new (p) Type (std::forward<Args> (args)...);
   }
 
   bool in_error () const { return allocated < 0; }


### PR DESCRIPTION
Building with clang complains about the use of `tuple_variations_t`'s implicit copy constructor and copy assignment operator, since automatic generation of these is deprecated when declaring a non-default destructor. This is a good warning because it isn't obvious that copies were being made instead of the object being moved and this struct should be moved and not copied. Declare all the special member functions, defaulting the moves and deleting the copies.

After making `tuple_variations_t` move only, an issue is revealed in `hb_vector_t::push` which has been requiring that objects be copyable. Remove the old non-emplacing `push` now that this works with all existing objects and make a single `push` which is more like `std::vector::emplace_back` since that is somewhat what the newer `push` is attempting to do.