### PR TITLE
[repacker] Rework how ClassDef sizes are estimated during splitting. 

### DIFF
--- a/src/graph/classdef-graph.hh
+++ b/src/graph/classdef-graph.hh
@@ -26,7 +26,6 @@
 
 #include "graph.hh"
 #include "../hb-ot-layout-common.hh"
-#include <cstdint>
 
 #ifndef GRAPH_CLASSDEF_GRAPH_HH
 #define GRAPH_CLASSDEF_GRAPH_HH

--- a/src/graph/classdef-graph.hh
+++ b/src/graph/classdef-graph.hh
@@ -248,8 +248,8 @@ struct class_def_size_estimator_t
   hb_hashmap_t<unsigned, hb_set_t> glyphs_per_class;
   hb_set_t included_classes;
   hb_set_t included_glyphs;
-  unsigned class_def_1_size = 4;
-  unsigned class_def_2_size = 4;
+  unsigned class_def_1_size;
+  unsigned class_def_2_size;
 };
 
 

--- a/src/graph/pairpos-graph.hh
+++ b/src/graph/pairpos-graph.hh
@@ -232,7 +232,7 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
 
     unsigned accumulated = base_size;
     unsigned coverage_size = 4;
-    unsigned class_def_1_size = 4;
+    unsigned class_def_1_size = 0;
     unsigned max_coverage_size = coverage_size;
     unsigned max_class_def_1_size = class_def_1_size;
 
@@ -248,7 +248,7 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
     {
       unsigned accumulated_delta = class1_record_size;
       coverage_size += estimator.incremental_coverage_size (i);
-      class_def_1_size += estimator.incremental_class_def_size (i);
+      class_def_1_size = estimator.class_def_size (i);
       max_coverage_size = hb_max (max_coverage_size, coverage_size);
       max_class_def_1_size = hb_max (max_class_def_1_size, class_def_1_size);
 
@@ -280,8 +280,10 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
         split_points.push (i);
         // split does not include i, so add the size for i when we reset the size counters.
         accumulated = base_size + accumulated_delta;
+
+        estimator.reset();
         coverage_size = 4 + estimator.incremental_coverage_size (i);
-        class_def_1_size = 4 + estimator.incremental_class_def_size (i);
+        class_def_1_size = estimator.class_def_size(i);
         visited.clear (); // node sharing isn't allowed between splits.
       }
     }

--- a/src/graph/pairpos-graph.hh
+++ b/src/graph/pairpos-graph.hh
@@ -247,8 +247,8 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
     for (unsigned i = 0; i < class1_count; i++)
     {
       unsigned accumulated_delta = class1_record_size;
-      coverage_size += estimator.incremental_coverage_size (i);
-      class_def_1_size = estimator.class_def_size (i);
+      class_def_1_size = estimator.add_class_def_size (i);
+      coverage_size += estimator.coverage_size ();
       max_coverage_size = hb_max (max_coverage_size, coverage_size);
       max_class_def_1_size = hb_max (max_class_def_1_size, class_def_1_size);
 
@@ -282,8 +282,8 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
         accumulated = base_size + accumulated_delta;
 
         estimator.reset();
-        coverage_size = 4 + estimator.incremental_coverage_size (i);
-        class_def_1_size = estimator.class_def_size(i);
+        class_def_1_size = estimator.add_class_def_size(i);
+        coverage_size = estimator.coverage_size();
         visited.clear (); // node sharing isn't allowed between splits.
       }
     }

--- a/src/graph/pairpos-graph.hh
+++ b/src/graph/pairpos-graph.hh
@@ -232,7 +232,7 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
 
     unsigned accumulated = base_size;
     unsigned coverage_size = 4;
-    unsigned class_def_1_size = 0;
+    unsigned class_def_1_size = 4;
     unsigned max_coverage_size = coverage_size;
     unsigned max_class_def_1_size = class_def_1_size;
 
