### PR TITLE
[repacker] rename hb-subset-repacker -> hb-subset-serialize.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ set (subset_project_sources
      ${PROJECT_SOURCE_DIR}/src/hb-subset-plan.cc
      ${PROJECT_SOURCE_DIR}/src/hb-subset-plan.hh
      ${PROJECT_SOURCE_DIR}/src/hb-subset-plan-member-list.hh
-     ${PROJECT_SOURCE_DIR}/src/hb-subset-repacker.cc
+     ${PROJECT_SOURCE_DIR}/src/hb-subset-serialize.cc
      ${PROJECT_SOURCE_DIR}/src/hb-subset.cc
      ${PROJECT_SOURCE_DIR}/src/hb-subset.hh
      ${PROJECT_SOURCE_DIR}/src/hb-repacker.hh
@@ -219,7 +219,7 @@ set (project_headers
 )
 set (subset_project_headers
      ${PROJECT_SOURCE_DIR}/src/hb-subset.h
-     ${PROJECT_SOURCE_DIR}/src/hb-subset-repacker.h
+     ${PROJECT_SOURCE_DIR}/src/hb-subset-serialize.h
 )
 
 ## Find and include needed header folders and libraries
@@ -513,7 +513,7 @@ endif ()
 ## Define harfbuzz-subset library
 if (HB_BUILD_SUBSET)
   add_library(harfbuzz-subset ${subset_project_sources} ${subset_project_headers})
-  list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-subset.h ${PROJECT_SOURCE_DIR}/src/hb-subset-repacker.h)
+  list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-subset.h ${PROJECT_SOURCE_DIR}/src/hb-subset-serialize.h)
   add_dependencies(harfbuzz-subset harfbuzz)
   target_link_libraries(harfbuzz-subset harfbuzz ${THIRD_PARTY_LIBS})
 

--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -919,8 +919,8 @@ hb_subset_flags_t
 hb_subset_input_t
 hb_subset_sets_t
 hb_subset_plan_t
-hb_link_t
-hb_object_t
+hb_subset_serialize_link_t
+hb_subset_serialize_object_t
 hb_subset_repack_or_fail
 <SUBSECTION Private>
 hb_subset_input_override_name_table

--- a/src/harfbuzz-subset.cc
+++ b/src/harfbuzz-subset.cc
@@ -58,7 +58,7 @@
 #include "hb-subset-instancer-iup.cc"
 #include "hb-subset-instancer-solver.cc"
 #include "hb-subset-plan.cc"
-#include "hb-subset-repacker.cc"
+#include "hb-subset-serialize.cc"
 #include "hb-subset.cc"
 #include "hb-ucd.cc"
 #include "hb-unicode.cc"

--- a/src/hb-serialize.hh
+++ b/src/hb-serialize.hh
@@ -36,7 +36,7 @@
 #include "hb-map.hh"
 #include "hb-pool.hh"
 
-#include "hb-subset-repacker.h"
+#include "hb-subset-serialize.h"
 
 /*
  * Serialize
@@ -73,7 +73,7 @@ struct hb_serialize_context_t
 
     object_t () = default;
 
-    object_t (const hb_object_t &o)
+    object_t (const hb_subset_serialize_object_t &o)
     {
       head = o.head;
       tail = o.tail;
@@ -144,7 +144,7 @@ struct hb_serialize_context_t
 
       link_t () = default;
 
-      link_t (const hb_link_t &o)
+      link_t (const hb_subset_serialize_link_t &o)
       {
         width = o.width;
         is_signed = 0;

--- a/src/hb-subset-serialize.cc
+++ b/src/hb-subset-serialize.cc
@@ -22,15 +22,15 @@
  * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
  *
  */
