### PR TITLE
[ci] Add a script to extract release notes from NEWS file

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -93,7 +93,8 @@ jobs:
         id: create_release
         run: |
           if ! gh release view ${{ github.ref_name }}; then
-            gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --draft
+            python3 src/check-release-notes.py NEWS ${{ github.ref_name }} > RELEASE_NOTES
+            gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --notes-file RELEASE_NOTES --draft
           fi
       - name: Populate release
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,5 +36,6 @@
 
 - [ ] Push the commit and tag out: `git push --follow-tags`.
 
-- [ ] Go to GitHub releases page and create a new release for the pushed tag. Or wait a few minutes and the CI job will create on automatically.
-      Add description to the release, which should be the NEWS file additions.
+- [ ] Wait a few minutes and the CI job will create a GitHub release automatically, and it will use the NEWS file additions for release description.
+      The new release will be in draft mode, check everything is fine, or make any needed edits, then publish the release.
+      The release should also automatically include Windows binaries, but they take a bit longer to build and upload.

--- a/src/check-release-notes.py
+++ b/src/check-release-notes.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import sys
+
+
+news_path = sys.argv[1]
+release = sys.argv[2]
+
+with open(news_path, "r", encoding="utf-8") as news_file:
+    lines = news_file.readlines()
+
+start = None
+end = None
+for i, line in enumerate(lines):
+    line = line.rstrip()
+    if line.startswith("Overview of changes leading to"):
+        if start is not None:  # Start of next release
+            end = i
+            break
+        if line.endswith(release):  # Start of the release
+            start = i + 3  # Skip the header lines
+
+assert start and end and end > start
+
+print("".join(lines[start:end]))

--- a/src/meson.build
+++ b/src/meson.build
@@ -1099,6 +1099,14 @@ if get_option('tests').enabled()
       suite: ['src'],
     )
   endforeach
+
+  test('check-release-notes',
+    find_program('check-release-notes.py'),
+    args: [
+      meson.current_source_dir() / '..' / 'NEWS',
+      meson.project_version()
+    ],
+  )
 endif
 
 install_headers(hb_headers + hb_subset_headers, subdir: meson.project_name())


### PR DESCRIPTION
Add a script to extract the release notes from the NEWS files and use them when creating GitHub releases, so that we don’t need to copy them manually.

Add also a test to make sure the NEWS file always have release notes for the current release.