### PR TITLE
hb-subset-plan.cc: Fix -Wparentheses warning.

### DIFF
--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -994,8 +994,8 @@ _update_instance_metrics_map_from_cff2 (hb_subset_plan_t *plan)
   OT::cff2::accelerator_t cff2 (plan->source);
   if (!cff2.is_valid ()) return;
 
-  hb_font_t *font = nullptr;
-  if (unlikely (!plan->check_success (font = _get_hb_font_with_variations (plan))))
+  hb_font_t *font = _get_hb_font_with_variations (plan);
+  if (unlikely (!plan->check_success (font != nullptr)))
   {
     hb_font_destroy (font);
     return;


### PR DESCRIPTION
```
In file included from hb-subset-plan.hh:30:0,
                 from hb-subset-plan.cc:27:
hb-subset-plan.cc: In function 'void _update_instance_metrics_map_from_cff2(hb_subset_plan_t*)':
hb-subset-plan.cc:998:81: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
   if (unlikely (!plan->check_success (font = _get_hb_font_with_variations (plan))))
                                                                                 ^
hb.hh:263:25: note: in definition of macro 'unlikely'
 #define unlikely(expr) (expr)
                         ^
```

Fixes: https://github.com/harfbuzz/harfbuzz/issues/4545
