### PR TITLE
Change the shebang used for python

### DIFF
--- a/src/relative_to.py
+++ b/src/relative_to.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 from os import path


### PR DESCRIPTION
The shebang `/usr/bin/python3` assumes python3 is installed in /usr/bin, which isn't always true (e.g., in the manylinux docker image).  Using `/usr/bin/env python3` uses the python3 that is in the path, which is more flexible.