### PR TITLE
Run subset tests with C-locale

### DIFF
--- a/test/subset/run-tests.py
+++ b/test/subset/run-tests.py
@@ -135,10 +135,13 @@ if not len (args):
 
 has_ots = has_ots()
 
+env = os.environ.copy()
+env['LC_ALL'] = 'C'
 process = subprocess.Popen ([hb_subset, '--batch'],
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
-                            stderr=sys.stdout)
+                            stderr=sys.stdout,
+                            env=env)
 
 fails = 0
 for path in args:


### PR DESCRIPTION
One problematic input is `--instance=wdth=112.5` which is parsed using the users local (`strtof`).
So while in C or US locales it yields 112.5 in some European locales it yields 112 as the dot is not valid in this position.

A European user might pass "112,5" instead but for the test the C locale is assumed, so enforce it.

Fixes #4854


If the parameter is intended to be always in C-locale format then an alternative would be to use `hb_parse_double` but that is a hidden symbol not available to the subset binary, or use a temporary C locale as in `hb_variation_to_string`