### PR TITLE
[match-backtrack] Fix syllable-setting logic

### DIFF
--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -523,9 +523,16 @@ struct skipping_iterator_t
 #endif
   void reset (unsigned int start_index_)
   {
+    // For GSUB forward iterator
     idx = start_index_;
     end = c->buffer->len;
     matcher.syllable = start_index_ == c->buffer->idx ? c->buffer->cur().syllable () : 0;
+  }
+  void reset_back (unsigned int start_index_, bool from_out_buffer = false)
+  {
+    // For GSUB backward iterator
+    idx = start_index_;
+    matcher.syllable = 0;
   }
 
 #ifndef HB_OPTIMIZE_SIZE
@@ -1554,7 +1561,7 @@ static bool match_backtrack (hb_ot_apply_context_t *c,
   TRACE_APPLY (nullptr);
 
   auto &skippy_iter = c->iter_context;
-  skippy_iter.reset (c->buffer->backtrack_len ());
+  skippy_iter.reset_back (c->buffer->backtrack_len ());
   skippy_iter.set_match_func (match_func, match_data);
   skippy_iter.set_glyph_data (backtrack);
 


### PR DESCRIPTION
If accidentally backtrack_len() was equal idx, we were setting syllable, even though we want to match backtrack, which shouldn't match syllable.

I'm surprised how this was not exposed before.

Fixes https://github.com/harfbuzz/harfbuzz/issues/5597