### PR TITLE
[instancer] templatize the priority queue, use custom type for varstore

### DIFF
--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -566,7 +566,7 @@ struct graph_t
 
     update_distances ();
 
-    hb_priority_queue_t queue;
+    hb_priority_queue_t<int64_t> queue;
     hb_vector_t<vertex_t> &sorted_graph = vertices_scratch_;
     if (unlikely (!check_success (sorted_graph.resize (vertices_.length)))) return;
     hb_vector_t<unsigned> id_map;
@@ -1369,7 +1369,7 @@ struct graph_t
       vertices_.arrayZ[i].distance = hb_int_max (int64_t);
     vertices_.tail ().distance = 0;
 
-    hb_priority_queue_t queue;
+    hb_priority_queue_t<int64_t> queue;
     queue.insert (0, vertices_.length - 1);
 
     hb_vector_t<bool> visited;

--- a/src/hb-priority-queue.hh
+++ b/src/hb-priority-queue.hh
@@ -42,10 +42,11 @@
  * priority of its children. The heap is stored in an array, with the
  * children of node i stored at indices 2i + 1 and 2i + 2.
  */
+template <typename K>
 struct hb_priority_queue_t
 {
  private:
-  typedef hb_pair_t<int64_t, unsigned> item_t;
+  typedef hb_pair_t<K, unsigned> item_t;
   hb_vector_t<item_t> heap;
 
  public:
@@ -57,7 +58,7 @@ struct hb_priority_queue_t
 #ifndef HB_OPTIMIZE_SIZE
   HB_ALWAYS_INLINE
 #endif
-  void insert (int64_t priority, unsigned value)
+  void insert (K priority, unsigned value)
   {
     heap.push (item_t (priority, value));
     if (unlikely (heap.in_error ())) return;

--- a/src/test-priority-queue.cc
+++ b/src/test-priority-queue.cc
@@ -30,7 +30,7 @@
 static void
 test_insert ()
 {
-  hb_priority_queue_t queue;
+  hb_priority_queue_t<int64_t> queue;
   assert (queue.is_empty ());
 
   queue.insert (10, 0);
@@ -53,7 +53,7 @@ test_insert ()
 static void
 test_extract ()
 {
-  hb_priority_queue_t queue;
+  hb_priority_queue_t<int32_t> queue;
   queue.insert (0, 0);
   queue.insert (60, 6);
   queue.insert (30, 3);


### PR DESCRIPTION
when instantiating varstore, we need to pop a tuple like (combined_gain, i, j), if combined gain is the same then we compare the value of i, and then j. So we'd like to use custom type as the key when popping from the queue. This would match fonttool's algorithm cause it uses heappop(): https://github.com/fonttools/fonttools/blob/main/Lib/fontTools/varLib/varStore.py#L586

I'll add a test for this later(in another PR that I'm still working on)