### PR TITLE
set harfbuzz version in cmake config file

### DIFF
--- a/src/harfbuzz-config.cmake.in
+++ b/src/harfbuzz-config.cmake.in
@@ -2,6 +2,8 @@
 
 set_and_check(HARFBUZZ_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 
+set(HARFBUZZ_VERSION "@HARFBUZZ_VERSION@")
+
 # Add the libraries.
 add_library(harfbuzz::harfbuzz @HB_LIBRARY_TYPE@ IMPORTED)
 set_target_properties(harfbuzz::harfbuzz PROPERTIES

--- a/src/meson.build
+++ b/src/meson.build
@@ -875,6 +875,7 @@ endmacro()
 cmake_config.set('PACKAGE_CMAKE_INSTALL_INCLUDEDIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_includedir))
 cmake_config.set('PACKAGE_CMAKE_INSTALL_LIBDIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_libdir))
 cmake_config.set('PACKAGE_INCLUDE_INSTALL_DIR', '${PACKAGE_PREFIX_DIR}/@0@/@1@'.format(cmake_install_includedir, meson.project_name()))
+cmake_config.set('HARFBUZZ_VERSION', meson.project_version())
 cmake_config.set('HB_HAVE_GOBJECT', have_gobject ? 'YES' : 'NO')
 cmake_config.set('HB_LIBRARY_TYPE', get_option('default_library') == 'static' ? 'STATIC' : 'SHARED')
 


### PR DESCRIPTION
Hi all!

As a follow-up to mesonbuild/meson#13959, I've tried to fix the underlying issue. Please find attached a possible fix for the error described in the linked ticket (tl;dr: meson is unable to recognize harfbuzz's version because it's not set in the cmake config file, which ultimately causes issues when building freetype with harfbuzz support enabled).

Happy to answer any questions that come up!