### PR TITLE
[instancer] try to simplify item_variation_t API calls

### DIFF
--- a/src/hb-ot-var-hvar-table.hh
+++ b/src/hb-ot-var-hvar-table.hh
@@ -347,21 +347,11 @@ struct HVARVVAR
 
     if (c->plan->normalized_coords)
     {
-      /* TODO: merge these 3 calls into 1 call that executes all 3
-       * functions */
       item_variations_t item_vars;
-      if (!item_vars.create_from_item_varstore (this+varStore,
-                                                c->plan->axes_old_index_tag_map,
-                                                hvar_plan.inner_maps.as_array ()))
-        return_trace (false);
-
-      if (!item_vars.instantiate (c->plan->axes_location, c->plan->axes_triple_distances))
-        return_trace (false);
-
-      /* if glyph indices are used as implicit delta-set indices, no need to
-       * optimiza varstore, maintain original variation indices */
-      if (!item_vars.as_item_varstore (advMap == 0 ? false : true,
-                                       false /* use_no_variation_idx = false */))
+      if (!item_vars.instantiate (this+varStore, c->plan,
+                                  advMap == 0 ? false : true,
+                                  false, /* use_no_variation_idx = false */
+                                  hvar_plan.inner_maps.as_array ()))
         return_trace (false);
 
       if (!out->varStore.serialize_serialize (c->serializer,

--- a/src/hb-ot-var-mvar-table.hh
+++ b/src/hb-ot-var-mvar-table.hh
@@ -105,13 +105,8 @@ struct MVAR
 
     item_variations_t item_vars;
     const VariationStore& src_var_store = this+varStore;
-    if (!item_vars.create_from_item_varstore (src_var_store, c->plan->axes_old_index_tag_map))
-      return_trace (false);
 
-    if (!item_vars.instantiate (c->plan->axes_location, c->plan->axes_triple_distances))
-      return_trace (false);
-
-    if (!item_vars.as_item_varstore ())
+    if (!item_vars.instantiate (src_var_store, c->plan))
       return_trace (false);
 
     /* serialize varstore */

--- a/src/test-item-varstore.cc
+++ b/src/test-item-varstore.cc
@@ -52,7 +52,7 @@ test_item_variations ()
   hb_hashmap_t<hb_tag_t, TripleDistances> axes_triple_distances;
   axes_triple_distances.set (axis_tag, TripleDistances (200.f, 500.f));
 
-  result = item_vars.instantiate (normalized_axes_location, axes_triple_distances);
+  result = item_vars.instantiate_tuple_vars (normalized_axes_location, axes_triple_distances);
   assert (result);
   result = item_vars.as_item_varstore (false);
   assert (result);


### PR DESCRIPTION
1. It's possible that region lists become empty after instantiation(e.g deltas become all zeros). Return true in this case. And varStore serialize() call will return false if regions are empty.
2.  add an API which does create (), instantiate tuple vars(), and as_item_varstore() together, and update MVAR and HVAR code to call this API instead.