### PR TITLE
[meson] build ragel as a native tool

### DIFF
--- a/subprojects/packagefiles/ragel/meson.build
+++ b/subprojects/packagefiles/ragel/meson.build
@@ -62,5 +62,5 @@ ragel = executable(
   meson.project_name(),
   ragel_sources,
   include_directories : ['aapl', 'ragel'],
-  install : true,
+  native : true,
 )


### PR DESCRIPTION
When cross compiling it will build a target (host) binary that can't be run on the building machine.

Also remove the install flag which is not compatible with the native flag, but the custom built ragel is correctly picked.