### PR TITLE
[shape] Use font-data for GDEF varStore cache

### DIFF
--- a/src/OT/Var/VARC/VARC.cc
+++ b/src/OT/Var/VARC/VARC.cc
@@ -392,7 +392,7 @@ VARC::get_path_at (const hb_varc_context_t &c,
 
   hb_ubytes_t record = (this+glyphRecords)[idx];
 
-  float static_cache[sizeof (void *) * 16];
+  VarRegionList::cache_t static_cache[sizeof (void *) * 16];
   VarRegionList::cache_t *cache = parent_cache ?
 				  parent_cache :
 				  (this+varStore).create_cache (hb_array (static_cache));

--- a/src/hb-atomic.hh
+++ b/src/hb-atomic.hh
@@ -50,7 +50,7 @@
 /* Defined externally, i.e. in config.h. */
 
 
-#elif !defined(HB_NO_MT) && defined(__ATOMIC_ACQUIRE) && 0
+#elif !defined(HB_NO_MT) && defined(__ATOMIC_ACQUIRE)
 
 /* C++11-style GCC primitives. We prefer these as they don't require linking to libstdc++ / libc++. */
 

--- a/src/hb-atomic.hh
+++ b/src/hb-atomic.hh
@@ -50,7 +50,7 @@
 /* Defined externally, i.e. in config.h. */
 
 
-#elif !defined(HB_NO_MT) && defined(__ATOMIC_ACQUIRE)
+#elif !defined(HB_NO_MT) && defined(__ATOMIC_ACQUIRE) && 0
 
 /* C++11-style GCC primitives. We prefer these as they don't require linking to libstdc++ / libc++. */
 

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -737,7 +737,8 @@ struct hb_ot_apply_context_t :
   hb_ot_apply_context_t (unsigned int table_index_,
 			 hb_font_t *font_,
 			 hb_buffer_t *buffer_,
-			 hb_blob_t *table_blob_) :
+			 hb_blob_t *table_blob_,
+			 ItemVariationStore::cache_t *var_store_cache_ = nullptr) :
 			table_index (table_index_),
 			font (font_), face (font->face), buffer (buffer_),
 			sanitizer (table_blob_),
@@ -756,25 +757,12 @@ struct hb_ot_apply_context_t :
 #endif
 			     ),
 			var_store (gdef.get_var_store ()),
