### PR TITLE
missing-field-initializers in test/api/test-ot-face.c

### DIFF
--- a/test/api/test-ot-face.c
+++ b/test/api/test-ot-face.c
@@ -44,7 +44,7 @@ test_font (hb_font_t *font, hb_codepoint_t cp)
   hb_position_t x = 0, y = 0;
   char buf[5] = {0};
   unsigned int len = 0;
-  hb_glyph_extents_t extents = {0};
+  hb_glyph_extents_t extents = {0, 0, 0, 0};
   hb_ot_font_set_funcs (font);
 
   set = hb_set_create ();
@@ -82,7 +82,7 @@ test_font (hb_font_t *font, hb_codepoint_t cp)
     unsigned count = 1;
     hb_aat_layout_get_feature_types (face, 0, &count, &feature);
     hb_aat_layout_feature_type_get_name_id (face, HB_AAT_LAYOUT_FEATURE_TYPE_CHARACTER_SHAPE);
-    hb_aat_layout_feature_selector_info_t setting = {0};
+    hb_aat_layout_feature_selector_info_t setting = {0, HB_AAT_LAYOUT_FEATURE_SELECTOR_ALL_TYPE_FEATURES_ON, HB_AAT_LAYOUT_FEATURE_SELECTOR_ALL_TYPE_FEATURES_ON, 0};
     unsigned default_index;
     count = 1;
     hb_aat_layout_feature_type_get_selector_infos (face, HB_AAT_LAYOUT_FEATURE_TYPE_DESIGN_COMPLEXITY_TYPE, 0, &count, &setting, &default_index);


### PR DESCRIPTION
FAILED: test/fuzzing/hb-shape-fuzzer.p/hb-shape-fuzzer.cc.o clang++ -Itest/fuzzing/hb-shape-fuzzer.p -Itest/fuzzing -I../test/fuzzing -I. -I.. -Isrc -I../src -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++11 -fno-exceptions -O3 -fno-exceptions -fno-rtti -fno-threadsafe-statics -fvisibility-inlines-hidden -DHAVE_CONFIG_H -Wall -Wextra -Werror -MD -MQ test/fuzzing/hb-shape-fuzzer.p/hb-shape-fuzzer.cc.o -MF test/fuzzing/hb-shape-fuzzer.p/hb-shape-fuzzer.cc.o.d -o test/fuzzing/hb-shape-fuzzer.p/hb-shape-fuzzer.cc.o -c ../test/fuzzing/hb-shape-fuzzer.cc In file included from ../test/fuzzing/hb-shape-fuzzer.cc:9: ../test/fuzzing/../api/test-ot-face.c:47:34: error: missing field 'y_bearing' initializer [-Werror,-Wmissing-field-initializers]
  hb_glyph_extents_t extents = {0};
                                 ^
../test/fuzzing/../api/test-ot-face.c:85:55: error: missing field 'enable' initializer [-Werror,-Wmissing-field-initializers]
    hb_aat_layout_feature_selector_info_t setting = {0};
                                                      ^
2 errors generated.