### PR TITLE
[ChainRule] Speed up sanitize

### DIFF
--- a/src/OT/Layout/GSUB/ReverseChainSingleSubstFormat1.hh
+++ b/src/OT/Layout/GSUB/ReverseChainSingleSubstFormat1.hh
@@ -34,10 +34,12 @@ struct ReverseChainSingleSubstFormat1
     if (!(coverage.sanitize (c, this) && backtrack.sanitize (c, this)))
       return_trace (false);
     hb_barrier ();
+    if (unlikely (backtrack.len > HB_MAX_CONTEXT_LENGTH)) return_trace (false);
     const auto &lookahead = StructAfter<decltype (lookaheadX)> (backtrack);
     if (!lookahead.sanitize (c, this))
       return_trace (false);
     hb_barrier ();
+    if (unlikely (lookahead.len > HB_MAX_CONTEXT_LENGTH)) return_trace (false);
     const auto &substitute = StructAfter<decltype (substituteX)> (lookahead);
     return_trace (substitute.sanitize (c));
   }

--- a/src/hb-machinery.hh
+++ b/src/hb-machinery.hh
@@ -104,6 +104,7 @@ static inline Type& StructAfter(TObject &X)
   unsigned int get_size () const { return (size); } \
   static constexpr unsigned null_size = (size); \
   static constexpr unsigned min_size = (size); \
+  static constexpr unsigned max_size = (size); \
   static constexpr unsigned static_size = (size)
 
 #define DEFINE_SIZE_UNION(size, _member) \
@@ -116,6 +117,10 @@ static inline Type& StructAfter(TObject &X)
   DEFINE_INSTANCE_ASSERTION (sizeof (*this) >= (size)) \
   static constexpr unsigned null_size = (size); \
   static constexpr unsigned min_size = (size)
+
+#define DEFINE_SIZE_MAX(size) \
+  DEFINE_INSTANCE_ASSERTION (sizeof (*this) <= (size)) \
+  static constexpr unsigned max_size = (size)
 
 #define DEFINE_SIZE_UNBOUNDED(size) \
   DEFINE_INSTANCE_ASSERTION (sizeof (*this) >= (size)) \

--- a/src/hb-null.hh
+++ b/src/hb-null.hh
@@ -49,6 +49,15 @@ using hb_has_min_size = _hb_has_min_size<T, void>;
 #define hb_has_min_size(T) hb_has_min_size<T>::value
 
 template <typename T, typename>
+struct _hb_has_max_size : hb_false_type {};
+template <typename T>
+struct _hb_has_max_size<T, hb_void_t<decltype (T::max_size)>>
+	: hb_true_type {};
+template <typename T>
+using hb_has_max_size = _hb_has_max_size<T, void>;
+#define hb_has_max_size(T) hb_has_max_size<T>::value
+
+template <typename T, typename>
 struct _hb_has_null_size : hb_false_type {};
 template <typename T>
 struct _hb_has_null_size<T, hb_void_t<decltype (T::null_size)>>


### PR DESCRIPTION
Limit backtrack-len and lookahead-len to HB_MAX_CONTEXT_LENGTH. Add a max_size for the struct, and bail early if max_size is within sanitize range.

Speeds up Gulzar sanitization by 20%.