### PR TITLE
Use float for main font scaling

### DIFF
--- a/src/OT/Var/VARC/VARC.cc
+++ b/src/OT/Var/VARC/VARC.cc
@@ -312,8 +312,8 @@ VarComponent::get_path_at (const hb_varc_context_t &c,
       transform.scaleY = transform.scaleX;
 
     total_transform.transform (transform.to_transform ());
-    total_transform.scale (c.font->x_mult ? 1.f / c.font->x_multf : 0.f,
-			   c.font->y_mult ? 1.f / c.font->y_multf : 0.f);
+    total_transform.scale (c.font->x_multf ? 1.f / c.font->x_multf : 0.f,
+			   c.font->y_multf ? 1.f / c.font->y_multf : 0.f);
 
     bool same_coords = component_coords.length == coords.length &&
 		       component_coords.arrayZ == coords.arrayZ;

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -2054,8 +2054,6 @@ DEFINE_NULL_INSTANCE (hb_font_t) =
   0.f, /* slant_xy; */
   1.f, /* x_multf */
   1.f, /* y_multf */
-  1<<16, /* x_mult */
-  1<<16, /* y_mult */
 
   0, /* x_ppem */
   0, /* y_ppem */
@@ -2092,7 +2090,6 @@ _hb_font_create (hb_face_t *face)
   font->x_scale = font->y_scale = face->get_upem ();
   font->embolden_in_place = true;
   font->x_multf = font->y_multf = 1.f;
-  font->x_mult = font->y_mult = 1 << 16;
   font->instance_index = HB_FONT_NO_VAR_NAMED_INSTANCE;
 
   return font;

--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -158,8 +158,8 @@ struct hb_font_t
   /* Convert from font-space to user-space */
   int64_t dir_mult (hb_direction_t direction)
   { return HB_DIRECTION_IS_VERTICAL(direction) ? y_mult : x_mult; }
-  hb_position_t em_scale_x (int16_t v) { return em_mult (v, x_mult); }
-  hb_position_t em_scale_y (int16_t v) { return em_mult (v, y_mult); }
+  hb_position_t em_scale_x (int32_t v) { return em_multf (v, x_multf); }
+  hb_position_t em_scale_y (int32_t v) { return em_multf (v, y_multf); }
   hb_position_t em_scalef_x (float v) { return em_multf (v, x_multf); }
   hb_position_t em_scalef_y (float v) { return em_multf (v, y_multf); }
   float em_fscale_x (int16_t v) { return em_fmult (v, x_multf); }

--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -133,8 +133,6 @@ struct hb_font_t
 
   float x_multf;
   float y_multf;
-  int64_t x_mult;
-  int64_t y_mult;
 
   unsigned int x_ppem;
   unsigned int y_ppem;
@@ -156,8 +154,8 @@ struct hb_font_t
 
 
   /* Convert from font-space to user-space */
-  int64_t dir_mult (hb_direction_t direction)
-  { return HB_DIRECTION_IS_VERTICAL(direction) ? y_mult : x_mult; }
+  float dir_multf (hb_direction_t direction)
+  { return HB_DIRECTION_IS_VERTICAL(direction) ? y_multf : x_multf; }
   hb_position_t em_scale_x (int32_t v) { return em_multf (v, x_multf); }
   hb_position_t em_scale_y (int32_t v) { return em_multf (v, y_multf); }
   hb_position_t em_scalef_x (float v) { return em_multf (v, x_multf); }
@@ -166,8 +164,8 @@ struct hb_font_t
   float em_fscale_y (int16_t v) { return em_fmult (v, y_multf); }
   float em_fscalef_x (float v) { return em_fmultf (v, x_multf); }
   float em_fscalef_y (float v) { return em_fmultf (v, y_multf); }
-  hb_position_t em_scale_dir (int16_t v, hb_direction_t direction)
-  { return em_mult (v, dir_mult (direction)); }
+  hb_position_t em_scale_dir (int32_t v, hb_direction_t direction)
+  { return em_multf (v, dir_multf (direction)); }
 
   /* Convert from parent-font user-space to our user-space */
   hb_position_t parent_scale_x_distance (hb_position_t v)
@@ -1152,10 +1150,6 @@ struct hb_font_t
 
     x_multf = x_scale / upem;
     y_multf = y_scale / upem;
-    bool x_neg = x_scale < 0;
-    x_mult = (x_neg ? -((int64_t) -x_scale << 16) : ((int64_t) x_scale << 16)) / upem;
-    bool y_neg = y_scale < 0;
-    y_mult = (y_neg ? -((int64_t) -y_scale << 16) : ((int64_t) y_scale << 16)) / upem;
 
     is_synthetic =  x_embolden || y_embolden || slant;
 
@@ -1169,8 +1163,6 @@ struct hb_font_t
     serial++;
   }
 
-  hb_position_t em_mult (int16_t v, int64_t mult)
-  { return (hb_position_t) ((v * mult + 32768) >> 16); }
   hb_position_t em_multf (float v, float mult)
   { return (hb_position_t) roundf (em_fmultf (v, mult)); }
   float em_fmultf (float v, float mult)

--- a/src/hb-ot-math-table.hh
+++ b/src/hb-ot-math-table.hh
@@ -704,14 +704,14 @@ struct MathGlyphPartRecord
   }
 
   void extract (hb_ot_math_glyph_part_t &out,
-		int64_t mult,
+		float multf,
 		hb_font_t *font) const
   {
     out.glyph			= glyph;
 
-    out.start_connector_length	= font->em_mult (startConnectorLength, mult);
-    out.end_connector_length	= font->em_mult (endConnectorLength, mult);
-    out.full_advance		= font->em_mult (fullAdvance, mult);
+    out.start_connector_length	= font->em_multf (startConnectorLength, multf);
+    out.end_connector_length	= font->em_multf (endConnectorLength, multf);
+    out.full_advance		= font->em_multf (fullAdvance, multf);
 
     static_assert ((unsigned int) HB_OT_MATH_GLYPH_PART_FLAG_EXTENDER ==
 		   (unsigned int) PartFlags::Extender, "");
@@ -776,7 +776,7 @@ struct MathGlyphAssembly
   {
     if (parts_count)
     {
-      int64_t mult = font->dir_mult (direction);
+      float mult = font->dir_multf (direction);
       for (auto _ : hb_zip (partRecords.as_array ().sub_array (start_offset, parts_count),
 			    hb_array (parts, *parts_count)))
 	_.first.extract (_.second, mult, font);
@@ -845,10 +845,10 @@ struct MathGlyphConstruction
   {
     if (variants_count)
     {
-      int64_t mult = font->dir_mult (direction);
+      float mult = font->dir_multf (direction);
       for (auto _ : hb_zip (mathGlyphVariantRecord.as_array ().sub_array (start_offset, variants_count),
 			    hb_array (variants, *variants_count)))
-	_.second = {_.first.variantGlyph, font->em_mult (_.first.advanceMeasurement, mult)};
+	_.second = {_.first.variantGlyph, font->em_multf (_.first.advanceMeasurement, mult)};
     }
     return mathGlyphVariantRecord.len;
   }


### PR DESCRIPTION
I measured `h-advances` on Mac and I measure no performance difference whatsoever. Haven't tested on Linux yet.