### PR TITLE
[meson] Clean up warnings and fix usage of file objects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,11 +32,16 @@ pkgmod = import('pkgconfig')
 cpp = meson.get_compiler('cpp')
 null_dep = dependency('', required: false)
 
+
+# Includes Microsoft Clang compiler with GNU arguments, see
+# https://github.com/harfbuzz/harfbuzz/pull/4394
+cpp_is_microsoft_compiler = host_machine.system() == 'windows' and cpp.get_define('_MSC_FULL_VER') != ''
+
 # Only perform these checks if cpp_std is c++11 as setting -std directly
 # produces a warning from meson.
 if get_option('cpp_std') == 'c++11'
   # Enforce C++14 requirement for MSVC STL
-  if cpp.get_id() == 'clang' and cpp.get_define('_MSC_FULL_VER') != ''
+  if cpp.get_id() == 'clang' and cpp_is_microsoft_compiler
     add_project_arguments('-std=c++14', language: 'cpp')
   elif cpp.get_id() == 'clang-cl'
     # Clang-cl produces a warning when using -std=c++14, but not when using /std:c++14

--- a/src/meson.build
+++ b/src/meson.build
@@ -1042,11 +1042,17 @@ if get_option('tests').enabled()
   env.set('libs', meson.current_build_dir()) # TODO: Merge this with builddir after autotools removal
   HBSOURCES = []
   foreach f : hb_sources
+    if meson.version().version_compare('>=1.4.0')
+      f = f.full_path()
+    endif
     HBSOURCES += '@0@'.format(f)
   endforeach
   env.set('HBSOURCES', ' '.join(HBSOURCES))
   HBHEADERS = []
   foreach f : hb_headers
+    if meson.version().version_compare('>=1.4.0')
+      f = f.full_path()
+    endif
     HBHEADERS += '@0@'.format(f)
   endforeach
   env.set('HBHEADERS', ' '.join(HBHEADERS))

--- a/src/meson.build
+++ b/src/meson.build
@@ -840,15 +840,10 @@ have_gobject = conf.get('HAVE_GOBJECT', 0) == 1
 cmake_config = configuration_data()
 cmake_config_dir = cmake_package_install_dir / 'harfbuzz'
 
-have_fs_relative_to = meson.version().version_compare('>=1.3.0')
-
-if not have_fs_relative_to
-  relative_to = find_program('relative_to.py')
-endif
-
-if have_fs_relative_to
+if meson.version().version_compare('>=1.3.0')
   cmake_package_prefix_dir = fs.relative_to(get_option('prefix'), get_option('prefix') / cmake_config_dir)
 else
+  relative_to = find_program('relative_to.py')
   cmake_package_prefix_dir = run_command(relative_to, get_option('prefix'), get_option('prefix') / cmake_config_dir, check: true).stdout().strip()
 endif
 
@@ -860,7 +855,7 @@ cmake_package_prefix_dir = '${CMAKE_CURRENT_LIST_DIR}/@0@'.format(cmake_package_
 cmake_install_includedir = get_option('includedir')
 
 if fs.is_absolute(cmake_install_includedir)
-  if have_fs_relative_to
+  if meson.version().version_compare('>=1.3.0')
     cmake_install_includedir = fs.relative_to(cmake_install_includedir, get_option('prefix'))
   else
     cmake_install_includedir = run_command(relative_to, cmake_install_includedir, get_option('prefix'), check: true).stdout().strip()
@@ -870,7 +865,7 @@ endif
 cmake_install_libdir = get_option('libdir')
 
 if fs.is_absolute(cmake_install_libdir)
-  if have_fs_relative_to
+  if meson.version().version_compare('>=1.3.0')
     cmake_install_libdir = fs.relative_to(cmake_install_libdir, get_option('prefix'))
   else
     cmake_install_libdir = run_command(relative_to, cmake_install_libdir, get_option('prefix'), check: true).stdout().strip()

--- a/src/meson.build
+++ b/src/meson.build
@@ -599,7 +599,7 @@ defs_list = [harfbuzz_def]
 version = '0.@0@.0'.format(hb_version_int)
 
 extra_hb_cpp_args = []
-if cpp.get_define('_MSC_FULL_VER') != ''
+if cpp_is_microsoft_compiler
   if get_option('default_library') != 'static'
     extra_hb_cpp_args += '-DHB_DLL_EXPORT'
   endif
@@ -721,7 +721,7 @@ if get_option('tests').enabled()
   # TODO: Microsoft LINK gives the following because extern, non dllexport
   # symbols can only be used when linking against a static library
   # error LNK2019: unresolved external symbol "unsigned __int64 const * const _hb_NullPool"
-  if cpp.get_define('_MSC_FULL_VER') == ''
+  if not cpp_is_microsoft_compiler
     noinst_programs = {
       'main': 'main.cc',
       'test-basics': 'test.cc',
@@ -768,7 +768,7 @@ if get_option('tests').enabled()
     'test-unicode-ranges': ['test-unicode-ranges.cc'],
   }
   foreach name, source : compiled_tests
-    if cpp.get_define('_MSC_FULL_VER') != '' and source.contains('hb-static.cc')
+    if cpp_is_microsoft_compiler and source.contains('hb-static.cc')
       # TODO: Microsoft compilers cannot link tests using hb-static.cc, fix them
       continue
     endif


### PR DESCRIPTION
Hi there, this is just a small cleanup to remove some of the repeated messages and warnings in the Meson build output. The first change just suppresses the repeated (about 20) calls to `Fetching value of define "_MSC_FULL_VER" : (undefined)` when compiling for Windows, while the second gets rid of `src/meson.build:850: WARNING: Project targets '>= 0.60.0' but uses feature introduced in '1.3.0': fs.relative_to.` by checking the Meson version directly in the if statements enclosing them.

The third is for a more serious issue: `src/meson.build:1055: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.3.0': str.format: Value other than strings, integers, bools, options, dictionaries and lists thereof..` However, the only way to get the actual paths for a files() object is to use the full_path() function which was only introduced in 1.4.0, so I had to enclose those in if statements as well.