### PR TITLE
Introducing HarfBuzz Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Codecov Code Coverage](https://codecov.io/gh/harfbuzz/harfbuzz/branch/main/graph/badge.svg)](https://codecov.io/gh/harfbuzz/harfbuzz)
 [![Packaging status](https://repology.org/badge/tiny-repos/harfbuzz.svg)](https://repology.org/project/harfbuzz/versions)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/harfbuzz/harfbuzz/badge)](https://securityscorecards.dev/viewer/?uri=github.com/harfbuzz/harfbuzz)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20HarfBuzz%20Guru-006BFF)](https://gurubase.io/g/harfbuzz)
 
 
 # HarfBuzz


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [HarfBuzz Guru](https://gurubase.io/g/harfbuzz) to Gurubase. HarfBuzz Guru uses the data from this repo and data from the [docs](https://harfbuzz.github.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "HarfBuzz Guru", which highlights that HarfBuzz now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable HarfBuzz Guru in Gurubase, just let me know that's totally fine.
