### PR TITLE
Revert "[set-digest] Branch-free tests (#5469)"

### DIFF
--- a/src/hb-set-digest.hh
+++ b/src/hb-set-digest.hh
@@ -60,11 +60,9 @@
  * of the input number (glyph-id in this case) and checks whether
  * its pattern is amongst the patterns of any of the accepted values.
  * The accepted patterns are represented as a "long" integer. The
- * check is done using four bitwise operations only and branch-free.
+ * check is done using four bitwise operations only.
  */
 
-// The order of these values used to matter when we were using if
-// statements. Now that we are branch-free, the order does not matter.
 static constexpr unsigned hb_set_digest_shifts[] = {4, 0, 6};
 
 struct hb_set_digest_t
@@ -154,18 +152,18 @@ struct hb_set_digest_t
   HB_ALWAYS_INLINE
   bool may_have (hb_codepoint_t g) const
   {
-    bool have = true;
     for (unsigned i = 0; i < n; i++)
-      have &= bool(masks[i] & (one << ((g >> hb_set_digest_shifts[i]) & mb1)));
-    return have;
+      if (!(masks[i] & (one << ((g >> hb_set_digest_shifts[i]) & mb1))))
+	return false;
+    return true;
   }
 
   bool may_intersect (const hb_set_digest_t &o) const
   {
-    bool have = true;
     for (unsigned i = 0; i < n; i++)
-      have &= bool(masks[i] & o.masks[i]);
-    return have;
+      if (!(masks[i] & o.masks[i]))
+	return false;
+    return true;
   }
 
   private:


### PR DESCRIPTION
This reverts commit a4d4c41023dd738d35f2e917d8deea2b473a38aa.

That commit had slowed down clang by 3% while sped up gcc by 3%. Revert, to keep the code *intention* clear. Rely on compiler to avoid branches if it sees fit.