### PR TITLE
[meson] Fix build with -Dfuzzer_ldflags on meson >= 1.4.0

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -429,6 +429,8 @@ hb_gobject_headers = files(
   'hb-gobject-structs.h',
 )
 
+hb_failing_alloc_sources = files('failing-alloc.c')
+
 ragel = find_program('ragel', version: '6.10', required: false)
 has_ragel = ragel.found()
 if not has_ragel and get_option('ragel_subproject')
@@ -621,10 +623,10 @@ endif
 
 if get_option('fuzzer_ldflags') != ''
   extra_hb_cpp_args += ['-DHB_CUSTOM_MALLOC']
-  hb_sources += 'failing-alloc.c'
-  hb_subset_sources += 'failing-alloc.c'
-  hb_icu_sources += 'failing-alloc.c'
-  hb_gobject_sources += 'failing-alloc.c'
+  hb_sources += hb_failing_alloc_sources
+  hb_subset_sources += hb_failing_alloc_sources
+  hb_icu_sources += hb_failing_alloc_sources
+  hb_gobject_sources += hb_failing_alloc_sources
 endif
 
 darwin_versions = [hb_version_int, '@0@.0.0'.format(hb_version_int)]


### PR DESCRIPTION
The failing-alloc.c file is appended to various hb_sources_* as a string, but on >= 1.4.0 we call full_path() on the sources, and this works only with file objects.