### PR TITLE
[coretext] Fix loading named instances

### DIFF
--- a/util/font-options.hh
+++ b/util/font-options.hh
@@ -101,7 +101,8 @@ font_options_t::post_parse (GError **error)
   hb_font_set_scale (font, scale_x, scale_y);
 
 #ifndef HB_NO_VAR
-  hb_font_set_var_named_instance (font, named_instance);
+  if (named_instance != HB_FONT_NO_VAR_NAMED_INSTANCE)
+    hb_font_set_var_named_instance (font, named_instance);
   hb_font_set_variations (font, variations, num_variations);
 #endif
 


### PR DESCRIPTION
Needs tests...

TTC indices > 0 can't be loaded with CoreText API it seems.

Fixes https://github.com/harfbuzz/harfbuzz/issues/5158