### PR TITLE
CMakeLists.txt + HB_HAVE_DIRECTWRITE=ON : linker error on Windows : 'unresolved external symbol __imp_DWriteCreateFactory'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ if (WIN32 AND HB_HAVE_DIRECTWRITE)
   endif ()
   add_definitions(-DHAVE_DIRECTWRITE)
   list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-directwrite.h)
+  list(APPEND THIRD_PARTY_LIBS dwrite)
 endif ()
 
 if (HB_HAVE_CAIRO)


### PR DESCRIPTION
When using HB_HAVE_DIRECTWRITE=ON then we get linker error:

harfbuzz.cc.obj : error LNK2019: unresolved external symbol __imp_DWriteCreateFactory referenced in function "public: __cdecl hb_directwrite_global_t::hb_directwrite_global_t(void)" (??0hb_directwrite_global_t@@QEAA@XZ)

Added linking to dwrite.lib on Windows.