### PR TITLE
[VARC] Graduate out of experimental

### DIFF
--- a/src/OT/Var/VARC/VARC.cc
+++ b/src/OT/Var/VARC/VARC.cc
@@ -11,6 +11,8 @@ namespace OT {
 //namespace Var {
 
 
+#ifndef HB_NO_DRAW
+
 struct hb_transforming_pen_context_t
 {
   hb_transform_t<> transform;
@@ -413,6 +415,8 @@ VARC::get_path_at (const hb_varc_context_t &c,
 
   return true;
 }
+
+#endif
 
 //} // namespace Var
 } // namespace OT

--- a/src/OT/Var/VARC/VARC.hh
+++ b/src/OT/Var/VARC/VARC.hh
@@ -195,6 +195,7 @@ struct VARC
 		 hb_codepoint_t gid,
 		 hb_glyph_extents_t *extents) const
     {
+#ifndef HB_NO_DRAW
       if (!table->has_data ()) return false;
 
       hb_extents_t<> f_extents;
@@ -208,6 +209,9 @@ struct VARC
 	*extents = f_extents.to_glyph_extents (font->x_scale < 0, font->y_scale < 0);
 
       return ret;
+#else
+      return false;
+#endif
     }
 
     private:

--- a/src/hb-config.hh
+++ b/src/hb-config.hh
@@ -38,7 +38,6 @@
 #ifndef HB_EXPERIMENTAL_API
 #define HB_NO_BEYOND_64K
 #define HB_NO_CUBIC_GLYF
-#define HB_NO_VAR_COMPOSITES
 #endif
 
 #ifdef HB_TINY

--- a/src/hb-config.hh
+++ b/src/hb-config.hh
@@ -90,7 +90,10 @@
 #ifdef HB_MINI
 #define HB_NO_AAT
 #define HB_NO_LEGACY
-#define HB_NO_BORING_EXPANSION
+#define HB_NO_BEYOND_64K
+#define HB_NO_CUBIC_GLYF
+#define HB_NO_VAR_COMPOSITES
+#define HB_NO_VAR_HVF
 #endif
 
 #ifdef __OPTIMIZE_SIZE__
@@ -110,12 +113,6 @@
 
 #ifdef HB_NO_SIMD
 #define HB_NO_APPLE_SIMD
-#endif
-
-#ifdef HB_NO_BORING_EXPANSION
-#define HB_NO_BEYOND_64K
-#define HB_NO_CUBIC_GLYF
-#define HB_NO_VAR_COMPOSITES
 #endif
 
 #ifdef HB_NO_VAR


### PR DESCRIPTION
I didn't remove it from `HB_NO_BORING_EXPANSION`; just out of `HB_EXPERIMENTAL_API`. I'm not sure what to do. for AVAR2, we removed it from both, making it survive anyone disabling boring-expansion using `HB_NO_BORING_EXPANSION`. The idea was that Apple shipped avar2, so it's not a boring-expansion project anymore...