### PR TITLE
[coretext] fix unsigned integer comparison

### DIFF
--- a/src/hb-coretext-font.cc
+++ b/src/hb-coretext-font.cc
@@ -410,8 +410,8 @@ hb_coretext_get_glyph_name (hb_font_t *font,
     return false;
 
   CFIndex len = CFStringGetLength (cf_name);
-  if (len > size - 1)
-    len = size - 1;
+  if (len > (CFIndex)size - 1)
+    len = (CFIndex)size - 1;
 
   CFStringGetBytes (cf_name, CFRangeMake (0, len),
 		    kCFStringEncodingUTF8, 0, false,

--- a/src/hb-coretext.cc
+++ b/src/hb-coretext.cc
@@ -167,8 +167,8 @@ create_cg_font (CFArrayRef ct_font_desc_array, unsigned int named_instance_index
   }
   else
     named_instance_index--;
-  auto ct_font_desc = (CFArrayGetCount (ct_font_desc_array) > named_instance_index) ?
-		      (CTFontDescriptorRef) CFArrayGetValueAtIndex (ct_font_desc_array, named_instance_index) : nullptr;
+  auto ct_font_desc = (CFArrayGetCount (ct_font_desc_array) > (CFIndex) named_instance_index) ?
+		      (CTFontDescriptorRef) CFArrayGetValueAtIndex (ct_font_desc_array, (CFIndex) named_instance_index) : nullptr;
   if (unlikely (!ct_font_desc))
   {
     CFRelease (ct_font_desc_array);


### PR DESCRIPTION
Comparing a CFIndex with an unsigned int results in a compilation error on iOS armv7 targets:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.4.sdk -Isrc/libharfbuzz.a.p -Isrc -I../src -I. -I.. -I/Volumes/External/videolanci/builds/vCi6yJP3/0/robUx4/vlc/contrib/armv7-iphoneos/include/freetype2 -I/Volumes/External/videolanci/builds/vCi6yJP3/0/robUx4/vlc/contrib/armv7-iphoneos/include -fdiagnostics-color=always -Wall -Winvalid-pch -std=c++11 -fno-exceptions -O2 -g -fno-exceptions -fno-rtti -fno-threadsafe-statics -fvisibility-inlines-hidden -DHAVE_CONFIG_H -mios-version-min=9.0 -arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.4.sdk -Werror=partial-availability -fno-stack-check -g -O2 -MD -MQ src/libharfbuzz.a.p/hb-coretext-font.cc.o -MF src/libharfbuzz.a.p/hb-coretext-font.cc.o.d -o src/libharfbuzz.a.p/hb-coretext-font.cc.o -c ../src/hb-coretext-font.cc ../src/hb-coretext-font.cc:413:11: error: comparison of integers of different signs: 'CFIndex' (aka 'long') and 'unsigned int' [-Werror,-Wsign-compare]
  if (len > size - 1)
      ~~~ ^ ~~~~~~~~
1 error generated.
```