### PR TITLE
Make hb_test_tools.py work in Python 3.13

### DIFF
--- a/test/shape/hb_test_tools.py
+++ b/test/shape/hb_test_tools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys, os, re, difflib, unicodedata, errno, cgi, itertools
+import sys, os, re, difflib, unicodedata, errno, html, itertools
 from itertools import *
 
 diff_symbols = "-+=*&^%$#@!~/"
@@ -45,7 +45,7 @@ class ColorFormatter:
 		def end_color ():
 			return '</span>'
 		@staticmethod
-		def escape (s): return cgi.escape (s)
+		def escape (s): return html.escape (s)
 		@staticmethod
 		def newline (): return '<br/>\n'
 


### PR DESCRIPTION
The `cgi` module was removed in Python 3.13.