### PR TITLE
[COLRv1] Push font transform trickery to hb-cairo

### DIFF
--- a/src/OT/Color/COLR/COLR.hh
+++ b/src/OT/Color/COLR/COLR.hh
@@ -938,13 +938,9 @@ struct PaintGlyph
   void paint_glyph (hb_paint_context_t *c) const
   {
     TRACE_PAINT (this);
-    c->funcs->push_inverse_font_transform (c->data, c->font);
     c->funcs->push_clip_glyph (c->data, gid, c->font);
-    c->funcs->push_font_transform (c->data, c->font);
     c->recurse (this+paint);
-    c->funcs->pop_transform (c->data);
     c->funcs->pop_clip (c->data);
-    c->funcs->pop_transform (c->data);
   }
 
   HBUINT8		format; /* format = 10 */
@@ -2819,13 +2815,8 @@ void PaintColrGlyph::paint_glyph (hb_paint_context_t *c) const
   if (unlikely (!node.visit (gid)))
     return;
 
-  c->funcs->push_inverse_font_transform (c->data, c->font);
   if (c->funcs->color_glyph (c->data, gid, c->font))
-  {
-    c->funcs->pop_transform (c->data);
     return;
-  }
-  c->funcs->pop_transform (c->data);
 
   const COLR *colr_table = c->get_colr_table ();
   const Paint *paint = colr_table->get_base_glyph_paint (gid);

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -193,7 +193,7 @@ hb_cairo_paint_color_glyph (hb_paint_funcs_t *pfuncs HB_UNUSED,
 }
 
 static void
-hb_cairo_push_clip_glyph (hb_paint_funcs_t *pfuncs HB_UNUSED,
+hb_cairo_push_clip_glyph (hb_paint_funcs_t *pfuncs,
 			  void *paint_data,
 			  hb_codepoint_t glyph,
 			  hb_font_t *font,
@@ -204,7 +204,11 @@ hb_cairo_push_clip_glyph (hb_paint_funcs_t *pfuncs HB_UNUSED,
 
   cairo_save (cr);
   cairo_new_path (cr);
+
+  hb_paint_push_inverse_font_transform (pfuncs, paint_data, font);
   hb_font_draw_glyph (font, glyph, hb_cairo_draw_get_funcs (), cr);
+  hb_paint_push_font_transform (pfuncs, paint_data, font);
+
   cairo_close_path (cr);
   cairo_clip (cr);
 }

--- a/src/hb-ft-colr.hh
+++ b/src/hb-ft-colr.hh
@@ -316,15 +316,11 @@ _hb_ft_paint (hb_ft_paint_context_t *c,
     break;
     case FT_COLR_PAINTFORMAT_GLYPH:
     {
-      c->funcs->push_inverse_font_transform (c->data, c->font);
       c->ft_font->lock.unlock ();
       c->funcs->push_clip_glyph (c->data, paint.u.glyph.glyphID, c->font);
       c->ft_font->lock.lock ();
-      c->funcs->push_font_transform (c->data, c->font);
       c->recurse (paint.u.glyph.paint);
-      c->funcs->pop_transform (c->data);
       c->funcs->pop_clip (c->data);
-      c->funcs->pop_transform (c->data);
     }
     break;
     case FT_COLR_PAINTFORMAT_COLR_GLYPH:
@@ -335,16 +331,13 @@ _hb_ft_paint (hb_ft_paint_context_t *c,
       if (unlikely (!node.visit (gid)))
 	return;
 
-      c->funcs->push_inverse_font_transform (c->data, c->font);
       c->ft_font->lock.unlock ();
       if (c->funcs->color_glyph (c->data, gid, c->font))
       {
 	c->ft_font->lock.lock ();
-	c->funcs->pop_transform (c->data);
 	return;
       }
       c->ft_font->lock.lock ();
-      c->funcs->pop_transform (c->data);
 
       FT_OpaquePaint other_paint = {0};
       if (FT_Get_Color_Glyph_Paint (ft_face, gid,


### PR DESCRIPTION
This simplifies the renderers but pushes the burdon to clients of the paint API. I am ambivalent about this change. All paint clients need to be updated. It's a breaking change.

This reduces one vector of allocations from hb-fontations paint implementation however.