### PR TITLE
[fontations] Make fontations use hb_malloc et al

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -184,6 +184,10 @@ uint8_t
 HB_EXTERN
 HB_DEPRECATED
 HB_DEPRECATED_FOR
+hb_malloc
+hb_calloc
+hb_realloc
+hb_free
 <SUBSECTION Private>
 HB_H_IN
 HB_OT_H_IN

--- a/src/fontations/lib.rs
+++ b/src/fontations/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_upper_case_globals)]
 include!(concat!(env!("OUT_DIR"), "/hb.rs"));
 
+use std::alloc::{GlobalAlloc, Layout};
 use std::mem::transmute;
 use std::os::raw::c_void;
 use std::ptr::null_mut;
@@ -22,6 +23,36 @@ use skrifa::outline::pen::OutlinePen;
 use skrifa::outline::DrawSettings;
 use skrifa::OutlineGlyphCollection;
 use skrifa::{GlyphId, MetadataProvider};
+
+extern "C" {
+    pub fn hb_malloc(_: usize) -> *const ::std::os::raw::c_void;
+    pub fn hb_calloc(_: usize, _: usize) -> *const ::std::os::raw::c_void;
+    pub fn hb_realloc(_: *const ::std::os::raw::c_void, _: usize) -> *const ::std::os::raw::c_void;
+    pub fn hb_free(_: *const ::std::os::raw::c_void);
+}
+
+struct MyAllocator;
+
+unsafe impl GlobalAlloc for MyAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        hb_malloc(layout.size()) as *mut u8
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        hb_calloc(layout.size(), 1) as *mut u8
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
+        hb_realloc(ptr as *const c_void, new_size) as *mut u8
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        hb_free(ptr as *mut c_void);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: MyAllocator = MyAllocator;
 
 // A struct for storing your “fontations” data
 #[repr(C)]

--- a/src/fontations/lib.rs
+++ b/src/fontations/lib.rs
@@ -24,13 +24,6 @@ use skrifa::outline::DrawSettings;
 use skrifa::OutlineGlyphCollection;
 use skrifa::{GlyphId, MetadataProvider};
 
