### PR TITLE
[directwrite] Add hb_directwrite_font_create()/font_get_font()

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -351,6 +351,8 @@ hb_coretext_font_set_funcs
 <FILE>hb-directwrite</FILE>
 hb_directwrite_face_create
 hb_directwrite_face_get_font_face
+hb_directwrite_font_create
+hb_directwrite_font_get_font
 </SECTION>
 
 <SECTION>

--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -29,6 +29,7 @@
 #include "hb-shaper-impl.hh"
 
 #include <dwrite_1.h>
+#include <dwrite_3.h>
 
 #include "hb-directwrite.h"
 
@@ -275,6 +276,8 @@ _hb_directwrite_shaper_font_data_create (hb_font_t *font)
 void
 _hb_directwrite_shaper_font_data_destroy (hb_directwrite_font_data_t *data)
 {
+  if (data != HB_SHAPER_DATA_SUCCEEDED)
+    ((IDWriteFont *) data)->Release();
 }
 
 
@@ -839,7 +842,7 @@ _hb_directwrite_reference_table (hb_face_t *face HB_UNUSED, hb_tag_t tag, void *
 }
 
 static void
-_hb_directwrite_font_release (void *data)
+_hb_directwrite_face_release (void *data)
 {
   if (data)
     ((IDWriteFontFace *) data)->Release ();
@@ -847,7 +850,7 @@ _hb_directwrite_font_release (void *data)
 
 /**
  * hb_directwrite_face_create:
- * @font_face: a DirectWrite IDWriteFontFace object.
+ * @dw_face: a DirectWrite IDWriteFontFace object.
  *
  * Constructs a new face object from the specified DirectWrite IDWriteFontFace.
  *
@@ -856,12 +859,12 @@ _hb_directwrite_font_release (void *data)
  * Since: 2.4.0
  **/
 hb_face_t *
-hb_directwrite_face_create (IDWriteFontFace *font_face)
+hb_directwrite_face_create (IDWriteFontFace *dw_face)
 {
-  if (font_face)
-    font_face->AddRef ();
-  return hb_face_create_for_tables (_hb_directwrite_reference_table, font_face,
-				    _hb_directwrite_font_release);
+  if (dw_face)
+    dw_face->AddRef ();
+  return hb_face_create_for_tables (_hb_directwrite_reference_table, dw_face,
+				    _hb_directwrite_face_release);
 }
 
 /**
@@ -880,5 +883,80 @@ hb_directwrite_face_get_font_face (hb_face_t *face)
   return face->data.directwrite->fontFace;
 }
 
+/**
+ * hb_directwrite_font_create:
+ * @dw_font: a DirectWrite IDWriteFont object.
+ *
+ * Constructs a new font object from the specified DirectWrite IDWriteFont.
+ *
+ * Return value: #hb_font_t object corresponding to the given input
+ *
+ * XSince: REPLACEME
+ **/
+hb_font_t *
+hb_directwrite_font_create (IDWriteFont *dw_font)
+{
+  IDWriteFontFace *dw_face = nullptr;
+  IDWriteFontFace5 *dw_face5 = nullptr;
+
+  if (FAILED (dw_font->CreateFontFace (&dw_face)))
+    return hb_font_get_empty ();
+
+  hb_face_t *face = hb_directwrite_face_create (dw_face);
+  hb_font_t *font = hb_font_create (face);
+  hb_face_destroy (face);
+
+  if (unlikely (hb_object_is_immutable (font)))
+    goto done;
+
+  /* Copy font variations */
+  if (SUCCEEDED (dw_face->QueryInterface (__uuidof (IDWriteFontFace5), (void**) &dw_face5)))
+  {
+    if (dw_face5->HasVariations ())
+    {
+      hb_vector_t<DWRITE_FONT_AXIS_VALUE> values;
+      uint32_t count = dw_face5->GetFontAxisValueCount ();
+      if (likely (values.resize_exact (count)) &&
+	  SUCCEEDED (dw_face5->GetFontAxisValues (values.arrayZ, count)))
+      {
+	hb_vector_t<hb_variation_t> vars;
+	if (likely (vars.resize_exact (count)))
+	{
+	  for (uint32_t i = 0; i < count; ++i)
+	  {
+	    hb_tag_t tag = values[i].axisTag;
+	    float value = values[i].value;
+	    vars[i] = {tag, value};
+	  }
+	  hb_font_set_variations (font, vars.arrayZ, vars.length);
+	}
+      }
+    }
+    dw_face5->Release ();
+  }
+
+  dw_font->AddRef ();
+  font->data.directwrite.cmpexch (nullptr, (hb_directwrite_font_data_t *) dw_font);
+
+done:
+  dw_face->Release ();
+  return font;
+}
+
+/**
+* hb_directwrite_font_get_font:
+* @font: a #hb_font_t object
+*
+* Gets the DirectWrite IDWriteFont associated with @font.
+*
+* Return value: DirectWrite IDWriteFont object corresponding to the given input
+*
+* XSince: REPLACEME
+**/
+IDWriteFont *
+hb_directwrite_font_get_font (hb_font_t *font)
+{
+  return (IDWriteFont *) (const void *) font->data.directwrite;
+}
 
 #endif

--- a/src/hb-directwrite.h
+++ b/src/hb-directwrite.h
@@ -30,10 +30,16 @@
 HB_BEGIN_DECLS
 
 HB_EXTERN hb_face_t *
-hb_directwrite_face_create (IDWriteFontFace *font_face);
+hb_directwrite_face_create (IDWriteFontFace *dw_face);
 
 HB_EXTERN IDWriteFontFace *
 hb_directwrite_face_get_font_face (hb_face_t *face);
+
+HB_EXTERN hb_font_t *
+hb_directwrite_font_create (IDWriteFont *dw_font);
+
+HB_EXTERN IDWriteFont *
+hb_directwrite_font_get_font (hb_font_t *font);
 
 HB_END_DECLS
 

--- a/test/api/meson.build
+++ b/test/api/meson.build
@@ -81,6 +81,12 @@ if conf.get('HAVE_CORETEXT', 0) == 1
   ]
 endif
 
