### PR TITLE
Disable OTS on the cmap4 overflow test case.

### DIFF
--- a/test/subset/data/tests/cmap4_overflow.tests
+++ b/test/subset/data/tests/cmap4_overflow.tests
@@ -9,3 +9,4 @@ SUBSETS:
 
 OPTIONS:
 no_fonttools
+no_ots

--- a/test/subset/run-tests.py
+++ b/test/subset/run-tests.py
@@ -215,8 +215,9 @@ for path in args:
         for test in test_suite.tests():
             # Tests are run with and without preprocessing, results should be the
             # same between them.
+            check_ots = has_ots and ("no_ots" not in test.options)
             for preprocess in [False, True]:
-                if run_test(test, has_ots, preprocess):
+                if run_test(test, check_ots, preprocess):
                     print("ok %d - %s" % (number, test))
 
 if fails != 0:


### PR DESCRIPTION
The test file has been stripped of most tables to avoid checking in a very large font (since it has a high number of codepoints), which causes OTS to fail on missing required tables.