### PR TITLE
Revert "[match-backtrack] Fix syllable-setting logic (#5617)"

### DIFF
--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -523,16 +523,9 @@ struct skipping_iterator_t
 #endif
   void reset (unsigned int start_index_)
   {
-    // For GSUB forward iterator
     idx = start_index_;
     end = c->buffer->len;
     matcher.syllable = start_index_ == c->buffer->idx ? c->buffer->cur().syllable () : 0;
-  }
-  void reset_back (unsigned int start_index_, bool from_out_buffer = false)
-  {
-    // For GSUB backward iterator
-    idx = start_index_;
-    matcher.syllable = 0;
   }
 
 #ifndef HB_OPTIMIZE_SIZE
@@ -1561,7 +1554,7 @@ static bool match_backtrack (hb_ot_apply_context_t *c,
   TRACE_APPLY (nullptr);
 
   auto &skippy_iter = c->iter_context;
-  skippy_iter.reset_back (c->buffer->backtrack_len ());
+  skippy_iter.reset (c->buffer->backtrack_len ());
   skippy_iter.set_match_func (match_func, match_data);
   skippy_iter.set_glyph_data (backtrack);
 


### PR DESCRIPTION
This reverts commit 2c934a6b396171df50bd867295b4c644316869f5.

Revert until implications are sorted out:
https://github.com/harfbuzz/harfbuzz/issues/5618