+if conf.get('HAVE_DIRECTWRITE', 0) == 1
+  tests += [
+    'test-directwrite.cc',
+  ]
+endif
+
 if conf.get('HAVE_FREETYPE', 0) == 1 and conf.get('HAVE_PTHREAD', 0) == 1
   tests += 'test-multithread.c'
 endif

--- a/test/api/test-directwrite.cc
+++ b/test/api/test-directwrite.cc
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2022 Red Hat, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Author: Matthias Clasen
+ */
+
+
+#include <dwrite_3.h>
+
+#include "hb-test.h"
+
+#include "hb-directwrite.h"
+
+/* Declare object creator for dynamic support of DWRITE */
+typedef HRESULT (WINAPI *t_DWriteCreateFactory)(
+  DWRITE_FACTORY_TYPE factoryType,
+  REFIID              iid,
+  IUnknown            **factory
+);
+
+IDWriteFont *
+get_dwfont (const wchar_t *family_name)
+{
+  HRESULT hr;
+  t_DWriteCreateFactory CreateFactory;
+  HMODULE dwrite_dll;
+  IDWriteFactory *factory;
+  IDWriteFactory7 *factory7;
+  IDWriteFontCollection3 *collection;
+  UINT32 count;
+  IDWriteFontFamily2 *family;
+  IDWriteFont *font;
+  UINT32 index = 0;
+
+  dwrite_dll = LoadLibrary (TEXT ("DWRITE"));
+  g_assert_nonnull (dwrite_dll);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+
+  CreateFactory = (t_DWriteCreateFactory) GetProcAddress (dwrite_dll, "DWriteCreateFactory");
+  g_assert_nonnull (CreateFactory);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+  hr = CreateFactory (DWRITE_FACTORY_TYPE_SHARED, __uuidof (IDWriteFactory), (IUnknown**) &factory);
+  g_assert_true (SUCCEEDED (hr));
+
+  hr = factory->QueryInterface (__uuidof (IDWriteFactory7), (void**) &factory7);
+  g_assert_true (SUCCEEDED (hr));
+
+  hr = factory7->GetSystemFontCollection (FALSE, DWRITE_FONT_FAMILY_MODEL_TYPOGRAPHIC, &collection);
+  g_assert_true (SUCCEEDED (hr));
+
+  count = collection->GetFontFamilyCount ();
+  g_assert_cmpuint (count, >, 0);
+
+  if (family_name)
+  {
+    BOOL exists;
+    hr = collection->FindFamilyName (family_name, &index, &exists);
+    g_assert_true (SUCCEEDED (hr));
+    g_assert_true (exists);
+  }
+
+  hr = collection->GetFontFamily (index, &family);
+  g_assert_true (SUCCEEDED (hr));
+
+  hr = family->GetFirstMatchingFont (DWRITE_FONT_WEIGHT_NORMAL,
+                                      DWRITE_FONT_STRETCH_NORMAL,
+                                      DWRITE_FONT_STYLE_NORMAL,
+                                      &font);
+  g_assert_true (SUCCEEDED (hr));
+
+  factory->Release ();
+
+  return font;
+}
+
+static void
+test_native_directwrite_basic (void)
+{
+  IDWriteFont *dwfont;
+  hb_font_t *font;
+  IDWriteFont *dwfont2;
+
+  dwfont = get_dwfont (nullptr);
+  g_assert_nonnull (dwfont);
+
+  font = hb_directwrite_font_create (dwfont);
+
+  dwfont2 = hb_directwrite_font_get_font (font);
+
+  g_assert_true (dwfont2 == dwfont);
+
+  hb_font_destroy (font);
+
+  dwfont->Release ();
+}
+
+
+static void
+test_native_directwrite_variations (void)
+{
+  IDWriteFont *dwfont;
+  hb_font_t *font;
+  unsigned int length;
+
+  dwfont = get_dwfont (L"Bahnschrift");
+  g_assert_nonnull (dwfont);
+
+  font = hb_directwrite_font_create (dwfont);
+  hb_font_get_var_coords_normalized(font, &length);
+  g_assert_cmpuint (length, !=, 0);
+
+  hb_font_destroy (font);
+
+  dwfont->Release ();
+}
+
+
+int
+main (int argc, char **argv)
+{
+  hb_test_init (&argc, &argv);
+
+  hb_test_add (test_native_directwrite_basic);
+  hb_test_add (test_native_directwrite_variations);
+
+  return hb_test_run ();
+}


### PR DESCRIPTION
Uses hb_directwrite_face_create() under the hood, but copies variations from directwrite to hb-font.

* Fixes #5072 