### PR TITLE
[coretext]: fix tvOS build

### DIFF
--- a/src/hb-coretext-font.cc
+++ b/src/hb-coretext-font.cc
@@ -34,7 +34,9 @@
 #include "hb-font.hh"
 #include "hb-machinery.hh"
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+#if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1080) \
+    || (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 60000) \
+    || (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 90000)
 #  define kCTFontOrientationDefault kCTFontDefaultOrientation
 #  define kCTFontOrientationHorizontal kCTFontHorizontalOrientation
 #  define kCTFontOrientationVertical kCTFontVerticalOrientation


### PR DESCRIPTION
define kCTFont* when unavailable, i.e. ios < 6.0, macOS < 10.8 or tvOS < 9.0. MAC_OS_X_VERSION_MIN_REQUIRED is always defined in AvailabilityMacros.h for all targets, while __ENVIRONMENT_*_VERSION_MIN_REQUIRED__ is defined by compiler when building a specific target