### PR TITLE
[subset] remove unnecessary check on name IDs

### DIFF
--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -646,8 +646,7 @@ struct FeatureParamsCharacterVariants
       return;
 
     unsigned last_name_id = (unsigned) firstParamUILabelNameID + (unsigned) numNamedParameters - 1;
-    if (last_name_id >= 256 && last_name_id <= 32767)
-      nameids_to_retain->add_range (firstParamUILabelNameID, last_name_id);
+    nameids_to_retain->add_range (firstParamUILabelNameID, last_name_id);
   }
 
   bool subset (hb_subset_context_t *c) const


### PR DESCRIPTION
From https://github.com/fonttools/fonttools/pull/3617
See: https://learn.microsoft.com/en-us/typography/opentype/spec/features_ae

The spec says they are expected to be in the font-specific name ID range (256–32767), though that is not a requirement in this Feature Parameters specification.