-#include "hb-subset-repacker.h"
+#include "hb-subset-serialize.h"
 #include "hb-repacker.hh"
 
 /**
  * hb_subset_repack_or_fail:
  * @table_tag: tag of the table being packed, needed to allow table specific optimizations.
- * @hb_objects: raw array of struct hb_object_t, which provides
+ * @hb_objects: raw array of struct hb_subset_serialize_object_t, which provides
  * object graph info
- * @num_hb_objs: number of hb_object_t in the hb_objects array.
+ * @num_hb_objs: number of hb_subset_serialize_object_t in the hb_objects array.
  *
  * Given the input object graph info, repack a table to eliminate
  * offset overflows. A nullptr is returned if the repacking attempt fails.
@@ -40,10 +40,10 @@
  * XSince: REPLACEME
  **/
 hb_blob_t* hb_subset_repack_or_fail (hb_tag_t table_tag,
-                                     hb_object_t* hb_objects,
+                                     hb_subset_serialize_object_t* hb_objects,
                                      unsigned num_hb_objs)
 {
-  hb_vector_t<const hb_object_t *> packed;
+  hb_vector_t<const hb_subset_serialize_object_t *> packed;
   packed.alloc (num_hb_objs + 1);
   packed.push (nullptr);
   for (unsigned i = 0 ; i < num_hb_objs ; i++)

--- a/src/hb-subset-serialize.h
+++ b/src/hb-subset-serialize.h
@@ -31,7 +31,7 @@
 HB_BEGIN_DECLS
 
 /**
- * hb_link_t:
+ * hb_subset_serialize_link_t:
  * @width:    offsetSize in bytes
  * @position: position of the offset field in bytes from
  *            beginning of subtable
@@ -40,15 +40,15 @@ HB_BEGIN_DECLS
  * Represents a link between two objects in the object graph
  * to be serialized.
  */
-typedef struct hb_link_t
+typedef struct hb_subset_serialize_link_t
 {
   unsigned width;
   unsigned position;
   unsigned objidx;
-} hb_link_t;
+} hb_subset_serialize_link_t;
 
 /**
- * hb_object_t:
+ * hb_subset_serialize_object_t:
  * @head:    start of object data
  * @tail:    end of object data
  * @num_real_links:    num of offset field in the object
@@ -60,19 +60,19 @@ typedef struct hb_link_t
  *
  * Represents an object in the object graph to be serialized.
  */
