### PR TITLE
fix CMake message warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(harfbuzz)
 
-message(WARN "HarfBuzz has a Meson port and tries to migrate all the other build systems to it, please consider using it as we might remove our cmake port soon.")
+message(WARNING "HarfBuzz has a Meson port and tries to migrate all the other build systems to it, please consider using it as we might remove our cmake port soon.")
 
 if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)


### PR DESCRIPTION
CMake message takes "WARNING" not "WARN"

This fixes this bad formatting:
```
C/C++: WARNHarfBuzz has a Meson port and tries to migrate all the other build systems to it, please consider using it as we might remove our cmake port soon.
```

(notice WARNHarfBuzz)

to now be the correct:
```
C/C++: CMake Warning at /Users/brenton/development/github/SDL_ttf/external/harfbuzz/CMakeLists.txt:4 (message):
C/C++:   HarfBuzz has a Meson port and tries to migrate all the other build systems
C/C++:   to it, please consider using it as we might remove our cmake port soon.
```