### PR TITLE
meson: refactor freetype dependency logic

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -102,44 +102,36 @@ check_funcs = [
 
 m_dep = cpp.find_library('m', required: false)
 
-if meson.version().version_compare('>=0.60.0')
+# Painful hack to handle multiple dependencies but also respect options
+if get_option('freetype').disabled()
+  freetype_dep = dependency('', required: false)
+else
   # Sadly, FreeType's versioning schemes are different between pkg-config and CMake
-  # pkg-config: freetype2, cmake: Freetype
+
+  # Try pkg-config name
   freetype_dep = dependency('freetype2',
                             version: freetype_min_version,
                             method: 'pkg-config',
                             required: false,
                             allow_fallback: false)
   if not freetype_dep.found()
-    freetype_dep = dependency('FreeType',
+    # Try cmake name
+    freetype_dep = dependency('Freetype',
                               version: freetype_min_version_actual,
                               method: 'cmake',
-                              required: get_option('freetype'),
-                              default_options: ['harfbuzz=disabled'],
-                              allow_fallback: true)
-  endif
-else
-  # painful hack to handle multiple dependencies but also respect options
-  freetype_opt = get_option('freetype')
-  # we want to handle enabled manually after fallbacks, but also handle disabled normally
-  if freetype_opt.enabled()
-    freetype_opt = false
-  endif
-  # try pkg-config name
-  freetype_dep = dependency('freetype2', version: freetype_min_version, method: 'pkg-config', required: freetype_opt)
-  # when disabled, leave it not-found
-  if not freetype_dep.found() and not get_option('freetype').disabled()
-    # Try cmake name
-    freetype_dep = dependency('Freetype', version: freetype_min_version_actual, method: 'cmake', required: false)
-    # Subproject fallback, `allow_fallback: true` means the fallback will be
-    # tried even if the freetype option is set to `auto`.
+                              required: false,
+                              allow_fallback: false)
+    # Subproject fallback
     if not freetype_dep.found()
-      freetype_dep = dependency('freetype2',
-                                version: freetype_min_version,
-                                method: 'pkg-config',
+      freetype_proj = subproject('freetype2',
+                                version: freetype_min_version_actual,
                                 required: get_option('freetype'),
-                                default_options: ['harfbuzz=disabled'],
-                                allow_fallback: true)
+                                default_options: ['harfbuzz=disabled'])
+      if freetype_proj.found()
+        freetype_dep = freetype_proj.get_variable('freetype_dep')
+      else
+        freetype_dep = dependency('', required: false)
+      endif
     endif
   endif
 endif


### PR DESCRIPTION
Simplify and respect -Dfreetype=disabled again.

Bug: https://bugs.gentoo.org/950274
Fixes: 1ad48fddd08654052da4f8a93609e7f4380d5c42
See-Also: 604fe807078ce41d0ac7742547e90b17c066709f

@eli-schwartz 