### PR TITLE
[Coverage] Cache NOT_COVERED effectively

### DIFF
--- a/src/OT/Layout/Common/Coverage.hh
+++ b/src/OT/Layout/Common/Coverage.hh
@@ -100,9 +100,14 @@ struct Coverage
 			     hb_ot_layout_mapping_cache_t *cache) const
   {
     unsigned coverage;
-    if (cache && cache->get (glyph_id, &coverage)) return coverage;
+    if (cache && cache->get (glyph_id, &coverage)) return coverage < cache->MAX_VALUE ? coverage : NOT_COVERED;
     coverage = get_coverage (glyph_id);
-    if (cache) cache->set (glyph_id, coverage);
+    if (cache) {
+      if (coverage == NOT_COVERED)
+	cache->set (glyph_id, cache->MAX_VALUE);
+      else if (likely (coverage < cache->MAX_VALUE))
+	cache->set (glyph_id, coverage);
+    }
     return coverage;
   }
 

--- a/src/hb-cache.hh
+++ b/src/hb-cache.hh
@@ -75,6 +75,8 @@ struct hb_cache_t
   static_assert ((key_bits >= cache_bits), "");
   static_assert ((key_bits + value_bits <= cache_bits + 8 * sizeof (item_t)), "");
 
+  static constexpr unsigned MAX_VALUE = (1u << value_bits) - 1;
+
   hb_cache_t () { clear (); }
 
   void clear ()


### PR DESCRIPTION
Before, our cache.set was always failing for NOT_COVERED, making the cache ineffective for uncovered glyphs. Fix that.

Some nice speedups in Latin fonts.

```
Comparing before to after
Benchmark                                                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/ot                +0.0006         +0.0006            80            80            80            80
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/ot                          -0.0060         -0.0059            96            96            96            95
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/ot                           +0.0025         +0.0024            39            39            39            39
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/ot                        -0.0263         -0.0266            25            25            25            25
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/ot                          -0.0718         -0.0722             8             8             8             8
BM_Shape/Roboto-Regular.ttf/en-words.txt/ot                                    -0.0615         -0.0620            11            11            11            11
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/ot                        -0.1325         -0.1323            84            73            84            73
OVERALL_GEOMEAN                                                                -0.0433         -0.0434             0             0             0             0

```