### PR TITLE
[ci] Pin Python version to 3.12 on macOS

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: '3.x'
+        python-version: '3.12'
     - name: Install Python Dependencies
       run: pip3 install -r .ci/requirements.txt --require-hashes
     - name: Setup Meson


### PR DESCRIPTION
It seems that lxml does not have 3.13 binary wheels (for macOS at least), and building it from source is failing.