### PR TITLE
[graphite2] Use signed int for current advance

### DIFF
--- a/src/hb-graphite2.cc
+++ b/src/hb-graphite2.cc
@@ -266,7 +266,7 @@ _hb_graphite2_shape (hb_shape_plan_t    *shape_plan HB_UNUSED,
   gr_segment *seg = nullptr;
   const gr_slot *is;
   unsigned int ci = 0, ic = 0;
-  unsigned int curradvx = 0, curradvy = 0;
+  int curradvx = 0, curradvy = 0;
 
   unsigned int scratch_size;
   hb_buffer_t::scratch_buffer_t *scratch = buffer->get_scratch_buffer (&scratch_size);


### PR DESCRIPTION
Graphite can return negative advances, but we were storing current x and y advances as unsigned ints. The `curradvx` and `curradvy` variables are used only when calculating the respective offset, but the advance itself it always taken from Graphite directly, so using signed here makes no difference to how advances are set, only the offsets.

Fixes https://github.com/harfbuzz/harfbuzz/issues/5439