### PR TITLE
[subset] bug fix for COLRv1 layer index closure

### DIFF
--- a/src/OT/Color/COLR/COLR.hh
+++ b/src/OT/Color/COLR/COLR.hh
@@ -178,7 +178,14 @@ struct hb_colrv1_closure_context_t :
   { glyphs->add (glyph_id); }
 
   void add_layer_indices (unsigned first_layer_index, unsigned num_of_layers)
-  { layer_indices->add_range (first_layer_index, first_layer_index + num_of_layers - 1); }
+  {
+    if (num_of_layers == 0)
+    {
+      layer_indices->add (first_layer_index);
+      return;
+    }
+    layer_indices->add_range (first_layer_index, first_layer_index + num_of_layers - 1);
+  }
 
   void add_palette_index (unsigned palette_index)
   { palette_indices->add (palette_index); }


### PR DESCRIPTION
In PaintColrLayers table, numLayers could be 0. 
The font file that could reproduce the issue(invalid new layer index(-1)) is 430MB. I'm unable to generate a small subset font file that reproduces the same issue because layers are compact after subsetting.