@@ -248,7 +248,7 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
     {
       unsigned accumulated_delta = class1_record_size;
       class_def_1_size = estimator.add_class_def_size (i);
-      coverage_size += estimator.coverage_size ();
+      coverage_size = estimator.coverage_size ();
       max_coverage_size = hb_max (max_coverage_size, coverage_size);
       max_class_def_1_size = hb_max (max_class_def_1_size, class_def_1_size);
 

--- a/src/graph/test-classdef-graph.cc
+++ b/src/graph/test-classdef-graph.cc
@@ -26,27 +26,113 @@
 
 #include "gsubgpos-context.hh"
 #include "classdef-graph.hh"
+#include "hb-iter.hh"
+#include "hb-serialize.hh"
 
 typedef hb_codepoint_pair_t gid_and_class_t;
 typedef hb_vector_t<gid_and_class_t> gid_and_class_list_t;
 
+template<typename It>
+static unsigned actual_class_def_size(It glyph_and_class) {
+  char buffer[100];
+  hb_serialize_context_t serializer(buffer, 100);
+  OT::ClassDef_serialize (&serializer, glyph_and_class);
+  serializer.end_serialize ();
+  assert(!serializer.in_error());
+  hb_bytes_t class_def_copy = serializer.copy_bytes ();
+  return class_def_copy.get_size();
+}
 
-static bool incremental_size_is (const gid_and_class_list_t& list, unsigned klass,
-                                 unsigned cov_expected, unsigned class_def_expected)
+static unsigned actual_class_def_size(gid_and_class_list_t consecutive_map, hb_vector_t<unsigned> classes) {
+  auto filtered_it =
+    + consecutive_map.as_sorted_array().iter()
+    | hb_filter([&] (unsigned c) {
+      for (unsigned klass : classes) {
+        if (c == klass) {
+          return true;
+        }
+      }
+      return false;
+    }, hb_second);
+  return actual_class_def_size(+ filtered_it);
+}
+
+template<typename It>
+static unsigned actual_coverage_size(It glyphs) {
+  char buffer[100];
+  hb_serialize_context_t serializer(buffer, 100);
+  OT::Layout::Common::Coverage_serialize (&serializer, glyphs);
+  serializer.end_serialize ();
+  assert(!serializer.in_error());
+  hb_bytes_t coverage_copy = serializer.copy_bytes ();
+  return coverage_copy.get_size();
+}
+
+static unsigned actual_coverage_size(gid_and_class_list_t consecutive_map, hb_vector_t<unsigned> classes) {
+  auto filtered_it =
+    + consecutive_map.as_sorted_array().iter()
+    | hb_filter([&] (unsigned c) {
+      for (unsigned klass : classes) {
+        if (c == klass) {
+          return true;
+        }
+      }
+      return false;
+    }, hb_second);
+  return actual_coverage_size(+ filtered_it | hb_map_retains_sorting(hb_first));
+}
+
+static bool check_coverage_size(graph::class_def_size_estimator_t& estimator,
+                                const gid_and_class_list_t& map,
+                                hb_vector_t<unsigned> klasses)
+{
+  unsigned result = estimator.coverage_size();
+  unsigned expected = actual_coverage_size(map, klasses);
+  if (result != expected) {
+    printf ("FAIL: estimated coverage expected size %u but was %u\n", expected, result);
+    return false;
+  }
+  return true;
+}
+
+static bool check_add_class_def_size(graph::class_def_size_estimator_t& estimator,
+                                     const gid_and_class_list_t& map,
+                                     unsigned klass, hb_vector_t<unsigned> klasses)
+{
+  unsigned result = estimator.add_class_def_size(klass);
+  unsigned expected = actual_class_def_size(map, klasses);
+  if (result != expected) {
+    printf ("FAIL: estimated class def expected size %u but was %u\n", expected, result);
+    return false;
+  }
+
+  return check_coverage_size(estimator, map, klasses);
+}
+
+static bool check_add_class_def_size (const gid_and_class_list_t& list, unsigned klass)
 {
   graph::class_def_size_estimator_t estimator (list.iter ());
 
   unsigned result = estimator.add_class_def_size (klass);
-  if (result != class_def_expected)
+  auto filtered_it =
+    + list.as_sorted_array().iter()
+    | hb_filter([&] (unsigned c) {
+      return c == klass;
+    }, hb_second);
+
+  unsigned expected = actual_class_def_size(filtered_it);
+  if (result != expected)
   {
-    printf ("FAIL: class def expected size %u but was %u\n", class_def_expected, result);
+    printf ("FAIL: class def expected size %u but was %u\n", expected, result);
     return false;
   }
 
+  auto cov_it = + filtered_it | hb_map_retains_sorting(hb_first);
   result = estimator.coverage_size ();
-  if (result != cov_expected)
+  expected = actual_coverage_size(cov_it);
+  if (result != expected)
   {
-    printf ("FAIL: coverage expected size %u but was %u\n", cov_expected, result);
+    printf ("FAIL: coverage expected size %u but was %u\n", expected, result);
     return false;
   }
 
@@ -55,30 +141,31 @@ static bool incremental_size_is (const gid_and_class_list_t& list, unsigned klas
 
 static void test_class_and_coverage_size_estimates ()
 {
-  // TODO(garretrieger): test against the actual serialized sizes of class def tables
   gid_and_class_list_t empty = {
   };
-  assert (incremental_size_is (empty, 0, 4, 4));
-  assert (incremental_size_is (empty, 1, 4, 4));
+  assert (check_add_class_def_size (empty, 0));
+  assert (check_add_class_def_size (empty, 1));
 
   gid_and_class_list_t class_zero = {
     {5, 0},
   };
-  assert (incremental_size_is (class_zero, 0, 6, 4));
+  assert (check_add_class_def_size (class_zero, 0));
 
   gid_and_class_list_t consecutive = {
     {4, 0},
     {5, 0},
+
     {6, 1},
     {7, 1},
+
     {8, 2},
     {9, 2},
     {10, 2},
     {11, 2},
   };
-  assert (incremental_size_is (consecutive, 0, 8, 4));
-  assert (incremental_size_is (consecutive, 1, 8, 8));
-  assert (incremental_size_is (consecutive, 2, 10, 10));
+  assert (check_add_class_def_size (consecutive, 0));
+  assert (check_add_class_def_size (consecutive, 1));
+  assert (check_add_class_def_size (consecutive, 2));
 
   gid_and_class_list_t non_consecutive = {
     {4, 0},
@@ -92,9 +179,9 @@ static void test_class_and_coverage_size_estimates ()
     {11, 2},
     {13, 2},
   };
-  assert (incremental_size_is (non_consecutive, 0, 8, 4));
-  assert (incremental_size_is (non_consecutive, 1, 8, 4 + 2*6));
-  assert (incremental_size_is (non_consecutive, 2, 12, 4 + 2*6));
+  assert (check_add_class_def_size (non_consecutive, 0));
+  assert (check_add_class_def_size (non_consecutive, 1));
+  assert (check_add_class_def_size (non_consecutive, 2));
 
   gid_and_class_list_t multiple_ranges = {
     {4, 0},
@@ -109,8 +196,8 @@ static void test_class_and_coverage_size_estimates ()
     {12, 1},
     {13, 1},
   };
-  assert (incremental_size_is (multiple_ranges, 0, 8, 4));
-  assert (incremental_size_is (multiple_ranges, 1, 4 + 2 * 6, 4 + 3 * 6));
+  assert (check_add_class_def_size (multiple_ranges, 0));
+  assert (check_add_class_def_size (multiple_ranges, 1));
 }
 
 static void test_running_class_and_coverage_size_estimates () {
@@ -136,18 +223,13 @@ static void test_running_class_and_coverage_size_estimates () {
   };
 
   graph::class_def_size_estimator_t estimator1(consecutive_map.iter());
-  assert(estimator1.add_class_def_size(1) == 4 + 6);  // format 2, 1 range
-  assert(estimator1.coverage_size() == 4 + 6);        // format 2, 1 range
-  assert(estimator1.add_class_def_size(2) == 4 + 10); // format 1, 5 glyphs
-  assert(estimator1.coverage_size() == 4 + 6);        // format 2, 1 range
-  assert(estimator1.add_class_def_size(3) == 4 + 18); // format 2, 3 ranges
-  assert(estimator1.coverage_size() == 4 + 6);        // format 2, 1 range
+  assert(check_add_class_def_size(estimator1, consecutive_map, 1, {1}));
+  assert(check_add_class_def_size(estimator1, consecutive_map, 2, {1, 2}));
+  assert(check_add_class_def_size(estimator1, consecutive_map, 3, {1, 2, 3}));
 
   estimator1.reset();
-  assert(estimator1.add_class_def_size(2) == 4 + 2);  // format 1, 1 glyph
-  assert(estimator1.coverage_size() == 4 + 2);        // format 1, 1 glyph
-  assert(estimator1.add_class_def_size(3) == 4 + 12); // format 2, 2 ranges
-  assert(estimator1.coverage_size() == 4 + 6);        // format 1, 1 range
+  assert(check_add_class_def_size(estimator1, consecutive_map, 2, {2}));
+  assert(check_add_class_def_size(estimator1, consecutive_map, 3, {2, 3}));
 
   // #### With non-consecutive gids: always uses format 2 ###
   gid_and_class_list_t non_consecutive_map = {
@@ -172,35 +254,30 @@ static void test_running_class_and_coverage_size_estimates () {
   };
 
   graph::class_def_size_estimator_t estimator2(non_consecutive_map.iter());
-  assert(estimator2.add_class_def_size(1) == 4 + 6);  // format 2, 1 range
-  assert(estimator2.coverage_size() == 4 + 6);        // format 2, 1 range
-  assert(estimator2.add_class_def_size(2) == 4 + 18); // format 2, 3 ranges
-  assert(estimator2.coverage_size() == 4 + 2 * 6);    // format 1, 6 glyphs
-  assert(estimator2.add_class_def_size(3) == 4 + 24); // format 2, 4 ranges
-  assert(estimator2.coverage_size() == 4 + 3 * 6);    // format 2, 3 ranges
+  assert(check_add_class_def_size(estimator2, non_consecutive_map, 1, {1}));
+  assert(check_add_class_def_size(estimator2, non_consecutive_map, 2, {1, 2}));
+  assert(check_add_class_def_size(estimator2, non_consecutive_map, 3, {1, 2, 3}));
 
   estimator2.reset();
-  assert(estimator2.add_class_def_size(2) == 4 + 12); // format 1, 1 range
-  assert(estimator2.coverage_size() == 4 + 4);        // format 1, 2 glyphs
-  assert(estimator2.add_class_def_size(3) == 4 + 18); // format 2, 2 ranges
-  assert(estimator2.coverage_size() == 4 + 2 * 6);    // format 2, 2 ranges
+  assert(check_add_class_def_size(estimator2, non_consecutive_map, 2, {2}));
+  assert(check_add_class_def_size(estimator2, non_consecutive_map, 3, {2, 3}));
 }
 
 static void test_running_class_size_estimates_with_locally_consecutive_glyphs () {
-  gid_and_class_list_t consecutive_map = {
+  gid_and_class_list_t map = {
     {1, 1},
     {6, 2},
     {7, 3},
   };
 
-  graph::class_def_size_estimator_t estimator(consecutive_map.iter());
-  assert(estimator.add_class_def_size(1) == 4 + 2);  // format 1, 1 glyph
-  assert(estimator.add_class_def_size(2) == 4 + 12); // format 2, 2 ranges
-  assert(estimator.add_class_def_size(3) == 4 + 18); // format 2, 3 ranges
+  graph::class_def_size_estimator_t estimator(map.iter());
+  assert(check_add_class_def_size(estimator, map, 1, {1}));
+  assert(check_add_class_def_size(estimator, map, 2, {1, 2}));
+  assert(check_add_class_def_size(estimator, map, 3, {1, 2, 3}));
 
   estimator.reset();
-  assert(estimator.add_class_def_size(2) == 4 + 2); // format 1, 1 glyphs
-  assert(estimator.add_class_def_size(3) == 4 + 4); // format 1, 2 glyphs
+  assert(check_add_class_def_size(estimator, map, 2, {2}));
+  assert(check_add_class_def_size(estimator, map, 3, {2, 3}));
 }
 
 int

--- a/src/graph/test-classdef-graph.cc
+++ b/src/graph/test-classdef-graph.cc
@@ -39,8 +39,11 @@ static unsigned actual_class_def_size(It glyph_and_class) {
   OT::ClassDef_serialize (&serializer, glyph_and_class);
   serializer.end_serialize ();
   assert(!serializer.in_error());
-  hb_bytes_t class_def_copy = serializer.copy_bytes ();
-  return class_def_copy.get_size();
+
+  hb_blob_t* blob = serializer.copy_blob();
+  unsigned size = hb_blob_get_length(blob);
+  hb_blob_destroy(blob);
+  return size;
 }
 
 static unsigned actual_class_def_size(gid_and_class_list_t consecutive_map, hb_vector_t<unsigned> classes) {
@@ -64,8 +67,11 @@ static unsigned actual_coverage_size(It glyphs) {
   OT::Layout::Common::Coverage_serialize (&serializer, glyphs);
   serializer.end_serialize ();
   assert(!serializer.in_error());
-  hb_bytes_t coverage_copy = serializer.copy_bytes ();
-  return coverage_copy.get_size();
+
+  hb_blob_t* blob = serializer.copy_blob();
+  unsigned size = hb_blob_get_length(blob);
+  hb_blob_destroy(blob);
+  return size;
 }
 
 static unsigned actual_coverage_size(gid_and_class_list_t consecutive_map, hb_vector_t<unsigned> classes) {

--- a/src/graph/test-classdef-graph.cc
+++ b/src/graph/test-classdef-graph.cc
@@ -225,6 +225,7 @@ static void test_running_class_and_coverage_size_estimates () {
   graph::class_def_size_estimator_t estimator1(consecutive_map.iter());
   assert(check_add_class_def_size(estimator1, consecutive_map, 1, {1}));
   assert(check_add_class_def_size(estimator1, consecutive_map, 2, {1, 2}));
+  assert(check_add_class_def_size(estimator1, consecutive_map, 2, {1, 2})); // check that adding the same class again works
   assert(check_add_class_def_size(estimator1, consecutive_map, 3, {1, 2, 3}));
 
   estimator1.reset();

--- a/src/test-repacker.cc
+++ b/src/test-repacker.cc
@@ -1986,12 +1986,12 @@ static void test_resolve_with_close_to_limit_pair_pos_2_split ()
   void* buffer = malloc (buffer_size);
   assert (buffer);
   hb_serialize_context_t c (buffer, buffer_size);
-  populate_serializer_with_large_pair_pos_2 <1, 1596, 10>(&c, true, false, false);
+  populate_serializer_with_large_pair_pos_2 <1, 1636, 10>(&c, true, false, false);
 
   void* expected_buffer = malloc (buffer_size);
   assert (expected_buffer);
   hb_serialize_context_t e (expected_buffer, buffer_size);
-  populate_serializer_with_large_pair_pos_2 <2, 798, 10>(&e, true, false, false);
+  populate_serializer_with_large_pair_pos_2 <2, 818, 10>(&e, true, false, false);
 
   run_resolve_overflow_test ("test_resolve_with_close_to_limit_pair_pos_2_split",
                              c,


### PR DESCRIPTION
The existing implementation was not correctly computing the final serialized sizes of class def tables. It was computing an approximate incremental size increase based only on the next class to be added. I've update the estimator to keep a running total for the current split. This allows the format to switch back and forth as needed.

To confirm the new implementation is correct I updated the tests to compare to actual classdef serialization sizes.