### PR TITLE
[rust] Don't use panic_immediate_abort

### DIFF
--- a/src/rust/meson.build
+++ b/src/rust/meson.build
@@ -36,7 +36,7 @@ buildtype = get_option('buildtype')
 if buildtype == 'release' or buildtype == 'debugoptimized'
   cargo_args += [
     '-Z', 'build-std=std,panic_abort',
-    '-Z', 'build-std-features=panic_immediate_abort',
+    '-Z', 'build-std-features=optimize_for_size',
   ]
   cargo_args += ['--profile', buildtype]
 endif


### PR DESCRIPTION
It has changed. Use optimize_for_size which seems to have the same size reduction effect.

Fixes https://github.com/harfbuzz/harfbuzz/issues/5584