-			var_store_cache (
-#ifndef HB_NO_VAR
-					 table_index == 1 && font->num_coords ? var_store.create_cache () : nullptr
-#else
-					 nullptr
-#endif
-					),
+			var_store_cache (var_store_cache_),
 			direction (buffer_->props.direction),
 			has_glyph_classes (gdef.has_glyph_classes ())
   {
     init_iters ();
     buffer->collect_codepoints (digest);
-  }
-
-  ~hb_ot_apply_context_t ()
-  {
-#ifndef HB_NO_VAR
-    ItemVariationStore::destroy_cache (var_store_cache);
-#endif
   }
 
   void init_iters ()

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -2015,7 +2015,11 @@ inline void hb_ot_map_t::apply (const Proxy &proxy,
 {
   const unsigned int table_index = proxy.table_index;
   unsigned int i = 0;
-  OT::hb_ot_apply_context_t c (table_index, font, buffer, proxy.accel.get_blob ());
+
+  auto *font_data = font->data.ot.get ();
+  auto *var_store_cache = font_data == HB_SHAPER_DATA_SUCCEEDED ? nullptr : (OT::ItemVariationStore::cache_t *) font_data;
+
+  OT::hb_ot_apply_context_t c (table_index, font, buffer, proxy.accel.get_blob (), var_store_cache);
   c.set_recurse_func (Proxy::Lookup::template dispatch_recurse_func<OT::hb_ot_apply_context_t>);
 
   for (unsigned int stage_index = 0; stage_index < stages[table_index].length; stage_index++)

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -431,8 +431,11 @@ struct hb_ot_font_data_t {
 hb_ot_font_data_t *
 _hb_ot_shaper_font_data_create (hb_font_t *font)
 {
+  if (!font->num_coords)
+    return (hb_ot_font_data_t *) HB_SHAPER_DATA_SUCCEEDED;
+
   const OT::ItemVariationStore &var_store = font->face->table.GDEF->table->get_var_store ();
-  auto *cache = font->num_coords ? (hb_ot_font_data_t *) var_store.create_cache () : nullptr;
+  auto *cache = (hb_ot_font_data_t *) var_store.create_cache ();
   return cache ? cache : (hb_ot_font_data_t *) HB_SHAPER_DATA_SUCCEEDED;
 }
 

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -46,6 +46,7 @@
 #include "hb-set.hh"
 
 #include "hb-aat-layout.hh"
+#include "hb-ot-layout-gdef-table.hh"
 #include "hb-ot-stat-table.hh"
 
 
@@ -423,17 +424,23 @@ _hb_ot_shaper_face_data_destroy (hb_ot_face_data_t *data)
  * shaper font data
  */
 
-struct hb_ot_font_data_t {};
+struct hb_ot_font_data_t {
+  OT::ItemVariationStore::cache_t unused; // Just for alignment
+};
 
 hb_ot_font_data_t *
-_hb_ot_shaper_font_data_create (hb_font_t *font HB_UNUSED)
+_hb_ot_shaper_font_data_create (hb_font_t *font)
 {
-  return (hb_ot_font_data_t *) HB_SHAPER_DATA_SUCCEEDED;
+  const OT::ItemVariationStore &var_store = font->face->table.GDEF->table->get_var_store ();
+  auto *cache = font->num_coords ? (hb_ot_font_data_t *) var_store.create_cache () : nullptr;
+  return cache ? cache : (hb_ot_font_data_t *) HB_SHAPER_DATA_SUCCEEDED;
 }
 
 void
-_hb_ot_shaper_font_data_destroy (hb_ot_font_data_t *data HB_UNUSED)
+_hb_ot_shaper_font_data_destroy (hb_ot_font_data_t *data)
 {
+  if (data == HB_SHAPER_DATA_SUCCEEDED) return;
+  OT::ItemVariationStore::destroy_cache ((OT::ItemVariationStore::cache_t *) data);
 }
 
 

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -408,7 +408,7 @@ _remap_variation_indices (const OT::ItemVariationStore &var_store,
 {
   if (&var_store == &Null (OT::ItemVariationStore)) return;
   unsigned subtable_count = var_store.get_sub_table_count ();
-  float *store_cache = var_store.create_cache ();
+  auto *store_cache = var_store.create_cache ();
 
   unsigned new_major = 0, new_minor = 0;
   unsigned last_major = (variation_indices.get_min ()) >> 16;
@@ -1161,12 +1161,12 @@ _update_instance_metrics_map_from_cff2 (hb_subset_plan_t *plan)
 
   hb_glyph_extents_t extents = {0x7FFF, -0x7FFF};
   OT::hmtx_accelerator_t _hmtx (plan->source);
-  float *hvar_store_cache = nullptr;
+  OT::ItemVariationStore::cache_t *hvar_store_cache = nullptr;
   if (_hmtx.has_data () && _hmtx.var_table.get_length ())
     hvar_store_cache = _hmtx.var_table->get_var_store ().create_cache ();
 
   OT::vmtx_accelerator_t _vmtx (plan->source);
-  float *vvar_store_cache = nullptr;
+  OT::ItemVariationStore::cache_t *vvar_store_cache = nullptr;
   if (_vmtx.has_data () && _vmtx.var_table.get_length ())
     vvar_store_cache = _vmtx.var_table->get_var_store ().create_cache ();
 


### PR DESCRIPTION
Last remaining alloc during shaping is gone!

Fixes https://github.com/harfbuzz/harfbuzz/issues/5237