### PR TITLE
Bump minimum required versions for glib and cairo in configure.ac.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,7 @@ AC_ARG_WITH(glib,
 			[Use glib @<:@default=auto@:>@])],,
 	[with_glib=auto])
 have_glib=false
-GLIB_DEPS="glib-2.0 >= 2.19.1"
+GLIB_DEPS="glib-2.0 >= 2.30"
 AC_SUBST(GLIB_DEPS)
 if test "x$with_glib" = "xyes" -o "x$with_glib" = "xauto"; then
 	PKG_CHECK_MODULES(GLIB, $GLIB_DEPS, have_glib=true, :)
@@ -193,7 +193,7 @@ AC_ARG_WITH(cairo,
 	[with_cairo=auto])
 have_cairo=false
 if test "x$with_cairo" = "xyes" -o "x$with_cairo" = "xauto"; then
-	PKG_CHECK_MODULES(CAIRO, cairo >= 1.8.0, have_cairo=true, :)
+	PKG_CHECK_MODULES(CAIRO, cairo >= 1.10, have_cairo=true, :)
 	save_libs=$LIBS
 	LIBS="$LIBS $CAIRO_LIBS"
 	AC_CHECK_FUNCS(cairo_user_font_face_set_render_color_glyph_func)

--- a/configure.ac
+++ b/configure.ac
@@ -242,7 +242,7 @@ AC_ARG_WITH(icu,
 	[with_icu=auto])
 have_icu=false
 if test "x$with_icu" = "xyes" -o "x$with_icu" = "xbuiltin" -o "x$with_icu" = "xauto"; then
-	PKG_CHECK_MODULES(ICU, icu-uc, have_icu=true, :)
+	PKG_CHECK_MODULES(ICU, icu-uc >= 49.0, have_icu=true, :)
 fi
 if test \( "x$with_icu" = "xyes" -o "x$with_icu" = "xbuiltin" \) -a "x$have_icu" != "xtrue"; then
 	AC_MSG_ERROR([icu support requested but icu-uc not found])

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,13 @@ project('harfbuzz', 'c', 'cpp',
   ],
 )
 
+glib_min_version = '>= 2.30.0'
+cairo_min_version = '>= 1.10.0'
+chafa_min_version = '>= 1.6.0'
+icu_min_version = '>= 49.0'
+graphite2_min_version = '>= 1.2.0'
+freetype_min_version = '>= 12.0.6'
+
 hb_version_arr = meson.project_version().split('.')
 hb_version_major = hb_version_arr[0].to_int()
 hb_version_minor = hb_version_arr[1].to_int()
@@ -95,6 +102,7 @@ m_dep = cpp.find_library('m', required: false)
 if meson.version().version_compare('>=0.60.0')
   # pkg-config: freetype2, cmake: Freetype
   freetype_dep = dependency('freetype2', 'Freetype',
+                            version: freetype_min_version,
                             required: get_option('freetype'),
                             default_options: ['harfbuzz=disabled'],
                             allow_fallback: true)
@@ -106,15 +114,16 @@ else
     freetype_opt = false
   endif
   # try pkg-config name
-  freetype_dep = dependency('freetype2', method: 'pkg-config', required: freetype_opt)
+  freetype_dep = dependency('freetype2', version: freetype_min_version, method: 'pkg-config', required: freetype_opt)
   # when disabled, leave it not-found
   if not freetype_dep.found() and not get_option('freetype').disabled()
     # Try cmake name
