### PR TITLE
[morx] Only collect glyphs that can initiate action in the machine

### DIFF
--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -939,7 +939,7 @@ struct StateTableDriver
   bool is_idempotent_on_all_out_of_bounds (context_t *c, hb_aat_apply_context_t *ac)
   {
     const auto entry = machine.get_entry (StateTableT::STATE_START_OF_TEXT, CLASS_OUT_OF_BOUNDS);
-    return !c->is_actionable (ac->buffer, this, entry) &&
+    return !c->is_actionable (ac->buffer, entry) &&
 	    machine.new_state (entry.newState) == StateTableT::STATE_START_OF_TEXT;
   }
 
@@ -1021,7 +1021,7 @@ struct StateTableDriver
       bool is_safe_to_break =
       (
           /* 1. */
-          !c->is_actionable (buffer, this, entry) &&
+          !c->is_actionable (buffer, entry) &&
 
           /* 2. */
           // This one is meh, I know...
@@ -1033,7 +1033,7 @@ struct StateTableDriver
 		    wouldbe_entry = &machine.get_entry(StateTableT::STATE_START_OF_TEXT, klass)
 		    ,
 		    /* 2c'. */
-		    !c->is_actionable (buffer, this, *wouldbe_entry) &&
+		    !c->is_actionable (buffer, *wouldbe_entry) &&
 		    /* 2c". */
 		    (
 		      next_state == machine.new_state(wouldbe_entry->newState) &&
@@ -1043,7 +1043,7 @@ struct StateTableDriver
 	  ) &&
 
           /* 3. */
-          !c->is_actionable (buffer, this, machine.get_entry (state, CLASS_END_OF_TEXT))
+          !c->is_actionable (buffer, machine.get_entry (state, CLASS_END_OF_TEXT))
       );
 
       if (!is_safe_to_break && buffer->backtrack_len () && buffer->idx < buffer->len)

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -31,7 +31,6 @@
 #include "hb-aat-map.hh"
 #include "hb-open-type.hh"
 #include "hb-cache.hh"
