### PR TITLE
[subset] bug fix for AnchorFormat3

### DIFF
--- a/src/OT/Layout/GPOS/AnchorFormat3.hh
+++ b/src/OT/Layout/GPOS/AnchorFormat3.hh
@@ -94,7 +94,8 @@ struct AnchorFormat3
     /* in case that all axes are pinned or no variations after instantiation,
      * both var_idxes will be mapped to HB_OT_LAYOUT_NO_VARIATIONS_INDEX */
     if (x_varidx == HB_OT_LAYOUT_NO_VARIATIONS_INDEX &&
-        y_varidx == HB_OT_LAYOUT_NO_VARIATIONS_INDEX)
+        y_varidx == HB_OT_LAYOUT_NO_VARIATIONS_INDEX &&
+        c->plan->normalized_coords)
       return_trace (c->serializer->check_assign (out->format, 1, HB_SERIALIZE_ERROR_INT_OVERFLOW));
 
     if (!c->serializer->embed (xDeviceTable)) return_trace (false);


### PR DESCRIPTION
Don't downgrade to format1 when subsetting, otherwise hinting device is dropped. 