-    freetype_dep = dependency('Freetype', method: 'cmake', required: false)
+    freetype_dep = dependency('Freetype', version: freetype_min_version, method: 'cmake', required: false)
     # Subproject fallback, `allow_fallback: true` means the fallback will be
     # tried even if the freetype option is set to `auto`.
     if not freetype_dep.found()
       freetype_dep = dependency('freetype2',
+                                version: freetype_min_version,
                                 method: 'pkg-config',
                                 required: get_option('freetype'),
                                 default_options: ['harfbuzz=disabled'],
@@ -123,10 +132,10 @@ else
   endif
 endif
 
-glib_dep = dependency('glib-2.0', required: get_option('glib'))
-gobject_dep = dependency('gobject-2.0', required: get_option('gobject'))
-graphite2_dep = dependency('graphite2', required: get_option('graphite2'))
-graphite_dep = dependency('graphite2', required: get_option('graphite'))
+glib_dep = dependency('glib-2.0', version: glib_min_version, required: get_option('glib'))
+gobject_dep = dependency('gobject-2.0', version: glib_min_version, required: get_option('gobject'))
+graphite2_dep = dependency('graphite2', version: graphite2_min_version, required: get_option('graphite2'))
+graphite_dep = dependency('graphite2', version: graphite2_min_version, required: get_option('graphite'))
 wasm_dep = cpp.find_library('iwasm', required: get_option('wasm'))
 # How to check whether iwasm was built, and hence requires, LLVM?
 #llvm_dep = cpp.find_library('LLVM-15', required: get_option('wasm'))
@@ -134,6 +143,7 @@ wasm_dep = cpp.find_library('iwasm', required: get_option('wasm'))
 if meson.version().version_compare('>=0.60.0')
   # pkg-config: icu-uc, cmake: ICU but with components
   icu_dep = dependency('icu-uc', 'ICU',
+                            version: icu_min_version,
                             components: 'uc',
                             required: get_option('icu'),
                             allow_fallback: true)
@@ -145,17 +155,18 @@ else
     icu_opt = false
   endif
   # try pkg-config name
-  icu_dep = dependency('icu-uc', method: 'pkg-config', required: icu_opt)
+  icu_dep = dependency('icu-uc', version: icu_min_version, method: 'pkg-config', required: icu_opt)
   # when disabled, leave it not-found
   if not icu_dep.found() and not get_option('icu').disabled()
     # Try cmake name
-    icu_dep = dependency('ICU', method: 'cmake', components: 'uc', required: false)
+    icu_dep = dependency('ICU', version: icu_min_version, method: 'cmake', components: 'uc', required: false)
     # Try again with subproject fallback. `allow_fallback: true` means the
     # fallback will be tried even if the icu option is set to `auto`, but
     # we cannot pass this option until Meson 0.59.0, because no wrap file
     # is checked into git.
     if not icu_dep.found()
       icu_dep = dependency('icu-uc',
+                           version: icu_min_version,
                            method: 'pkg-config',
                            required: get_option('icu'))
     endif
@@ -172,8 +183,8 @@ endif
 cairo_dep = null_dep
 cairo_ft_dep = null_dep
 if not get_option('cairo').disabled()
-  cairo_dep = dependency('cairo', required: false)
-  cairo_ft_dep = dependency('cairo-ft', required: false)
+  cairo_dep = dependency('cairo', version: cairo_min_version, required: false)
+  cairo_ft_dep = dependency('cairo-ft', version: cairo_min_version, required: false)
 
   if (not cairo_dep.found() and
       cpp.get_argument_syntax() == 'msvc' and
@@ -191,13 +202,13 @@ if not get_option('cairo').disabled()
     # dependency cycle here because we have configured freetype2 above with
     # harfbuzz support disabled, so when cairo will lookup freetype2 dependency
     # it will be forced to use that one.
-    cairo_dep = dependency('cairo', required: get_option('cairo'))
+    cairo_dep = dependency('cairo', version: cairo_min_version, required: get_option('cairo'))
     cairo_ft_required = get_option('cairo').enabled() and get_option('freetype').enabled()
-    cairo_ft_dep = dependency('cairo-ft', required: cairo_ft_required)
+    cairo_ft_dep = dependency('cairo-ft', version: cairo_min_version, required: cairo_ft_required)
   endif
 endif
 
-chafa_dep = dependency('chafa', version: '>= 1.6.0', required: get_option('chafa'))
+chafa_dep = dependency('chafa', version: chafa_min_version, required: get_option('chafa'))
 
 conf = configuration_data()
 incconfig = include_directories('.')

--- a/test/api/hb-test.h
+++ b/test/api/hb-test.h
@@ -172,6 +172,12 @@ typedef void (*hb_test_fixture_func_t) (void);
 #ifndef g_assert_true
 #define g_assert_true g_assert
 #endif
+#ifndef g_assert_false
+#define g_assert_false(expr) g_assert(!(expr))
+#endif
+#ifndef g_assert_nonnull
+#define g_assert_nonnull  g_assert
+#endif
 #ifndef g_assert_cmpmem
 #define g_assert_cmpmem(m1, l1, m2, l2) g_assert_true (l1 == l2 && memcmp (m1, m2, l1) == 0)
 #endif


### PR DESCRIPTION
Bumps minimum required versions for glib and cairo in configure.ac:
glib2 >= 2.30 is needed for g_unicode_script_from_iso15924() and
g_unicode_script_to_iso15924(), and cairo >= 1.10 is needed for the
new cairo_operator_t members like CAIRO_OPERATOR_SCREEN. It also
defines g_assert_false and g_assert_nonnull for old glib2 versions
in hb-test.h (like it is done for g_assert_true.)

For meson: It doesn't check versions at all. It walks through a lot of
weirdness when a requirement isn't found, so I didn't touch it as I am
not proficient with it.

For cmake: It doesn't check versions at all. It is weirdly written, so
I didn't touch it as I am not very proficient with it..

Reference issue: https://github.com/harfbuzz/harfbuzz/issues/4577
Reference issue: https://github.com/harfbuzz/harfbuzz/issues/4624

CC: @khaledhosny
CC: @lzsiga
