### PR TITLE
[docs/coretext] Fix hb_coretext_font_set_funcs() documentation

### DIFF
--- a/src/hb-coretext-font.cc
+++ b/src/hb-coretext-font.cc
@@ -511,10 +511,6 @@ _hb_coretext_get_font_funcs ()
  * created with hb_face_create(), and therefore was not
  * initially configured to use CoreText font functions.
  *
- * An #hb_font_t object created with hb_coretext_font_create()
- * is preconfigured for CoreText font functions and does not
- * require this function to be used.
- *
  * <note>Note: Internally, this function creates a CTFont.
 * </note>
  *


### PR DESCRIPTION
Remove the note that fonts created with hb_coretext_font_create() have these font functions configured for them, which is not true.

hb_coretext_font_create() documents this correctly.