### PR TITLE
clean up tests using deprecated api

### DIFF
--- a/test/api/test-buffer.c
+++ b/test/api/test-buffer.c
@@ -145,7 +145,7 @@ test_buffer_properties (fixture_t *fixture, gconstpointer user_data HB_UNUSED)
 
   /* but not these: */
 
-  g_assert (hb_buffer_get_flags (b) != HB_BUFFER_FLAGS_DEFAULT);
+  g_assert (hb_buffer_get_flags (b) != HB_BUFFER_FLAG_DEFAULT);
   g_assert (hb_buffer_get_replacement_codepoint (b) != HB_BUFFER_REPLACEMENT_CODEPOINT_DEFAULT);
 
 
@@ -172,7 +172,7 @@ test_buffer_properties (fixture_t *fixture, gconstpointer user_data HB_UNUSED)
   g_assert (hb_buffer_get_direction (b) == HB_DIRECTION_INVALID);
   g_assert (hb_buffer_get_script (b) == HB_SCRIPT_INVALID);
   g_assert (hb_buffer_get_language (b) == NULL);
-  g_assert (hb_buffer_get_flags (b) == HB_BUFFER_FLAGS_DEFAULT);
+  g_assert (hb_buffer_get_flags (b) == HB_BUFFER_FLAG_DEFAULT);
   g_assert (hb_buffer_get_replacement_codepoint (b) == HB_BUFFER_REPLACEMENT_CODEPOINT_DEFAULT);
 }
 

--- a/test/api/test-unicode.c
+++ b/test/api/test-unicode.c
@@ -419,7 +419,7 @@ static const test_pair_t script_tests_more[] =
   /* Unicode-5.2 additions */
   {  0x10B00, HB_SCRIPT_AVESTAN },
   {   0xA6A0, HB_SCRIPT_BAMUM },
-  {   0x1400, HB_SCRIPT_CANADIAN_ABORIGINAL },
+  {   0x1400, HB_SCRIPT_CANADIAN_SYLLABICS },
   {  0x13000, HB_SCRIPT_EGYPTIAN_HIEROGLYPHS },
   {  0x10840, HB_SCRIPT_IMPERIAL_ARAMAIC },
   {   0x1CED, HB_SCRIPT_INHERITED },


### PR DESCRIPTION
Clean up tests using deprecated API
- HB_BUFFER_FLAGS_DEFAULT
- HB_SCRIPT_CANADIAN_ABORIGINAL
