### PR TITLE
[ci] Try to fix macOS build

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         export HOMEBREW_NO_AUTO_UPDATE=1
         export HOMEBREW_NO_INSTALL_CLEANUP=1
+        brew unlink pkg-config || true
         brew install \
           cairo \
           freetype \
@@ -34,6 +35,8 @@ jobs:
           meson \
           ninja \
           pkg-config
+        brew unlink pkgconf || true
+        brew link pkg-config || true
     - name: Setup Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:


### PR DESCRIPTION
It seems that Homebrew now packages an alternative implementation of pkg-config called pkgconf and some of the packages we install depend on it, and installing both pkgconf and pkg-config is not supported.

Looks like pkgconf can’t find dependencies for us, so we do some brew unlink/link dance to get both installed, and hope for the best.