### PR TITLE
[repacker] Implement table splitting for LigatureSubst

### DIFF
--- a/src/OT/Layout/GSUB/LigatureSet.hh
+++ b/src/OT/Layout/GSUB/LigatureSet.hh
@@ -11,11 +11,11 @@ namespace GSUB_impl {
 template <typename Types>
 struct LigatureSet
 {
-  protected:
+  public:
   Array16OfOffset16To<Ligature<Types>>
                 ligature;               /* Array LigatureSet tables
                                          * ordered by preference */
-  public:
+  
   DEFINE_SIZE_ARRAY (2, ligature);
 
   bool sanitize (hb_sanitize_context_t *c) const

--- a/src/graph/classdef-graph.hh
+++ b/src/graph/classdef-graph.hh
@@ -74,7 +74,7 @@ struct ClassDef : public OT::ClassDef
     class_def_link->width = SmallTypes::size;
     class_def_link->objidx = class_def_prime_id;
     class_def_link->position = link_position;
-    class_def_prime_vertex.add_parent (parent_id);
+    class_def_prime_vertex.add_parent (parent_id, false);
 
     return true;
   }

--- a/src/graph/coverage-graph.hh
+++ b/src/graph/coverage-graph.hh
@@ -98,7 +98,7 @@ struct Coverage : public OT::Layout::Common::Coverage
     coverage_link->width = SmallTypes::size;
     coverage_link->objidx = coverage_prime_id;
     coverage_link->position = link_position;
-    coverage_prime_vertex.add_parent (parent_id);
+    coverage_prime_vertex.add_parent (parent_id, false);
 
     return (Coverage*) coverage_prime_vertex.obj.head;
   }

--- a/src/graph/coverage-graph.hh
+++ b/src/graph/coverage-graph.hh
@@ -103,6 +103,28 @@ struct Coverage : public OT::Layout::Common::Coverage
     return (Coverage*) coverage_prime_vertex.obj.head;
   }
 
+  // Filter an existing coverage table to glyphs at indices [start, end) and replace it with the filtered version.
+  static bool filter_coverage (gsubgpos_graph_context_t& c,
+                               unsigned existing_coverage,
+                               unsigned start, unsigned end) {
+    unsigned coverage_size = c.graph.vertices_[existing_coverage].table_size ();
+    auto& coverage_v = c.graph.vertices_[existing_coverage];
+    Coverage* coverage_table = (Coverage*) coverage_v.obj.head;
+    if (!coverage_table || !coverage_table->sanitize (coverage_v))
+      return false;
+
+    auto new_coverage =
+        + hb_zip (coverage_table->iter (), hb_range ())
+        | hb_filter ([&] (hb_pair_t<unsigned, unsigned> p) {
+          return p.second >= start && p.second < end;
+        })
+        | hb_map_retains_sorting (hb_first)
+        ;
+
+    return make_coverage (c, new_coverage, existing_coverage, coverage_size * 2 + 100);
+  }
+
+  // Replace the coverage table at dest obj with one covering 'glyphs'.
   template<typename It>
   static bool make_coverage (gsubgpos_graph_context_t& c,
                              It glyphs,

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -501,6 +501,9 @@ struct graph_t
       for (const auto &l : v.obj.real_links) {
         printf("%u, ", l.objidx);
       }
+      for (const auto &l : v.obj.virtual_links) {
+        printf("v%u, ", l.objidx);
+      }
       printf("]\n");
     }
   }
@@ -1284,6 +1287,7 @@ struct graph_t
     if (!DEBUG_ENABLED(SUBSET_REPACK)) return;
 
     DEBUG_MSG (SUBSET_REPACK, nullptr, "Graph is not fully connected.");
