### PR TITLE
Fix IUP differences accoss platforms.

### DIFF
--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -1031,7 +1031,7 @@ struct tuple_delta_t
 
   bool optimize (const contour_point_vector_t& contour_points,
                  bool is_composite,
-                 double tolerance = 0.5)
+                 double tolerance = 0.5 + 1e-10)
   {
     unsigned count = contour_points.length;
     if (deltas_x.length != count ||

--- a/src/hb-subset-instancer-iup.cc
+++ b/src/hb-subset-instancer-iup.cc
@@ -51,20 +51,20 @@ static void _iup_contour_bound_forced_set (const hb_array_t<const contour_point_
       int dj, ldj, ndj;
       if (j == 0)
       {
-        cj = contour_points.arrayZ[i].x;
+        cj = static_cast<double> (contour_points.arrayZ[i].x);
         dj = x_deltas.arrayZ[i];
-        lcj = contour_points.arrayZ[last_i].x;
+        lcj = static_cast<double> (contour_points.arrayZ[last_i].x);
         ldj = x_deltas.arrayZ[last_i];
-        ncj = contour_points.arrayZ[next_i].x;
+        ncj = static_cast<double> (contour_points.arrayZ[next_i].x);
         ndj = x_deltas.arrayZ[next_i];
       }
       else
       {
-        cj = contour_points.arrayZ[i].y;
+        cj = static_cast<double> (contour_points.arrayZ[i].y);
         dj = y_deltas.arrayZ[i];
-        lcj = contour_points.arrayZ[last_i].y;
+        lcj = static_cast<double> (contour_points.arrayZ[last_i].y);
         ldj = y_deltas.arrayZ[last_i];
-        ncj = contour_points.arrayZ[next_i].y;
+        ncj = static_cast<double> (contour_points.arrayZ[next_i].y);
         ndj = y_deltas.arrayZ[next_i];
       }
 
@@ -194,16 +194,16 @@ static bool _iup_segment (const hb_array_t<const contour_point_t> contour_points
     double *out;
     if (j == 0)
     {
-      x1 = p1.x;
-      x2 = p2.x;
+      x1 = static_cast<double> (p1.x);
+      x2 = static_cast<double> (p2.x);
       d1 = p1_dx;
       d2 = p2_dx;
       out = interp_x_deltas.arrayZ;
     }
     else
     {
-      x1 = p1.y;
-      x2 = p2.y;
+      x1 = static_cast<double> (p1.y);
+      x2 = static_cast<double> (p2.y);
       d1 = p1_dy;
       d2 = p2_dy;
       out = interp_y_deltas.arrayZ;
@@ -233,7 +233,7 @@ static bool _iup_segment (const hb_array_t<const contour_point_t> contour_points
     double scale = (d2 - d1) / (x2 - x1);
     for (unsigned i = 0; i < n; i++)
     {
-      double x = (j == 0 ? contour_points.arrayZ[i].x : contour_points.arrayZ[i].y);
+      double x = (j == 0 ? static_cast<double> (contour_points.arrayZ[i].x) : static_cast<double> (contour_points.arrayZ[i].y));
       double d;
       if (x <= x1)
         d = d1;
@@ -266,10 +266,10 @@ static bool _can_iup_in_between (const hb_array_t<const contour_point_t> contour
 
   for (unsigned i = 0; i < num; i++)
   {
-    double dx = x_deltas.arrayZ[i] - interp_x_deltas.arrayZ[i];
-    double dy = y_deltas.arrayZ[i] - interp_y_deltas.arrayZ[i];
+    double dx = static_cast<double> (x_deltas.arrayZ[i]) - interp_x_deltas.arrayZ[i];
+    double dy = static_cast<double> (y_deltas.arrayZ[i]) - interp_y_deltas.arrayZ[i];
   
-    if (sqrt ((double)dx * dx + (double)dy * dy) > tolerance)
+    if (sqrt (dx * dx + dy * dy) > tolerance)
       return false;
   }
   return true;

--- a/test/subset/meson.build
+++ b/test/subset/meson.build
@@ -77,15 +77,8 @@ tests = [
   'value_format_partial_instance',
   'feature_variation_instance_collect_lookups',
   'sync_vmetrics',
+  'empty_region_vardata',
 ]
-
-if host_machine.cpu_family() != 'x86'
-  # These tests exhibit some inconsequential rounding differences on 32bit machines in IUP
-  # optimization that causes the tests to fail, so only include them on non-32bit.
-  tests += [
-    'empty_region_vardata',
-  ]
-endif
 
 if get_option('experimental_api')
   tests += [


### PR DESCRIPTION
- Slightly increase the tolerance to account for differences in floating point math across platforms.
- The specific issue is a fused multiply add (d = d1 + (x - x1) * scale; in hb-subset-instancer-iup.cc)
- Also fix more implicit double conversion warnings.