### PR TITLE
[subset] Add hb_subset_cff_get_all_charstrings_data and hb_subset_cff2_get_all_charstrings_data.

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -956,7 +956,9 @@ hb_subset_serialize_or_fail
 <SUBSECTION Private>
 hb_subset_input_override_name_table
 hb_subset_cff_get_charstring_data
+hb_subset_cff_get_charstrings_index
 hb_subset_cff2_get_charstring_data
+hb_subset_cff2_get_charstrings_index
 </SECTION>
 
 <SECTION>

--- a/src/gen-def.py
+++ b/src/gen-def.py
@@ -22,7 +22,9 @@ if '--experimental-api' not in sys.argv:
 """hb_shape_justify
 hb_subset_input_override_name_table
 hb_subset_cff_get_charstring_data
+hb_subset_cff_get_charstrings_index
 hb_subset_cff2_get_charstring_data
+hb_subset_cff2_get_charstrings_index
 """.splitlines ()
 	symbols = [x for x in symbols if x not in experimental_symbols]
 symbols = "\n".join (symbols)

--- a/src/hb-subset.cc
+++ b/src/hb-subset.cc
@@ -737,6 +737,27 @@ static hb_blob_t* get_charstrings_data(accel_t& accel, hb_codepoint_t glyph_inde
   return hb_blob_create_sub_blob(cff_blob, (uint32_t) offset, bytes.length);
 }
 
+template<typename accel_t>
+static hb_blob_t* get_charstrings_index(accel_t& accel) {
+  if (!accel.is_valid()) {
+    return hb_blob_get_empty ();
+  }
+
+  const char* charstrings_start = (const char*) accel.charStrings;
+  unsigned charstrings_length = accel.charStrings->get_size();
+
+  hb_blob_t* cff_blob = accel.get_blob();
+  uint32_t length;
+  const char* cff_data = hb_blob_get_data(cff_blob, &length) ;
+
+  long int offset = charstrings_start - cff_data;
+  if (offset < 0 || offset > UINT32_MAX) {
+    return hb_blob_get_empty ();
+  }
+
+  return hb_blob_create_sub_blob(cff_blob, (uint32_t) offset, charstrings_length);
+}
+
 /**
  * hb_subset_cff_get_charstring_data:
  * @face: A face object
@@ -746,12 +767,25 @@ static hb_blob_t* get_charstrings_data(accel_t& accel, hb_codepoint_t glyph_inde
  *
  * XSince: EXPERIMENTAL
  **/
- HB_EXTERN hb_blob_t*
- hb_subset_cff_get_charstring_data(hb_face_t* face, hb_codepoint_t glyph_index) {
+HB_EXTERN hb_blob_t*
+hb_subset_cff_get_charstring_data(hb_face_t* face, hb_codepoint_t glyph_index) {
   return get_charstrings_data(*face->table.cff1, glyph_index);
- }
+}
 
- /**
+/**
+ * hb_subset_cff_get_charstrings_index:
+ * @face: A face object
+ *
+ * Returns the raw CFF CharStrings INDEX from the CFF table.
+ *
+ * XSince: EXPERIMENTAL
+ **/
+HB_EXTERN hb_blob_t*
+hb_subset_cff_get_charstrings_index (hb_face_t* face) {
+  return get_charstrings_index (*face->table.cff1);
+}
+ 
+/**
  * hb_subset_cff2_get_charstring_data:
  * @face: A face object
  * @glyph_index: Glyph index to get data for.
@@ -760,8 +794,21 @@ static hb_blob_t* get_charstrings_data(accel_t& accel, hb_codepoint_t glyph_inde
  *
  * XSince: EXPERIMENTAL
  **/
- HB_EXTERN hb_blob_t*
- hb_subset_cff2_get_charstring_data(hb_face_t* face, hb_codepoint_t glyph_index) {
+HB_EXTERN hb_blob_t*
+hb_subset_cff2_get_charstring_data(hb_face_t* face, hb_codepoint_t glyph_index) {
   return get_charstrings_data(*face->table.cff2, glyph_index);
- }
- #endif
+}
+
+/**
+ * hb_subset_cff2_get_charstrings_index:
+ * @face: A face object
+ *
+ * Returns the raw CFF2 CharStrings INDEX from the CFF2 table.
+ *
+ * XSince: EXPERIMENTAL
+ **/
+HB_EXTERN hb_blob_t*
+hb_subset_cff2_get_charstrings_index (hb_face_t* face) {
+  return get_charstrings_index (*face->table.cff2);
+}
+#endif

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -235,7 +235,13 @@ HB_EXTERN hb_blob_t*
 hb_subset_cff_get_charstring_data (hb_face_t* face, hb_codepoint_t glyph_index);
 
 HB_EXTERN hb_blob_t*
+hb_subset_cff_get_charstrings_index (hb_face_t* face);
+
+HB_EXTERN hb_blob_t*
 hb_subset_cff2_get_charstring_data (hb_face_t* face, hb_codepoint_t glyph_index);
+
+HB_EXTERN hb_blob_t*
+hb_subset_cff2_get_charstrings_index (hb_face_t* face);
 #endif
 
 HB_EXTERN hb_face_t *


### PR DESCRIPTION
These methods allow retrieving the entire charstrings index structure from a CFF or CFF2 table.