### PR TITLE
Add support for Apple framework builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,9 +563,7 @@ if (UNIX OR MINGW OR VITA)
     set (CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "")
     set_target_properties(harfbuzz PROPERTIES LINKER_LANGUAGE C)
     if (HB_BUILD_SUBSET)
-      set_target_properties(harfbuzz-subset PROPERTIES 
-        LINKER_LANGUAGE C
-      )
+      set_target_properties(harfbuzz-subset PROPERTIES LINKER_LANGUAGE C)
     endif ()
 
     # No threadsafe statics as we do it ourselves
@@ -594,7 +592,7 @@ if (HB_HAVE_GOBJECT)
   target_link_libraries(harfbuzz-gobject harfbuzz ${GOBJECT_LIBRARIES} ${THIRD_PARTY_LIBS})
 
   if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz harfbuzz-icu PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+    set_target_properties(harfbuzz harfbuzz-gobject PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
 
     if (BUILD_FRAMEWORK)
       set_target_properties(harfbuzz-gobject PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,6 @@ message(WARN "HarfBuzz has a Meson port and tries to migrate all the other build
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-  if (BUILD_FRAMEWORK)
-    # Compilation fails on iOS targets with CMAKE_MACOSX_RPATH=ON
-    set (CMAKE_MACOSX_RPATH ON)
-    set (BUILD_SHARED_LIBS ON)
-  endif ()
-
-
 ## Disallow in-source builds, as CMake generated make files can collide with autotools ones
 if (NOT MSVC AND "${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
   message(FATAL_ERROR
@@ -64,6 +57,14 @@ option(HB_HAVE_INTROSPECTION "Enable building introspection (.gir/.typelib) file
 if (HB_HAVE_INTROSPECTION)
   set (HB_HAVE_GOBJECT ON)
   set (HB_HAVE_GLIB ON)
+endif ()
+
+if (APPLE)
+  option(BUILD_FRAMEWORK "Build as Apple Frameworks" OFF)
+endif ()
+if (BUILD_FRAMEWORK)
+  set (CMAKE_MACOSX_RPATH ON)
+  set (BUILD_SHARED_LIBS OFF)
 endif ()
 
 include_directories(AFTER
@@ -506,7 +507,6 @@ if (HB_HAVE_ICU)
       PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-icu"
       XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
       OUTPUT_NAME "harfbuzz-icu"
-      # DEBUG_POSTFIX ""
       XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
       MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-icu"
       MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
@@ -523,22 +523,19 @@ if (HB_BUILD_SUBSET)
   add_dependencies(harfbuzz-subset harfbuzz)
   target_link_libraries(harfbuzz-subset harfbuzz ${THIRD_PARTY_LIBS})
 
-  if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz harfbuzz-subset PROPERTIES 
-      VISIBILITY_INLINES_HIDDEN TRUE
-      FRAMEWORK TRUE
-      FRAMEWORK_VERSION "${HB_VERSION}"
-      PUBLIC_HEADER "${project_headers}"
-      PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-subset"
-      XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
-      OUTPUT_NAME "harfbuzz-subset"
-      # DEBUG_POSTFIX ""
-      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
-      MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-subset"
-      MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
-      MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
-    )
-  endif ()
+  set_target_properties(harfbuzz harfbuzz-subset PROPERTIES 
+    VISIBILITY_INLINES_HIDDEN TRUE
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION "${HB_VERSION}"
+    PUBLIC_HEADER "${project_headers}"
+    PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-subset"
+    XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+    OUTPUT_NAME "harfbuzz-subset"
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+    MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-subset"
+    MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+    MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+  )
 endif ()
 
 if (UNIX OR MINGW OR VITA)
@@ -558,7 +555,9 @@ if (UNIX OR MINGW OR VITA)
     set (CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "")
     set_target_properties(harfbuzz PROPERTIES LINKER_LANGUAGE C)
     if (HB_BUILD_SUBSET)
-      set_target_properties(harfbuzz-subset PROPERTIES LINKER_LANGUAGE C)
+      set_target_properties(harfbuzz-subset PROPERTIES 
+        LINKER_LANGUAGE C
+      )
     endif ()
 
     # No threadsafe statics as we do it ourselves
@@ -595,7 +594,6 @@ if (HB_HAVE_GOBJECT)
       PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-gobject"
       XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
       OUTPUT_NAME "harfbuzz-gobject"
-      # DEBUG_POSTFIX ""
       XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
       MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-gobject"
       MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
@@ -614,14 +612,12 @@ if (HB_HAVE_CAIRO)
   if (BUILD_SHARED_LIBS)
     set_target_properties(harfbuzz-cairo PROPERTIES 
       VISIBILITY_INLINES_HIDDEN TRUE
-      VISIBILITY_INLINES_HIDDEN TRUE
       FRAMEWORK TRUE
       FRAMEWORK_VERSION "${HB_VERSION}"
       PUBLIC_HEADER "${project_headers}"
       PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harbuzz-cairo"
       XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
       OUTPUT_NAME "harfbuzz-cairo"
-      # DEBUG_POSTFIX ""
       XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
       MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-cairo"
       MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
@@ -770,7 +766,6 @@ if (BUILD_FRAMEWORK)
     PRODUCT_BUNDLE_IDENTIFIER "harfbuzz"
     XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
     OUTPUT_NAME "harfbuzz"
-    # DEBUG_POSTFIX ""
     XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
   )
   set (MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz")
@@ -932,7 +927,8 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    FRAMEWORK DESTINATION Library/Frameworks
+    FRAMEWORK DESTINATION Library/Frameworks 
+    COMPONENT runtime OPTIONAL
   )
   make_pkgconfig_pc_file("harfbuzz")
   install(EXPORT harfbuzzConfig
@@ -944,7 +940,8 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      FRAMEWORK DESTINATION Library/Frameworks
+      FRAMEWORK DESTINATION Library/Frameworks 
+      COMPONENT runtime OPTIONAL
     )
     make_pkgconfig_pc_file("harfbuzz-icu")
   endif ()
@@ -953,16 +950,20 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      FRAMEWORK DESTINATION Library/Frameworks
+      FRAMEWORK DESTINATION Library/Frameworks 
+      COMPONENT runtime OPTIONAL
     )
     make_pkgconfig_pc_file("harfbuzz-cairo")
   endif ()
   if (HB_BUILD_SUBSET)
     install(TARGETS harfbuzz-subset
+      EXPORT harfbuzz-subset
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      FRAMEWORK DESTINATION Library/Frameworks
+      FRAMEWORK DESTINATION Library/Frameworks 
+      COMPONENT runtime OPTIONAL
+      # INCLUDES DESTINATION ${project_headers}
     )
     make_pkgconfig_pc_file("harfbuzz-subset")
   endif ()
@@ -997,9 +998,12 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
   endif ()
   if (HB_HAVE_GOBJECT)
     install(TARGETS harfbuzz-gobject
+      EXPORT harfbuzz-gobject
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR} 
+      COMPONENT runtime OPTIONAL
     )
     make_pkgconfig_pc_file("harfbuzz-gobject")
     if (HB_HAVE_INTROSPECTION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 project(harfbuzz)
 
 message(WARN "HarfBuzz has a Meson port and tries to migrate all the other build systems to it, please consider using it as we might remove our cmake port soon.")
@@ -6,18 +6,11 @@ message(WARN "HarfBuzz has a Meson port and tries to migrate all the other build
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-## Limit framework build to Xcode generator
-if (BUILD_FRAMEWORK)
-  # for a framework build on macOS, use:
-  # cmake -DBUILD_FRAMEWORK=ON -Bbuild -H. -GXcode && cmake --build build
-  if (NOT "${CMAKE_GENERATOR}" STREQUAL "Xcode")
-    message(FATAL_ERROR
-      "You should use Xcode generator with BUILD_FRAMEWORK enabled")
+  if (BUILD_FRAMEWORK)
+    # Compilation fails on iOS targets with CMAKE_MACOSX_RPATH=ON
+    set (CMAKE_MACOSX_RPATH ON)
+    set (BUILD_SHARED_LIBS ON)
   endif ()
-  set (CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD_32_64_BIT)")
-  set (CMAKE_MACOSX_RPATH ON)
-  set (BUILD_SHARED_LIBS ON)
-endif ()
 
 
 ## Disallow in-source builds, as CMake generated make files can collide with autotools ones
@@ -505,7 +498,20 @@ if (HB_HAVE_ICU)
   target_link_libraries(harfbuzz-icu harfbuzz ${THIRD_PARTY_LIBS})
 
   if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz harfbuzz-icu PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+    set_target_properties(harfbuzz harfbuzz-icu PROPERTIES 
+      VISIBILITY_INLINES_HIDDEN TRUE
+      FRAMEWORK TRUE
+      FRAMEWORK_VERSION "${HB_VERSION}"
+      PUBLIC_HEADER "${project_headers}"
+      PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-icu"
+      XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+      OUTPUT_NAME "harfbuzz-icu"
+      # DEBUG_POSTFIX ""
+      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+      MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-icu"
+      MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+      MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+    )
   endif ()
 endif ()
 
@@ -518,7 +524,20 @@ if (HB_BUILD_SUBSET)
   target_link_libraries(harfbuzz-subset harfbuzz ${THIRD_PARTY_LIBS})
 
   if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz harfbuzz-subset PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+    set_target_properties(harfbuzz harfbuzz-subset PROPERTIES 
+      VISIBILITY_INLINES_HIDDEN TRUE
+      FRAMEWORK TRUE
+      FRAMEWORK_VERSION "${HB_VERSION}"
+      PUBLIC_HEADER "${project_headers}"
+      PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-subset"
+      XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+      OUTPUT_NAME "harfbuzz-subset"
+      # DEBUG_POSTFIX ""
+      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+      MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-subset"
+      MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+      MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+    )
   endif ()
 endif ()
 
@@ -568,7 +587,20 @@ if (HB_HAVE_GOBJECT)
   target_link_libraries(harfbuzz-gobject harfbuzz ${GOBJECT_LIBRARIES} ${THIRD_PARTY_LIBS})
 
   if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz-gobject PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+    set_target_properties(harfbuzz-gobject PROPERTIES 
+      VISIBILITY_INLINES_HIDDEN TRUE
+      FRAMEWORK TRUE
+      FRAMEWORK_VERSION "${HB_VERSION}"
+      PUBLIC_HEADER "${project_headers}"
+      PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-gobject"
+      XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+      OUTPUT_NAME "harfbuzz-gobject"
+      # DEBUG_POSTFIX ""
+      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+      MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-gobject"
+      MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+      MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+    )
   endif ()
 endif ()
 
@@ -580,7 +612,21 @@ if (HB_HAVE_CAIRO)
   target_link_libraries(harfbuzz-cairo harfbuzz ${THIRD_PARTY_LIBS})
 
   if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz-cairo PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+    set_target_properties(harfbuzz-cairo PROPERTIES 
+      VISIBILITY_INLINES_HIDDEN TRUE
+      VISIBILITY_INLINES_HIDDEN TRUE
+      FRAMEWORK TRUE
+      FRAMEWORK_VERSION "${HB_VERSION}"
+      PUBLIC_HEADER "${project_headers}"
+      PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harbuzz-cairo"
+      XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+      OUTPUT_NAME "harfbuzz-cairo"
+      # DEBUG_POSTFIX ""
+      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+      MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-cairo"
+      MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+      MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+    )
   endif ()
 endif()
 
@@ -719,8 +765,13 @@ if (BUILD_FRAMEWORK)
   set (CMAKE_MACOSX_RPATH ON)
   set_target_properties(harfbuzz PROPERTIES
     FRAMEWORK TRUE
+    FRAMEWORK_VERSION "${HB_VERSION}"
     PUBLIC_HEADER "${project_headers}"
+    PRODUCT_BUNDLE_IDENTIFIER "harfbuzz"
     XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+    OUTPUT_NAME "harfbuzz"
+    # DEBUG_POSTFIX ""
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
   )
   set (MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz")
   set (MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}")
@@ -909,6 +960,9 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
   if (HB_BUILD_SUBSET)
     install(TARGETS harfbuzz-subset
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      FRAMEWORK DESTINATION Library/Frameworks
     )
     make_pkgconfig_pc_file("harfbuzz-subset")
   endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,19 +499,22 @@ if (HB_HAVE_ICU)
   target_link_libraries(harfbuzz-icu harfbuzz ${THIRD_PARTY_LIBS})
 
   if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz harfbuzz-icu PROPERTIES 
-      VISIBILITY_INLINES_HIDDEN TRUE
-      FRAMEWORK TRUE
-      FRAMEWORK_VERSION "${HB_VERSION}"
-      PUBLIC_HEADER "${project_headers}"
-      PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-icu"
-      XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
-      OUTPUT_NAME "harfbuzz-icu"
-      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
-      MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-icu"
-      MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
-      MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
-    )
+    set_target_properties(harfbuzz harfbuzz-icu PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+
+    if (BUILD_FRAMEWORK)
+      set_target_properties(harfbuzz harfbuzz-icu PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION "${HB_VERSION}"
+        PUBLIC_HEADER "${project_headers}"
+        PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-icu"
+        XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+        OUTPUT_NAME "harfbuzz-icu"
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+        MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-icu"
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+        MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+      )
+    endif ()
   endif ()
 endif ()
 
@@ -523,19 +526,24 @@ if (HB_BUILD_SUBSET)
   add_dependencies(harfbuzz-subset harfbuzz)
   target_link_libraries(harfbuzz-subset harfbuzz ${THIRD_PARTY_LIBS})
 
-  set_target_properties(harfbuzz harfbuzz-subset PROPERTIES 
-    VISIBILITY_INLINES_HIDDEN TRUE
-    FRAMEWORK TRUE
-    FRAMEWORK_VERSION "${HB_VERSION}"
-    PUBLIC_HEADER "${project_headers}"
-    PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-subset"
-    XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
-    OUTPUT_NAME "harfbuzz-subset"
-    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
-    MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-subset"
-    MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
-    MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
-  )
+  if (BUILD_SHARED_LIBS)
+    set_target_properties(harfbuzz harfbuzz-subset PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+
+    if (BUILD_FRAMEWORK)
+      set_target_properties(harfbuzz harfbuzz-subset PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION "${HB_VERSION}"
+        PUBLIC_HEADER "${project_headers}"
+        PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-subset"
+        XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+        OUTPUT_NAME "harfbuzz-subset"
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+        MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-subset"
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+        MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+      )
+    endif ()
+  endif ()
 endif ()
 
 if (UNIX OR MINGW OR VITA)
@@ -586,19 +594,22 @@ if (HB_HAVE_GOBJECT)
   target_link_libraries(harfbuzz-gobject harfbuzz ${GOBJECT_LIBRARIES} ${THIRD_PARTY_LIBS})
 
   if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz-gobject PROPERTIES 
-      VISIBILITY_INLINES_HIDDEN TRUE
-      FRAMEWORK TRUE
-      FRAMEWORK_VERSION "${HB_VERSION}"
-      PUBLIC_HEADER "${project_headers}"
-      PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-gobject"
-      XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
-      OUTPUT_NAME "harfbuzz-gobject"
-      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
-      MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-gobject"
-      MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
-      MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
-    )
+    set_target_properties(harfbuzz harfbuzz-icu PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+
+    if (BUILD_FRAMEWORK)
+      set_target_properties(harfbuzz-gobject PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION "${HB_VERSION}"
+        PUBLIC_HEADER "${project_headers}"
+        PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harfbuzz-gobject"
+        XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+        OUTPUT_NAME "harfbuzz-gobject"
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+        MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-gobject"
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+        MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+      )
+    endif ()
   endif ()
 endif ()
 
@@ -610,19 +621,22 @@ if (HB_HAVE_CAIRO)
   target_link_libraries(harfbuzz-cairo harfbuzz ${THIRD_PARTY_LIBS})
 
   if (BUILD_SHARED_LIBS)
-    set_target_properties(harfbuzz-cairo PROPERTIES 
-      VISIBILITY_INLINES_HIDDEN TRUE
-      FRAMEWORK TRUE
-      FRAMEWORK_VERSION "${HB_VERSION}"
-      PUBLIC_HEADER "${project_headers}"
-      PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harbuzz-cairo"
-      XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
-      OUTPUT_NAME "harfbuzz-cairo"
-      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
-      MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-cairo"
-      MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
-      MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
-    )
+    set_target_properties(harfbuzz-cairo PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+
+    if (BUILD_FRAMEWORK)
+      set_target_properties(harfbuzz-cairo PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION "${HB_VERSION}"
+        PUBLIC_HEADER "${project_headers}"
+        PRODUCT_BUNDLE_IDENTIFIER "harfbuzz.harbuzz-cairo"
+        XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+        OUTPUT_NAME "harfbuzz-cairo"
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+        MACOSX_FRAMEWORK_IDENTIFIER "harfbuzz-cairo"
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${HB_VERSION}"
+        MACOSX_FRAMEWORK_BUNDLE_VERSION "${HB_VERSION}"
+      )
+    endif ()
   endif ()
 endif()
 
@@ -963,7 +977,6 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
       FRAMEWORK DESTINATION Library/Frameworks 
       COMPONENT runtime OPTIONAL
-      # INCLUDES DESTINATION ${project_headers}
     )
     make_pkgconfig_pc_file("harfbuzz-subset")
   endif ()


### PR DESCRIPTION

Building the main harfbuzz library for an iOS target is now possible. To achieve this, the `BUILD_SHARED_LIBS` option needs to be explicitly set to OFF at line 12 of the project's CMakeLists.txt (please ignore the comment I falsely written...)
```bash
cmake -S. -B _build -DBUILD_FRAMEWORK=ON -DCMAKE_SYSTEM_NAME=iOS -H. 

sudo cmake --build _build --config Release --target install -- CODE_SIGNING_ALLOWED=NO
```
This configuration will build the harfbuzz library as a static library, and will not build the libharfbuzz-subset library.


Building with `BUILD_SHARED_LIBS` enabled results in a compilation failure in `hb-coretext-font.cc` when targeting iOS due to issues with dynamic library linking on the platform.
