### PR TITLE
[instancer/varstore] Sync to fonttools algorithmic change

### DIFF
--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -2503,20 +2503,6 @@ struct delta_row_encoding_t
     const delta_row_encoding_t *a = (const delta_row_encoding_t *)pa;
     const delta_row_encoding_t *b = (const delta_row_encoding_t *)pb;
 
-    int gain_a = a->get_gain ();
-    int gain_b = b->get_gain ();
-
-    if (gain_a != gain_b)
-      return gain_b - gain_a;
-
-    return b->chars.cmp (a->chars);
-  }
-
-  static int cmp_width (const void *pa, const void *pb)
-  {
-    const delta_row_encoding_t *a = (const delta_row_encoding_t *)pa;
-    const delta_row_encoding_t *b = (const delta_row_encoding_t *)pb;
-
     if (a->width != b->width)
       return (int) a->width - (int) b->width;
 

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -1975,7 +1975,7 @@ struct item_variations_t
     }
 
     /* sort again based on width, make result deterministic */
-    encodings.qsort (delta_row_encoding_t::cmp_width);
+    encodings.qsort ();
 
     return compile_varidx_map (front_mapping);
   }


### PR DESCRIPTION
This is fonttools commits:
https://github.com/fonttools/fonttools/commit/548ffda37bf6a36c4bd3f45255d178d371bb9cf9
https://github.com/fonttools/fonttools/commit/d4565155b8d265030c10886d60008a7297ae7a0c

One test fails, needs rebasing perhaps?