### PR TITLE
[ci/msys2] Drop mingw32 build

### DIFF
--- a/.github/workflows/msys2-ci.yml
+++ b/.github/workflows/msys2-ci.yml
@@ -17,8 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - MSYSTEM: MINGW32
-            MSYS2_ARCH: i686
           - MSYSTEM: MINGW64
             MSYS2_ARCH: x86_64
           - MSYSTEM: CLANG64


### PR DESCRIPTION
Upstream is dropping it, and mingw-w64-i686-icu package is already gone.

https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages
https://github.com/msys2/MINGW-packages/discussions/19326