### PR TITLE
[ot/ft] Round glyph extents instead of floor/ceil

### DIFF
--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -198,10 +198,10 @@ struct hb_font_t
     float x2 = em_scale_x (extents->x_bearing + extents->width);
     float y2 = em_scale_y (extents->y_bearing + extents->height);
 
-    extents->x_bearing = floorf (x1);
-    extents->y_bearing = floorf (y1);
-    extents->width = ceilf (x2) - extents->x_bearing;
-    extents->height = ceilf (y2) - extents->y_bearing;
+    extents->x_bearing = round (x1);
+    extents->y_bearing = round (y1);
+    extents->width = round (x2) - extents->x_bearing;
+    extents->height = round (y2) - extents->y_bearing;
   }
 
   void synthetic_glyph_extents (hb_glyph_extents_t *extents)

--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -667,10 +667,10 @@ hb_ft_get_glyph_extents (hb_font_t *font,
   float x2 = x1 + x_mult *  ft_face->glyph->metrics.width;
   float y2 = y1 + y_mult * -ft_face->glyph->metrics.height;
 
-  extents->x_bearing = floorf (x1);
-  extents->y_bearing = floorf (y1);
-  extents->width = ceilf (x2) - extents->x_bearing;
-  extents->height = ceilf (y2) - extents->y_bearing;
+  extents->x_bearing = round (x1);
+  extents->y_bearing = round (y1);
+  extents->width = round (x2) - extents->x_bearing;
+  extents->height = round (y2) - extents->y_bearing;
 
   return true;
 }


### PR DESCRIPTION
1. The floor/ceil was being applied in the wrong order for y direction.
2. If the scale is negative, the floor/ceil should be reversed.

Just round them instead. That's what coretext / directwrite / fontations font-funcs do.