### PR TITLE
[COLRv1] `paint-bounds`

### DIFF
--- a/src/OT/Color/COLR/COLR.hh
+++ b/src/OT/Color/COLR/COLR.hh
@@ -33,6 +33,7 @@
 #include "../../../hb-open-type.hh"
 #include "../../../hb-ot-var-common.hh"
 #include "../../../hb-paint.hh"
+#include "../../../hb-paint-bounded.hh"
 #include "../../../hb-paint-extents.hh"
 
 #include "../CPAL/CPAL.hh"
@@ -49,6 +50,7 @@ struct hb_paint_context_t;
 
 struct hb_colr_scratch_t
 {
+  hb_paint_bounded_context_t paint_bounded;
   hb_paint_extents_context_t paint_extents;
 };
 
@@ -2709,23 +2711,22 @@ struct COLR
 	  }
 	  else
 	  {
-	    auto *extents_funcs = hb_paint_extents_get_funcs ();
-	    scratch.paint_extents.clear ();
+	    clip = false;
+	    is_bounded = false;
+	  }
+
+	  if (!is_bounded)
+	  {
+	    auto *bounded_funcs = hb_paint_bounded_get_funcs ();
+	    scratch.paint_bounded.clear ();
 
 	    paint_glyph (font, glyph,
-			 extents_funcs, &scratch.paint_extents,
+			 bounded_funcs, &scratch.paint_bounded,
 			 palette_index, foreground,
 			 false,
 			 scratch);
 
-	    auto extents = scratch.paint_extents.get_extents ();
-	    is_bounded = scratch.paint_extents.is_bounded ();
-
-	    c.funcs->push_clip_rectangle (c.data,
-					  extents.xmin,
-					  extents.ymin,
-					  extents.xmax,
-					  extents.ymax);
+	    is_bounded = scratch.paint_bounded.is_bounded ();
 	  }
 	}
 

--- a/src/OT/Color/COLR/COLR.hh
+++ b/src/OT/Color/COLR/COLR.hh
@@ -2695,6 +2695,7 @@ struct COLR
       {
         // COLRv1 glyph
 
+	bool is_bounded = true;
 	if (clip)
 	{
 	  hb_glyph_extents_t extents;
@@ -2709,12 +2710,30 @@ struct COLR
 					  extents.y_bearing);
 	  }
 	  else
+	  {
 	    clip = false;
+	    is_bounded = false;
+	  }
+
+	  if (!is_bounded)
+	  {
+	    auto *bounded_funcs = hb_paint_bounded_get_funcs ();
+	    scratch.paint_bounded.clear ();
+
+	    paint_glyph (font, glyph,
+			 bounded_funcs, &scratch.paint_bounded,
+			 palette_index, foreground,
+			 false,
+			 scratch);
+
+	    is_bounded = scratch.paint_bounded.is_bounded ();
+	  }
 	}
 
 	c.funcs->push_font_transform (c.data, font);
 
-	c.recurse (*paint);
+	if (is_bounded)
+	  c.recurse (*paint);
 
 	c.funcs->pop_transform (c.data);
 

--- a/src/OT/Color/COLR/COLR.hh
+++ b/src/OT/Color/COLR/COLR.hh
@@ -2695,7 +2695,6 @@ struct COLR
       {
         // COLRv1 glyph
 
-	bool is_bounded = true;
 	if (clip)
 	{
 	  hb_glyph_extents_t extents;
@@ -2710,30 +2709,12 @@ struct COLR
 					  extents.y_bearing);
 	  }
 	  else
-	  {
 	    clip = false;
-	    is_bounded = false;
-	  }
-
-	  if (!is_bounded)
-	  {
-	    auto *bounded_funcs = hb_paint_bounded_get_funcs ();
-	    scratch.paint_bounded.clear ();
-
-	    paint_glyph (font, glyph,
-			 bounded_funcs, &scratch.paint_bounded,
-			 palette_index, foreground,
-			 false,
-			 scratch);
-
-	    is_bounded = scratch.paint_bounded.is_bounded ();
-	  }
 	}
 
 	c.funcs->push_font_transform (c.data, font);
 
-	if (is_bounded)
-	  c.recurse (*paint);
+	c.recurse (*paint);
 
 	c.funcs->pop_transform (c.data);
 

--- a/src/harfbuzz-subset.cc
+++ b/src/harfbuzz-subset.cc
@@ -43,6 +43,7 @@
 #include "hb-ot-tag.cc"
 #include "hb-ot-var.cc"
 #include "hb-outline.cc"
+#include "hb-paint-bounded.cc"
 #include "hb-paint-extents.cc"
 #include "hb-paint.cc"
 #include "hb-set.cc"

