### PR TITLE
[ci] Port minsize job from Alpine to Ubuntu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,18 +58,19 @@ jobs:
       - run: meson compile -Cbuild -j9
       - run: RUN_VALGRIND=1 meson test -Cbuild -t 10 --no-suite=slow --wrap='valgrind --leak-check=full --error-exitcode=1' --print-errorlogs --num-processes=$(($(nproc)/2 + 1))
 
-  alpine:
+  minsize:
     docker:
-      - image: alpine
+      - image: ubuntu
     steps:
       - checkout
-      - run: apk update && apk add ragel gcc g++ glib-dev freetype-dev cairo-dev git py3-pip ninja
+      - run: apt update
+      - run: DEBIAN_FRONTEND=noninteractive apt install -y ninja-build binutils gcc g++ pkg-config ragel libfreetype6-dev libglib2.0-dev libcairo2-dev python3 python3-pip python3-venv
       - run: |
           python3 -m venv venv
           source venv/bin/activate
           pip3 install meson==0.56.0
           meson setup build --buildtype=minsize
-          meson compile -Cbuild -j9
+          meson compile -Cbuild
           meson test -Cbuild --print-errorlogs
 
   asan-ubsan:
@@ -199,7 +200,7 @@ workflows:
             branches:
               ignore: /.*/
       - fedora-valgrind
-      - alpine
+      - minsize
       - asan-ubsan
       - tsan
       - msan


### PR DESCRIPTION
Alpine is frequently failing with compiler crashing, but we don’t really need Alpine. No other job building with --buildtype=minsize, so keep it but use Ubuntu.