### PR TITLE
[subset] keep East Asian spacing vhal, halt, chws, vchw by default

### DIFF
--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -123,6 +123,12 @@ hb_subset_input_t::hb_subset_input_t ()
     //justify
     HB_TAG ('j', 'a', 'l', 't'), // HarfBuzz doesn't use; others might
 
+    //East Asian spacing
+    HB_TAG ('c', 'h', 'w', 's'),
+    HB_TAG ('v', 'c', 'h', 'w'),
+    HB_TAG ('h', 'a', 'l', 't'),
+    HB_TAG ('v', 'h', 'a', 'l'),
+
     //private
     HB_TAG ('H', 'a', 'r', 'f'),
     HB_TAG ('H', 'A', 'R', 'F'),


### PR DESCRIPTION
Closes: https://github.com/harfbuzz/harfbuzz/issues/4451