### PR TITLE
[style][doc] Mention explicitly it goes through STAT table

### DIFF
--- a/src/hb-style.cc
+++ b/src/hb-style.cc
@@ -61,7 +61,7 @@ _hb_ratio_to_angle (float r)
  * @style_tag: a style tag.
  *
  * Searches variation axes of a #hb_font_t object for a specific axis first,
- * if not set, first tries to get default style values in STAT table
+ * if not set, first tries to get default style values in `STAT` table
  * then tries to polyfill from different tables of the font.
  *
  * Returns: Corresponding axis or default value to a style tag.

--- a/src/hb-style.cc
+++ b/src/hb-style.cc
@@ -61,8 +61,8 @@ _hb_ratio_to_angle (float r)
  * @style_tag: a style tag.
  *
  * Searches variation axes of a #hb_font_t object for a specific axis first,
- * if not set, then tries to get default style values from different
- * tables of the font.
+ * if not set, first tries to get default style values in STAT table
+ * then tries to polyfill from different tables of the font.
  *
  * Returns: Corresponding axis or default value to a style tag.
  *


### PR DESCRIPTION
I asked Wolthera regarding their comment in https://wolthera.info/2024/07/making-sense-of-font-selection/

> Finally, some fonts have a [STAT](https://learn.microsoft.com/en-us/typography/opentype/spec/stat) table, which gives even more info about those axes (if a variable font) and allows for non-variable families to describe their relations in an axis like manner. There’s no API to retrieve this info in Harfbuzz, however, FontConfig knows nothing about it either, and even the CSS working group hasn’t made any statements on whether to interpret the STAT table at all.

and they gave me comprehensive feedback regarding the API which the first part was the documentation that can be improved as apparently it wasn't apparent to them that the API is able to deal with STAT also.

They also gave me other insightful comments, such as a need for `hb_ot_var_get_axis_infos` like API for STAT table, which I hope they can post separately so we can improve them also if possible.

