### PR TITLE
Fix hb_buffer deserialization

### DIFF
--- a/src/hb-buffer-deserialize-json.hh
+++ b/src/hb-buffer-deserialize-json.hh
@@ -789,7 +789,7 @@ _again:
 
   *end_ptr = p;
 
-  return p == pe && *(p-1) != ']';
+  return p == pe && *(p-1) == ']';
 }
 
 #endif /* HB_BUFFER_DESERIALIZE_JSON_HH */

--- a/src/hb-buffer-deserialize-json.rl
+++ b/src/hb-buffer-deserialize-json.rl
@@ -138,7 +138,7 @@ _hb_buffer_deserialize_json (hb_buffer_t *buffer,
 
   *end_ptr = p;
 
-  return p == pe && *(p-1) != ']';
+  return p == pe && *(p-1) == ']';
 }
 
 #endif /* HB_BUFFER_DESERIALIZE_JSON_HH */


### PR DESCRIPTION
IIUC this line intends to check that the last
character closes the buffer array and != should be ==.