--- a/src/harfbuzz.cc
+++ b/src/harfbuzz.cc
@@ -52,6 +52,7 @@
 #include "hb-ot-tag.cc"
 #include "hb-ot-var.cc"
 #include "hb-outline.cc"
+#include "hb-paint-bounded.cc"
 #include "hb-paint-extents.cc"
 #include "hb-paint.cc"
 #include "hb-set.cc"

--- a/src/hb-draw.cc
+++ b/src/hb-draw.cc
@@ -28,6 +28,11 @@
 
 #include "hb-draw.hh"
 
+#include "hb-geometry.hh"
+
+#include "hb-machinery.hh"
+
+
 /**
  * SECTION:hb-draw
  * @title: hb-draw
@@ -452,6 +457,94 @@ hb_draw_close_path (hb_draw_funcs_t *dfuncs, void *draw_data,
 		    hb_draw_state_t *st)
 {
   dfuncs->close_path (draw_data, *st);
+}
+
+
+static void
+hb_draw_extents_move_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
+			 void *data,
+			 hb_draw_state_t *st,
+			 float to_x, float to_y,
+			 void *user_data HB_UNUSED)
+{
+  hb_extents_t *extents = (hb_extents_t *) data;
+
+  extents->add_point (to_x, to_y);
+}
+
+static void
+hb_draw_extents_line_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
+			 void *data,
+			 hb_draw_state_t *st,
+			 float to_x, float to_y,
+			 void *user_data HB_UNUSED)
+{
+  hb_extents_t *extents = (hb_extents_t *) data;
+
+  extents->add_point (to_x, to_y);
+}
+
+static void
+hb_draw_extents_quadratic_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
+			      void *data,
+			      hb_draw_state_t *st,
+			      float control_x, float control_y,
+			      float to_x, float to_y,
+			      void *user_data HB_UNUSED)
+{
+  hb_extents_t *extents = (hb_extents_t *) data;
+
+  extents->add_point (control_x, control_y);
+  extents->add_point (to_x, to_y);
+}
+
+static void
+hb_draw_extents_cubic_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
+			  void *data,
+			  hb_draw_state_t *st,
+			  float control1_x, float control1_y,
+			  float control2_x, float control2_y,
+			  float to_x, float to_y,
+			  void *user_data HB_UNUSED)
+{
+  hb_extents_t *extents = (hb_extents_t *) data;
+
+  extents->add_point (control1_x, control1_y);
+  extents->add_point (control2_x, control2_y);
+  extents->add_point (to_x, to_y);
+}
+
+static inline void free_static_draw_extents_funcs ();
+
+static struct hb_draw_extents_funcs_lazy_loader_t : hb_draw_funcs_lazy_loader_t<hb_draw_extents_funcs_lazy_loader_t>
+{
+  static hb_draw_funcs_t *create ()
+  {
+    hb_draw_funcs_t *funcs = hb_draw_funcs_create ();
+
+    hb_draw_funcs_set_move_to_func (funcs, hb_draw_extents_move_to, nullptr, nullptr);
+    hb_draw_funcs_set_line_to_func (funcs, hb_draw_extents_line_to, nullptr, nullptr);
+    hb_draw_funcs_set_quadratic_to_func (funcs, hb_draw_extents_quadratic_to, nullptr, nullptr);
+    hb_draw_funcs_set_cubic_to_func (funcs, hb_draw_extents_cubic_to, nullptr, nullptr);
+
+    hb_draw_funcs_make_immutable (funcs);
+
+    hb_atexit (free_static_draw_extents_funcs);
+
+    return funcs;
+  }
+} static_draw_extents_funcs;
+
+static inline
+void free_static_draw_extents_funcs ()
+{
+  static_draw_extents_funcs.free_instance ();
+}
+
+hb_draw_funcs_t *
+hb_draw_extents_get_funcs ()
+{
+  return static_draw_extents_funcs.get_unconst ();
 }
 
 

--- a/src/hb-draw.hh
+++ b/src/hb-draw.hh
@@ -244,4 +244,9 @@ struct hb_draw_session_t
   hb_draw_state_t st;
 };
 
+
+HB_INTERNAL hb_draw_funcs_t *
+hb_draw_extents_get_funcs ();
+
+
 #endif /* HB_DRAW_HH */

--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -35,7 +35,6 @@
 #include "hb-atomic.hh"
 #include "hb-shaper.hh"
 #include "hb-outline.hh"
