### PR TITLE
missing-field-initializers in main.cc

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -217,7 +217,7 @@ layered_glyph_dump (hb_font_t *font, hb_draw_funcs_t *funcs, unsigned face_index
       {
 	hb_font_extents_t font_extents;
 	hb_font_get_extents_for_direction (font, HB_DIRECTION_LTR, &font_extents);
-	hb_glyph_extents_t extents = {0};
+	hb_glyph_extents_t extents = {0, 0, 0, 0};
 	if (!hb_font_get_glyph_extents (font, gid, &extents))
 	{
 	  printf ("Skip gid: %u\n", gid);
@@ -267,7 +267,7 @@ dump_glyphs (hb_font_t *font, hb_draw_funcs_t *funcs, unsigned face_index)
   {
     hb_font_extents_t font_extents;
     hb_font_get_extents_for_direction (font, HB_DIRECTION_LTR, &font_extents);
-    hb_glyph_extents_t extents = {0};
+    hb_glyph_extents_t extents = {0, 0, 0, 0};
     if (!hb_font_get_glyph_extents (font, gid, &extents))
     {
       printf ("Skip gid: %u\n", gid);


### PR DESCRIPTION
FAILED: src/main.p/main.cc.o
clang++ -Isrc/main.p -Isrc -I../src -I. -I.. -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/sysprof-6 -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++11 -fno-exceptions -O3 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fvisibility-inlines-hidden -DHAVE_CONFIG_H -Wall -Wextra -Werror -pthread -Wno-non-virtual-dtor -UNDEBUG -MD -MQ src/main.p/main.cc.o -MF src/main.p/main.cc.o.d -o src/main.p/main.cc.o -c ../src/main.cc ../src/main.cc:220:33: error: missing field 'y_bearing' initializer [-Werror,-Wmissing-field-initializers]
        hb_glyph_extents_t extents = {0};
                                       ^
../src/main.cc:270:36: error: missing field 'y_bearing' initializer [-Werror,-Wmissing-field-initializers]
    hb_glyph_extents_t extents = {0};
                                   ^
2 errors generated.