-extern "C" {
-    pub fn hb_malloc(_: usize) -> *const ::std::os::raw::c_void;
-    pub fn hb_calloc(_: usize, _: usize) -> *const ::std::os::raw::c_void;
-    pub fn hb_realloc(_: *const ::std::os::raw::c_void, _: usize) -> *const ::std::os::raw::c_void;
-    pub fn hb_free(_: *const ::std::os::raw::c_void);
-}
-
 struct MyAllocator;
 
 unsafe impl GlobalAlloc for MyAllocator {
@@ -43,7 +36,7 @@ unsafe impl GlobalAlloc for MyAllocator {
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
-        hb_realloc(ptr as *const c_void, new_size) as *mut u8
+        hb_realloc(ptr as *mut c_void, new_size) as *mut u8
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {

--- a/src/hb-common.cc
+++ b/src/hb-common.cc
@@ -1217,6 +1217,58 @@ uint8_t
   return hb_color_get_blue (color);
 }
 
+/**
+ * hb_malloc:
+ * @size: The size of the memory to allocate.
+ *
+ * Allocates @size bytes of memory, using the allocator set at
+ * compile-time. Typically just malloc().
+ *
+ * Return value: A pointer to the allocated memory.
+ *
+ * XSince: REPLACEME
+ **/
+void* hb_malloc(size_t size) { return hb_malloc_impl (size); }
+
+/**
+ * hb_calloc:
+ * @nmemb: The number of elements to allocate.
+ * @size: The size of each element.
+ *
+ * Allocates @nmemb elements of @size bytes each, initialized to zero,
+ * using the allocator set at compile-time. Typically just calloc().
+ *
+ * Return value: A pointer to the allocated memory.
+ *
+ * XSince: REPLACEME
+ **/
+void* hb_calloc(size_t nmemb, size_t size) { return hb_calloc_impl (nmemb, size); }
+
+/**
+ * hb_realloc:
+ * @ptr: The pointer to the memory to reallocate.
+ * @size: The new size of the memory.
+ *
+ * Reallocates the memory pointed to by @ptr to @size bytes, using the
+ * allocator set at compile-time. Typically just realloc().
+ *
+ * Return value: A pointer to the reallocated memory.
+ *
+ * XSince: REPLACEME
+ **/
+void* hb_realloc(void *ptr, size_t size) { return hb_realloc_impl (ptr, size); }
+
+/**
+ * hb_free:
+ * @ptr: The pointer to the memory to free.
+ *
+ * Frees the memory pointed to by @ptr, using the allocator set at
+ * compile-time. Typically just free().
+ *
+ * XSince: REPLACEME
+ **/
+void  hb_free(void *ptr) { hb_free_impl (ptr); }
+
 
 /* If there is no visibility control, then hb-static.cc will NOT
  * define anything.  Instead, we get it to define one set in here

--- a/src/hb-common.h
+++ b/src/hb-common.h
@@ -65,6 +65,7 @@ typedef unsigned __int64 uint64_t;
 #else
 #  include <inttypes.h>
 #endif
+#include <stddef.h>
 
 #if defined(__GNUC__) && ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
 #define HB_DEPRECATED __attribute__((__deprecated__))
@@ -947,6 +948,16 @@ typedef struct hb_glyph_extents_t {
  *
  */
 typedef struct hb_font_t hb_font_t;
+
+/* Not of much use to clients. */
+HB_EXTERN void*
+hb_malloc (size_t size);
+HB_EXTERN void*
+hb_calloc (size_t nmemb, size_t size);
+HB_EXTERN void*
+hb_realloc (void *ptr, size_t size);
+HB_EXTERN void
+hb_free (void *ptr);
 
 HB_END_DECLS
 

--- a/src/hb-static.cc
+++ b/src/hb-static.cc
@@ -40,12 +40,8 @@
 #include "hb-ot-hmtx-table.hh"
 #include "hb-ot-maxp-table.hh"
 
-void* hb_malloc(size_t size) { return hb_malloc_impl (size); }
-void* hb_calloc(size_t nmemb, size_t size) { return hb_calloc_impl (nmemb, size); }
-void* hb_realloc(void *ptr, size_t size) { return hb_realloc_impl (ptr, size); }
-void  hb_free(void *ptr) { hb_free_impl (ptr); }
-
 #ifndef HB_NO_VISIBILITY
+
 #include "hb-ot-name-language-static.hh"
 
 uint64_t const _hb_NullPool[(HB_NULL_POOL_SIZE + sizeof (uint64_t) - 1) / sizeof (uint64_t)] = {};

--- a/src/hb-static.cc
+++ b/src/hb-static.cc
@@ -40,6 +40,11 @@
 #include "hb-ot-hmtx-table.hh"
 #include "hb-ot-maxp-table.hh"
 
+void* hb_malloc(size_t size) { return hb_malloc_impl (size); }
+void* hb_calloc(size_t nmemb, size_t size) { return hb_calloc_impl (nmemb, size); }
+void* hb_realloc(void *ptr, size_t size) { return hb_realloc_impl (ptr, size); }
+void  hb_free(void *ptr) { hb_free_impl (ptr); }
+
 #ifndef HB_NO_VISIBILITY
 #include "hb-ot-name-language-static.hh"
 

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -533,10 +533,6 @@ extern "C" void  hb_free_impl(void *ptr);
 #define hb_realloc_impl realloc
 #define hb_free_impl free
 #endif
-extern "C" void* hb_malloc(size_t size);
-extern "C" void* hb_calloc(size_t nmemb, size_t size);
-extern "C" void* hb_realloc(void *ptr, size_t size);
-extern "C" void  hb_free(void *ptr);
 
 
 

--- a/src/hb.hh
+++ b/src/hb.hh
@@ -230,33 +230,6 @@
 #define HB_PASTE(a,b) HB_PASTE1(a,b)
 
 
-/* Compile-time custom allocator support. */
-
-#if !defined(HB_CUSTOM_MALLOC) \
-  && defined(hb_malloc_impl) \
-  && defined(hb_calloc_impl) \
-  && defined(hb_realloc_impl) \
-  && defined(hb_free_impl)
-#define HB_CUSTOM_MALLOC
-#endif
-
-#ifdef HB_CUSTOM_MALLOC
-extern "C" void* hb_malloc_impl(size_t size);
-extern "C" void* hb_calloc_impl(size_t nmemb, size_t size);
-extern "C" void* hb_realloc_impl(void *ptr, size_t size);
-extern "C" void  hb_free_impl(void *ptr);
-#define hb_malloc hb_malloc_impl
-#define hb_calloc hb_calloc_impl
-#define hb_realloc hb_realloc_impl
-#define hb_free hb_free_impl
-#else
-#define hb_malloc malloc
-#define hb_calloc calloc
-#define hb_realloc realloc
-#define hb_free free
-#endif
-
-
 /*
  * Compiler attributes
  */
@@ -538,6 +511,33 @@ static_assert ((sizeof (hb_var_int_t) == 4), "");
 // https://github.com/harfbuzz/harfbuzz/issues/4166
 #define HB_PI 3.14159265358979f
 #define HB_2_PI (2.f * HB_PI)
+
+/* Compile-time custom allocator support. */
+
+#if !defined(HB_CUSTOM_MALLOC) \
+  && defined(hb_malloc_impl) \
+  && defined(hb_calloc_impl) \
+  && defined(hb_realloc_impl) \
+  && defined(hb_free_impl)
+#define HB_CUSTOM_MALLOC
+#endif
+
+#ifdef HB_CUSTOM_MALLOC
+extern "C" void* hb_malloc_impl(size_t size);
+extern "C" void* hb_calloc_impl(size_t nmemb, size_t size);
+extern "C" void* hb_realloc_impl(void *ptr, size_t size);
+extern "C" void  hb_free_impl(void *ptr);
+#else
+#define hb_malloc_impl malloc
+#define hb_calloc_impl calloc
+#define hb_realloc_impl realloc
+#define hb_free_impl free
+#endif
+extern "C" void* hb_malloc(size_t size);
+extern "C" void* hb_calloc(size_t nmemb, size_t size);
+extern "C" void* hb_realloc(void *ptr, size_t size);
+extern "C" void  hb_free(void *ptr);
+
 
 
 /* Headers we include for everyone.  Keep topologically sorted by dependency.


### PR DESCRIPTION
Going to close. Just leaving here for the future.

It requires making `hb_malloc` etc public. Which would have no purpose for us as is.