### PR TITLE
[aat] Speed up Lucida Grande among others

### DIFF
--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -40,6 +40,8 @@ namespace AAT {
 
 using namespace OT;
 
+#define HB_AAT_BUFFER_DIGEST_THRESHOLD 32
+
 struct ankr;
 
 using hb_aat_class_cache_t = hb_cache_t<15, 8, 7>;

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -68,6 +68,7 @@ struct hb_aat_apply_context_t :
   hb_set_digest_t buffer_digest = hb_set_digest_t::full ();
   const hb_set_t *left_set = nullptr;
   const hb_set_t *right_set = nullptr;
+  hb_set_digest_t machine_glyph_set = hb_set_digest_t::full ();
   hb_aat_class_cache_t *machine_class_cache = nullptr;
   hb_mask_t subtable_flags = 0;
 
@@ -941,7 +942,7 @@ struct StateTableDriver
   {
     const auto entry = machine.get_entry (StateTableT::STATE_START_OF_TEXT, CLASS_OUT_OF_BOUNDS);
     return !c->is_actionable (ac->buffer, this, entry) &&
-           machine.new_state (entry.newState) == StateTableT::STATE_START_OF_TEXT;
+	    machine.new_state (entry.newState) == StateTableT::STATE_START_OF_TEXT;
   }
 
   template <typename context_t>

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -40,8 +40,6 @@ namespace AAT {
 
 using namespace OT;
 
-#define HB_AAT_BUFFER_DIGEST_THRESHOLD 32
-
 struct ankr;
 
 using hb_aat_class_cache_t = hb_cache_t<15, 8, 7>;

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -936,6 +936,14 @@ struct StateTableDriver
 	      num_glyphs (face_->get_num_glyphs ()) {}
 
   template <typename context_t>
+  bool is_idempotent_on_all_out_of_bounds (context_t *c, hb_aat_apply_context_t *ac)
+  {
+    const auto entry = machine.get_entry (StateTableT::STATE_START_OF_TEXT, CLASS_OUT_OF_BOUNDS);
+    return !c->is_actionable (ac->buffer, this, entry) &&
+           machine.new_state (entry.newState) == StateTableT::STATE_START_OF_TEXT;
+  }
+
+  template <typename context_t>
   void drive (context_t *c, hb_aat_apply_context_t *ac)
   {
     hb_buffer_t *buffer = ac->buffer;

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -65,6 +65,7 @@ struct hb_aat_apply_context_t :
   const ankr *ankr_table;
   const OT::GDEF *gdef_table;
   const hb_sorted_vector_t<hb_aat_map_t::range_flags_t> *range_flags = nullptr;
+  hb_set_digest_t buffer_digest = hb_set_digest_t::full ();
   const hb_set_t *left_set = nullptr;
   const hb_set_t *right_set = nullptr;
   hb_aat_class_cache_t *machine_class_cache = nullptr;

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -967,10 +967,7 @@ struct KerxTable
   {
     c->buffer->unsafe_to_concat ();
 
-    if (c->buffer->len < HB_AAT_BUFFER_DIGEST_THRESHOLD)
-      c->buffer_digest = c->buffer->digest ();
-    else
-      c->buffer_digest = hb_set_digest_t::full ();
+    c->buffer_digest = c->buffer->digest ();
 
     typedef typename T::SubTable SubTable;
 

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -967,8 +967,6 @@ struct KerxTable
   {
     c->buffer->unsafe_to_concat ();
 
-    c->buffer_digest = c->buffer->digest ();
-
     typedef typename T::SubTable SubTable;
 
     bool ret = false;

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -967,6 +967,11 @@ struct KerxTable
   {
     c->buffer->unsafe_to_concat ();
 
+    if (c->buffer->len < HB_AAT_BUFFER_DIGEST_THRESHOLD)
+      c->buffer_digest = c->buffer->digest ();
+    else
+      c->buffer_digest = hb_set_digest_t::full ();
+
     typedef typename T::SubTable SubTable;
 
     bool ret = false;

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -1133,10 +1133,11 @@ struct Chain
     {
       bool reverse;
 
+      hb_mask_t subtable_flags = subtable->subFeatureFlags;
       if (hb_none (hb_iter (c->range_flags) |
-		   hb_map ([&subtable] (const hb_aat_map_t::range_flags_t _) -> bool { return subtable->subFeatureFlags & (_.flags); })))
+		   hb_map ([subtable_flags] (const hb_aat_map_t::range_flags_t _) -> bool { return subtable_flags & (_.flags); })))
 	goto skip;
-      c->subtable_flags = subtable->subFeatureFlags;
+      c->subtable_flags = subtable_flags;
       c->machine_class_cache = accel ? &accel->subtables[i].class_cache : nullptr;
 
       if (!(subtable->get_coverage() & ChainSubtable<Types>::AllDirections) &&

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -171,6 +171,10 @@ struct RearrangementSubtable
 
     StateTableDriver<Types, EntryData> driver (machine, c->face);
 
+    if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
+	!c->buffer_digest.may_have (c->machine_glyph_set))
+      return_trace (false);
+
     driver.drive (&dc, c);
 
     return_trace (dc.ret);
@@ -331,6 +335,10 @@ struct ContextualSubtable
     driver_context_t dc (this, c);
 
     StateTableDriver<Types, EntryData> driver (machine, c->face);
+
+    if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
+	!c->buffer_digest.may_have (c->machine_glyph_set))
+      return_trace (false);
 
     driver.drive (&dc, c);
 
@@ -590,6 +598,10 @@ struct LigatureSubtable
     driver_context_t dc (this, c);
 
     StateTableDriver<Types, EntryData> driver (machine, c->face);
+
+    if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
+	!c->buffer_digest.may_have (c->machine_glyph_set))
+      return_trace (false);
 
     driver.drive (&dc, c);
 
@@ -863,6 +875,10 @@ struct InsertionSubtable
 
     StateTableDriver<Types, EntryData> driver (machine, c->face);
 
+    if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
+	!c->buffer_digest.may_have (c->machine_glyph_set))
+      return_trace (false);
+
     driver.drive (&dc, c);
 
     return_trace (dc.ret);
@@ -919,11 +935,25 @@ struct hb_accelerate_subtables_context_t :
     friend struct hb_aat_layout_lookup_accelerator_t;
 
     public:
+    hb_set_digest_t digest;
     mutable hb_aat_class_cache_t class_cache;
+
+    template <typename T>
+    auto init_ (const T &obj_, unsigned num_glyphs, hb_priority<1>) HB_AUTO_RETURN
+    (
+      obj_.machine.collect_glyphs (this->digest, num_glyphs)
+    )
+
+    template <typename T>
+    void init_ (const T &obj_, unsigned num_glyphs, hb_priority<0>)
+    {
+      digest = digest.full ();
+    }
 
     template <typename T>
     void init (const T &obj_, unsigned num_glyphs)
     {
+      init_ (obj_, num_glyphs, hb_prioritize);
       class_cache.clear ();
     }
 
@@ -1143,6 +1173,7 @@ struct Chain
 		   hb_map ([subtable_flags] (const hb_aat_map_t::range_flags_t _) -> bool { return subtable_flags & (_.flags); })))
 	goto skip;
       c->subtable_flags = subtable_flags;
