### PR TITLE
Fix unary minus operator applied to unsigned type, result still unsigned

### DIFF
--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -678,7 +678,7 @@ hb_ot_get_glyph_v_origins (hb_font_t *font,
 	hb_position_t origin;
 	unsigned cv;
 	if (origin_cache->get (*first_glyph, &cv))
-	  origin = font->y_scale < 0 ? -cv : cv;
+	  origin = font->y_scale < 0 ? -static_cast<hb_position_t>(cv) : static_cast<hb_position_t>(cv);
 	else
 	{
 	  origin = font->em_scalef_y (VORG.get_y_origin (*first_glyph));
@@ -702,7 +702,7 @@ hb_ot_get_glyph_v_origins (hb_font_t *font,
 	hb_position_t origin;
 	unsigned cv;
 	if (origin_cache->get (*first_glyph, &cv))
-	  origin = font->y_scale < 0 ? -cv : cv;
+	  origin = font->y_scale < 0 ? -static_cast<hb_position_t>(cv) : static_cast<hb_position_t>(cv);
 	else
 	{
 	  origin = font->em_scalef_y (VORG.get_y_origin (*first_glyph) +
@@ -745,7 +745,7 @@ hb_ot_get_glyph_v_origins (hb_font_t *font,
       hb_position_t origin;
       unsigned cv;
       if (origin_cache->get (*first_glyph, &cv))
-	origin = font->y_scale < 0 ? -cv : cv;
+	origin = font->y_scale < 0 ? -static_cast<hb_position_t>(cv) : static_cast<hb_position_t>(cv);
       else
       {
 	origin = font->em_scalef_y (glyf.get_v_origin_with_var_unscaled (*first_glyph, font, *scratch, gvar_cache));
@@ -779,7 +779,7 @@ hb_ot_get_glyph_v_origins (hb_font_t *font,
       unsigned cv;
 
       if (origin_cache->get (*first_glyph, &cv))
-	origin = font->y_scale < 0 ? -cv : cv;
+	origin = font->y_scale < 0 ? -static_cast<hb_position_t>(cv) : static_cast<hb_position_t>(cv);
       else
       {
 	hb_glyph_extents_t extents = {0};


### PR DESCRIPTION
Fixes errors/warnings under MSVC:
```
../src/hb-ot-font.cc(681): error C4146: unary minus operator applied to unsigned type, result still unsigned
../src/hb-ot-font.cc(705): error C4146: unary minus operator applied to unsigned type, result still unsigned
../src/hb-ot-font.cc(748): error C4146: unary minus operator applied to unsigned type, result still unsigned
../src/hb-ot-font.cc(782): error C4146: unary minus operator applied to unsigned type, result still unsigned
```