+
     parents_invalid = true;
     update_parents();
 

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -137,7 +137,7 @@ struct graph_t
       if (!(as_bytes () == other.as_bytes ()))
       {
         DEBUG_MSG (SUBSET_REPACK, nullptr,
-                   "vertex %u [%lu] bytes != %u [%lu] bytes, depth = %u",
+                   "vertex %u [%lu bytes] != %u [%lu bytes], depth = %u",
                    this_index,
                    (unsigned long) table_size (),
                    other_index,
@@ -726,9 +726,8 @@ struct graph_t
     if (!r.table)
       return vertex_and_table_t<T> ();
 
-    if (!r.table->sanitize (*(r.vertex), std::forward<Ts>(ds)...)) {
+    if (!r.table->sanitize (*(r.vertex), std::forward<Ts>(ds)...))
       return vertex_and_table_t<T> ();
-    }
 
     return r;
   }

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -944,9 +944,11 @@ struct graph_t
   /*
    * Moves the child of old_parent_idx pointed to by old_offset to a new
    * vertex at the new_offset.
+   *
+   * Returns the id of the child node that was moved.
    */
   template<typename O>
-  void move_child (unsigned old_parent_idx,
+  unsigned move_child (unsigned old_parent_idx,
                    const O* old_offset,
                    unsigned new_parent_idx,
                    const O* new_offset)
@@ -970,6 +972,8 @@ struct graph_t
 
     old_v.remove_real_link (child_id, old_offset);
     child.remove_parent (old_parent_idx);
+
+    return child_id;
   }
 
   /*

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -709,8 +709,9 @@ struct graph_t
     if (!r.table)
       return vertex_and_table_t<T> ();
 
-    if (!r.table->sanitize (*(r.vertex), std::forward<Ts>(ds)...))
+    if (!r.table->sanitize (*(r.vertex), std::forward<Ts>(ds)...)) {
       return vertex_and_table_t<T> ();
+    }
 
     return r;
   }

--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -127,7 +127,9 @@ struct graph_t
       }
     }
 
-    bool equals (const vertex_t& other,
+    bool equals (unsigned this_index,
+                 unsigned other_index,
+                 const vertex_t& other,
                  const graph_t& graph,
                  const graph_t& other_graph,
                  unsigned depth) const
@@ -135,8 +137,10 @@ struct graph_t
       if (!(as_bytes () == other.as_bytes ()))
       {
         DEBUG_MSG (SUBSET_REPACK, nullptr,
-                   "vertex [%lu] bytes != [%lu] bytes, depth = %u",
+                   "vertex %u [%lu] bytes != %u [%lu] bytes, depth = %u",
+                   this_index,
                    (unsigned long) table_size (),
+                   other_index,
                    (unsigned long) other.table_size (),
                    depth);
 
@@ -418,7 +422,7 @@ struct graph_t
             link_a.bias != link_b.bias)
           return false;
 
-        if (!graph.vertices_[link_a.objidx].equals (
+        if (!graph.vertices_[link_a.objidx].equals (link_a.objidx, link_b.objidx,
                 other_graph.vertices_[link_b.objidx], graph, other_graph, depth + 1))
           return false;
 
@@ -500,7 +504,7 @@ struct graph_t
 
   bool operator== (const graph_t& other) const
   {
-    return root ().equals (other.root (), *this, other, 0);
+    return root ().equals (root_idx(), other.root_idx(), other.root (), *this, other, 0);
   }
 
   void print () const {

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -24,12 +24,11 @@
  * Google Author(s): Garret Rieger
  */
 
-#include "../OT/Layout/GSUB/SubstLookupSubTable.hh"
 #include "graph.hh"
 #include "../hb-ot-layout-gsubgpos.hh"
 #include "../OT/Layout/GSUB/ExtensionSubst.hh"
+#include "../OT/Layout/GSUB/SubstLookupSubTable.hh"
 #include "gsubgpos-context.hh"
-#include "hb-ot.h"
 #include "pairpos-graph.hh"
 #include "markbasepos-graph.hh"
 #include "ligature-graph.hh"

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -126,15 +126,7 @@ struct Lookup : public OT::Lookup
     if (c.table_tag != HB_OT_TAG_GPOS && c.table_tag != HB_OT_TAG_GSUB)
       return true;
 
-    bool supported_gsub = (c.table_tag == HB_OT_TAG_GSUB) && (
-      type == OT::Layout::GSUB_impl::SubstLookupSubTable::Type::Ligature
-    );
-    bool supported_gpos = (c.table_tag == HB_OT_TAG_GPOS) && (
-      type == OT::Layout::GPOS_impl::PosLookupSubTable::Type::Pair ||
-      type == OT::Layout::GPOS_impl::PosLookupSubTable::Type::MarkBase
-    );
-
-    if (!is_ext && !supported_gpos && !supported_gsub)
+    if (!is_ext && !is_supported_gpos_type(type, c) && !is_supported_gsub_type(type, c))
       return true;
 
     hb_vector_t<hb_pair_t<unsigned, hb_vector_t<unsigned>>> all_new_subtables;
@@ -153,8 +145,7 @@ struct Lookup : public OT::Lookup
 
         subtable_index = extension->get_subtable_index (c.graph, ext_subtable_index);
         type = extension->get_lookup_type ();
-        if (type != OT::Layout::GPOS_impl::PosLookupSubTable::Type::Pair
-            && type != OT::Layout::GPOS_impl::PosLookupSubTable::Type::MarkBase)
+        if (!is_supported_gpos_type(type, c) && !is_supported_gsub_type(type, c))
           continue;
       }
 
