### PR TITLE
[face] Add fallback implementation to hb_face_reference_blob

### DIFF
--- a/src/hb-face.cc
+++ b/src/hb-face.cc
@@ -493,9 +493,10 @@ hb_face_reference_table (const hb_face_t *face,
  * hb_face_reference_blob:
  * @face: A face object
  *
- * Fetches a pointer to the binary blob that contains the
- * specified face. Returns an empty blob if referencing face data is not
- * possible.
+ * Fetches a pointer to the binary blob that contains the specified face.
+ * If referencing the face data is not possible, this function creates a blob
+ * out of individual table blobs if hb_face_get_table_tags() works with this
+ * face, otherwise it returns an empty blob.
  *
  * Return value: (transfer full): A pointer to the blob for @face
  *

--- a/src/hb-face.h
+++ b/src/hb-face.h
@@ -73,9 +73,14 @@ hb_face_create_from_file_or_fail (const char   *file_name,
  * @tag: the tag of the table to reference
  * @user_data: User data pointer passed by the caller
  *
- * Callback function for hb_face_create_for_tables().
+ * Callback function for hb_face_create_for_tables(). The @tag is the tag of the
+ * table to reference, and the special tag #HB_TAG_NONE is used to reference the
+ * blob of the face itself. If referencing the face blob is not possible, it is
+ * recommended to set hb_get_table_tags_func_t on the @face to allow
+ * hb_face_reference_blob() to create a face blob out of individual table blobs.
  *
- * Return value: (transfer full): A pointer to the @tag table within @face
+ * Return value: (transfer full): A pointer to the @tag table within @face or
+ * `NULL` if the table is not found or cannot be referenced.
  *
  * Since: 0.9.2
  */


### PR DESCRIPTION
If referencing the face blob is not possible (e.g. not implemented by the font functions), use face builder to create a blob out of individual table blobs.

Fixes https://github.com/harfbuzz/harfbuzz/issues/5036