### PR TITLE
Avoid UB if shrink_vector(0) is called on an already-empty vector

### DIFF
--- a/src/hb-vector.hh
+++ b/src/hb-vector.hh
@@ -444,9 +444,9 @@ struct hb_vector_t
     if (!std::is_trivially_destructible<Type>::value)
     {
       unsigned count = length - size;
-      Type *p = arrayZ + length - 1;
+      Type *p = arrayZ + length;
       while (count--)
-        p--->~Type ();
+        (--p)->~Type ();
     }
     length = size;
   }


### PR DESCRIPTION
Fixes #5489