### PR TITLE
[meson] Update wrap files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
       - run: |
           python3 -m venv venv
           source venv/bin/activate
-          pip3 install meson==0.60.0
+          pip3 install meson==1.6.0
           bash .ci/build-win32.sh
       - store_artifacts:
           path: harfbuzz-win32.zip
@@ -162,7 +162,7 @@ jobs:
       - run: |
           python3 -m venv venv
           source venv/bin/activate
-          pip3 install meson==0.60.0
+          pip3 install meson==1.6.0
           bash .ci/build-win64.sh
       - store_artifacts:
           path: harfbuzz-win64.zip

--- a/subprojects/cairo.wrap
+++ b/subprojects/cairo.wrap
@@ -1,8 +1,10 @@
-[wrap-git]
-directory=cairo
-url=https://gitlab.freedesktop.org/cairo/cairo.git
-depth=1
-revision=1.17.8
+[wrap-file]
+directory = cairo-1.18.2
+source_url = https://www.cairographics.org/releases/cairo-1.18.2.tar.xz
+source_filename = cairo-1.18.2.tar.xz
+source_hash = a62b9bb42425e844cc3d6ddde043ff39dbabedd1542eba57a2eb79f85889d45a
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/cairo_1.18.2-1/cairo-1.18.2.tar.xz
+wrapdb_version = 1.18.2-1
 
 [provide]
-dependency_names = cairo
+dependency_names = cairo, cairo-gobject

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,9 +1,10 @@
 [wrap-file]
-directory = freetype-2.13.0
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.13.0.tar.xz
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.13.0-1/freetype-2.13.0.tar.xz
-source_filename = freetype-2.13.0.tar.xz
-source_hash = 5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c
+directory = freetype-2.13.3
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.13.3-1/freetype-2.13.3.tar.xz
+source_filename = freetype-2.13.3.tar.xz
+source_hash = 0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289
+wrapdb_version = 2.13.3-1
 
 [provide]
 freetype2 = freetype_dep

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = glib-2.74.4
-source_url = https://download.gnome.org/sources/glib/2.74/glib-2.74.4.tar.xz
-source_fallback_url = https://ftp.acc.umu.se/pub/gnome/sources/glib/2.74/glib-2.74.4.tar.xz
-source_filename = glib-2.74.4.tar.xz
-source_hash = 0e82da5ea129b4444227c7e4a9e598f7288d1994bf63f129c44b90cfd2432172
-wrapdb_version = 2.74.4-1
+directory = glib-2.82.2
+source_url = https://download.gnome.org/sources/glib/2.82/glib-2.82.2.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/glib_2.82.2-1/glib-2.82.2.tar.xz
+source_filename = glib-2.82.2.tar.xz
+source_hash = ab45f5a323048b1659ee0fbda5cecd94b099ab3e4b9abf26ae06aeb3e781fd63
+wrapdb_version = 2.82.2-1
 
 [provide]
 dependency_names = gthread-2.0, gobject-2.0, gmodule-no-export-2.0, gmodule-export-2.0, gmodule-2.0, glib-2.0, gio-2.0, gio-windows-2.0, gio-unix-2.0

--- a/subprojects/google-benchmark.wrap
+++ b/subprojects/google-benchmark.wrap
@@ -1,12 +1,14 @@
 [wrap-file]
-directory = benchmark-1.7.1
-source_url = https://github.com/google/benchmark/archive/refs/tags/v1.7.1.tar.gz
-source_filename = benchmark-1.7.1.tar.gz
-source_hash = 6430e4092653380d9dc4ccb45a1e2dc9259d581f4866dc0759713126056bc1d7
-patch_filename = google-benchmark_1.7.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.7.1-1/get_patch
-patch_hash = 9c6694328ac971cd781aa67c45c64291c087f118e23b75946f52670caacf49b7
-wrapdb_version = 1.7.1-1
+directory = benchmark-1.8.4
+source_url = https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz
+source_filename = benchmark-1.8.4.tar.gz
+source_hash = 3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45
+patch_filename = google-benchmark_1.8.4-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-1/get_patch
+patch_hash = 77cdae534fe12b6783c1267de3673d3462b229054519034710d581b419e73cca
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-1/benchmark-1.8.4.tar.gz
+wrapdb_version = 1.8.4-1
 
 [provide]
 benchmark = google_benchmark_dep
+benchmark-main = google_benchmark_main_dep


### PR DESCRIPTION
This also updates the meson version on Windows cross-build jobs as wraps now requires newer versions of meson. We still require only meson 0.55.0 for building HarfBuzz, but building with fallback wraps is allowed to require newer meson.