-#include "hb-paint-bounded.hh"
 
 
 /*
@@ -525,19 +524,6 @@ struct hb_font_t
                     unsigned int palette,
                     hb_color_t foreground)
   {
-    /* COLRv1 spec says a glyph must not be painted if the paint graph
-     * draws unbounded. Implement this here such that all font-funcs
-     * benefit, since we have the code. */
-    auto *bounded_funcs = hb_paint_bounded_get_funcs ();
-    hb_paint_bounded_context_t bounded_data;
-    klass->get.f.paint_glyph (this, user_data,
-                              glyph,
-                              bounded_funcs, &bounded_data,
-                              palette, foreground,
-                              !klass->user_data ? nullptr : klass->user_data->paint_glyph);
-    if (!bounded_data.is_bounded ())
-      return;
-
     klass->get.f.paint_glyph (this, user_data,
                               glyph,
                               paint_funcs, paint_data,

--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -35,6 +35,7 @@
 #include "hb-atomic.hh"
 #include "hb-shaper.hh"
 #include "hb-outline.hh"
+#include "hb-paint-bounded.hh"
 
 
 /*
@@ -524,6 +525,19 @@ struct hb_font_t
                     unsigned int palette,
                     hb_color_t foreground)
   {
+    /* COLRv1 spec says a glyph must not be painted if the paint graph
+     * draws unbounded. Implement this here such that all font-funcs
+     * benefit, since we have the code. */
+    auto *bounded_funcs = hb_paint_bounded_get_funcs ();
+    hb_paint_bounded_context_t bounded_data;
+    klass->get.f.paint_glyph (this, user_data,
+                              glyph,
+                              bounded_funcs, &bounded_data,
+                              palette, foreground,
+                              !klass->user_data ? nullptr : klass->user_data->paint_glyph);
+    if (!bounded_data.is_bounded ())
+      return;
+
     klass->get.f.paint_glyph (this, user_data,
                               glyph,
                               paint_funcs, paint_data,

--- a/src/hb-ft-colr.hh
+++ b/src/hb-ft-colr.hh
@@ -28,7 +28,7 @@
 #include "hb.hh"
 
 #include "hb-decycler.hh"
-#include "hb-paint-extents.hh"
+#include "hb-paint-bounded.hh"
 
 #include FT_COLOR_H
 
@@ -512,7 +512,8 @@ hb_ft_paint_glyph_colr (hb_font_t *font,
     hb_decycler_node_t node (c.glyphs_decycler);
     node.visit (gid);
 
-    bool is_bounded = true;
+    bool clip = false;
+    bool is_bounded = false;
     FT_ClipBox clip_box;
     if (FT_Get_Color_Glyph_ClipBox (ft_face, gid, &clip_box))
     {
@@ -525,39 +526,31 @@ hb_ft_paint_glyph_colr (hb_font_t *font,
 				      roundf (hb_max (font->slant_xy * clip_box.bottom_right.y,
 						      font->slant_xy * clip_box.top_right.y)),
 				    clip_box.top_right.y);
+      clip = true;
+      is_bounded = true;
     }
-    else
+    if (!is_bounded)
     {
-
-      auto *extents_funcs = hb_paint_extents_get_funcs ();
-      hb_paint_extents_context_t extents_data;
+      auto *bounded_funcs = hb_paint_bounded_get_funcs ();
+      hb_paint_bounded_context_t bounded_data;
       hb_ft_paint_context_t ce (ft_font, font,
-			        extents_funcs, &extents_data,
+			        bounded_funcs, &bounded_data,
 			        palette_array, palette_index, foreground);
       hb_decycler_node_t node2 (ce.glyphs_decycler);
       node2.visit (gid);
-      ce.funcs->push_font_transform (ce.data, font);
       ce.recurse (paint);
-      ce.funcs->pop_transform (ce.data);
-      hb_extents_t extents = extents_data.get_extents ();
-      is_bounded = extents_data.is_bounded ();
-
-      c.funcs->push_clip_rectangle (c.data,
-				    extents.xmin,
-				    extents.ymin,
-				    extents.xmax,
-				    extents.ymax);
+      is_bounded = bounded_data.is_bounded ();
     }
 
     c.funcs->push_font_transform (c.data, font);
 
     if (is_bounded)
-     {
       c.recurse (paint);
-     }
 
     c.funcs->pop_transform (c.data);
-    c.funcs->pop_clip (c.data);
+
+    if (clip)
+      c.funcs->pop_clip (c.data);
 
     return true;
   }

--- a/src/hb-ft-colr.hh
+++ b/src/hb-ft-colr.hh
@@ -28,7 +28,6 @@
 #include "hb.hh"
 
 #include "hb-decycler.hh"
-#include "hb-paint-bounded.hh"
 
 #include FT_COLOR_H
 
@@ -513,7 +512,6 @@ hb_ft_paint_glyph_colr (hb_font_t *font,
     node.visit (gid);
 
     bool clip = false;
-    bool is_bounded = false;
     FT_ClipBox clip_box;
     if (FT_Get_Color_Glyph_ClipBox (ft_face, gid, &clip_box))
     {
@@ -527,25 +525,11 @@ hb_ft_paint_glyph_colr (hb_font_t *font,
 						      font->slant_xy * clip_box.top_right.y)),
 				    clip_box.top_right.y);
       clip = true;
-      is_bounded = true;
-    }
-    if (!is_bounded)
-    {
-      auto *bounded_funcs = hb_paint_bounded_get_funcs ();
-      hb_paint_bounded_context_t bounded_data;
-      hb_ft_paint_context_t ce (ft_font, font,
-			        bounded_funcs, &bounded_data,
-			        palette_array, palette_index, foreground);
-      hb_decycler_node_t node2 (ce.glyphs_decycler);
-      node2.visit (gid);
-      ce.recurse (paint);
-      is_bounded = bounded_data.is_bounded ();
     }
 
     c.funcs->push_font_transform (c.data, font);
 
-    if (is_bounded)
-      c.recurse (paint);
+    c.recurse (paint);
 
     c.funcs->pop_transform (c.data);
 

--- a/src/hb-paint-bounded.cc
+++ b/src/hb-paint-bounded.cc
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2022 Behdad Esfahbod
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#include "hb.hh"
+
+#ifndef HB_NO_PAINT
+
+#include "hb-paint-bounded.hh"
+
+#include "hb-machinery.hh"
+
+
+/*
+ * This file implements boundedness computation of COLRv1 fonts as described in:
+ *
+ * https://learn.microsoft.com/en-us/typography/opentype/spec/colr#glyph-metrics-and-boundedness
+ */
+
+static void
+hb_paint_bounded_push_clip_glyph (hb_paint_funcs_t *funcs HB_UNUSED,
+				  void *paint_data,
+				  hb_codepoint_t glyph,
+				  hb_font_t *font,
+				  void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->push_clip ();
+}
+
+static void
+hb_paint_bounded_push_clip_rectangle (hb_paint_funcs_t *funcs HB_UNUSED,
+				      void *paint_data,
+				      float xmin, float ymin, float xmax, float ymax,
+				      void *user_data)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->push_clip ();
+}
+
+static void
+hb_paint_bounded_pop_clip (hb_paint_funcs_t *funcs HB_UNUSED,
+			   void *paint_data,
+			   void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->pop_clip ();
+}
+
+static void
+hb_paint_bounded_push_group (hb_paint_funcs_t *funcs HB_UNUSED,
+			     void *paint_data,
+			     void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->push_group ();
+}
+
+static void
+hb_paint_bounded_pop_group (hb_paint_funcs_t *funcs HB_UNUSED,
+			    void *paint_data,
+			    hb_paint_composite_mode_t mode,
+			    void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->pop_group (mode);
+}
+
+static hb_bool_t
+hb_paint_bounded_paint_image (hb_paint_funcs_t *funcs HB_UNUSED,
+			      void *paint_data,
+			      hb_blob_t *blob HB_UNUSED,
+			      unsigned int width HB_UNUSED,
+			      unsigned int height HB_UNUSED,
+			      hb_tag_t format HB_UNUSED,
+			      float slant HB_UNUSED,
+			      hb_glyph_extents_t *glyph_extents,
+			      void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->push_clip ();
+  c->paint ();
+  c->pop_clip ();
+
+  return true;
+}
+
+static void
+hb_paint_bounded_paint_color (hb_paint_funcs_t *funcs HB_UNUSED,
+			      void *paint_data,
+			      hb_bool_t use_foreground HB_UNUSED,
+			      hb_color_t color HB_UNUSED,
+			      void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->paint ();
+}
+
+static void
+hb_paint_bounded_paint_linear_gradient (hb_paint_funcs_t *funcs HB_UNUSED,
+				        void *paint_data,
+				        hb_color_line_t *color_line HB_UNUSED,
+				        float x0 HB_UNUSED, float y0 HB_UNUSED,
+				        float x1 HB_UNUSED, float y1 HB_UNUSED,
+				        float x2 HB_UNUSED, float y2 HB_UNUSED,
+				        void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->paint ();
+}
+
+static void
+hb_paint_bounded_paint_radial_gradient (hb_paint_funcs_t *funcs HB_UNUSED,
+				        void *paint_data,
+				        hb_color_line_t *color_line HB_UNUSED,
+				        float x0 HB_UNUSED, float y0 HB_UNUSED, float r0 HB_UNUSED,
+				        float x1 HB_UNUSED, float y1 HB_UNUSED, float r1 HB_UNUSED,
+				        void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->paint ();
+}
+
+static void
+hb_paint_bounded_paint_sweep_gradient (hb_paint_funcs_t *funcs HB_UNUSED,
+				       void *paint_data,
+				       hb_color_line_t *color_line HB_UNUSED,
+				       float cx HB_UNUSED, float cy HB_UNUSED,
+				       float start_angle HB_UNUSED,
+				       float end_angle HB_UNUSED,
+				       void *user_data HB_UNUSED)
+{
+  hb_paint_bounded_context_t *c = (hb_paint_bounded_context_t *) paint_data;
+
+  c->paint ();
+}
+
+static inline void free_static_paint_bounded_funcs ();
+
+static struct hb_paint_bounded_funcs_lazy_loader_t : hb_paint_funcs_lazy_loader_t<hb_paint_bounded_funcs_lazy_loader_t>
+{
+  static hb_paint_funcs_t *create ()
+  {
+    hb_paint_funcs_t *funcs = hb_paint_funcs_create ();
+
+    hb_paint_funcs_set_push_clip_glyph_func (funcs, hb_paint_bounded_push_clip_glyph, nullptr, nullptr);
+    hb_paint_funcs_set_push_clip_rectangle_func (funcs, hb_paint_bounded_push_clip_rectangle, nullptr, nullptr);
+    hb_paint_funcs_set_pop_clip_func (funcs, hb_paint_bounded_pop_clip, nullptr, nullptr);
+    hb_paint_funcs_set_push_group_func (funcs, hb_paint_bounded_push_group, nullptr, nullptr);
+    hb_paint_funcs_set_pop_group_func (funcs, hb_paint_bounded_pop_group, nullptr, nullptr);
+    hb_paint_funcs_set_color_func (funcs, hb_paint_bounded_paint_color, nullptr, nullptr);
+    hb_paint_funcs_set_image_func (funcs, hb_paint_bounded_paint_image, nullptr, nullptr);
+    hb_paint_funcs_set_linear_gradient_func (funcs, hb_paint_bounded_paint_linear_gradient, nullptr, nullptr);
+    hb_paint_funcs_set_radial_gradient_func (funcs, hb_paint_bounded_paint_radial_gradient, nullptr, nullptr);
+    hb_paint_funcs_set_sweep_gradient_func (funcs, hb_paint_bounded_paint_sweep_gradient, nullptr, nullptr);
+
+    hb_paint_funcs_make_immutable (funcs);
+
+    hb_atexit (free_static_paint_bounded_funcs);
+
+    return funcs;
+  }
+} static_paint_bounded_funcs;
+
+static inline
+void free_static_paint_bounded_funcs ()
+{
+  static_paint_bounded_funcs.free_instance ();
+}
+
+hb_paint_funcs_t *
+hb_paint_bounded_get_funcs ()
+{
+  return static_paint_bounded_funcs.get_unconst ();
+}
+
+
+#endif

