### PR TITLE
[set] Fix reallocation

### DIFF
--- a/src/hb-bit-set.hh
+++ b/src/hb-bit-set.hh
@@ -88,7 +88,7 @@ struct hb_bit_set_t
   {
     if (unlikely (!successful)) return false;
 
-    if (pages.length < count && count <= 2)
+    if (pages.length < count && (unsigned) pages.allocated < count && count <= 2)
       exact_size = true; // Most sets are small and local
 
     if (unlikely (!pages.resize (count, clear, exact_size) ||

--- a/src/hb-vector.hh
+++ b/src/hb-vector.hh
@@ -442,7 +442,6 @@ struct hb_vector_t
 	new_allocated += (new_allocated >> 1) + 8;
     }
 
-
     /* Reallocate */
 
     bool overflows =


### PR DESCRIPTION
Was shrinking malloced vectors inadverently.