### PR TITLE
Create man pages with useful whatis entry

### DIFF
--- a/util/meson.build
+++ b/util/meson.build
@@ -21,7 +21,7 @@ if not get_option('docs').disabled()
 else
   help2man = disabler()
 endif
-help2man_command = [help2man, '--help-option=--help-all', '--no-info', '--output=' + '@OUTPUT@', '@INPUT@']
+help2man_command = ['sh', '-c', help2man.full_path() + ' --help-option=--help-all --no-info -n "$(@INPUT@ --help | head -n 4 | tail -n 1)" --output=$0 @INPUT@', '@OUTPUT@']
 help2man_env = environment()
 help2man_env.set('HB_UTIL_HELP_VERBOSE', '1')
 


### PR DESCRIPTION
The whatis entry (the brief description found in the NAME section) for
manual pages created by help2man is of the form:                      
                                                                      
program - manual page for program                                     
                                                                      
This conveys no information about what the program is for and is repetitive.
The short description should contain brief information about what the 
program is for to aid in searching with apropos and similar programs. 