+      c->machine_glyph_set = accel ? accel->subtables[i].digest : hb_set_digest_t::full ();
       c->machine_class_cache = accel ? &accel->subtables[i].class_cache : nullptr;
 
       if (!(subtable->get_coverage() & ChainSubtable<Types>::AllDirections) &&

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -173,7 +173,10 @@ struct RearrangementSubtable
 
     if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
 	!c->buffer_digest.may_have (c->machine_glyph_set))
+    {
+      (void) c->buffer->message (c->font, "skipped chainsubtable because no glyph matches");
       return_trace (false);
+    }
 
     driver.drive (&dc, c);
 
@@ -338,7 +341,10 @@ struct ContextualSubtable
 
     if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
 	!c->buffer_digest.may_have (c->machine_glyph_set))
+    {
+      (void) c->buffer->message (c->font, "skipped chainsubtable because no glyph matches");
       return_trace (false);
+    }
 
     driver.drive (&dc, c);
 
@@ -601,7 +607,10 @@ struct LigatureSubtable
 
     if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
 	!c->buffer_digest.may_have (c->machine_glyph_set))
+    {
+      (void) c->buffer->message (c->font, "skipped chainsubtable because no glyph matches");
       return_trace (false);
+    }
 
     driver.drive (&dc, c);
 
@@ -877,7 +886,10 @@ struct InsertionSubtable
 
     if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
 	!c->buffer_digest.may_have (c->machine_glyph_set))
+    {
+      (void) c->buffer->message (c->font, "skipped chainsubtable because no glyph matches");
       return_trace (false);
+    }
 
     driver.drive (&dc, c);
 

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -1404,10 +1404,7 @@ struct mortmorx
 
     c->buffer->unsafe_to_concat ();
 
-    if (c->buffer->len < HB_AAT_BUFFER_DIGEST_THRESHOLD)
-      c->buffer_digest = c->buffer->digest ();
-    else
-      c->buffer_digest = hb_set_digest_t::full ();
+    c->buffer_digest = c->buffer->digest ();
 
     c->set_lookup_index (0);
     const Chain<Types> *chain = &firstChain;


### PR DESCRIPTION
It has a lot of small chains, many of them for Hebrew, or other scripts. But using the buffer-digest, for all buffers, not only short ones, we can skip such subchains.