### PR TITLE
use `calloc(nmemb, size)`, not `calloc(size, nmemb)`

### DIFF
--- a/src/hb-object.hh
+++ b/src/hb-object.hh
@@ -325,7 +325,7 @@ retry:
   hb_user_data_array_t *user_data = obj->header.user_data.get_acquire ();
   if (unlikely (!user_data))
   {
-    user_data = (hb_user_data_array_t *) hb_calloc (sizeof (hb_user_data_array_t), 1);
+    user_data = (hb_user_data_array_t *) hb_calloc (1, sizeof (hb_user_data_array_t));
     if (unlikely (!user_data))
       return false;
     user_data->init ();

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -1416,7 +1416,7 @@ struct cff1
       hb_sorted_vector_t<gname_t> *names = glyph_names.get_acquire ();
       if (unlikely (!names))
       {
-	names = (hb_sorted_vector_t<gname_t> *) hb_calloc (sizeof (hb_sorted_vector_t<gname_t>), 1);
+	names = (hb_sorted_vector_t<gname_t> *) hb_calloc (1, sizeof (hb_sorted_vector_t<gname_t>));
 	if (likely (names))
 	{
 	  names->init ();


### PR DESCRIPTION
This minor mismatch is detected by new `-Wcalloc-transposed-args` `gcc-14` warning as:

    In file included from ../src/hb-subset-plan.cc:38:
    ../src/hb-ot-cff1-table.hh: In member function 'bool OT::cff1::accelerator_t::get_glyph_from_name(const char*, int, hb_codepoint_t*) const':
    ../src/hb-ot-cff1-table.hh:1419:60: warning: 'void* calloc(size_t, size_t)' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
     1419 |         names = (hb_sorted_vector_t<gname_t> *) hb_calloc (sizeof (hb_sorted_vector_t<gname_t>), 1);
          |                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~