-#include "hb-bit-page.hh"
 
 namespace OT {
 struct GDEF;
@@ -157,7 +156,6 @@ struct LookupSegmentSingle
   template <typename set_t, typename filter_t>
   void collect_glyphs_filtered (set_t &glyphs, const filter_t &filter) const
   {
-    if (first == DELETED_GLYPH) return;
     if (!filter (value)) return;
     glyphs.add_range (first, last);
   }
@@ -247,7 +245,6 @@ struct LookupSegmentArray
   template <typename set_t, typename filter_t>
   void collect_glyphs_filtered (set_t &glyphs, const void *base, const filter_t &filter) const
   {
-    if (first == DELETED_GLYPH) return;
     const auto &values = base+valuesZ;
     for (hb_codepoint_t i = first; i <= last; i++)
       if (filter (values[i - first]))
@@ -348,7 +345,6 @@ struct LookupSingle
   template <typename set_t, typename filter_t>
   void collect_glyphs_filtered (set_t &glyphs, const filter_t &filter) const
   {
-    if (glyph == DELETED_GLYPH) return;
     if (!filter (value)) return;
     glyphs.add (glyph);
   }
@@ -708,6 +704,7 @@ struct StateTable
     // Collect all classes going out from the start state.
     unsigned num_classes = nClasses;
     hb_set_t filter;
+
     for (unsigned i = 0; i < num_classes; i++)
     {
       const auto &entry = get_entry (STATE_START_OF_TEXT, i);

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -939,7 +939,7 @@ struct StateTableDriver
   bool is_idempotent_on_all_out_of_bounds (context_t *c, hb_aat_apply_context_t *ac)
   {
     const auto entry = machine.get_entry (StateTableT::STATE_START_OF_TEXT, CLASS_OUT_OF_BOUNDS);
-    return !c->is_actionable (ac->buffer, entry) &&
+    return !c->is_actionable (entry) &&
 	    machine.new_state (entry.newState) == StateTableT::STATE_START_OF_TEXT;
   }
 
@@ -1021,7 +1021,7 @@ struct StateTableDriver
       bool is_safe_to_break =
       (
           /* 1. */
-          !c->is_actionable (buffer, entry) &&
+          !c->is_actionable (entry) &&
 
           /* 2. */
           // This one is meh, I know...
@@ -1033,7 +1033,7 @@ struct StateTableDriver
 		    wouldbe_entry = &machine.get_entry(StateTableT::STATE_START_OF_TEXT, klass)
 		    ,
 		    /* 2c'. */
-		    !c->is_actionable (buffer, *wouldbe_entry) &&
+		    !c->is_actionable (*wouldbe_entry) &&
 		    /* 2c". */
 		    (
 		      next_state == machine.new_state(wouldbe_entry->newState) &&
@@ -1043,7 +1043,7 @@ struct StateTableDriver
 	  ) &&
 
           /* 3. */
-          !c->is_actionable (buffer, machine.get_entry (state, CLASS_END_OF_TEXT))
+          !c->is_actionable (machine.get_entry (state, CLASS_END_OF_TEXT))
       );
 
       if (!is_safe_to_break && buffer->backtrack_len () && buffer->idx < buffer->len)

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -939,7 +939,7 @@ struct StateTableDriver
   bool is_idempotent_on_all_out_of_bounds (context_t *c, hb_aat_apply_context_t *ac)
   {
     const auto entry = machine.get_entry (StateTableT::STATE_START_OF_TEXT, CLASS_OUT_OF_BOUNDS);
-    return !c->is_actionable (entry) &&
+    return !c->table->is_actionable (entry) &&
 	    machine.new_state (entry.newState) == StateTableT::STATE_START_OF_TEXT;
   }
 
@@ -1021,7 +1021,7 @@ struct StateTableDriver
       bool is_safe_to_break =
       (
           /* 1. */
-          !c->is_actionable (entry) &&
+          !c->table->is_actionable (entry) &&
 
           /* 2. */
           // This one is meh, I know...
@@ -1033,7 +1033,7 @@ struct StateTableDriver
 		    wouldbe_entry = &machine.get_entry(StateTableT::STATE_START_OF_TEXT, klass)
 		    ,
 		    /* 2c'. */
-		    !c->is_actionable (*wouldbe_entry) &&
+		    !c->table->is_actionable (*wouldbe_entry) &&
 		    /* 2c". */
 		    (
 		      next_state == machine.new_state(wouldbe_entry->newState) &&
@@ -1043,7 +1043,7 @@ struct StateTableDriver
 	  ) &&
 
           /* 3. */
-          !c->is_actionable (machine.get_entry (state, CLASS_END_OF_TEXT))
+          !c->table->is_actionable (machine.get_entry (state, CLASS_END_OF_TEXT))
       );
 
       if (!is_safe_to_break && buffer->backtrack_len () && buffer->idx < buffer->len)

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -31,6 +31,8 @@
 #include "hb-aat-map.hh"
 #include "hb-open-type.hh"
 #include "hb-cache.hh"
+#include "hb-bit-page.hh"
+
 
 namespace OT {
 struct GDEF;
@@ -701,9 +703,16 @@ struct StateTable
   template <typename set_t, typename table_t>
   void collect_initial_glyphs (set_t &glyphs, unsigned num_glyphs, const table_t &table) const
   {
-    // Collect all classes going out from the start state.
     unsigned num_classes = nClasses;
-    hb_set_t filter;
+
+    if (unlikely (num_classes > hb_bit_page_t::BITS))
+    {
+      (this+classTable).collect_glyphs (glyphs, num_glyphs);
+      return;
+    }
+
+    // Collect all classes going out from the start state.
+    hb_bit_page_t filter;
 
     for (unsigned i = 0; i < num_classes; i++)
     {

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -924,7 +924,7 @@ struct ExtendedTypes
   }
 };
 
-template <typename Types, typename EntryData>
+template <typename Types, typename EntryData, typename Flags>
 struct StateTableDriver
 {
   using StateTableT = StateTable<Types, EntryData>;
@@ -1027,7 +1027,7 @@ struct StateTableDriver
           // This one is meh, I know...
 	  (
                  state == StateTableT::STATE_START_OF_TEXT
-              || ((entry.flags & context_t::DontAdvance) && next_state == StateTableT::STATE_START_OF_TEXT)
+              || ((entry.flags & Flags::DontAdvance) && next_state == StateTableT::STATE_START_OF_TEXT)
               || (
 		    /* 2c. */
 		    wouldbe_entry = &machine.get_entry(StateTableT::STATE_START_OF_TEXT, klass)
@@ -1037,7 +1037,7 @@ struct StateTableDriver
 		    /* 2c". */
 		    (
 		      next_state == machine.new_state(wouldbe_entry->newState) &&
-		      (entry.flags & context_t::DontAdvance) == (wouldbe_entry->flags & context_t::DontAdvance)
+		      (entry.flags & Flags::DontAdvance) == (wouldbe_entry->flags & Flags::DontAdvance)
 		    )
 		 )
 	  ) &&
@@ -1057,7 +1057,7 @@ struct StateTableDriver
       if (buffer->idx == buffer->len || unlikely (!buffer->successful))
 	break;
 
-      if (!(entry.flags & context_t::DontAdvance) || buffer->max_ops-- <= 0)
+      if (!(entry.flags & Flags::DontAdvance) || buffer->max_ops-- <= 0)
 	(void) buffer->next_glyph ();
     }
 

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -1035,14 +1035,6 @@ struct StateTableDriver
 	      num_glyphs (face_->get_num_glyphs ()) {}
 
   template <typename context_t>
-  bool is_idempotent_on_all_out_of_bounds (context_t *c, hb_aat_apply_context_t *ac)
-  {
-    const auto entry = machine.get_entry (StateTableT::STATE_START_OF_TEXT, CLASS_OUT_OF_BOUNDS);
-    return !c->table->is_action_initiable (entry) &&
-	    machine.new_state (entry.newState) == StateTableT::STATE_START_OF_TEXT;
-  }
-
-  template <typename context_t>
   void drive (context_t *c, hb_aat_apply_context_t *ac)
   {
     hb_buffer_t *buffer = ac->buffer;

--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -718,7 +718,7 @@ struct StateTable
     {
       const auto &entry = get_entry (STATE_START_OF_TEXT, i);
       if (new_state (entry.newState) == STATE_START_OF_TEXT &&
-	  !table.is_actionable (entry))
+	  !table.is_action_initiable (entry) && !table.is_actionable (entry))
 	continue;
 
       filter.add (i);
@@ -1038,7 +1038,7 @@ struct StateTableDriver
   bool is_idempotent_on_all_out_of_bounds (context_t *c, hb_aat_apply_context_t *ac)
   {
     const auto entry = machine.get_entry (StateTableT::STATE_START_OF_TEXT, CLASS_OUT_OF_BOUNDS);
-    return !c->table->is_actionable (entry) &&
+    return !c->table->is_action_initiable (entry) &&
 	    machine.new_state (entry.newState) == StateTableT::STATE_START_OF_TEXT;
   }
 

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -207,6 +207,9 @@ struct Format1Entry<false>
 
   typedef void EntryData;
 
+  static bool initiateAction (const Entry<EntryData> &entry)
+  { return entry.flags & Push; }
+
   static bool performAction (const Entry<EntryData> &entry)
   { return entry.flags & Offset; }
 
@@ -228,6 +231,10 @@ struct KerxSubTableFormat1
     DontAdvance	= Format1EntryT::DontAdvance,
   };
 
+  bool is_action_initiable (const Entry<EntryData> &entry) const
+  {
+    return Format1EntryT::initiateAction (entry);
+  }
   bool is_actionable (const Entry<EntryData> &entry) const
   { return Format1EntryT::performAction (entry); }
 
@@ -509,8 +516,14 @@ struct KerxSubTableFormat4
     Reserved		= 0x3FFF,	/* Not used; set to 0. */
   };
 
+  bool is_action_initiable (const Entry<EntryData> &entry) const
+  {
+    return (entry.flags & Mark);
+  }
   bool is_actionable (const Entry<EntryData> &entry) const
-  { return entry.data.ankrActionIndex != 0xFFFF; }
+  {
+    return entry.data.ankrActionIndex != 0xFFFF;
+  }
 
   struct driver_context_t
   {

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -223,13 +223,14 @@ struct KerxSubTableFormat1
   typedef Format1Entry<Types::extended> Format1EntryT;
   typedef typename Format1EntryT::EntryData EntryData;
 
+  enum Flags
+  {
+    DontAdvance	= Format1EntryT::DontAdvance,
+  };
+
   struct driver_context_t
   {
     static constexpr bool in_place = true;
-    enum
-    {
-      DontAdvance	= Format1EntryT::DontAdvance,
-    };
 
     driver_context_t (const KerxSubTableFormat1 *table_,
 		      hb_aat_apply_context_t *c_) :
@@ -245,7 +246,7 @@ struct KerxSubTableFormat1
     bool is_actionable (const Entry<EntryData> &entry)
     { return Format1EntryT::performAction (entry); }
     void transition (hb_buffer_t *buffer,
-		     StateTableDriver<Types, EntryData> *driver,
+		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
     {
       unsigned int flags = entry.flags;
@@ -364,7 +365,7 @@ struct KerxSubTableFormat1
 
     driver_context_t dc (this, c);
 
-    StateTableDriver<Types, EntryData> driver (machine, c->font->face);
+    StateTableDriver<Types, EntryData, Flags> driver (machine, c->font->face);
 
     driver.drive (&dc, c);
 
@@ -498,17 +499,17 @@ struct KerxSubTableFormat4
     DEFINE_SIZE_STATIC (2);
   };
 
+  enum Flags
+  {
+    Mark		= 0x8000,	/* If set, remember this glyph as the marked glyph. */
+    DontAdvance	= 0x4000,	/* If set, don't advance to the next glyph before
+				       * going to the new state. */
+    Reserved		= 0x3FFF,	/* Not used; set to 0. */
+  };
+
   struct driver_context_t
   {
     static constexpr bool in_place = true;
-    enum Flags
-    {
-      Mark		= 0x8000,	/* If set, remember this glyph as the marked glyph. */
-      DontAdvance	= 0x4000,	/* If set, don't advance to the next glyph before
-					 * going to the new state. */
-      Reserved		= 0x3FFF,	/* Not used; set to 0. */
-    };
-
     enum SubTableFlags
     {
       ActionType	= 0xC0000000,	/* A two-bit field containing the action type. */
@@ -529,7 +530,7 @@ struct KerxSubTableFormat4
     bool is_actionable (const Entry<EntryData> &entry)
     { return entry.data.ankrActionIndex != 0xFFFF; }
     void transition (hb_buffer_t *buffer,
-		     StateTableDriver<Types, EntryData> *driver,
+		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
     {
       if (mark_set && entry.data.ankrActionIndex != 0xFFFF && buffer->idx < buffer->len)
@@ -631,7 +632,7 @@ struct KerxSubTableFormat4
 
     driver_context_t dc (this, c);
 
-    StateTableDriver<Types, EntryData> driver (machine, c->font->face);
+    StateTableDriver<Types, EntryData, Flags> driver (machine, c->font->face);
 
     driver.drive (&dc, c);
 

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -243,7 +243,6 @@ struct KerxSubTableFormat1
 	crossStream (table->header.coverage & table->header.CrossStream) {}
 
     bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			StateTableDriver<Types, EntryData> *driver HB_UNUSED,
 			const Entry<EntryData> &entry)
     { return Format1EntryT::performAction (entry); }
     void transition (hb_buffer_t *buffer,
@@ -529,7 +528,6 @@ struct KerxSubTableFormat4
 	mark (0) {}
 
     bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			StateTableDriver<Types, EntryData> *driver HB_UNUSED,
 			const Entry<EntryData> &entry)
     { return entry.data.ankrActionIndex != 0xFFFF; }
     void transition (hb_buffer_t *buffer,

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -242,8 +242,7 @@ struct KerxSubTableFormat1
 	depth (0),
 	crossStream (table->header.coverage & table->header.CrossStream) {}
 
-    bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			const Entry<EntryData> &entry)
+    bool is_actionable (const Entry<EntryData> &entry)
     { return Format1EntryT::performAction (entry); }
     void transition (hb_buffer_t *buffer,
 		     StateTableDriver<Types, EntryData> *driver,
@@ -527,8 +526,7 @@ struct KerxSubTableFormat4
 	mark_set (false),
 	mark (0) {}
 
-    bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			const Entry<EntryData> &entry)
+    bool is_actionable (const Entry<EntryData> &entry)
     { return entry.data.ankrActionIndex != 0xFFFF; }
     void transition (hb_buffer_t *buffer,
 		     StateTableDriver<Types, EntryData> *driver,

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -74,8 +74,7 @@ struct RearrangementSubtable
 	ret (false),
 	start (0), end (0) {}
 
-    bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			const Entry<EntryData> &entry) const
+    bool is_actionable (const Entry<EntryData> &entry) const
     {
       return (entry.flags & Verb) && start < end;
     }
@@ -231,12 +230,8 @@ struct ContextualSubtable
 	table (table_),
 	subs (table+table->substitutionTables) {}
 
-    bool is_actionable (hb_buffer_t *buffer,
-			const Entry<EntryData> &entry) const
+    bool is_actionable (const Entry<EntryData> &entry) const
     {
-      if (buffer->idx == buffer->len && !mark_set)
-	return false;
-
       return entry.data.markIndex != 0xFFFF || entry.data.currentIndex != 0xFFFF;
     }
     void transition (hb_buffer_t *buffer,
@@ -482,8 +477,7 @@ struct LigatureSubtable
 	ligature (table+table->ligature),
 	match_length (0) {}
 
-    bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			const Entry<EntryData> &entry) const
+    bool is_actionable (const Entry<EntryData> &entry) const
     {
       return LigatureEntryT::performAction (entry);
     }
@@ -791,8 +785,7 @@ struct InsertionSubtable
 	mark (0),
 	insertionAction (table+table->insertionAction) {}
 
-    bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			const Entry<EntryData> &entry) const
+    bool is_actionable (const Entry<EntryData> &entry) const
     {
       return (entry.flags & (CurrentInsertCount | MarkedInsertCount)) &&
 	     (entry.data.currentInsertIndex != 0xFFFF ||entry.data.markedInsertIndex != 0xFFFF);

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -67,9 +67,13 @@ struct RearrangementSubtable
     Verb		= 0x000F,	/* The type of rearrangement specified. */
   };
 
+  bool is_action_initiable (const Entry<EntryData> &entry) const
+  {
+    return (entry.flags & MarkFirst);
+  }
   bool is_actionable (const Entry<EntryData> &entry) const
   {
-    return (entry.flags & (MarkFirst | MarkLast | Verb));
+    return (entry.flags & Verb);
   }
 
   struct driver_context_t
@@ -220,9 +224,13 @@ struct ContextualSubtable
     Reserved		= 0x3FFF,	/* These bits are reserved and should be set to 0. */
   };
 
+  bool is_action_initiable (const Entry<EntryData> &entry) const
+  {
+    return (entry.flags & SetMark);
+  }
   bool is_actionable (const Entry<EntryData> &entry) const
   {
-    return (entry.flags & SetMark) || entry.data.markIndex != 0xFFFF || entry.data.currentIndex != 0xFFFF;
+    return entry.data.markIndex != 0xFFFF || entry.data.currentIndex != 0xFFFF;
   }
 
   struct driver_context_t
@@ -417,6 +425,9 @@ struct LigatureEntry<true>
     Reserved		= 0x1FFF,	/* These bits are reserved and should be set to 0. */
   };
 
+  static bool initiateAction (const Entry<EntryData> &entry)
+  { return entry.flags & SetComponent; }
+
   static bool performAction (const Entry<EntryData> &entry)
   { return entry.flags & PerformAction; }
 
@@ -439,6 +450,9 @@ struct LigatureEntry<false>
 					 * multiple of 4. */
   };
 
+  static bool initiateAction (const Entry<EntryData> &entry)
+  { return entry.flags & SetComponent; }
+
   static bool performAction (const Entry<EntryData> &entry)
   { return entry.flags & Offset; }
 
@@ -460,6 +474,10 @@ struct LigatureSubtable
     DontAdvance	= LigatureEntryT::DontAdvance,
   };
 
+  bool is_action_initiable (const Entry<EntryData> &entry) const
+  {
+    return LigatureEntryT::initiateAction (entry);
+  }
   bool is_actionable (const Entry<EntryData> &entry) const
   {
     return LigatureEntryT::performAction (entry);
@@ -739,7 +757,7 @@ struct InsertionSubtable
   enum Flags
   {
     SetMark		= 0x8000,     /* If set, mark the current glyph. */
-    DontAdvance	= 0x4000,	      /* If set, don't advance to the next glyph before
+    DontAdvance		= 0x4000,     /* If set, don't advance to the next glyph before
 				       * going to the new state.  This does not mean
 				       * that the glyph pointed to is the same one as
 				       * before. If you've made insertions immediately
@@ -784,6 +802,10 @@ struct InsertionSubtable
 				       * marked location is 31 glyphs. */
   };
 
+  bool is_action_initiable (const Entry<EntryData> &entry) const
+  {
+    return (entry.flags & SetMark);
+  }
   bool is_actionable (const Entry<EntryData> &entry) const
   {
     return (entry.flags & (CurrentInsertCount | MarkedInsertCount)) &&

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -69,7 +69,7 @@ struct RearrangementSubtable
 
   bool is_actionable (const Entry<EntryData> &entry) const
   {
-    return (entry.flags & Verb); // && start < end;
+    return (entry.flags & (MarkFirst | MarkLast | Verb));
   }
 
   struct driver_context_t
@@ -222,7 +222,7 @@ struct ContextualSubtable
 
   bool is_actionable (const Entry<EntryData> &entry) const
   {
-    return entry.data.markIndex != 0xFFFF || entry.data.currentIndex != 0xFFFF;
+    return (entry.flags & SetMark) || entry.data.markIndex != 0xFFFF || entry.data.currentIndex != 0xFFFF;
   }
 
   struct driver_context_t
@@ -967,7 +967,7 @@ struct hb_accelerate_subtables_context_t :
     template <typename T>
     auto init_ (const T &obj_, unsigned num_glyphs, hb_priority<1>) HB_AUTO_RETURN
     (
-      obj_.machine.collect_glyphs (glyph_set, num_glyphs)
+      obj_.machine.collect_initial_glyphs (glyph_set, num_glyphs, obj_)
     )
 
     template <typename T>

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -698,7 +698,7 @@ struct NoncontextualSubtable
   }
 
   template <typename set_t>
-  void collect_glyphs (set_t &glyphs, unsigned num_glyphs) const
+  void collect_initial_glyphs (set_t &glyphs, unsigned num_glyphs) const
   {
     substitute.collect_glyphs (glyphs, num_glyphs);
   }
@@ -973,7 +973,7 @@ struct hb_accelerate_subtables_context_t :
     template <typename T>
     void init_ (const T &obj_, unsigned num_glyphs, hb_priority<0>)
     {
-      obj_.collect_glyphs (glyph_set, num_glyphs);
+      obj_.collect_initial_glyphs (glyph_set, num_glyphs);
     }
 
     template <typename T>

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -177,8 +177,7 @@ struct RearrangementSubtable
 
     StateTableDriver<Types, EntryData, Flags> driver (machine, c->face);
 
-    if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
-	!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
+    if (!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
     {
       (void) c->buffer->message (c->font, "skipped chainsubtable because no glyph matches");
       return_trace (false);
@@ -348,8 +347,7 @@ struct ContextualSubtable
 
     StateTableDriver<Types, EntryData, Flags> driver (machine, c->face);
 
-    if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
-	!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
+    if (!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
     {
       (void) c->buffer->message (c->font, "skipped chainsubtable because no glyph matches");
       return_trace (false);
@@ -625,8 +623,7 @@ struct LigatureSubtable
 
     StateTableDriver<Types, EntryData, Flags> driver (machine, c->face);
 
-    if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
-	!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
+    if (!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
     {
       (void) c->buffer->message (c->font, "skipped chainsubtable because no glyph matches");
       return_trace (false);
@@ -920,8 +917,7 @@ struct InsertionSubtable
 
     StateTableDriver<Types, EntryData, Flags> driver (machine, c->face);
 
-    if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
-	!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
+    if (!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
     {
       (void) c->buffer->message (c->font, "skipped chainsubtable because no glyph matches");
       return_trace (false);

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -53,22 +53,23 @@ struct RearrangementSubtable
 
   typedef void EntryData;
 
-  struct driver_context_t
+  enum Flags
   {
-    static constexpr bool in_place = true;
-    enum Flags
-    {
-      MarkFirst		= 0x8000,	/* If set, make the current glyph the first
+    MarkFirst		= 0x8000,	/* If set, make the current glyph the first
 					 * glyph to be rearranged. */
-      DontAdvance	= 0x4000,	/* If set, don't advance to the next glyph
+    DontAdvance		= 0x4000,	/* If set, don't advance to the next glyph
 					 * before going to the new state. This means
 					 * that the glyph index doesn't change, even
 					 * if the glyph at that index has changed. */
-      MarkLast		= 0x2000,	/* If set, make the current glyph the last
+    MarkLast		= 0x2000,	/* If set, make the current glyph the last
 					 * glyph to be rearranged. */
-      Reserved		= 0x1FF0,	/* These bits are reserved and should be set to 0. */
-      Verb		= 0x000F,	/* The type of rearrangement specified. */
-    };
+    Reserved		= 0x1FF0,	/* These bits are reserved and should be set to 0. */
+    Verb		= 0x000F,	/* The type of rearrangement specified. */
+  };
+
+  struct driver_context_t
+  {
+    static constexpr bool in_place = true;
 
     driver_context_t (const RearrangementSubtable *table HB_UNUSED) :
 	ret (false),
@@ -79,7 +80,7 @@ struct RearrangementSubtable
       return (entry.flags & Verb) && start < end;
     }
     void transition (hb_buffer_t *buffer,
-		     StateTableDriver<Types, EntryData> *driver,
+		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
     {
       unsigned int flags = entry.flags;
@@ -167,7 +168,7 @@ struct RearrangementSubtable
 
     driver_context_t dc (this);
 
-    StateTableDriver<Types, EntryData> driver (machine, c->face);
+    StateTableDriver<Types, EntryData, Flags> driver (machine, c->face);
 
     if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
 	!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
@@ -208,16 +209,17 @@ struct ContextualSubtable
     DEFINE_SIZE_STATIC (4);
   };
 
+  enum Flags
+  {
+    SetMark		= 0x8000,	/* If set, make the current glyph the marked glyph. */
+    DontAdvance	= 0x4000,	/* If set, don't advance to the next glyph before
+				       * going to the new state. */
+    Reserved		= 0x3FFF,	/* These bits are reserved and should be set to 0. */
+  };
+
   struct driver_context_t
   {
     static constexpr bool in_place = true;
-    enum Flags
-    {
-      SetMark		= 0x8000,	/* If set, make the current glyph the marked glyph. */
-      DontAdvance	= 0x4000,	/* If set, don't advance to the next glyph before
-					 * going to the new state. */
-      Reserved		= 0x3FFF,	/* These bits are reserved and should be set to 0. */
-    };
 
     driver_context_t (const ContextualSubtable *table_,
 			     hb_aat_apply_context_t *c_) :
@@ -235,7 +237,7 @@ struct ContextualSubtable
       return entry.data.markIndex != 0xFFFF || entry.data.currentIndex != 0xFFFF;
     }
     void transition (hb_buffer_t *buffer,
-		     StateTableDriver<Types, EntryData> *driver,
+		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
     {
       /* Looks like CoreText applies neither mark nor current substitution for
@@ -332,7 +334,7 @@ struct ContextualSubtable
 
     driver_context_t dc (this, c);
 
-    StateTableDriver<Types, EntryData> driver (machine, c->face);
+    StateTableDriver<Types, EntryData, Flags> driver (machine, c->face);
 
     if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
 	!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
@@ -390,6 +392,16 @@ struct LigatureEntry;
 template <>
 struct LigatureEntry<true>
 {
+
+  struct EntryData
+  {
+    HBUINT16	ligActionIndex;	/* Index to the first ligActionTable entry
+				 * for processing this group, if indicated
+				 * by the flags. */
+    public:
+    DEFINE_SIZE_STATIC (2);
+  };
+
   enum Flags
   {
     SetComponent	= 0x8000,	/* Push this glyph onto the component stack for
@@ -401,15 +413,6 @@ struct LigatureEntry<true>
     Reserved		= 0x1FFF,	/* These bits are reserved and should be set to 0. */
   };
 
-  struct EntryData
-  {
-    HBUINT16	ligActionIndex;	/* Index to the first ligActionTable entry
-				 * for processing this group, if indicated
-				 * by the flags. */
-    public:
-    DEFINE_SIZE_STATIC (2);
-  };
-
   static bool performAction (const Entry<EntryData> &entry)
   { return entry.flags & PerformAction; }
 
@@ -419,6 +422,8 @@ struct LigatureEntry<true>
 template <>
 struct LigatureEntry<false>
 {
+  typedef void EntryData;
+
   enum Flags
   {
     SetComponent	= 0x8000,	/* Push this glyph onto the component stack for
@@ -429,8 +434,6 @@ struct LigatureEntry<false>
 					 * ligature action list. This value must be a
 					 * multiple of 4. */
   };
-
-  typedef void EntryData;
 
   static bool performAction (const Entry<EntryData> &entry)
   { return entry.flags & Offset; }
@@ -448,13 +451,14 @@ struct LigatureSubtable
   typedef LigatureEntry<Types::extended> LigatureEntryT;
   typedef typename LigatureEntryT::EntryData EntryData;
 
+  enum Flags
+  {
+    DontAdvance	= LigatureEntryT::DontAdvance,
+  };
+
   struct driver_context_t
   {
     static constexpr bool in_place = false;
-    enum
-    {
-      DontAdvance	= LigatureEntryT::DontAdvance,
-    };
     enum LigActionFlags
     {
       LigActionLast	= 0x80000000,	/* This is the last action in the list. This also
@@ -482,7 +486,7 @@ struct LigatureSubtable
       return LigatureEntryT::performAction (entry);
     }
     void transition (hb_buffer_t *buffer,
-		     StateTableDriver<Types, EntryData> *driver,
+		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
     {
       DEBUG_MSG (APPLY, nullptr, "Ligature transition at %u", buffer->idx);
@@ -596,7 +600,7 @@ struct LigatureSubtable
 
     driver_context_t dc (this, c);
 
-    StateTableDriver<Types, EntryData> driver (machine, c->face);
+    StateTableDriver<Types, EntryData, Flags> driver (machine, c->face);
 
     if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
 	!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))
@@ -727,56 +731,57 @@ struct InsertionSubtable
     DEFINE_SIZE_STATIC (4);
   };
 
+  enum Flags
+  {
+    SetMark		= 0x8000,     /* If set, mark the current glyph. */
+    DontAdvance	= 0x4000,	      /* If set, don't advance to the next glyph before
+				       * going to the new state.  This does not mean
+				       * that the glyph pointed to is the same one as
+				       * before. If you've made insertions immediately
+				       * downstream of the current glyph, the next glyph
+				       * processed would in fact be the first one
+				       * inserted. */
+    CurrentIsKashidaLike= 0x2000,     /* If set, and the currentInsertList is nonzero,
+				       * then the specified glyph list will be inserted
+				       * as a kashida-like insertion, either before or
+				       * after the current glyph (depending on the state
+				       * of the currentInsertBefore flag). If clear, and
+				       * the currentInsertList is nonzero, then the
+				       * specified glyph list will be inserted as a
+				       * split-vowel-like insertion, either before or
+				       * after the current glyph (depending on the state
+				       * of the currentInsertBefore flag). */
+    MarkedIsKashidaLike= 0x1000,      /* If set, and the markedInsertList is nonzero,
+				       * then the specified glyph list will be inserted
+				       * as a kashida-like insertion, either before or
+				       * after the marked glyph (depending on the state
+				       * of the markedInsertBefore flag). If clear, and
+				       * the markedInsertList is nonzero, then the
+				       * specified glyph list will be inserted as a
+				       * split-vowel-like insertion, either before or
+				       * after the marked glyph (depending on the state
+				       * of the markedInsertBefore flag). */
+    CurrentInsertBefore= 0x0800,      /* If set, specifies that insertions are to be made
+				       * to the left of the current glyph. If clear,
+				       * they're made to the right of the current glyph. */
+    MarkedInsertBefore= 0x0400,	      /* If set, specifies that insertions are to be
+				       * made to the left of the marked glyph. If clear,
+				       * they're made to the right of the marked glyph. */
+    CurrentInsertCount= 0x3E0,	      /* This 5-bit field is treated as a count of the
+				       * number of glyphs to insert at the current
+				       * position. Since zero means no insertions, the
+				       * largest number of insertions at any given
+				       * current location is 31 glyphs. */
+    MarkedInsertCount= 0x001F,	      /* This 5-bit field is treated as a count of the
+				       * number of glyphs to insert at the marked
+				       * position. Since zero means no insertions, the
+				       * largest number of insertions at any given
+				       * marked location is 31 glyphs. */
+  };
+
   struct driver_context_t
   {
     static constexpr bool in_place = false;
-    enum Flags
-    {
-      SetMark		= 0x8000,	/* If set, mark the current glyph. */
-      DontAdvance	= 0x4000,	/* If set, don't advance to the next glyph before
-					 * going to the new state.  This does not mean
-					 * that the glyph pointed to is the same one as
-					 * before. If you've made insertions immediately
-					 * downstream of the current glyph, the next glyph
-					 * processed would in fact be the first one
-					 * inserted. */
-      CurrentIsKashidaLike= 0x2000,	/* If set, and the currentInsertList is nonzero,
-					 * then the specified glyph list will be inserted
-					 * as a kashida-like insertion, either before or
-					 * after the current glyph (depending on the state
-					 * of the currentInsertBefore flag). If clear, and
-					 * the currentInsertList is nonzero, then the
-					 * specified glyph list will be inserted as a
-					 * split-vowel-like insertion, either before or
-					 * after the current glyph (depending on the state
-					 * of the currentInsertBefore flag). */
-      MarkedIsKashidaLike= 0x1000,	/* If set, and the markedInsertList is nonzero,
-					 * then the specified glyph list will be inserted
-					 * as a kashida-like insertion, either before or
-					 * after the marked glyph (depending on the state
-					 * of the markedInsertBefore flag). If clear, and
-					 * the markedInsertList is nonzero, then the
-					 * specified glyph list will be inserted as a
-					 * split-vowel-like insertion, either before or
-					 * after the marked glyph (depending on the state
-					 * of the markedInsertBefore flag). */
-      CurrentInsertBefore= 0x0800,	/* If set, specifies that insertions are to be made
-					 * to the left of the current glyph. If clear,
-					 * they're made to the right of the current glyph. */
-      MarkedInsertBefore= 0x0400,	/* If set, specifies that insertions are to be
-					 * made to the left of the marked glyph. If clear,
-					 * they're made to the right of the marked glyph. */
-      CurrentInsertCount= 0x3E0,	/* This 5-bit field is treated as a count of the
-					 * number of glyphs to insert at the current
-					 * position. Since zero means no insertions, the
-					 * largest number of insertions at any given
-					 * current location is 31 glyphs. */
-      MarkedInsertCount= 0x001F,	/* This 5-bit field is treated as a count of the
-					 * number of glyphs to insert at the marked
-					 * position. Since zero means no insertions, the
-					 * largest number of insertions at any given
-					 * marked location is 31 glyphs. */
-    };
 
     driver_context_t (const InsertionSubtable *table,
 		      hb_aat_apply_context_t *c_) :
@@ -791,7 +796,7 @@ struct InsertionSubtable
 	     (entry.data.currentInsertIndex != 0xFFFF ||entry.data.markedInsertIndex != 0xFFFF);
     }
     void transition (hb_buffer_t *buffer,
-		     StateTableDriver<Types, EntryData> *driver,
+		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
     {
       unsigned int flags = entry.flags;
@@ -883,7 +888,7 @@ struct InsertionSubtable
 
     driver_context_t dc (this, c);
 
-    StateTableDriver<Types, EntryData> driver (machine, c->face);
+    StateTableDriver<Types, EntryData, Flags> driver (machine, c->face);
 
     if (driver.is_idempotent_on_all_out_of_bounds (&dc, c) &&
 	!c->buffer_glyph_set.may_intersect (*c->machine_glyph_set))

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -75,7 +75,6 @@ struct RearrangementSubtable
 	start (0), end (0) {}
 
     bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			StateTableDriver<Types, EntryData> *driver HB_UNUSED,
 			const Entry<EntryData> &entry) const
     {
       return (entry.flags & Verb) && start < end;
@@ -233,7 +232,6 @@ struct ContextualSubtable
 	subs (table+table->substitutionTables) {}
 
     bool is_actionable (hb_buffer_t *buffer,
-			StateTableDriver<Types, EntryData> *driver,
 			const Entry<EntryData> &entry) const
     {
       if (buffer->idx == buffer->len && !mark_set)
@@ -485,7 +483,6 @@ struct LigatureSubtable
 	match_length (0) {}
 
     bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			StateTableDriver<Types, EntryData> *driver HB_UNUSED,
 			const Entry<EntryData> &entry) const
     {
       return LigatureEntryT::performAction (entry);
@@ -795,7 +792,6 @@ struct InsertionSubtable
 	insertionAction (table+table->insertionAction) {}
 
     bool is_actionable (hb_buffer_t *buffer HB_UNUSED,
-			StateTableDriver<Types, EntryData> *driver HB_UNUSED,
 			const Entry<EntryData> &entry) const
     {
       return (entry.flags & (CurrentInsertCount | MarkedInsertCount)) &&

--- a/src/hb-bit-page.hh
+++ b/src/hb-bit-page.hh
@@ -89,6 +89,8 @@ struct hb_vector_size_t
 
 struct hb_bit_page_t
 {
+  hb_bit_page_t () { init0 (); }
+
   void init0 () { v.init0 (); population = 0; }
   void init1 () { v.init1 (); population = PAGE_BITS; }
 
@@ -115,6 +117,9 @@ struct hb_bit_page_t
   void del (hb_codepoint_t g) { elt (g) &= ~mask (g); dirty (); }
   void set (hb_codepoint_t g, bool value) { if (value) add (g); else del (g); }
   bool get (hb_codepoint_t g) const { return elt (g) & mask (g); }
+
+  bool operator [] (hb_codepoint_t g) const { return get (g); }
+  bool operator () (hb_codepoint_t g) const { return get (g); }
 
   void add_range (hb_codepoint_t a, hb_codepoint_t b)
   {


### PR DESCRIPTION
And match them against the buffer glyph_set.
    
4% speedup in LucidaGrande. 12% in Times.
