### PR TITLE
Remove unnecessary std::move().

### DIFF
--- a/src/hb-ot-var-avar-table.hh
+++ b/src/hb-ot-var-avar-table.hh
@@ -230,7 +230,7 @@ struct SegmentMaps : Array16Of<AxisValueMap>
        * duplicates here */
       if (mapping.must_include ())
         continue;
-      value_mappings.push (std::move (mapping));
+      value_mappings.push (mapping);
     }
 
     AxisValueMap m;


### PR DESCRIPTION
This fixes a warning from clang-tidy:

    warning: std::move of the variable 'mapping' of the trivially-copyable
        type 'AxisValueMap' has no effect [performance-move-const-arg]