--- a/src/hb-paint-bounded.hh
+++ b/src/hb-paint-bounded.hh
@@ -59,6 +59,7 @@ struct hb_paint_bounded_context_t
 
   void pop_clip ()
   {
+    if (clips == 0) return;
     clips--;
   }
 
@@ -99,13 +100,13 @@ struct hb_paint_bounded_context_t
 
   void paint ()
   {
-    if (clips <= 0)
+    if (!clips)
       bounded = false;
   }
 
   protected:
   bool bounded; // true if current drawing bounded
-  int clips; // number of active clips
+  unsigned clips; // number of active clips
   hb_vector_t<bool> groups; // true if group bounded
 };
 

--- a/src/hb-paint-bounded.hh
+++ b/src/hb-paint-bounded.hh
@@ -38,8 +38,8 @@ struct hb_paint_bounded_context_t
   void clear ()
   {
     clips = 0;
+    bounded = true;
     groups.clear ();
-    groups.push (true);
   }
 
   hb_paint_bounded_context_t ()
@@ -49,7 +49,7 @@ struct hb_paint_bounded_context_t
 
   bool is_bounded ()
   {
-    return groups.tail();
+    return bounded;
   }
 
   void push_clip ()
@@ -64,13 +64,15 @@ struct hb_paint_bounded_context_t
 
   void push_group ()
   {
-    groups.push (true);
+    groups.push (bounded);
+    bounded = true;
   }
 
   void pop_group (hb_paint_composite_mode_t mode)
   {
-    const bool src_bounded = groups.pop ();
-    bool &backdrop_bounded = groups.tail ();
+    const bool src_bounded = bounded;
+    bounded = groups.pop ();
+    bool &backdrop_bounded = bounded;
 
     // https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-32-paintcomposite
     switch ((int) mode)
@@ -97,15 +99,14 @@ struct hb_paint_bounded_context_t
 
   void paint ()
   {
-    bool &group = groups.tail ();
-
     if (clips <= 0)
-      group = false;
+      bounded = false;
   }
 
   protected:
+  bool bounded; // true if current drawing bounded
   int clips; // number of active clips
-  hb_vector_t<bool> groups; // true if bounded
+  hb_vector_t<bool> groups; // true if group bounded
 };
 
 HB_INTERNAL hb_paint_funcs_t *

