### PR TITLE
[ci] Fix Codecov upload

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -72,4 +72,5 @@ jobs:
     - name: Upload Coverage
       uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: build/meson-logs/coverage.xml

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -63,4 +63,5 @@ jobs:
     - name: Upload Coverage
       uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: build/meson-logs/coverage.xml


### PR DESCRIPTION
Setup a repository token and use it, this seems to be required now.