### PR TITLE
Fix invalid reinterpret_cast

### DIFF
--- a/src/hb-atomic.hh
+++ b/src/hb-atomic.hh
@@ -149,7 +149,7 @@ struct hb_atomic_t
   hb_atomic_t () = default;
   constexpr hb_atomic_t (T v) : v (v) {}
   constexpr hb_atomic_t (const hb_atomic_t& o) : v (o.get_relaxed ()) {}
-  constexpr hb_atomic_t (hb_atomic_t&& o) : v (o.get_relaxed ()) { o.set_relaxed({}); }
+  constexpr hb_atomic_t (hb_atomic_t&& o) : v (o.get_relaxed ()) { o.set_relaxed ({}); }
 
   hb_atomic_t &operator= (const hb_atomic_t& o) { set_relaxed (o.get_relaxed ()); return *this; }
   hb_atomic_t &operator= (hb_atomic_t&& o){ set_relaxed (o.get_relaxed ()); o.set_relaxed ({}); return *this; }


### PR DESCRIPTION
https://github.com/harfbuzz/harfbuzz/blob/ebcc20d085c305b1a6022f5fcfff766f9b27f8c5/src/hb-atomic.hh#L86
and the same below
with:
https://github.com/harfbuzz/harfbuzz/blob/b33f6fd213870323ecf0ae76d5f742e33af66489/src/hb-common.cc#L45
(only one example)

equivalent of this pseudo-code:
```cpp
int i;
reinterpret_cast<std::atomic<int>*>(&i)->some_atomic_op(...);
```

reinterpret_cast from non-atomic object to atomic object is not valid.

https://eel.is/c++draft/atomics.types.generic#general-3
>[Note 2: The representation of an atomic specialization need not have the same size and alignment requirement as its corresponding argument type. — end note]

https://eel.is/c++draft/basic.compound#5
>5 Two objects a and b are pointer-interconvertible if
>(5.1) they are the same object, or
>(5.2) one is a union object and the other is a non-static data member of that object ([class.union]), or
>(5.3) one is a standard-layout class object and the other is the first non-static data member of that object or any base class subobject of that object ([class.mem]), or
>(5.4) there exists an object c such that a and c are pointer-interconvertible, and c and b are pointer-interconvertible.
>If two objects are pointer-interconvertible, then they have the same address, and it is possible to obtain a pointer to one from a pointer to the other via a reinterpret_cast ([expr.reinterpret.cast]).

objects of types `int` and `std::atomic<int>` are not _pointer-interconvertible_ (an object of type `int` is not first non-static data member of `std::atomic<int>`)

https://eel.is/c++draft/basic.lval#11
>11 An object of dynamic type T-obj is type-accessible through a glvalue of type T-ref if T-ref is similar ([conv.qual]) to:
>(11.1) T-obj,
>(11.2) a type that is the signed or unsigned type corresponding to T-obj, or
>(11.3) a char, unsigned char, or std::byte type.
>If a program attempts to access ([defns.access]) the stored value of an object through a glvalue through which it is not type-accessible, the behavior is undefined

The original code resulted in **undefined behavior**.

p.s. Code formatting is done using the provided `.clang-format` file;
headers `hb.hh` and `hb-meta.hh` were recursively dependent on `hb-atomic.hh` ([gave the same error as HERE](https://github.com/clangd/clangd/issues/1407))

other:
https://stackoverflow.com/questions/8749038/how-to-use-stdatomic-efficiently