--- a/src/hb-paint-bounded.hh
+++ b/src/hb-paint-bounded.hh
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2022 Behdad Esfahbod
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#ifndef HB_PAINT_BOUNDED_HH
+#define HB_PAINT_BOUNDED_HH
+
+#include "hb.hh"
+#include "hb-paint.h"
+
+#include "hb-geometry.hh"
+
+
+typedef struct  hb_paint_bounded_context_t hb_paint_bounded_context_t;
+
+struct hb_paint_bounded_context_t
+{
+  void clear ()
+  {
+    clips.clear ();
+    groups.clear ();
+
+    clips.push (false);
+    groups.push (true);
+  }
+
+  hb_paint_bounded_context_t ()
+  {
+    clear ();
+  }
+
+  bool is_bounded ()
+  {
+    return groups.tail();
+  }
+
+  void push_clip ()
+  {
+    clips.push (true);
+  }
+
+  void pop_clip ()
+  {
+    clips.pop ();
+  }
+
+  void push_group ()
+  {
+    groups.push (true);
+  }
+
+  void pop_group (hb_paint_composite_mode_t mode)
+  {
+    const bool src_bounded = groups.pop ();
+    bool &backdrop_bounded = groups.tail ();
+
+    // https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-32-paintcomposite
+    switch ((int) mode)
+    {
+      case HB_PAINT_COMPOSITE_MODE_CLEAR:
+	backdrop_bounded = true;
+	break;
+      case HB_PAINT_COMPOSITE_MODE_SRC:
+      case HB_PAINT_COMPOSITE_MODE_SRC_OUT:
+	backdrop_bounded = src_bounded;
+	break;
+      case HB_PAINT_COMPOSITE_MODE_DEST:
+      case HB_PAINT_COMPOSITE_MODE_DEST_OUT:
+	break;
+      case HB_PAINT_COMPOSITE_MODE_SRC_IN:
+      case HB_PAINT_COMPOSITE_MODE_DEST_IN:
+	backdrop_bounded = backdrop_bounded && src_bounded;
+	break;
+      default:
+	backdrop_bounded = backdrop_bounded || src_bounded;
+	break;
+     }
+  }
+
+  void paint ()
+  {
+    const bool &clip = clips.tail ();
+    bool &group = groups.tail ();
+
+    if (!clip)
+      group = false;
+  }
+
+  protected:
+  hb_vector_t<bool> clips; // true if clipped
+  hb_vector_t<bool> groups; // true if bounded
+};
+
+HB_INTERNAL hb_paint_funcs_t *
+hb_paint_bounded_get_funcs ();
+
+
+#endif /* HB_PAINT_BOUNDED_HH */

