### PR TITLE
[ci] Try to fix pip install on macOS runner

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -38,6 +38,10 @@ jobs:
           pkg-config \
           python3 \
           python3-setuptools
+    - name: Setup Python
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      with:
+        python-version: '3.x'
     - name: Install Python Dependencies
       run: sudo pip3 install -r .ci/requirements.txt --require-hashes
     - name: Setup Meson

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -42,8 +42,9 @@ jobs:
       run: pip3 install -r .ci/requirements.txt --require-hashes
     - name: Setup Meson
       env:
-        PKG_CONFIG_PATH: "/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig"
+        PKG_CONFIG_PATH: "/usr/local/opt/libffi/lib/pkgconfig"
       run: |
+        brew link --force icu4c
         ccache --version
         meson setup build \
           -Dauto_features=enabled \

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -34,11 +34,16 @@ jobs:
           meson \
           ninja \
           pkg-config
+    - name: Setup Python
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      with:
+        python-version: '3.x'
     - name: Install Python Dependencies
       run: pip3 install -r .ci/requirements.txt --require-hashes
     - name: Setup Meson
+      env:
+        PKG_CONFIG_PATH: "/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig"
       run: |
-        export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig"
         ccache --version
         meson setup build \
           -Dauto_features=enabled \


### PR DESCRIPTION
Use setup-python action which which I think uses venv so pip install will not fail as now installing system-wide packages with pip is disallowed.