### PR TITLE
[coretext] Always set all variations

### DIFF
--- a/src/hb-coretext-shape.cc
+++ b/src/hb-coretext-shape.cc
@@ -86,8 +86,6 @@ _hb_coretext_shaper_font_data_create (hb_font_t *font)
       hb_ot_var_axis_info_t info;
       unsigned int c = 1;
       hb_ot_var_get_axis_infos (font->face, i, &c, &info);
-      if (font->design_coords[i] == info.default_value)
-	continue;
       float v = hb_clamp (font->design_coords[i], info.min_value, info.max_value);
 
       CFNumberRef tag_number = CFNumberCreate (kCFAllocatorDefault, kCFNumberIntType, &info.tag);


### PR DESCRIPTION
Even when at default, looks like this is necessary.

Fixes https://github.com/harfbuzz/harfbuzz/issues/5142