-typedef struct hb_object_t
+typedef struct hb_subset_serialize_object_t
 {
   char *head;
   char *tail;
   unsigned num_real_links;
-  hb_link_t *real_links;
+  hb_subset_serialize_link_t *real_links;
   unsigned num_virtual_links;
-  hb_link_t *virtual_links;
-} hb_object_t;
+  hb_subset_serialize_link_t *virtual_links;
+} hb_subset_serialize_object_t;
 
 HB_EXTERN hb_blob_t*
 hb_subset_repack_or_fail (hb_tag_t table_tag,
-                          hb_object_t* hb_objects,
+                          hb_subset_serialize_object_t* hb_objects,
                           unsigned num_hb_objs);
 
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -383,7 +383,7 @@ hb_subset_sources = files(
   'hb-subset-plan.cc',
   'hb-subset-plan.hh',
   'hb-subset-plan-member-list.hh',
-  'hb-subset-repacker.cc',
+  'hb-subset-serialize.cc',
   'graph/gsubgpos-context.cc',
   'graph/gsubgpos-context.hh',
   'graph/gsubgpos-graph.hh',
@@ -398,7 +398,7 @@ hb_subset_sources = files(
 
 hb_subset_headers = files(
   'hb-subset.h',
-  'hb-subset-repacker.h'
+  'hb-subset-serialize.h'
 )
 
 hb_gobject_sources = files(

--- a/test/api/test-subset-repacker.c
+++ b/test/api/test-subset-repacker.c
@@ -26,15 +26,14 @@
 #include "hb-test.h"
 #include "hb-subset-test.h"
 
-#ifdef HB_EXPERIMENTAL_API
-#include "hb-subset-repacker.h"
+#include "hb-subset-serialize.h"
 
 char test_gsub_data[106] = "\x0\x1\x0\x0\x0\xa\x0\x1e\x0\x2c\x0\x1\x6c\x61\x74\x6e\x0\x8\x0\x4\x0\x0\x0\x0\xff\xff\x0\x1\x0\x0\x0\x1\x74\x65\x73\x74\x0\x8\x0\x0\x0\x1\x0\x1\x0\x2\x0\x2a\x0\x6\x0\x5\x0\x0\x0\x1\x0\x8\x0\x1\x0\x8\x0\x1\x0\xe\x0\x1\x0\x1\x0\x1\x0\x1\x0\x4\x0\x2\x0\x1\x0\x2\x0\x1\x0\x0\x0\x1\x0\x0\x0\x1\x0\x8\x0\x1\x0\x6\x0\x1\x0\x1\x0\x1\x0\x2";
 
 static void
 test_hb_repack_with_cy_struct (void)
 {
-  hb_object_t *hb_objs = calloc (15, sizeof (hb_object_t));
+  hb_subset_serialize_object_t *hb_objs = calloc (15, sizeof (hb_subset_serialize_object_t));
 
   hb_objs[0].head = &(test_gsub_data[100]);
   hb_objs[0].tail = &(test_gsub_data[105]) + 1;
@@ -47,7 +46,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[1].tail = &(test_gsub_data[100]);
   hb_objs[1].num_real_links = 1;
   hb_objs[1].num_virtual_links = 0;
-  hb_objs[1].real_links = malloc (sizeof (hb_link_t));
+  hb_objs[1].real_links = malloc (sizeof (hb_subset_serialize_link_t));
   hb_objs[1].real_links[0].width = 2;
   hb_objs[1].real_links[0].position = 2;
   hb_objs[1].real_links[0].objidx = 1;
@@ -58,7 +57,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[2].tail = &(test_gsub_data[94]);
   hb_objs[2].num_real_links = 1;
   hb_objs[2].num_virtual_links = 0;
-  hb_objs[2].real_links = malloc (sizeof (hb_link_t));
+  hb_objs[2].real_links = malloc (sizeof (hb_subset_serialize_link_t));
   hb_objs[2].real_links[0].width = 2;
   hb_objs[2].real_links[0].position = 6;
   hb_objs[2].real_links[0].objidx = 2;
@@ -75,7 +74,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[4].tail = &(test_gsub_data[76]);
   hb_objs[4].num_real_links = 1;
   hb_objs[4].num_virtual_links = 0;
-  hb_objs[4].real_links = malloc (sizeof (hb_link_t));
+  hb_objs[4].real_links = malloc (sizeof (hb_subset_serialize_link_t));
   hb_objs[4].real_links[0].width = 2;
   hb_objs[4].real_links[0].position = 2;
   hb_objs[4].real_links[0].objidx = 4;
@@ -92,7 +91,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[6].tail = &(test_gsub_data[66]);
   hb_objs[6].num_real_links = 2;
   hb_objs[6].num_virtual_links = 0;
-  hb_objs[6].real_links = calloc (2, sizeof (hb_link_t));
+  hb_objs[6].real_links = calloc (2, sizeof (hb_subset_serialize_link_t));
   hb_objs[6].real_links[0].width = 2;
   hb_objs[6].real_links[0].position = 6;
   hb_objs[6].real_links[0].objidx = 5;
@@ -105,7 +104,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[7].tail = &(test_gsub_data[58]);
   hb_objs[7].num_real_links = 1;
   hb_objs[7].num_virtual_links = 0;
-  hb_objs[7].real_links = malloc (sizeof (hb_link_t));
+  hb_objs[7].real_links = malloc (sizeof (hb_subset_serialize_link_t));
   hb_objs[7].real_links[0].width = 2;
   hb_objs[7].real_links[0].position = 6;
   hb_objs[7].real_links[0].objidx = 7;
@@ -115,7 +114,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[8].tail = &(test_gsub_data[50]);
   hb_objs[8].num_real_links = 2;
   hb_objs[8].num_virtual_links = 0;
-  hb_objs[8].real_links = calloc (2, sizeof (hb_link_t));
+  hb_objs[8].real_links = calloc (2, sizeof (hb_subset_serialize_link_t));
   hb_objs[8].real_links[0].width = 2;
   hb_objs[8].real_links[0].position = 2;
   hb_objs[8].real_links[0].objidx = 3;
@@ -135,7 +134,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[10].tail = &(test_gsub_data[38]);
   hb_objs[10].num_real_links = 1;
   hb_objs[10].num_virtual_links = 0;
-  hb_objs[10].real_links = malloc (sizeof (hb_link_t));
+  hb_objs[10].real_links = malloc (sizeof (hb_subset_serialize_link_t));
   hb_objs[10].real_links[0].width = 2;
   hb_objs[10].real_links[0].position = 6;
   hb_objs[10].real_links[0].objidx = 10;
@@ -152,7 +151,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[12].tail = &(test_gsub_data[22]);
   hb_objs[12].num_real_links = 1;
   hb_objs[12].num_virtual_links = 0;
-  hb_objs[12].real_links = malloc (sizeof (hb_link_t));
+  hb_objs[12].real_links = malloc (sizeof (hb_subset_serialize_link_t));
   hb_objs[12].real_links[0].width = 2;
   hb_objs[12].real_links[0].position = 0;
   hb_objs[12].real_links[0].objidx = 12;
@@ -162,7 +161,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[13].tail = &(test_gsub_data[18]);
   hb_objs[13].num_real_links = 1;
   hb_objs[13].num_virtual_links = 0;
-  hb_objs[13].real_links = malloc (sizeof (hb_link_t));
+  hb_objs[13].real_links = malloc (sizeof (hb_subset_serialize_link_t));
   hb_objs[13].real_links[0].width = 2;
   hb_objs[13].real_links[0].position = 6;
   hb_objs[13].real_links[0].objidx = 13;
@@ -172,7 +171,7 @@ test_hb_repack_with_cy_struct (void)
   hb_objs[14].tail = &(test_gsub_data[10]);
   hb_objs[14].num_real_links = 3;
   hb_objs[14].num_virtual_links = 0;
-  hb_objs[14].real_links = calloc (3, sizeof (hb_link_t));
+  hb_objs[14].real_links = calloc (3, sizeof (hb_subset_serialize_link_t));
   hb_objs[14].real_links[0].width = 2;
   hb_objs[14].real_links[0].position = 8;
   hb_objs[14].real_links[0].objidx = 9;
@@ -217,9 +216,3 @@ main (int argc, char **argv)
 
   return hb_test_run();
 }
-#else
-int main (int argc HB_UNUSED, char **argv HB_UNUSED)
-{
-  return 0;
-}
-#endif

--- a/test/fuzzing/hb-repacker-fuzzer.cc
+++ b/test/fuzzing/hb-repacker-fuzzer.cc
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include "hb-subset-repacker.h"
+#include "hb-subset-serialize.h"
 
 typedef struct
 {
@@ -42,7 +42,7 @@ bool read(const uint8_t** data, size_t* size, T* out)
   return true;
 }
 
-void cleanup (hb_object_t* objects, uint16_t num_objects)
+void cleanup (hb_subset_serialize_object_t* objects, uint16_t num_objects)
 {
   for (uint32_t i = 0; i < num_objects; i++)
   {
@@ -51,7 +51,7 @@ void cleanup (hb_object_t* objects, uint16_t num_objects)
   }
 }
 
-void add_links_to_objects (hb_object_t* objects, uint16_t num_objects,
+void add_links_to_objects (hb_subset_serialize_object_t* objects, uint16_t num_objects,
                            link_t* links, uint16_t num_links)
 {
   unsigned* link_count = (unsigned*) calloc (num_objects, sizeof (unsigned));
@@ -65,7 +65,7 @@ void add_links_to_objects (hb_object_t* objects, uint16_t num_objects,
   for (uint32_t i = 0; i < num_objects; i++)
   {
     objects[i].num_real_links = link_count[i];
-    objects[i].real_links = (hb_link_t*) calloc (link_count[i], sizeof (hb_link_t));
+    objects[i].real_links = (hb_subset_serialize_link_t*) calloc (link_count[i], sizeof (hb_subset_serialize_link_t));
     objects[i].num_virtual_links = 0;
     objects[i].virtual_links = nullptr;
   }
@@ -74,7 +74,7 @@ void add_links_to_objects (hb_object_t* objects, uint16_t num_objects,
   {
     uint16_t parent_idx = links[i].parent;
     uint16_t child_idx = links[i].child + 1; // All indices are shifted by 1 by the null object.
-    hb_link_t* link = &(objects[parent_idx].real_links[link_count[parent_idx] - 1]);
+    hb_subset_serialize_link_t* link = &(objects[parent_idx].real_links[link_count[parent_idx] - 1]);
 
     link->width = links[i].width;
     link->position = links[i].position;
@@ -91,7 +91,7 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   alloc_state = _fuzzing_alloc_state (data, size);
 
   uint16_t num_objects = 0;
-  hb_object_t* objects = nullptr;
+  hb_subset_serialize_object_t* objects = nullptr;
 
   uint16_t num_real_links = 0;
   link_t* links = nullptr;
@@ -100,7 +100,7 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   if (!read<hb_tag_t> (&data, &size, &table_tag)) goto end;
   if (!read<uint16_t> (&data, &size, &num_objects)) goto end;
 
-  objects = (hb_object_t*) calloc (num_objects, sizeof (hb_object_t));
+  objects = (hb_subset_serialize_object_t*) calloc (num_objects, sizeof (hb_subset_serialize_object_t));
   for (uint32_t i = 0; i < num_objects; i++)
   {
     uint16_t blob_size;


### PR DESCRIPTION
Also hb_link_t and hb_object_t to hb_subset_serialize_link_t and hb_subset_serialize_object_t.

As requested here: https://github.com/harfbuzz/harfbuzz/issues/4984#issuecomment-2576036569