@@ -355,6 +346,19 @@ struct Lookup : public OT::Lookup
   }
 
  private:
+  bool is_supported_gsub_type(unsigned type, gsubgpos_graph_context_t& c) const {
+    return (c.table_tag == HB_OT_TAG_GSUB) && (
+      type == OT::Layout::GSUB_impl::SubstLookupSubTable::Type::Ligature
+    );
+  }
+
+  bool is_supported_gpos_type(unsigned type, gsubgpos_graph_context_t& c) const {
+   return (c.table_tag == HB_OT_TAG_GPOS) && (
+      type == OT::Layout::GPOS_impl::PosLookupSubTable::Type::Pair ||
+      type == OT::Layout::GPOS_impl::PosLookupSubTable::Type::MarkBase
+    );
+  }
+
   unsigned extension_type (hb_tag_t table_tag) const
   {
     switch (table_tag)

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -238,7 +238,7 @@ struct Lookup : public OT::Lookup
         if (is_ext)
         {
           unsigned ext_id = create_extension_subtable (c, subtable_id, type);
-          c.graph.vertices_[subtable_id].add_parent (ext_id);
+          c.graph.vertices_[subtable_id].add_parent (ext_id, false);
           subtable_id = ext_id;
         }
 
@@ -247,7 +247,7 @@ struct Lookup : public OT::Lookup
         link->objidx = subtable_id;
         link->position = (char*) &new_lookup->subTable[offset_index++] -
                          (char*) new_lookup;
-        c.graph.vertices_[subtable_id].add_parent (this_index);
+        c.graph.vertices_[subtable_id].add_parent (this_index, false);
       }
     }
 
@@ -338,7 +338,7 @@ struct Lookup : public OT::Lookup
 
     // Make extension point at the subtable.
     auto& ext_vertex = c.graph.vertices_[ext_index];
-    ext_vertex.add_parent (lookup_index);
+    ext_vertex.add_parent (lookup_index, false);
     if (!existing_ext_index)
       subtable_vertex.remap_parent (lookup_index, ext_index);
 

