### PR TITLE
fix build with HB_TINY

### DIFF
--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -515,6 +515,7 @@ _cmap_closure (hb_face_t	   *face,
   cmap.table->closure_glyphs (unicodes, glyphset);
 }
 
+#ifndef HB_NO_VAR
 static void
 _remap_colrv1_delta_set_index_indices (const OT::DeltaSetIndexMap &index_map,
                                        const hb_set_t &delta_set_idxes,
@@ -547,6 +548,7 @@ _remap_colrv1_delta_set_index_indices (const OT::DeltaSetIndexMap &index_map,
   }
   variation_idx_delta_map = std::move (delta_set_idx_delta_map);
 }
+#endif
 
 static void _colr_closure (hb_subset_plan_t* plan,
                            hb_set_t *glyphs_colred)
@@ -570,6 +572,7 @@ static void _colr_closure (hb_subset_plan_t* plan,
   _remap_indexes (&layer_indices, &plan->colrv1_layers);
   _remap_palette_indexes (&palette_indices, &plan->colr_palettes);
 
+#ifndef HB_NO_VAR
   if (!colr.has_var_store () || !variation_indices) return;
 
   const OT::ItemVariationStore &var_store = colr.get_var_store ();
@@ -600,6 +603,7 @@ static void _colr_closure (hb_subset_plan_t* plan,
                                              plan->colrv1_variation_idx_delta_map,
                                              plan->colrv1_new_deltaset_idx_varidx_map);
   }
+#endif
 }
 
 static inline void


### PR DESCRIPTION
For #4762. This just fixes the issue with variations related code in subset plan, there're still issues with the HB_TINY build. linker failure and unused variable warnings
e.g:
```
[3/170] Linking target src/libharfbuzz-cairo.so.0.60850.0
FAILED: src/libharfbuzz-cairo.so.0.60850.0 
cc  -o src/libharfbuzz-cairo.so.0.60850.0 src/libharfbuzz-cairo.so.0.60850.0.p/hb-cairo.cc.o src/libharfbuzz-cairo.so.0.60850.0.p/hb-cairo-utils.cc.o src/libharfbuzz-cairo.so.0.60850.0.p/hb-static.cc.o -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,--start-group -Wl,-soname,libharfbuzz-cairo.so.0 -Bsymbolic-functions '-Wl,-rpath,$ORIGIN/' -Wl,-rpath-link,/usr/local/google/home/qxliu/harfbuzz/tiny/src src/libharfbuzz.so.0.60850.0 -lm /usr/lib/x86_64-linux-gnu/libcairo.so -Wl,--end-group
/usr/bin/ld: src/libharfbuzz-cairo.so.0.60850.0.p/hb-cairo.cc.o: in function `hb_cairo_init_scaled_font(_cairo_scaled_font*, _cairo*, cairo_font_extents_t*)':
/usr/local/google/home/qxliu/harfbuzz/tiny/../src/hb-cairo.cc:501:(.text+0xf60): undefined reference to `hb_font_set_variations'
/usr/bin/ld: src/libharfbuzz-cairo.so.0.60850.0.p/hb-cairo.cc.o: in function `user_font_face_create(hb_face_t*)':
/usr/local/google/home/qxliu/harfbuzz/tiny/../src/hb-cairo.cc:656:(.text+0x1551): undefined reference to `hb_ot_color_has_png'
/usr/bin/ld: /usr/local/google/home/qxliu/harfbuzz/tiny/../src/hb-cairo.cc:656:(.text+0x1561): undefined reference to `hb_ot_color_has_layers'
/usr/bin/ld: /usr/local/google/home/qxliu/harfbuzz/tiny/../src/hb-cairo.cc:656:(.text+0x1571): undefined reference to `hb_ot_color_has_paint'
/usr/bin/ld: src/libharfbuzz-cairo.so.0.60850.0.p/hb-cairo.cc.o: in function `hb_cairo_draw_funcs_lazy_loader_t::create()':
```
```
FAILED: src/test-number.p/test-number.cc.o 
c++ -Isrc/test-number.p -Isrc -I../src -I. -I.. -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++11 -fno-exceptions -O0 -g -fno-exceptions -fno-rtti -fno-threadsafe-statics -fvisibility-inlines-hidden -DHAVE_CONFIG_H -DHB_TINY -pthread -Wno-non-virtual-dtor -DMAIN -UNDEBUG -MD -MQ src/test-number.p/test-number.cc.o -MF src/test-number.p/test-number.cc.o.d -o src/test-number.p/test-number.cc.o -c ../src/test-number.cc
../src/test-number.cc: In function ‘int main(int, char**)’:
../src/test-number.cc:35:17: error: unused variable ‘pp’ [-Werror=unused-variable]
   35 |     const char *pp = str;
```




