### PR TITLE
[meson] keep asserts in test programs

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -712,7 +712,7 @@ if get_option('tests').enabled()
     foreach name, source : noinst_programs
       executable(name, source,
         include_directories: incconfig,
-        cpp_args: cpp_args,
+        cpp_args: cpp_args + ['-UNDEBUG'],
         dependencies: libharfbuzz_dep,
         install: false,
       )


### PR DESCRIPTION
Some test programs like the other tests use asserts for error checking.

```
[83/323] Compiling C++ object src/test-set.p/test-set.cc.o
../src/test-set.cc: In function 'int main(int, char**)':
../src/test-set.cc:116:20: warning: variable 'start' set but not used [-Wunused-but-set-variable]
  116 |     hb_codepoint_t start = HB_SET_VALUE_INVALID, last = HB_SET_VALUE_INVALID;
      |                    ^~~~~
../src/test-set.cc:116:50: warning: variable 'last' set but not used [-Wunused-but-set-variable]
  116 |     hb_codepoint_t start = HB_SET_VALUE_INVALID, last = HB_SET_VALUE_INVALID;
      |                                                  ^~~~
[84/323] Compiling C++ object src/test-classdef-graph.p/graph_test-classdef-graph.cc.o
FAILED: src/test-classdef-graph.p/graph_test-classdef-graph.cc.o
g++ -Isrc/test-classdef-graph.p -Isrc -I../src -I. -I.. -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -flto=auto -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++11 -fno-exceptions -fno-exceptions -fno-rtti -fno-threadsafe-s
tatics -fvisibility-inlines-hidden -DHAVE_CONFIG_H -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe -g -ffile-prefix-map=/builddir/harfbuzz-8.2.1/build=. -pthread -Wno-non-virtual-dtor -MD -MQ src/test-classdef-graph.p/graph_test-classdef-graph.cc.o -MF src/test-classdef-graph.p/graph_test-classde
f-graph.cc.o.d -o src/test-classdef-graph.p/graph_test-classdef-graph.cc.o -c ../src/graph/test-classdef-graph.cc
../src/graph/test-classdef-graph.cc:34:13: error: 'bool incremental_size_is(const gid_and_class_list_t&, unsigned int, unsigned int, unsigned int)' defined but not used [-Werror=unused-function]
   34 | static bool incremental_size_is (const gid_and_class_list_t& list, unsigned klass,
      |             ^~~~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
[85/323] Compiling C++ object src/test-map.p/test-map.cc.o
[86/323] Compiling C++ object src/test-iter.p/test-iter.cc.o
FAILED: src/test-iter.p/test-iter.cc.o
g++ -Isrc/test-iter.p -Isrc -I../src -I. -I.. -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -flto=auto -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++11 -fno-exceptions -fno-exceptions -fno-rtti -fno-threadsafe-statics -fv
isibility-inlines-hidden -DHAVE_CONFIG_H -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe -g -ffile-prefix-map=/builddir/harfbuzz-8.2.1/build=. -pthread -Wno-non-virtual-dtor -MD -MQ src/test-iter.p/test-iter.cc.o -MF src/test-iter.p/test-iter.cc.o.d -o src/test-iter.p/test-iter.cc.o -c ../src/tes
t-iter.cc
../src/test-iter.cc: In instantiation of 'void check_sequential(It) [with It = hb_concat_iter_t<hb_array_t<const int>, hb_array_t<const int> >]':
../src/test-iter.cc:146:20:   required from here
../src/test-iter.cc:120:12: error: unused variable 'v' [-Werror=unused-variable]
  120 |   for (int v : +it) {
      |            ^
../src/test-iter.cc:119:7: error: unused variable 'i' [-Werror=unused-variable]
  119 |   int i = 1;
      |       ^
../src/test-iter.cc: In instantiation of 'void check_sequential(It) [with It = hb_concat_iter_t<hb_bit_set_invertible_t::iter_t, hb_bit_set_invertible_t::iter_t>]':
../src/test-iter.cc:176:20:   required from here
../src/test-iter.cc:120:12: error: unused variable 'v' [-Werror=unused-variable]
  120 |   for (int v : +it) {
      |            ^
../src/test-iter.cc:119:7: error: unused variable 'i' [-Werror=unused-variable]
  119 |   int i = 1;
      |       ^
cc1plus: some warnings being treated as errors
```