### PR TITLE
[buffer] Retain digest in the buffer

### DIFF
--- a/src/hb-buffer.hh
+++ b/src/hb-buffer.hh
@@ -32,6 +32,7 @@
 
 #include "hb.hh"
 #include "hb-unicode.hh"
+#include "hb-set-digest.hh"
 
 
 static_assert ((sizeof (hb_glyph_info_t) == 20), "");
@@ -109,6 +110,7 @@ struct hb_buffer_t
   hb_codepoint_t context[2][CONTEXT_LENGTH];
   unsigned int context_len[2];
 
+  hb_set_digest_t digest; /* Manually updated sometimes */
 
   /*
    * Managed by enter / leave
@@ -198,6 +200,12 @@ struct hb_buffer_t
   template <typename set_t>
   void collect_codepoints (set_t &d) const
   { d.clear (); d.add_array (&info[0].codepoint, len, sizeof (info[0])); }
+
+  void update_digest ()
+  {
+    digest = hb_set_digest_t ();
+    collect_codepoints (digest);
+  }
 
   HB_INTERNAL void similar (const hb_buffer_t &src);
   HB_INTERNAL void reset ();

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -715,7 +715,6 @@ struct hb_ot_apply_context_t :
   const hb_ot_layout_lookup_accelerator_t *lookup_accel = nullptr;
   const ItemVariationStore &var_store;
   hb_scalar_cache_t *var_store_cache;
-  hb_set_digest_t digest;
 
   hb_direction_t direction;
   hb_mask_t lookup_mask = 1;
@@ -764,7 +763,6 @@ struct hb_ot_apply_context_t :
 			has_glyph_classes (gdef.has_glyph_classes ())
   {
     init_iters ();
-    buffer->collect_codepoints (digest);
     match_positions.set_storage (stack_match_positions);
   }
 
@@ -837,7 +835,7 @@ struct hb_ot_apply_context_t :
 			  bool ligature = false,
 			  bool component = false)
   {
-    digest.add (glyph_index);
+    buffer->digest.add (glyph_index);
 
     if (new_syllables != (unsigned) -1)
       buffer->cur().syllable() = new_syllables;

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -2028,11 +2028,8 @@ inline void hb_ot_map_t::apply (const Proxy &proxy,
       if (buffer->messaging () &&
 	  !buffer->message (font, "start lookup %u feature '%c%c%c%c'", lookup_index, HB_UNTAG (lookup.feature_tag))) continue;
 
-      /* c.digest is a digest of all the current glyphs in the buffer
-       * (plus some past glyphs).
-       *
-       * Only try applying the lookup if there is any overlap. */
-      if (accel->digest.may_intersect (c.digest))
+      /* Only try applying the lookup if there is any overlap. */
+      if (accel->digest.may_intersect (buffer->digest))
       {
 	c.set_lookup_index (lookup_index);
 	c.set_lookup_mask (lookup.mask, false);
@@ -2058,7 +2055,7 @@ inline void hb_ot_map_t::apply (const Proxy &proxy,
       if (stage->pause_func (plan, font, buffer))
       {
 	/* Refresh working buffer digest since buffer changed. */
-	buffer->collect_codepoints (c.digest);
+	buffer->update_digest ();
       }
     }
   }

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -934,6 +934,7 @@ hb_ot_substitute_pre (const hb_ot_shape_context_t *c)
   hb_ot_substitute_default (c);
 
   _hb_buffer_allocate_gsubgpos_vars (c->buffer);
+  c->buffer->update_digest ();
 
   hb_ot_substitute_plan (c);
 


### PR DESCRIPTION
We don't have to reinitialize it for GPOS now, showing some 1.5% speedup on Roboto-Regular benchmark.

Over time we can change the various gsub_pauses to update the digest in-place instead of returning true.