### PR TITLE
set(CMAKE_CXX_STANDARD 14) instead of set(CMAKE_CXX_STANDARD 11) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## Disallow in-source builds, as CMake generated make files can collide with autotools ones


### PR DESCRIPTION
The CMake file currently enforces C++11, but the HarfBuzz codebase uses features that require at least C++14. Some compilers strictly enforce the specified standard and will fail to compile the code under C++11.

For example, Clang targeting PS5 emits this error:

3>yvals.h(199,5): error : The standard library implementation cannot be used with the compiler mode older than C++14.
3>   #error The standard library implementation cannot be used with the compiler mode older than C++14.

Command line is
%(AdditionalOptions) -std=c++17 -g -std=gnu++11 -frtti

This patch updates CMAKE_CXX_STANDARD to 14 to match the actual requirements of the codebase and ensure compatibility with strict toolchains.

std=gnu++11 is added because of 
set(CMAKE_CXX_STANDARD 11)

Changing to

set(CMAKE_CXX_STANDARD 14)

Fix the issue

I doesn't make sense to have set(CMAKE_CXX_STANDARD 11) because the code requires C++14