--- a/src/hb-paint-bounded.hh
+++ b/src/hb-paint-bounded.hh
@@ -37,10 +37,8 @@ struct hb_paint_bounded_context_t
 {
   void clear ()
   {
-    clips.clear ();
+    clips = 0;
     groups.clear ();
-
-    clips.push (false);
     groups.push (true);
   }
 
@@ -56,12 +54,12 @@ struct hb_paint_bounded_context_t
 
   void push_clip ()
   {
-    clips.push (true);
+    clips++;
   }
 
   void pop_clip ()
   {
-    clips.pop ();
+    clips--;
   }
 
   void push_group ()
@@ -99,15 +97,14 @@ struct hb_paint_bounded_context_t
 
   void paint ()
   {
-    const bool &clip = clips.tail ();
     bool &group = groups.tail ();
 
-    if (!clip)
+    if (clips <= 0)
       group = false;
   }
 
   protected:
-  hb_vector_t<bool> clips; // true if clipped
+  int clips; // number of active clips
   hb_vector_t<bool> groups; // true if bounded
 };
 

--- a/src/hb-paint-extents.cc
+++ b/src/hb-paint-extents.cc
@@ -34,8 +34,7 @@
 
 
 /*
- * This file implements bounds-extraction as well as boundedness
- * computation of COLRv1 fonts as described in:
+ * This file implements bounds-extraction computation of COLRv1 fonts as described in:
  *
  * https://learn.microsoft.com/en-us/typography/opentype/spec/colr#glyph-metrics-and-boundedness
  */

--- a/src/hb-paint-extents.cc
+++ b/src/hb-paint-extents.cc
@@ -28,7 +28,7 @@
 
 #include "hb-paint-extents.hh"
 
-#include "hb-draw.h"
+#include "hb-draw.hh"
 
 #include "hb-machinery.hh"
 