--- a/src/graph/ligature-graph.hh
+++ b/src/graph/ligature-graph.hh
@@ -1,0 +1,367 @@
+/*
+ * Copyright © 2025  Google, Inc.
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Google Author(s): Garret Rieger
+ */
+
+#ifndef GRAPH_LIGATURE_GRAPH_HH
+#define GRAPH_LIGATURE_GRAPH_HH
+
+#include "OT/Layout/GSUB/LigatureSet.hh"
+#include "OT/Layout/types.hh"
+#include "hb-ot-layout-common.hh"
+
+#include "graph.hh"
+#include "../OT/Layout/GSUB/LigatureSubst.hh"
+#include "../OT/Layout/GSUB/LigatureSubstFormat1.hh"
+#include <algorithm>
+#include <utility>
+
+namespace graph {
+
+struct LigatureSet : public OT::Layout::GSUB_impl::LigatureSet<SmallTypes>
+{
+  bool sanitize (graph_t::vertex_t& vertex) const
+  {
+    int64_t vertex_len = vertex.obj.tail - vertex.obj.head;
+    if (vertex_len < OT::Layout::GSUB_impl::LigatureSet<SmallTypes>::min_size) return false;
+    hb_barrier ();
+
+    int64_t total_len = ligature.get_size() + OT::Layout::GSUB_impl::LigatureSet<SmallTypes>::min_size - ligature.len.get_size();
+    if (vertex_len < total_len) {
+      return false;
+    }
+    return true;
+  }
+};
+
+struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1_2<SmallTypes>
+{
+  bool sanitize (graph_t::vertex_t& vertex) const
+  {
+    int64_t vertex_len = vertex.obj.tail - vertex.obj.head;
+    unsigned min_size = OT::Layout::GSUB_impl::LigatureSubstFormat1_2<SmallTypes>::min_size;
+    if (vertex_len < min_size) return false;
+    hb_barrier ();
+
+    return vertex_len >=
+        min_size + ligatureSet.get_size() - ligatureSet.len.get_size();
+  }
+
+  hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
+                                         unsigned parent_index,
+                                         unsigned this_index)
+  {
+    auto split_points = compute_split_points(c, parent_index, this_index);
+    split_context_t split_context {
+      c,
+      this,
+      c.graph.duplicate_if_shared (parent_index, this_index),
+    };
+    return actuate_subtable_split<split_context_t> (split_context, split_points);
+  }
+
+ private:
+  hb_vector_t<unsigned> compute_split_points(gsubgpos_graph_context_t& c,
+                                             unsigned parent_index,
+                                             unsigned this_index) const
+  {
+    // For ligature subst coverage is always packed last, and as a result is where an overflow
+    // will happen if there is one, so we can check the estimate length of the
+    // LigatureSubstFormat1 -> Coverage offset length which is the sum of all data in the
+    // retained sub graph except for the coverage table itself.
+    const unsigned base_size = OT::Layout::GSUB_impl::LigatureSubstFormat1_2<SmallTypes>::min_size;
+    unsigned accumulated = base_size;
+
+    unsigned ligature_index = 0;
+    hb_vector_t<unsigned> split_points;
+    for (unsigned i = 0; i < ligatureSet.len; i++)
+    {
+      accumulated += OT::HBUINT16::static_size; // for ligature set offset
+      accumulated += OT::Layout::GSUB_impl::LigatureSet<SmallTypes>::min_size; // for ligature set table
+
+      auto liga_set = c.graph.as_table<LigatureSet>(this_index, &ligatureSet[i]);
+      if (!liga_set.table) {
+        return hb_vector_t<unsigned> {};
+      }
+
+      for (unsigned j = 0; j < liga_set.table->ligature.len; j++)
+      {
+        const unsigned liga_id = c.graph.index_for_offset (liga_set.index, &liga_set.table->ligature[j]);
+        const unsigned liga_size = c.graph.vertices_[liga_id].table_size ();
+
+        accumulated += OT::HBUINT16::static_size; // for ligature offset
+        accumulated += liga_size; // for the ligature table
+        
+        
+        if (accumulated >= (1 << 16))
+        {
+          split_points.push(ligature_index);
+          // We're going to split such that the current ligature will be in the new sub table.
+          // That means we'll have one ligature subst (base_base), one ligature set, and one liga table
+          accumulated = base_size + // for liga subst subtable
+            (OT::HBUINT16::static_size * 2) + // for liga set and liga offset
+            OT::Layout::GSUB_impl::LigatureSet<SmallTypes>::min_size + // for liga set subtable
+            liga_size; // for liga sub table
+        }
+
+        ligature_index++;
+      }
+    }
+
+    return split_points;
+  }
+
+
+  struct split_context_t
+  {
+    gsubgpos_graph_context_t& c;
+    LigatureSubstFormat1* thiz;
+    unsigned this_index;
+
+    unsigned original_count ()
+    {
+      unsigned total = 0;
+      for (unsigned i = 0; i < thiz->ligatureSet.len; i++)
+      { 
+        auto liga_set = c.graph.as_table<LigatureSet>(this_index, &thiz->ligatureSet[i]);
+        if (!liga_set.table) {
+          return 0;
+        }
+        total += liga_set.table->ligature.len;
+      }
+      return total;
+    }
+
+    unsigned clone_range (unsigned start, unsigned end)
+    {
+      return thiz->clone_range (c, this_index, start, end);
+    }
+
+    bool shrink (unsigned count)
+    {
+      return thiz->shrink (c, this_index, original_count(), count);
+    }
+  };
+
+  std::pair<unsigned, LigatureSet*> new_liga_set(gsubgpos_graph_context_t& c, unsigned count) const {
+    unsigned prime_size = OT::Layout::GSUB_impl::LigatureSet<SmallTypes>::min_size
+                          + count * SmallTypes::size;
+
+    unsigned prime_id = c.create_node (prime_size);
+    if (prime_id == (unsigned) -1) return std::make_pair(-1, nullptr);
+
+    LigatureSet* prime = (LigatureSet*) c.graph.object (prime_id).head;
+    prime->ligature.len = count;
+    return std::make_pair(prime_id, prime);
+  }
+   
+  unsigned clone_range (gsubgpos_graph_context_t& c,
+                        unsigned this_index,
+                        unsigned start, unsigned end) const
+  {
+    DEBUG_MSG (SUBSET_REPACK, nullptr,
+               "  Cloning LigatureSubstFormat1 (%u) range [%u, %u).", this_index, start, end);
+
+    // Create an oversized new liga subst, we'll adjust the size down later. We don't know
+    // the final size until we process it but we also need it to exist while we're processing
+    // so that nodes can be moved to it as needed.
+    unsigned prime_size = OT::Layout::GSUB_impl::LigatureSubstFormat1_2<SmallTypes>::min_size
+                          + ligatureSet.get_size() - ligatureSet.len.get_size();
+                           
+    unsigned liga_subst_prime_id = c.create_node (prime_size);
+    if (liga_subst_prime_id == (unsigned) -1) return -1;
+
+    LigatureSubstFormat1* liga_subst_prime = (LigatureSubstFormat1*) c.graph.object (liga_subst_prime_id).head;
+    liga_subst_prime->format = this->format;
+    liga_subst_prime->ligatureSet.len = this->ligatureSet.len;
+
+    // Locate all liga sets with ligas between start and end.
+    // Clone or move them as needed.
+    unsigned count = 0;
+    unsigned liga_set_count = 0;
+    unsigned liga_set_start = -1;
+    unsigned liga_set_end = 0; // inclusive
+    for (unsigned i = 0; i < ligatureSet.len; i++)
+    {
+      auto liga_set_index = c.graph.index_for_offset(this_index, &ligatureSet[i]);
+      auto liga_set = c.graph.as_table<LigatureSet>(this_index, &ligatureSet[i]);
+      if (!liga_set.table) {
+        return -1;
+      }
+      unsigned num_ligas = liga_set.table->ligature.len;
+
+      unsigned current_start = count;
+      unsigned current_end = count + num_ligas;
+
+      if (current_start >= start && current_end <= end) {
+        // This liga set is fully contined within [start, end)
+        // We can move the entire ligaset to the new liga subset object.
+        liga_set_end = i;
+        if (i < liga_set_start) liga_set_start = i;
+        c.graph.move_child<> (this_index,
+                              &ligatureSet[i],
+                              liga_subst_prime_id,
+                              &liga_subst_prime->ligatureSet[liga_set_count++]);
+      }
+      else if (current_start < end && start < current_end)
+      {
+        // This liga set partially overlaps [start, end). We'll need to create
+        // a new liga set sub table and move the intersecting ligas to it.
+        unsigned liga_count = std::min(end, current_end) - std::max(start, current_start);
+        auto result = new_liga_set(c, liga_count);
+        unsigned prime_id = result.first;
+        LigatureSet* prime = result.second;
+        if (prime_id == (unsigned) -1) return -1;
+
+        unsigned new_index = 0;
+        for (unsigned j = std::max(start, current_start) - count; j < std::min(end, current_end) - count; j++) {
+          c.graph.move_child<> (liga_set_index,
+                                &liga_set.table->ligature[j],
+                                prime_id,
+                                &prime->ligature[new_index++]);
+        }
+
+        liga_set_end = i;
+        if (i < liga_set_start) liga_set_start = i;
+        c.graph.add_link(&liga_subst_prime->ligatureSet[liga_set_count++], liga_subst_prime_id, prime_id);
+      }
+      
+      count += num_ligas;
+    }
+
+    c.graph.vertices_[liga_subst_prime_id].obj.tail -= (liga_subst_prime->ligatureSet.len - liga_set_count) * SmallTypes::size;
+    liga_subst_prime->ligatureSet.len = liga_set_count;
+
+    unsigned coverage_id = c.graph.index_for_offset (this_index, &coverage);
+    if (!Coverage::clone_coverage (c,
+                                   coverage_id,
+                                   liga_subst_prime_id,
+                                   2,
+                                   liga_set_start, liga_set_end))
+      return -1;
+
+    return liga_subst_prime_id;
+  }
+
+  bool shrink (gsubgpos_graph_context_t& c,
+               unsigned this_index,
+               unsigned old_count,
+               unsigned count)
+  {
+    DEBUG_MSG (SUBSET_REPACK, nullptr,
+               "  Shrinking LigatureSubstFormat1 (%u) to [0, %u).",
+               this_index,
+               count);
+    if (count >= old_count)
+      return true;                  
+
+    unsigned new_liga_set_count = 0;
+    for (unsigned i = 0; i < ligatureSet.len; i++)
+    {
+      auto liga_set = c.graph.as_table<LigatureSet>(this_index, &ligatureSet[i]);
+      if (!liga_set.table) {
+        return false;
+      }
+
+      unsigned num_ligas = liga_set.table->ligature.len;
+      if (num_ligas <= count) {
+        count -= num_ligas;
+        continue;
+      }
+
+      if (count == 0) {
+        // drop this liga set an all subsequent ones.
+        new_liga_set_count = i;
+        break;
+      }
+
+      // drop the trailing liga's from this set and all subsequent liga sets
+      new_liga_set_count = i + 1;
+      c.graph.vertices_[liga_set.index].obj.tail -= (num_ligas - count) * SmallTypes::size;
+      liga_set.table->ligature.len = count;
+      break;
+    }
+
+    // Adjust liga set array
+    c.graph.vertices_[this_index].obj.tail -= (ligatureSet.len - new_liga_set_count) * SmallTypes::size;
+    ligatureSet.len = new_liga_set_count;
+
+    // Coverage matches the number of liga sets so rebuild as needed
+    auto coverage = c.graph.as_mutable_table<Coverage> (this_index, &this->coverage);
+    if (!coverage) return false;
+
+    unsigned coverage_size = coverage.vertex->table_size ();
+    auto new_coverage =
+        + hb_zip (coverage.table->iter (), hb_range ())
+        | hb_filter ([&] (hb_pair_t<unsigned, unsigned> p) {
+          return p.second < new_liga_set_count;
+        })
+        | hb_map_retains_sorting (hb_first)
+        ;
+
+    return Coverage::make_coverage (c, new_coverage, coverage.index, coverage_size);
+  }
+};
+
+struct LigatureSubst : public OT::Layout::GSUB_impl::LigatureSubst
+{
+
+  hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
+                                         unsigned parent_index,
+                                         unsigned this_index)
+  {
+    switch (u.format) {
+    case 1:
+      return ((LigatureSubstFormat1*)(&u.format1))->split_subtables (c, parent_index, this_index);
+#ifndef HB_NO_BEYOND_64K
+    case 2: HB_FALLTHROUGH;
+      // Don't split 24bit Ligature Subs
+#endif
+    default:
+      return hb_vector_t<unsigned> ();
+    }
+  }
+
+  bool sanitize (graph_t::vertex_t& vertex) const
+  {
+    int64_t vertex_len = vertex.obj.tail - vertex.obj.head;
+    if (vertex_len < u.format.get_size ()) return false;
+    hb_barrier ();
+
+    switch (u.format) {
+    case 1:
+      return ((LigatureSubstFormat1*)(&u.format1))->sanitize (vertex);
+#ifndef HB_NO_BEYOND_64K
+    case 2:  HB_FALLTHROUGH;
+#endif
+    default:
+      // We don't handle format 2 here.
+      return false;
+    }
+  }
+};
+
+}
+
+#endif  // GRAPH_LIGATURE_GRAPH_HH

