### PR TITLE
[fontations] Use the proposed pop_layer_with_mode

### DIFF
--- a/src/fontations/Cargo.lock
+++ b/src/fontations/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.27.4"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1cb3d8f1eff7ebef84ca77c0ef99e84e40459132a71bd678e96c6b7f0e6c1e"
+checksum = "f14974c88fb4fd0a7203719f98020209248c9dbebaf9d10d860337797a905097"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d58313d717b05488e8c8bae9b4cb34191aa6168d07430e17a2c0a12695fe735"
+checksum = "7c0ca53de9bb9bee1720c727606275148463cd938eb6bde249dcedeec4967747"
 dependencies = [
  "bytemuck",
  "read-fonts",

--- a/src/fontations/Cargo.toml
+++ b/src/fontations/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 
 [dependencies]
 read-fonts = "0.27"
-skrifa = "0.29.1"
+skrifa = "0.29.2"
 
 [lib]
 name = "harfbuzz_fontations"

--- a/src/fontations/lib.rs
+++ b/src/fontations/lib.rs
@@ -415,7 +415,6 @@ struct HbColorPainter<'a> {
     paint_data: *mut c_void,
     color_records: &'a [ColorRecord],
     foreground: hb_color_t,
-    composite_mode: Vec<CompositeMode>,
 }
 
 impl HbColorPainter<'_> {
@@ -706,18 +705,13 @@ impl ColorPainter for HbColorPainter<'_> {
             }
         }
     }
-    fn push_layer(&mut self, mode: CompositeMode) {
-        self.composite_mode.push(mode);
+    fn push_layer(&mut self, _mode: CompositeMode) {
         unsafe {
             hb_paint_push_group(self.paint_funcs, self.paint_data);
         }
     }
-    fn pop_layer(&mut self) {
-        let mode = self.composite_mode.pop();
-        if mode.is_none() {
-            return;
-        }
-        let mode = mode.unwrap() as hb_paint_composite_mode_t; // They are the same
+    fn pop_layer_with_mode(&mut self, mode: CompositeMode) {
+        let mode = mode as hb_paint_composite_mode_t; // They are the same
         unsafe {
             hb_paint_pop_group(self.paint_funcs, self.paint_data, mode);
         }
@@ -777,7 +771,6 @@ extern "C" fn _hb_fontations_paint_glyph(
         paint_data,
         color_records,
         foreground,
-        composite_mode: Vec::new(),
     };
     unsafe {
         hb_paint_push_font_transform(paint_funcs, paint_data, font);


### PR DESCRIPTION
Reduces one Vec use.

https://github.com/googlefonts/fontations/pull/1419

Needs to wait for a Skrifa merge & release.