### PR TITLE
Sidestep nontrivial-memaccess warning in Crap()

### DIFF
--- a/src/hb-null.hh
+++ b/src/hb-null.hh
@@ -176,7 +176,7 @@ template <typename Type>
 static inline Type& Crap () {
   static_assert (hb_null_size (Type) <= HB_NULL_POOL_SIZE, "Increase HB_NULL_POOL_SIZE.");
   Type *obj = reinterpret_cast<Type *> (_hb_CrapPool);
-  memcpy (obj, std::addressof (Null (Type)), sizeof (*obj));
+  memcpy (reinterpret_cast<void*>(obj), std::addressof (Null (Type)), sizeof (*obj));
   return *obj;
 }
 template <typename QType>


### PR DESCRIPTION
With `-Wnontrivial-memaccess`, recent versions of clang flag the usage of memcpy in hb-null.hh with pointers to nontrivially-copyable types. Sidestep this warning by casting the problematic pointer to `void*`.