### PR TITLE
meson: Fix builds against ICU >= 75.x on Visual Studio

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -186,7 +186,8 @@ else
 endif
 
 if icu_dep.found() and icu_dep.version().version_compare('>=75.1') and (get_option('cpp_std') == 'c++11' or get_option('cpp_std') == 'c++14')
-  add_project_arguments('-std=c++17', language: 'cpp')
+  cpp17_arg = cpp.get_argument_syntax() == 'msvc' ? '/std:c++17' : '-std=c++17'
+  add_project_arguments(cpp17_arg, language: 'cpp')
 endif
 
 if icu_dep.found() and icu_dep.type_name() == 'pkgconfig'


### PR DESCRIPTION
Hi,

This brings PR #4734 to also work with Visual Studio as it expects `/std:c++17` and does not understand `-std=c++17`, so that builds on Visual Studio against ICU >= 75.x will work without passing `-Dcpp_std=c++17` in the Meson setup command line.

With blessings, thank you!