### PR TITLE
[set-digest] Branch-free may_have

### DIFF
--- a/src/hb-set-digest.hh
+++ b/src/hb-set-digest.hh
@@ -60,9 +60,11 @@
  * of the input number (glyph-id in this case) and checks whether
  * its pattern is amongst the patterns of any of the accepted values.
  * The accepted patterns are represented as a "long" integer. The
- * check is done using four bitwise operations only.
+ * check is done using four bitwise operations only and branch-free.
  */
 
+// The order of these values used to matter when we were using if
+// statements. Now that we are branch-free, the order does not matter.
 static constexpr unsigned hb_set_digest_shifts[] = {4, 0, 6};
 
 struct hb_set_digest_t
@@ -152,18 +154,18 @@ struct hb_set_digest_t
   HB_ALWAYS_INLINE
   bool may_have (hb_codepoint_t g) const
   {
+    bool have = true;
     for (unsigned i = 0; i < n; i++)
-      if (!(masks[i] & (one << ((g >> hb_set_digest_shifts[i]) & mb1))))
-	return false;
-    return true;
+      have &= bool(masks[i] & (one << ((g >> hb_set_digest_shifts[i]) & mb1)));
+    return have;
   }
 
   bool may_intersect (const hb_set_digest_t &o) const
   {
+    bool have = true;
     for (unsigned i = 0; i < n; i++)
-      if (!(masks[i] & o.masks[i]))
-	return false;
-    return true;
+      have &= bool(masks[i] & o.masks[i]);
+    return have;
   }
 
   private:


### PR DESCRIPTION
```
Comparing before to after
Benchmark                                                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/ot                -0.0105         -0.0107            82            81            81            81
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/ot                          +0.0005         +0.0004            96            97            96            96
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/ot                           -0.0224         -0.0220            39            38            38            38
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/ot                        -0.0503         -0.0501            25            24            25            24
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/ot                          -0.0339         -0.0338             7             6             7             6
BM_Shape/Roboto-Regular.ttf/en-words.txt/ot                                    -0.0321         -0.0322            10            10            10            10
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/ot                        +0.0054         +0.0057            72            72            71            72
OVERALL_GEOMEAN                                                                -0.0207         -0.0206             0             0             0             0
```