### PR TITLE
missing-field-initializers in hb-draw.h

### DIFF
--- a/src/hb-draw.h
+++ b/src/hb-draw.h
@@ -70,7 +70,7 @@ typedef struct hb_draw_state_t {
  *
  * The default #hb_draw_state_t at the start of glyph drawing.
  */
-#define HB_DRAW_STATE_DEFAULT {0, 0.f, 0.f, 0.f, 0.f, {0.}, {0.}, {0.}}
+#define HB_DRAW_STATE_DEFAULT {0, 0.f, 0.f, 0.f, 0.f, {0.}, {0.}, {0.}, {0.}, {0.}, {0.}, {0.}}
 
 
 /**


### PR DESCRIPTION
With clang build, I got:
FAILED: test/api/test-draw.p/test-draw.c.o
clang -Itest/api/test-draw.p -Itest/api -I../test/api -I. -I.. -Isrc -I../src -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/freetype2 -I/usr/include/libpng16 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -DHAVE_CONFIG_H -Wall -Wextra -Werror -pthread -MD -MQ test/api/test-draw.p/test-draw.c.o -MF test/api/test-draw.p/test-draw.c.o.d -o test/api/test-draw.p/test-draw.c.o -c ../test/api/test-draw.c ../test/api/test-draw.c:920:26: error: missing field 'reserved4' initializer [-Werror,-Wmissing-field-initializers]
    hb_draw_state_t st = HB_DRAW_STATE_DEFAULT;
                         ^
../src/hb-draw.h:73:71: note: expanded from macro 'HB_DRAW_STATE_DEFAULT' define HB_DRAW_STATE_DEFAULT {0, 0.f, 0.f, 0.f, 0.f, {0.}, {0.}, {0.}}