### PR TITLE
Fixing compiler warnings

### DIFF
--- a/src/OT/glyf/glyf-helpers.hh
+++ b/src/OT/glyf/glyf-helpers.hh
@@ -5,6 +5,7 @@
 #include "../../hb-open-type.hh"
 #include "../../hb-subset-plan.hh"
 
+#include "inttypes.h"
 #include "loca.hh"
 
 
@@ -38,7 +39,7 @@ _write_loca (IteratorIn&& it,
 
     unsigned padded_size = *it++;
     offset += padded_size;
-    DEBUG_MSG (SUBSET, nullptr, "loca entry gid %u offset %u padded-size %u", gid, offset, padded_size);
+    DEBUG_MSG (SUBSET, nullptr, "loca entry gid %" PRIu32 " offset %u padded-size %u", gid, offset, padded_size);
     value = offset >> right_shift;
     *dest++ = value;
 

--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -28,6 +28,7 @@
 
 #include "hb.hh"
 #include "hb-machinery.hh"
+#include "inttypes.h"
 
 
 /**
@@ -996,7 +997,7 @@ hb_feature_to_string (hb_feature_t *feature,
   if (feature->value > 1)
   {
     s[len++] = '=';
-    len += hb_max (0, snprintf (s + len, ARRAY_LENGTH (s) - len, "%u", feature->value));
+    len += hb_max (0, snprintf (s + len, ARRAY_LENGTH (s) - len, "%" PRIu32 "", feature->value));
   }
   assert (len < ARRAY_LENGTH (s));
   len = hb_min (len, size - 1);

--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -33,6 +33,7 @@
 
 #include "hb-face.hh"
 #include "hb-shaper.hh"
+#include "inttypes.h"
 
 
 /*
@@ -651,7 +652,7 @@ struct hb_font_t
   {
     if (get_glyph_name (glyph, s, size)) return;
 
-    if (size && snprintf (s, size, "gid%u", glyph) < 0)
+    if (size && snprintf (s, size, "gid%" PRIu32 "", glyph) < 0)
       *s = '\0';
   }
 

--- a/src/hb-ot-shaper-arabic.cc
+++ b/src/hb-ot-shaper-arabic.cc
@@ -30,7 +30,7 @@
 
 #include "hb-ot-shaper-arabic.hh"
 #include "hb-ot-shape.hh"
-
+#include "inttypes.h"
 
 /* buffer var allocations */
 #define arabic_shaping_action() ot_shaper_var_u8_auxiliary() /* arabic shaping action */
@@ -560,9 +560,9 @@ apply_stch (const hb_ot_shape_plan_t *plan HB_UNUSED,
 
       DEBUG_MSG (ARABIC, nullptr, "%s stretch at (%u,%u,%u)",
 		 step == MEASURE ? "measuring" : "cutting", context, start, end);
-      DEBUG_MSG (ARABIC, nullptr, "rest of word:    count=%u width %d", start - context, w_total);
-      DEBUG_MSG (ARABIC, nullptr, "fixed tiles:     count=%d width=%d", n_fixed, w_fixed);
-      DEBUG_MSG (ARABIC, nullptr, "repeating tiles: count=%d width=%d", n_repeating, w_repeating);
+      DEBUG_MSG (ARABIC, nullptr, "rest of word:    count=%u width %" PRId32 "", start - context, w_total);
+      DEBUG_MSG (ARABIC, nullptr, "fixed tiles:     count=%d width=%" PRId32 "", n_fixed, w_fixed);
+      DEBUG_MSG (ARABIC, nullptr, "repeating tiles: count=%d width=%" PRId32 "", n_repeating, w_repeating);
 
       /* Number of additional times to repeat each repeating tile. */
       int n_copies = 0;
@@ -602,7 +602,7 @@ apply_stch (const hb_ot_shape_plan_t *plan HB_UNUSED,
 	  if (info[k - 1].arabic_shaping_action() == STCH_REPEATING)
 	    repeat += n_copies;
 
-	  DEBUG_MSG (ARABIC, nullptr, "appending %u copies of glyph %u; j=%u",
+	  DEBUG_MSG (ARABIC, nullptr, "appending %u copies of glyph %" PRIu32 "; j=%u",
 		     repeat, info[k - 1].codepoint, j);
 	  pos[k - 1].x_advance = 0;
 	  for (unsigned int n = 0; n < repeat; n++)

--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -27,6 +27,7 @@
  */
 
 #include "hb.hh"
+#include "inttypes.h"
 
 #ifndef HB_NO_OT_TAG
 
@@ -547,7 +548,7 @@ hb_ot_tag_to_language (hb_tag_t tag)
       buf[3] = '-';
       str += 4;
     }
-    snprintf (str, 16, "x-hbot-%08x", tag);
+    snprintf (str, 16, "x-hbot-%08" PRIx32 "", tag);
     return hb_language_from_string (&*buf, -1);
   }
 }


### PR DESCRIPTION
All warning are for format specifiers (-WFormat) in sprintf().

Test: Compile only