### PR TITLE
Added #include "stdlib.h" in test/threads/hb-sunset-threads

### DIFF
--- a/test/threads/hb-subset-threads.cc
+++ b/test/threads/hb-subset-threads.cc
@@ -11,6 +11,7 @@
 #endif
 
 #include "hb-subset.h"
+#include "stdlib.h"
 
 enum operation_t
 {


### PR DESCRIPTION
hey i was recently trying to compile harbuzz and i got an error telling me that free, calloc, atoi because stdlib was not loaded. 
if the problem is coming from me or if this pull request is bad im sry that's my first one