@@ -61,93 +61,6 @@ hb_paint_extents_pop_transform (hb_paint_funcs_t *funcs HB_UNUSED,
   hb_paint_extents_context_t *c = (hb_paint_extents_context_t *) paint_data;
 
   c->pop_transform ();
-}
-
-static void
-hb_draw_extents_move_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
-			 void *data,
-			 hb_draw_state_t *st,
-			 float to_x, float to_y,
-			 void *user_data HB_UNUSED)
-{
-  hb_extents_t *extents = (hb_extents_t *) data;
-
-  extents->add_point (to_x, to_y);
-}
-
-static void
-hb_draw_extents_line_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
-			 void *data,
-			 hb_draw_state_t *st,
-			 float to_x, float to_y,
-			 void *user_data HB_UNUSED)
-{
-  hb_extents_t *extents = (hb_extents_t *) data;
-
-  extents->add_point (to_x, to_y);
-}
-
-static void
-hb_draw_extents_quadratic_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
-			      void *data,
-			      hb_draw_state_t *st,
-			      float control_x, float control_y,
-			      float to_x, float to_y,
-			      void *user_data HB_UNUSED)
-{
-  hb_extents_t *extents = (hb_extents_t *) data;
-
-  extents->add_point (control_x, control_y);
-  extents->add_point (to_x, to_y);
-}
-
-static void
-hb_draw_extents_cubic_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
-			  void *data,
-			  hb_draw_state_t *st,
-			  float control1_x, float control1_y,
-			  float control2_x, float control2_y,
-			  float to_x, float to_y,
-			  void *user_data HB_UNUSED)
-{
-  hb_extents_t *extents = (hb_extents_t *) data;
-
-  extents->add_point (control1_x, control1_y);
-  extents->add_point (control2_x, control2_y);
-  extents->add_point (to_x, to_y);
-}
-
-static inline void free_static_draw_extents_funcs ();
-
-static struct hb_draw_extents_funcs_lazy_loader_t : hb_draw_funcs_lazy_loader_t<hb_draw_extents_funcs_lazy_loader_t>
-{
-  static hb_draw_funcs_t *create ()
-  {
-    hb_draw_funcs_t *funcs = hb_draw_funcs_create ();
-
-    hb_draw_funcs_set_move_to_func (funcs, hb_draw_extents_move_to, nullptr, nullptr);
-    hb_draw_funcs_set_line_to_func (funcs, hb_draw_extents_line_to, nullptr, nullptr);
-    hb_draw_funcs_set_quadratic_to_func (funcs, hb_draw_extents_quadratic_to, nullptr, nullptr);
-    hb_draw_funcs_set_cubic_to_func (funcs, hb_draw_extents_cubic_to, nullptr, nullptr);
-
-    hb_draw_funcs_make_immutable (funcs);
-
-    hb_atexit (free_static_draw_extents_funcs);
-
-    return funcs;
-  }
-} static_draw_extents_funcs;
-
-static inline
-void free_static_draw_extents_funcs ()
-{
-  static_draw_extents_funcs.free_instance ();
-}
-
-static hb_draw_funcs_t *
-hb_draw_extents_get_funcs ()
-{
-  return static_draw_extents_funcs.get_unconst ();
 }
 
 static void

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,6 +53,8 @@ hb_base_sources = files(
   'hb-geometry.hh',
   'hb-paint.cc',
   'hb-paint.hh',
+  'hb-paint-bounded.cc',
+  'hb-paint-bounded.hh',
   'hb-paint-extents.cc',
   'hb-paint-extents.hh',
   'hb-face.cc',

--- a/test/api/results-paint/test-106
+++ b/test/api/results-paint/test-106
@@ -1,28 +1,26 @@
-start clip rectangle 250 183 750 817
-  start transform 1 0 0 1 0 0
+start transform 1 0 0 1 0 0
+  push group
+    start transform 1 0 -0 1 0 0
+      start clip glyph 3
+        start transform 1 0 0 1 0 0
+          solid 0 0 255 127
+        end transform
+      end clip
+    end transform
     push group
-      start transform 1 0 -0 1 0 0
-        start clip glyph 3
-          start transform 1 0 0 1 0 0
-            solid 0 0 255 127
-          end transform
-        end clip
-      end transform
-      push group
-        start transform 1 0 0 1 500 500
-          start transform 1 0.268 -0 1 0 0
-            start transform 1 0 0 1 -500 -500
-              start transform 1 0 -0 1 0 0
-                start clip glyph 3
-                  start transform 1 0 0 1 0 0
-                    solid 255 165 0 178
-                  end transform
-                end clip
-              end transform
+      start transform 1 0 0 1 500 500
+        start transform 1 0.268 -0 1 0 0
+          start transform 1 0 0 1 -500 -500
+            start transform 1 0 -0 1 0 0
+              start clip glyph 3
+                start transform 1 0 0 1 0 0
+                  solid 255 165 0 178
+                end transform
+              end clip
             end transform
           end transform
         end transform
-      pop group mode 4
-    pop group mode 3
-  end transform
-end clip
+      end transform
+    pop group mode 4
+  pop group mode 3
+end transform

--- a/test/api/results-paint/test-116
+++ b/test/api/results-paint/test-116
@@ -1,24 +1,22 @@
-start clip rectangle 250 250 850 750
-  start transform 1 0 0 1 0 0
-    push group
-      start transform 1 0 -0 1 0 0
-        start clip glyph 3
-          start transform 1 0 0 1 0 0
-            solid 0 0 255 127
-          end transform
-        end clip
-      end transform
-      push group
-        start transform 1 0 0 1 100 0
-          start transform 1 0 -0 1 0 0
-            start clip glyph 3
-              start transform 1 0 0 1 0 0
-                solid 255 165 0 178
-              end transform
-            end clip
-          end transform
+start transform 1 0 0 1 0 0
+  push group
+    start transform 1 0 -0 1 0 0
+      start clip glyph 3
+        start transform 1 0 0 1 0 0
+          solid 0 0 255 127
         end transform
-      pop group mode 4
-    pop group mode 3
-  end transform
-end clip
+      end clip
+    end transform
+    push group
+      start transform 1 0 0 1 100 0
+        start transform 1 0 -0 1 0 0
+          start clip glyph 3
+            start transform 1 0 0 1 0 0
+              solid 255 165 0 178
+            end transform
+          end clip
+        end transform
+      end transform
+    pop group mode 4
+  pop group mode 3
+end transform

--- a/test/api/results-paint/testvf-106
+++ b/test/api/results-paint/testvf-106
@@ -1,28 +1,26 @@
-start clip rectangle 250 183 750 817
-  start transform 1 0 0 1 0 0
+start transform 1 0 0 1 0 0
+  push group
+    start transform 1 0 -0 1 0 0
+      start clip glyph 3
+        start transform 1 0 0 1 0 0
+          solid 0 0 255 127
+        end transform
+      end clip
+    end transform
     push group
-      start transform 1 0 -0 1 0 0
-        start clip glyph 3
-          start transform 1 0 0 1 0 0
-            solid 0 0 255 127
-          end transform
-        end clip
-      end transform
-      push group
-        start transform 1 0 0 1 500 500
-          start transform 1 0.268 -0 1 0 0
-            start transform 1 0 0 1 -500 -500
-              start transform 1 0 -0 1 0 0
-                start clip glyph 3
-                  start transform 1 0 0 1 0 0
-                    solid 255 165 0 178
-                  end transform
-                end clip
-              end transform
+      start transform 1 0 0 1 500 500
+        start transform 1 0.268 -0 1 0 0
+          start transform 1 0 0 1 -500 -500
+            start transform 1 0 -0 1 0 0
+              start clip glyph 3
+                start transform 1 0 0 1 0 0
+                  solid 255 165 0 178
+                end transform
+              end clip
             end transform
           end transform
         end transform
-      pop group mode 4
-    pop group mode 3
-  end transform
-end clip
+      end transform
+    pop group mode 4
+  pop group mode 3
+end transform

--- a/test/api/results-paint/testvf-116
+++ b/test/api/results-paint/testvf-116
@@ -1,24 +1,22 @@
-start clip rectangle 250 250 850 750
-  start transform 1 0 0 1 0 0
-    push group
-      start transform 1 0 -0 1 0 0
-        start clip glyph 3
-          start transform 1 0 0 1 0 0
-            solid 0 0 255 127
-          end transform
-        end clip
-      end transform
-      push group
-        start transform 1 0 0 1 100 0
-          start transform 1 0 -0 1 0 0
-            start clip glyph 3
-              start transform 1 0 0 1 0 0
-                solid 255 165 0 178
-              end transform
-            end clip
-          end transform
+start transform 1 0 0 1 0 0
+  push group
+    start transform 1 0 -0 1 0 0
+      start clip glyph 3
+        start transform 1 0 0 1 0 0
+          solid 0 0 255 127
         end transform
-      pop group mode 4
-    pop group mode 3
-  end transform
-end clip
+      end clip
+    end transform
+    push group
+      start transform 1 0 0 1 100 0
+        start transform 1 0 -0 1 0 0
+          start clip glyph 3
+            start transform 1 0 0 1 0 0
+              solid 255 165 0 178
+            end transform
+          end clip
+        end transform
+      end transform
+    pop group mode 4
+  pop group mode 3
+end transform


### PR DESCRIPTION
Implement boundedness calculator separately from bounds calculator. Is many times faster for COLRv1 fonts without clipbox.