### PR TITLE
[buffer-message] Disable "more" messages by default

### DIFF
--- a/src/hb-debug.hh
+++ b/src/hb-debug.hh
@@ -488,7 +488,7 @@ struct hb_no_trace_t {
 
 
 #ifndef HB_BUFFER_MESSAGE_MORE
-#define HB_BUFFER_MESSAGE_MORE (HB_DEBUG+1)
+#define HB_BUFFER_MESSAGE_MORE (HB_DEBUG+0)
 #endif
 
 


### PR DESCRIPTION
This was not suppoosed to be turned on by default, as it has a performance overhead. Instead, tools like Crowbar should define HB_BUFFER_MESSAGE_MORE to 1 when building HarfBuzz.