### PR TITLE
[ligature] Add a set-digest on the second component

### DIFF
--- a/src/OT/Layout/GSUB/Ligature.hh
+++ b/src/OT/Layout/GSUB/Ligature.hh
@@ -44,6 +44,12 @@ struct Ligature
     c->output->add (ligGlyph);
   }
 
+  template <typename set_t>
+  void collect_second (set_t &s) const
+  {
+    s.add (component[1]); // This adds codepoint 0 if component array is empty.
+  }
+
   bool would_apply (hb_would_apply_context_t *c) const
   {
     if (c->len != component.lenP1)

--- a/src/OT/Layout/GSUB/LigatureSet.hh
+++ b/src/OT/Layout/GSUB/LigatureSet.hh
@@ -62,6 +62,15 @@ struct LigatureSet
     ;
   }
 
+  template <typename set_t>
+  void collect_seconds (set_t &s) const
+  {
+    + hb_iter (ligature)
+    | hb_map (hb_add (this))
+    | hb_apply ([&s] (const Ligature<Types> &_) { _.collect_second (s); })
+    ;
+  }
+
   bool would_apply (hb_would_apply_context_t *c) const
   {
     return
@@ -72,7 +81,7 @@ struct LigatureSet
     ;
   }
 
-  bool apply (hb_ot_apply_context_t *c) const
+  bool apply (hb_ot_apply_context_t *c, const hb_set_digest_t *seconds = nullptr) const
   {
     TRACE_APPLY (this);
 
@@ -91,7 +100,7 @@ struct LigatureSet
       return_trace (false);
     }
 
-    /* This version is optimized for speed by matching the first component
+    /* This version is optimized for speed by matching the second component
      * of the ligature here, instead of calling into the ligation code.
      *
      * This is replicated in ChainRuleSet and RuleSet. */
@@ -101,11 +110,11 @@ struct LigatureSet
     skippy_iter.set_match_func (match_always, nullptr);
     skippy_iter.set_glyph_data ((HBUINT16 *) nullptr);
     unsigned unsafe_to;
-    hb_codepoint_t first = (unsigned) -1;
+    hb_codepoint_t second = (unsigned) -1;
     bool matched = skippy_iter.next (&unsafe_to);
     if (likely (matched))
     {
-      first = c->buffer->info[skippy_iter.idx].codepoint;
+      second = c->buffer->info[skippy_iter.idx].codepoint;
       unsafe_to = skippy_iter.idx + 1;
 
       if (skippy_iter.may_skip (c->buffer->info[skippy_iter.idx]))
@@ -118,13 +127,14 @@ struct LigatureSet
     else
       goto slow;
 
+    if (seconds && !seconds->may_have (second))
+      return_trace (false);
     bool unsafe_to_concat = false;
-
     for (unsigned int i = 0; i < num_ligs; i++)
     {
       const auto &lig = this+ligature.arrayZ[i];
       if (unlikely (lig.component.lenP1 <= 1) ||
-	  lig.component.arrayZ[0] == first)
+	  lig.component.arrayZ[0] == second)
       {
 	if (lig.apply (c))
 	{


### PR DESCRIPTION
```
Comparing before to after
Benchmark                                                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/ot                +0.0154         +0.0158            80            81            79            80
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/ot                          +0.0136         +0.0133            96            98            96            97
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/ot                           +0.0085         +0.0087            38            38            38            38
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/ot                        -0.0030         -0.0029            25            25            25            25
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/ot                          -0.1004         -0.1006             7             7             7             7
BM_Shape/Roboto-Regular.ttf/en-words.txt/ot                                    -0.0981         -0.0984            11            10            11            10
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/ot                        -0.0031         -0.0034            71            71            71            71
OVERALL_GEOMEAN                                                                -0.0251         -0.0252             0             0             0             0
```