### PR TITLE
[glyf] Don't access gvar/GVAR until needed

### DIFF
--- a/src/OT/glyf/Glyph.hh
+++ b/src/OT/glyf/Glyph.hh
@@ -386,19 +386,20 @@ struct Glyph
     if (coords)
     {
 #ifndef HB_NO_BEYOND_64K
-      if (glyf_accelerator.GVAR->has_data ())
-	glyf_accelerator.GVAR->apply_deltas_to_points (gid,
-						       coords,
-						       points.as_array ().sub_array (old_length),
-						       scratch,
-						       phantom_only && type == SIMPLE);
+      const GVAR_accelerator_t *GVAR = font->face->table.GVAR;
+      if (GVAR->has_data ())
+	GVAR->apply_deltas_to_points (gid,
+				      coords,
+				      points.as_array ().sub_array (old_length),
+				      scratch,
+				      phantom_only && type == SIMPLE);
       else
 #endif
-	glyf_accelerator.gvar->apply_deltas_to_points (gid,
-						       coords,
-						       points.as_array ().sub_array (old_length),
-						       scratch,
-						       phantom_only && type == SIMPLE);
+	font->face->table.gvar->apply_deltas_to_points (gid,
+							coords,
+							points.as_array ().sub_array (old_length),
+							scratch,
+							phantom_only && type == SIMPLE);
     }
 #endif
 

--- a/src/OT/glyf/glyf.hh
+++ b/src/OT/glyf/glyf.hh
@@ -170,12 +170,6 @@ struct glyf_accelerator_t
     num_glyphs = 0;
     loca_table = nullptr;
     glyf_table = nullptr;
-#ifndef HB_NO_VAR
-    gvar = nullptr;
-#ifndef HB_NO_BEYOND_64K
-    GVAR = nullptr;
-#endif
-#endif
     hmtx = nullptr;
 #ifndef HB_NO_VERTICAL
     vmtx = nullptr;
@@ -188,12 +182,6 @@ struct glyf_accelerator_t
 
     loca_table = face->table.loca.get_blob (); // Needs no destruct!
     glyf_table = hb_sanitize_context_t ().reference_table<glyf> (face);
-#ifndef HB_NO_VAR
-    gvar = face->table.gvar;
-#ifndef HB_NO_BEYOND_64K
-    GVAR = face->table.GVAR;
-#endif
-#endif
     hmtx = face->table.hmtx;
 #ifndef HB_NO_VERTICAL
     vmtx = face->table.vmtx;
@@ -527,12 +515,6 @@ struct glyf_accelerator_t
 		       scratch);
   }
 
-#ifndef HB_NO_VAR
-  const gvar_accelerator_t *gvar;
-#ifndef HB_NO_BEYOND_64K
-  const GVAR_accelerator_t *GVAR;
-#endif
-#endif
   const hmtx_accelerator_t *hmtx;
 #ifndef HB_NO_VERTICAL
   const vmtx_accelerator_t *vmtx;


### PR DESCRIPTION
This doesn't quite do what I want it to do, since we don't optimize all-coords-are-zero case. I have code in another branch that does that, so I suggest we land this regardless, and will be working when other branch lands.