### PR TITLE
[ot-math] Fix constant scaling when checking if the font is Cambria Math

### DIFF
--- a/src/hb-ot-math-table.hh
+++ b/src/hb-ot-math-table.hh
@@ -69,6 +69,8 @@ struct MathValueRecord
 
 struct MathConstants
 {
+  friend struct MATH;
+
   MathConstants* copy (hb_serialize_context_t *c) const
   {
     TRACE_SERIALIZE (this);
@@ -1109,8 +1111,8 @@ struct MATH
   {
 #ifndef HB_NO_MATH
     switch HB_CODEPOINT_ENCODE3 (font->face->table.MATH.get_blob ()->length,
-                                 get_constant (HB_OT_MATH_CONSTANT_DISPLAY_OPERATOR_MIN_HEIGHT, font),
-                                 get_constant (HB_OT_MATH_CONSTANT_DELIMITED_SUB_FORMULA_MIN_HEIGHT, font))
+                                 (this+mathConstants).minHeight[1], // displayOperatorMinHeight
+                                 (this+mathConstants).minHeight[0]) // delimitedSubFormulaMinHeight
     {
       /* sha1sum:ab4a4fe054d23061f3c039493d6f665cfda2ecf5  cambria.ttc
        * sha1sum:086855301bff644f9d8827b88491fcf73a6d4cb9  cambria.ttc


### PR DESCRIPTION
As discussed in #4653, the workaround for Cambria Math is not working since `get_constant` returns a scaled version of `displayOperatorMinHeight` and `delimitedSubFormulaMinHeight`. Replace with a direct lookup to `minHeight`.