--- a/src/graph/ligature-graph.hh
+++ b/src/graph/ligature-graph.hh
@@ -206,7 +206,7 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
 
   void add_virtual_link(gsubgpos_graph_context_t& c, unsigned from, unsigned to) const {
     auto& from_obj = c.graph.vertices_[from].obj;
-    c.graph.vertices_[to].add_parent(from);
+    c.graph.vertices_[to].add_parent(from, true);
     auto& link = *from_obj.virtual_links.push ();
     link.objidx = to;
   }
@@ -243,7 +243,7 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
     coverage_prime_link->width = SmallTypes::size;
     coverage_prime_link->objidx = coverage_prime_id;
     coverage_prime_link->position = 2;
-    coverage_prime_vertex.add_parent (liga_subst_prime_id);
+    coverage_prime_vertex.add_parent (liga_subst_prime_id, false);
 
     // Locate all liga sets with ligas between start and end.
     // Clone or move them as needed.

--- a/src/graph/ligature-graph.hh
+++ b/src/graph/ligature-graph.hh
@@ -27,13 +27,11 @@
 #ifndef GRAPH_LIGATURE_GRAPH_HH
 #define GRAPH_LIGATURE_GRAPH_HH
 
-#include "OT/Layout/GSUB/LigatureSet.hh"
-#include "OT/Layout/types.hh"
-#include "hb-ot-layout-common.hh"
-
 #include "graph.hh"
 #include "../OT/Layout/GSUB/LigatureSubst.hh"
 #include "../OT/Layout/GSUB/LigatureSubstFormat1.hh"
