### PR TITLE
[font] Don't apply slant to singular glyph origin functions either

### DIFF
--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -445,9 +445,7 @@ struct hb_font_t
 
     if (synthetic && ret)
     {
-      /* Slant */
-      if (slant_xy)
-	*x += roundf (*y * slant_xy);
+      /* Slant is ignored as it does not affect glyph origin */
 
       /* Embolden */
       if (!embolden_in_place)
@@ -471,9 +469,7 @@ struct hb_font_t
 
     if (synthetic && ret)
     {
-      /* Slant */
-      if (slant_xy)
-	*x += roundf (*y * slant_xy);
+      /* Slant is ignored as it does not affect glyph origin */
 
       /* Embolden */
       if (!embolden_in_place)


### PR DESCRIPTION
Followup to 6105bad18730fe05916b8b87903333d804ef8b84