### PR TITLE
[lookup] Give each subtable an external-cache opportunity

### DIFF
--- a/src/OT/Layout/GPOS/PairPosFormat1.hh
+++ b/src/OT/Layout/GPOS/PairPosFormat1.hh
@@ -103,10 +103,6 @@ struct PairPosFormat1_3
 
   const Coverage &get_coverage () const { return this+coverage; }
 
-  unsigned cache_cost () const
-  {
-    return (this+coverage).cost ();
-  }
   static void * cache_func (void *p, hb_ot_subtable_cache_op_t op)
   {
     switch (op)
@@ -119,7 +115,7 @@ struct PairPosFormat1_3
 	return cache;
       }
       case hb_ot_subtable_cache_op_t::ENTER:
-	return (void *) true;
+	return nullptr;
       case hb_ot_subtable_cache_op_t::LEAVE:
 	return nullptr;
       case hb_ot_subtable_cache_op_t::DESTROY:

--- a/src/OT/Layout/GPOS/PairPosFormat2.hh
+++ b/src/OT/Layout/GPOS/PairPosFormat2.hh
@@ -130,10 +130,6 @@ struct PairPosFormat2_4 : ValueBase
     hb_ot_layout_mapping_cache_t second;
   };
 
-  unsigned cache_cost () const
-  {
-    return (this+coverage).cost () + (this+classDef1).cost () + (this+classDef2).cost ();
-  }
   static void * cache_func (void *p, hb_ot_subtable_cache_op_t op)
   {
     switch (op)
@@ -150,7 +146,7 @@ struct PairPosFormat2_4 : ValueBase
 	return cache;
       }
       case hb_ot_subtable_cache_op_t::ENTER:
-	return (void *) true;
+	return nullptr;
       case hb_ot_subtable_cache_op_t::LEAVE:
 	return nullptr;
       case hb_ot_subtable_cache_op_t::DESTROY:

--- a/src/OT/Layout/GSUB/LigatureSubstFormat1.hh
+++ b/src/OT/Layout/GSUB/LigatureSubstFormat1.hh
@@ -78,10 +78,6 @@ struct LigatureSubstFormat1_2
     return lig_set.would_apply (c);
   }
 
-  unsigned cache_cost () const
-  {
-    return (this+coverage).cost ();
-  }
   static void * cache_func (void *p, hb_ot_subtable_cache_op_t op)
   {
     switch (op)
@@ -94,7 +90,7 @@ struct LigatureSubstFormat1_2
 	return cache;
       }
       case hb_ot_subtable_cache_op_t::ENTER:
-	return (void *) true;
+	return nullptr;
       case hb_ot_subtable_cache_op_t::LEAVE:
 	return nullptr;
       case hb_ot_subtable_cache_op_t::DESTROY:


### PR DESCRIPTION
```
Comparing before to after
Benchmark                                                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/ot                -0.0402         -0.0396            85            81            84            81
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/ot                          -0.0139         -0.0138           101            99           100            99
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/ot                           -0.0080         -0.0077            39            39            39            39
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/ot                        -0.0315         -0.0313            26            25            25            25
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/ot                          -0.0764         -0.0759             9             8             9             8
BM_Shape/Roboto-Regular.ttf/en-words.txt/ot                                    -0.0572         -0.0571            12            11            12            11
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/ot                        -0.1479         -0.1470            98            83            97            83
OVERALL_GEOMEAN                                                                -0.0546         -0.0543             0             0             0             0

```