### PR TITLE
Fix coverity defects: Null pointer dereferences

### DIFF
--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -1472,6 +1472,7 @@ struct TupleVariationData
         unsigned *idx;
         if (m.has (&(var.axis_tuples), &idx))
         {
+          if (!idx) return false;
           new_vars[*idx] += var;
         }
         else


### PR DESCRIPTION
Make coverity happy, but I think this pointer will not be null when hashmap has() call returns true