### PR TITLE
Fixes "too many sections"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,9 @@ endif ()
 ## Define harfbuzz library
 add_library(harfbuzz ${project_sources} ${project_extra_sources} ${project_headers})
 target_link_libraries(harfbuzz ${THIRD_PARTY_LIBS})
+if (MINGW)
+    target_compile_options(harfbuzz PRIVATE "-Wa,-mbig-obj")
+endif()
 target_include_directories(harfbuzz PUBLIC
                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/harfbuzz>")
@@ -534,6 +537,10 @@ if (HB_BUILD_SUBSET)
   target_link_libraries(harfbuzz-subset harfbuzz ${THIRD_PARTY_LIBS})
   set_target_properties(harfbuzz-subset PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
 
+  if (MINGW)
+    target_compile_options(harfbuzz-subset PRIVATE "-Wa,-mbig-obj")
+  endif()
+  
   if (BUILD_SHARED_LIBS)
     if (BUILD_FRAMEWORK)
       set_target_properties(harfbuzz harfbuzz-subset PROPERTIES


### PR DESCRIPTION
> Specific issues are reported at [#5372 ](https://github.com/harfbuzz/harfbuzz/issues/5372)

**Problem Analysis:**
  1. **COFF section limit exceeded** - Windows object files (COFF format) have a hard limit of 65,535 sections. The harfbuzz.cc source generates 33,788 sections, approaching this limit.
  2. **Large file size** - The temporary assembly file (ccwnO9s0.s) exceeds the assembler's handling capacity.

**Solution:**

Enable the `-mbig-obj` option for MinGW