### PR TITLE
cmake: Switch to `find_package(Python3)`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,8 @@ include_directories(AFTER
   ${PROJECT_BINARY_DIR}/src
 )
 
-# We need PYTHON_EXECUTABLE to be set for running the tests...
-include (FindPythonInterp)
+# We need Python3_EXECUTABLE to be set for running the tests...
+find_package(Python3 COMPONENTS Interpreter)
 
 ## Functions and headers
 include (CheckFunctionExists)
@@ -377,13 +377,13 @@ if (HB_HAVE_GOBJECT)
     # in the standard cmd.exe shell that we use, so we need to
     # first determine whether glib-mkenums is a Python or PERL
     # script
-    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "${GLIB_MKENUMS}" --version
+    execute_process(COMMAND "${Python3_EXECUTABLE}" "${GLIB_MKENUMS}" --version
       RESULT_VARIABLE GLIB_MKENUMS_PYTHON
       OUTPUT_QUIET ERROR_QUIET
     )
     if (GLIB_MKENUMS_PYTHON EQUAL 0)
       message("${GLIB_MKENUMS} is a Python script.")
-      set (GLIB_MKENUMS_CMD "${PYTHON_EXECUTABLE}" "${GLIB_MKENUMS}")
+      set (GLIB_MKENUMS_CMD "${Python3_EXECUTABLE}" "${GLIB_MKENUMS}")
     else ()
       execute_process(COMMAND "${PERL_EXECUTABLE}" "${GLIB_MKENUMS}" --version
         RESULT_VARIABLE GLIB_MKENUMS_PERL
@@ -589,8 +589,8 @@ if (HB_HAVE_INTROSPECTION)
 
   if (WIN32 AND NOT MINGW)
     # Note that since we already enable HB_HAVE_GOBJECT
-    # we would already have PYTHON_EXECUTABLE handy
-    set (G_IR_SCANNER_CMD "${PYTHON_EXECUTABLE}" "${G_IR_SCANNER}")
+    # we would already have Python3_EXECUTABLE handy
+    set (G_IR_SCANNER_CMD "${Python3_EXECUTABLE}" "${G_IR_SCANNER}")
   else ()
     set (G_IR_SCANNER_CMD "${G_IR_SCANNER}")
   endif ()


### PR DESCRIPTION
The existing way of working used in this file was deprecated in cmake 3.12 and a new way supplied.

See https://cmake.org/cmake/help/latest/policy/CMP0148.html