### PR TITLE
fix clang-format repeated flags

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AllowShortLoopsOnASingleLine: true
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterEnum: true
-  AfterStruct: false
+  AfterStruct: true
   SplitEmptyFunction: false
   AfterClass: true
   AfterControlStatement: true


### PR DESCRIPTION
some flags were listed twice with opposite meanings