### PR TITLE
set msvc style flag std when building with clang-cl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,9 +22,16 @@ pkgmod = import('pkgconfig')
 cpp = meson.get_compiler('cpp')
 null_dep = dependency('', required: false)
 
-# Enforce C++14 requirement for MSVC STL
-if ['clang', 'clang-cl'].contains(cpp.get_id()) and cpp.get_define('_MSC_FULL_VER') != ''
-  add_project_arguments('-std=c++14', language: 'cpp')
+# Only perform these checks if cpp_std is c++11 as setting -std directly
+# produces a warning from meson.
+if get_option('cpp_std') == 'c++11'
+  # Enforce C++14 requirement for MSVC STL
+  if cpp.get_id() == 'clang' and cpp.get_define('_MSC_FULL_VER') != ''
+    add_project_arguments('-std=c++14', language: 'cpp')
+  elif cpp.get_id() == 'clang-cl'
+    # Clang-cl produces a warning when using -std=c++14, but not when using /std:c++14
+    add_project_arguments('/std:c++14', language : 'cpp')
+  endif
 endif
 
 if cpp.get_argument_syntax() == 'msvc'


### PR DESCRIPTION
sets `/std:c++14` as opposed to `-std=c++14`, also restricts the check to only happen when `cpp_std=c++11` so when consumed as a subproject overriding the `cpp_std` of harfbuzz doesnt produce any warning at all.

meson 1.3.0 has support for `cpp_std=c++14,c++11` but thats quite a new version... 