+#include "../OT/Layout/GSUB/LigatureSet.hh"
+#include "../OT/Layout/types.hh"
 #include <algorithm>
 #include <utility>
 
@@ -181,16 +179,16 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
     }
   };
 
-  std::pair<unsigned, LigatureSet*> new_liga_set(gsubgpos_graph_context_t& c, unsigned count) const {
+  hb_pair_t<unsigned, LigatureSet*> new_liga_set(gsubgpos_graph_context_t& c, unsigned count) const {
     unsigned prime_size = OT::Layout::GSUB_impl::LigatureSet<SmallTypes>::min_size
                           + count * SmallTypes::size;
 
     unsigned prime_id = c.create_node (prime_size);
-    if (prime_id == (unsigned) -1) return std::make_pair(-1, nullptr);
+    if (prime_id == (unsigned) -1) return hb_pair(-1, nullptr);
 
     LigatureSet* prime = (LigatureSet*) c.graph.object (prime_id).head;
     prime->ligature.len = count;
-    return std::make_pair(prime_id, prime);
+    return hb_pair(prime_id, prime);
   }
 
   void clear_virtual_links (gsubgpos_graph_context_t& c, unsigned node_index) const
@@ -325,14 +323,14 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
       {
         // This liga set partially overlaps [start, end). We'll need to create
         // a new liga set sub table and move the intersecting ligas to it.
-        unsigned liga_count = std::min(end, current_end) - std::max(start, current_start);
+        unsigned liga_count = hb_min(end, current_end) - hb_max(start, current_start);
         auto result = new_liga_set(c, liga_count);
         liga_set_prime_id = result.first;
         LigatureSet* prime = result.second;
         if (liga_set_prime_id == (unsigned) -1) return -1;
 
         unsigned new_index = 0;
-        for (unsigned j = std::max(start, current_start) - count; j < std::min(end, current_end) - count; j++) {
+        for (unsigned j = hb_max(start, current_start) - count; j < hb_min(end, current_end) - count; j++) {
           c.graph.move_child<> (liga_set_index,
                                 &liga_set.table->ligature[j],
                                 liga_set_prime_id,

--- a/src/graph/ligature-graph.hh
+++ b/src/graph/ligature-graph.hh
@@ -77,11 +77,25 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
       c,
       this,
       c.graph.duplicate_if_shared (parent_index, this_index),
+      total_number_ligas(c, this_index),
     };
     return actuate_subtable_split<split_context_t> (split_context, split_points);
   }
 
  private:
+  unsigned total_number_ligas(gsubgpos_graph_context_t& c, unsigned this_index) const {
+    unsigned total = 0;
+    for (unsigned i = 0; i < ligatureSet.len; i++)
+    {
+      auto liga_set = c.graph.as_table<LigatureSet>(this_index, &ligatureSet[i]);
+      if (!liga_set.table) {
+        return 0;
+      }
+      total += liga_set.table->ligature.len;
+    }
+    return total;
+  }
+
   hb_vector_t<unsigned> compute_split_points(gsubgpos_graph_context_t& c,
                                              unsigned parent_index,
                                              unsigned this_index) const
@@ -137,19 +151,11 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
     gsubgpos_graph_context_t& c;
     LigatureSubstFormat1* thiz;
     unsigned this_index;
+    unsigned original_count_;
 
     unsigned original_count ()
     {
-      unsigned total = 0;
-      for (unsigned i = 0; i < thiz->ligatureSet.len; i++)
-      {
-        auto liga_set = c.graph.as_table<LigatureSet>(this_index, &thiz->ligatureSet[i]);
-        if (!liga_set.table) {
-          return 0;
-        }
-        total += liga_set.table->ligature.len;
-      }
-      return total;
+      return original_count_;
     }
 
     unsigned clone_range (unsigned start, unsigned end)

--- a/src/graph/pairpos-graph.hh
+++ b/src/graph/pairpos-graph.hh
@@ -423,7 +423,7 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
     class_def_link->width = SmallTypes::size;
     class_def_link->objidx = class_def_2_id;
     class_def_link->position = 10;
-    graph.vertices_[class_def_2_id].add_parent (pair_pos_prime_id);
+    graph.vertices_[class_def_2_id].add_parent (pair_pos_prime_id, false);
     graph.duplicate (pair_pos_prime_id, class_def_2_id);
 
     return pair_pos_prime_id;

--- a/src/graph/serialize.hh
+++ b/src/graph/serialize.hh
@@ -172,8 +172,11 @@ void print_overflows (graph_t& graph,
 template <typename O> inline void
 serialize_link_of_type (const hb_serialize_context_t::object_t::link_t& link,
                         char* head,
+                        unsigned size,
                         hb_serialize_context_t* c)
 {
+  assert(link.position + link.width <= size);
+
   OT::Offset<O>* offset = reinterpret_cast<OT::Offset<O>*> (head + link.position);
   *offset = 0;
   c->add_link (*offset,
@@ -187,6 +190,7 @@ serialize_link_of_type (const hb_serialize_context_t::object_t::link_t& link,
 inline
 void serialize_link (const hb_serialize_context_t::object_t::link_t& link,
                      char* head,
+                     unsigned size,
                      hb_serialize_context_t* c)
 {
   switch (link.width)
@@ -197,21 +201,21 @@ void serialize_link (const hb_serialize_context_t::object_t::link_t& link,
     case 4:
       if (link.is_signed)
       {
-        serialize_link_of_type<OT::HBINT32> (link, head, c);
+        serialize_link_of_type<OT::HBINT32> (link, head, size, c);
       } else {
-        serialize_link_of_type<OT::HBUINT32> (link, head, c);
+        serialize_link_of_type<OT::HBUINT32> (link, head, size, c);
       }
       return;
     case 2:
       if (link.is_signed)
       {
-        serialize_link_of_type<OT::HBINT16> (link, head, c);
+        serialize_link_of_type<OT::HBINT16> (link, head, size, c);
       } else {
-        serialize_link_of_type<OT::HBUINT16> (link, head, c);
+        serialize_link_of_type<OT::HBUINT16> (link, head, size, c);
       }
       return;
     case 3:
-      serialize_link_of_type<OT::HBUINT24> (link, head, c);
+      serialize_link_of_type<OT::HBUINT24> (link, head, size, c);
       return;
     default:
       // Unexpected link width.
@@ -251,7 +255,7 @@ inline hb_blob_t* serialize (const graph_t& graph)
 
     // Only real links needs to be serialized.
     for (const auto& link : vertices[i].obj.real_links)
-      serialize_link (link, start, &c);
+      serialize_link (link, start, size, &c);
 
     // All duplications are already encoded in the graph, so don't
     // enable sharing during packing.

--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -266,7 +266,7 @@ bool _resolve_shared_overflow(const hb_vector_t<graph::overflow_record_t>& overf
     result = sorted_graph.duplicate(&parents, r.child);
   }
 
-  if (result == (unsigned) -1) return result;
+  if (result == (unsigned) -1) return false;
 
   if (parents.get_population() > 1) {
     // If the duplicated node has more than one parent pre-emptively raise it's priority to the maximum.
@@ -283,7 +283,7 @@ bool _resolve_shared_overflow(const hb_vector_t<graph::overflow_record_t>& overf
     sorted_graph.vertices_[result].give_max_priority();
   }
 
-  return result;
+  return true;
 }
 
 static inline
@@ -302,8 +302,11 @@ bool _process_overflows (const hb_vector_t<graph::overflow_record_t>& overflows,
     {
       // The child object is shared, we may be able to eliminate the overflow
       // by duplicating it.
-      if (!_resolve_shared_overflow(overflows, i, sorted_graph)) continue;
-      return true;
+      if (_resolve_shared_overflow(overflows, i, sorted_graph))
+        return true;
+
+      // Sometimes we can't duplicate a node which looks shared because it's not actually shared
+      // (eg. all links from the same parent) in this case continue on to other resolution options.
     }
 
     if (child.is_leaf () && !priority_bumped_parents.has (r.parent))

--- a/src/test-repacker.cc
+++ b/src/test-repacker.cc
@@ -148,6 +148,17 @@ static unsigned add_extension (unsigned child,
 static unsigned add_coverage (unsigned start, unsigned end,
                               hb_serialize_context_t* c)
 {
+  if (end - start == 0) {
+    uint8_t coverage[] = {
+      0, 1, // format
+      0, 1, // count
+
+      (uint8_t) ((start >> 8) & 0xFF),
+      (uint8_t) (start & 0xFF), // glyph[0]
+    };
+    return add_object ((char*) coverage, 6, c);
+  }
+
   if (end - start == 1)
   {
     uint8_t coverage[] = {
@@ -1607,7 +1618,7 @@ populate_serializer_with_large_liga (hb_serialize_context_t* c)
   unsigned liga_subst[liga_subst_count];
 
   for (unsigned l = 0; l < liga_subst_count; l++) {
-    unsigned coverage = add_coverage(0, liga_set_count * liga_per_set_count - 1, c);
+    unsigned coverage = add_coverage(0, liga_set_count - 1, c);
 
     unsigned liga[liga_set_count * liga_per_set_count];
     unsigned liga_set[liga_set_count];


### PR DESCRIPTION
Ran into cases where fonts (eg. symbol fonts) with large number of ligatures are overflowing LigatureSubst subtables. This adds support for splitting them to resolve overflows.

Also fixes a bug with handling of node duplication where there are virtual links (LigatureSubst's use virtual links to enforce ordering of the coverage table).