### PR TITLE
unused-parameter in test/fuzzing/hb-draw-fuzzer.cc

### DIFF
--- a/test/fuzzing/hb-draw-fuzzer.cc
+++ b/test/fuzzing/hb-draw-fuzzer.cc
@@ -16,10 +16,10 @@ struct _draw_data_t
 
 #include <cstdio>
 static void
-_move_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
+_move_to (hb_draw_funcs_t *dfuncs HB_UNUSED, void *draw_data_,
 	  hb_draw_state_t *st,
 	  float to_x, float to_y,
-	  void *user_data)
+	  void *user_data HB_UNUSED)
 {
   _draw_data_t *draw_data = (_draw_data_t *) draw_data_;
   assert (!st->path_open);
@@ -28,10 +28,10 @@ _move_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
 }
 
 static void
-_line_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
+_line_to (hb_draw_funcs_t *dfuncs HB_UNUSED, void *draw_data_,
 	  hb_draw_state_t *st,
 	  float to_x, float to_y,
-	  void *user_data)
+	  void *user_data HB_UNUSED)
 {
   _draw_data_t *draw_data = (_draw_data_t *) draw_data_;
   assert (st->path_open);
@@ -41,11 +41,11 @@ _line_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
 }
 
 static void
-_quadratic_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
+_quadratic_to (hb_draw_funcs_t *dfuncs HB_UNUSED, void *draw_data_,
 	       hb_draw_state_t *st,
-	       float control_x, float control_y,
+	       float control_x HB_UNUSED, float control_y HB_UNUSED,
 	       float to_x, float to_y,
-	       void *user_data)
+	       void *user_data HB_UNUSED)
 {
   _draw_data_t *draw_data = (_draw_data_t *) draw_data_;
   assert (st->path_open);
@@ -55,12 +55,12 @@ _quadratic_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
 }
 
 static void
-_cubic_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
+_cubic_to (hb_draw_funcs_t *dfuncs HB_UNUSED, void *draw_data_,
 	   hb_draw_state_t *st,
-	   float control1_x, float control1_y,
-	   float control2_x, float control2_y,
+	   float control1_x HB_UNUSED, float control1_y HB_UNUSED,
+	   float control2_x HB_UNUSED, float control2_y HB_UNUSED,
 	   float to_x, float to_y,
-	   void *user_data)
+	   void *user_data HB_UNUSED)
 {
   _draw_data_t *draw_data = (_draw_data_t *) draw_data_;
   assert (st->path_open);
@@ -70,9 +70,9 @@ _cubic_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
 }
 
 static void
-_close_path (hb_draw_funcs_t *dfuncs, void *draw_data_,
+_close_path (hb_draw_funcs_t *dfuncs HB_UNUSED, void *draw_data_,
 	     hb_draw_state_t *st,
-	     void *user_data)
+	     void *user_data HB_UNUSED)
 {
   _draw_data_t *draw_data = (_draw_data_t *) draw_data_;
   assert (st->path_open && draw_data->path_len != 0);


### PR DESCRIPTION
../test/fuzzing/hb-draw-fuzzer.cc:19:28: error: unused parameter 'dfuncs' [-Werror,-Wunused-parameter] _move_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
                           ^
../test/fuzzing/hb-draw-fuzzer.cc:22:10: error: unused parameter 'user_data' [-Werror,-Wunused-parameter]
          void *user_data)
                ^
../test/fuzzing/hb-draw-fuzzer.cc:31:28: error: unused parameter 'dfuncs' [-Werror,-Wunused-parameter] _line_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
                           ^
../test/fuzzing/hb-draw-fuzzer.cc:34:10: error: unused parameter 'user_data' [-Werror,-Wunused-parameter]
          void *user_data)
                ^
../test/fuzzing/hb-draw-fuzzer.cc:44:33: error: unused parameter 'dfuncs' [-Werror,-Wunused-parameter] _quadratic_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
                                ^
../test/fuzzing/hb-draw-fuzzer.cc:46:15: error: unused parameter 'control_x' [-Werror,-Wunused-parameter]
               float control_x, float control_y,
                     ^
../test/fuzzing/hb-draw-fuzzer.cc:46:32: error: unused parameter 'control_y' [-Werror,-Wunused-parameter]
               float control_x, float control_y,
                                      ^
../test/fuzzing/hb-draw-fuzzer.cc:48:15: error: unused parameter 'user_data' [-Werror,-Wunused-parameter]
               void *user_data)
                     ^
../test/fuzzing/hb-draw-fuzzer.cc:58:29: error: unused parameter 'dfuncs' [-Werror,-Wunused-parameter] _cubic_to (hb_draw_funcs_t *dfuncs, void *draw_data_,
                            ^
../test/fuzzing/hb-draw-fuzzer.cc:60:11: error: unused parameter 'control1_x' [-Werror,-Wunused-parameter]
           float control1_x, float control1_y,
                 ^
../test/fuzzing/hb-draw-fuzzer.cc:60:29: error: unused parameter 'control1_y' [-Werror,-Wunused-parameter]
           float control1_x, float control1_y,
                                   ^
../test/fuzzing/hb-draw-fuzzer.cc:61:11: error: unused parameter 'control2_x' [-Werror,-Wunused-parameter]
           float control2_x, float control2_y,
                 ^
../test/fuzzing/hb-draw-fuzzer.cc:61:29: error: unused parameter 'control2_y' [-Werror,-Wunused-parameter]
           float control2_x, float control2_y,
                                   ^
../test/fuzzing/hb-draw-fuzzer.cc:63:11: error: unused parameter 'user_data' [-Werror,-Wunused-parameter]
           void *user_data)
                 ^
../test/fuzzing/hb-draw-fuzzer.cc:73:31: error: unused parameter 'dfuncs' [-Werror,-Wunused-parameter] _close_path (hb_draw_funcs_t *dfuncs, void *draw_data_,
                              ^
../test/fuzzing/hb-draw-fuzzer.cc:75:13: error: unused parameter 'user_data' [-Werror,-Wunused-parameter]
             void *user_data)
                   ^
16 errors generated.