### PR TITLE
[test] Exclude google-benchmark tests by default if meson "recent" an…

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -468,7 +468,7 @@ if meson.version().version_compare('>=0.57.0')
   # Re glib, see https://github.com/harfbuzz/harfbuzz/issues/4153#issuecomment-2646347531
   add_test_setup('default',
                  exclude_suites: ['google-benchmark'],
-                 is_default: glib_dep.type_name() != 'internal')
+                 is_default: glib_dep.type_name() != 'internal' and not meson.is_subproject())
 endif
 
 build_summary = {

--- a/meson.build
+++ b/meson.build
@@ -464,6 +464,13 @@ configure_file(output: 'config.h', configuration: conf)
 alias_target('lib', libharfbuzz)
 alias_target('libs', libharfbuzz, libharfbuzz_subset)
 
+if meson.version().version_compare('>=0.57.0')
+  # Re glib, see https://github.com/harfbuzz/harfbuzz/issues/4153#issuecomment-2646347531
+  add_test_setup('default',
+                 exclude_suites: ['google-benchmark'],
+                 is_default: glib_dep.type_name() != 'internal')
+endif
+
 build_summary = {
   'Directories':
     {'prefix': get_option('prefix'),


### PR DESCRIPTION
…d...

...glib not built internally.

Second try.

See https://github.com/harfbuzz/harfbuzz/issues/4153#issuecomment-2646347531