### PR TITLE
[meson] Update wrap files

### DIFF
--- a/subprojects/cairo.wrap
+++ b/subprojects/cairo.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = cairo-1.18.2
-source_url = https://www.cairographics.org/releases/cairo-1.18.2.tar.xz
-source_filename = cairo-1.18.2.tar.xz
-source_hash = a62b9bb42425e844cc3d6ddde043ff39dbabedd1542eba57a2eb79f85889d45a
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/cairo_1.18.2-1/cairo-1.18.2.tar.xz
-wrapdb_version = 1.18.2-1
+directory = cairo-1.18.4
+source_url = https://www.cairographics.org/releases/cairo-1.18.4.tar.xz
+source_filename = cairo-1.18.4.tar.xz
+source_hash = 445ed8208a6e4823de1226a74ca319d3600e83f6369f99b14265006599c32ccb
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/cairo_1.18.4-2/cairo-1.18.4.tar.xz
+wrapdb_version = 1.18.4-2
 
 [provide]
-dependency_names = cairo, cairo-gobject
+dependency_names = cairo, cairo-gobject, cairo-script-interpreter

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,11 +1,10 @@
 [wrap-file]
-directory = freetype-2.13.3
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.13.3-1/freetype-2.13.3.tar.xz
-source_filename = freetype-2.13.3.tar.xz
-source_hash = 0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289
-wrapdb_version = 2.13.3-1
+directory = freetype-2.14.1
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.14.1-1/freetype-2.14.1.tar.xz
+source_filename = freetype-2.14.1.tar.xz
+source_hash = 32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc
+wrapdb_version = 2.14.1-1
 
 [provide]
-freetype2 = freetype_dep
-freetype = freetype_dep
+dependency_names = freetype2

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = glib-2.82.2
-source_url = https://download.gnome.org/sources/glib/2.82/glib-2.82.2.tar.xz
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/glib_2.82.2-1/glib-2.82.2.tar.xz
-source_filename = glib-2.82.2.tar.xz
-source_hash = ab45f5a323048b1659ee0fbda5cecd94b099ab3e4b9abf26ae06aeb3e781fd63
-wrapdb_version = 2.82.2-1
+directory = glib-2.86.1
+source_url = https://download.gnome.org/sources/glib/2.86/glib-2.86.1.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/glib_2.86.1-1/glib-2.86.1.tar.xz
+source_filename = glib-2.86.1.tar.xz
+source_hash = 119d1708ca022556d6d2989ee90ad1b82bd9c0d1667e066944a6d0020e2d5e57
+wrapdb_version = 2.86.1-1
 
 [provide]
 dependency_names = gthread-2.0, gobject-2.0, gmodule-no-export-2.0, gmodule-export-2.0, gmodule-2.0, glib-2.0, gio-2.0, gio-windows-2.0, gio-unix-2.0

--- a/subprojects/google-benchmark.wrap
+++ b/subprojects/google-benchmark.wrap
@@ -3,12 +3,11 @@ directory = benchmark-1.8.4
 source_url = https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz
 source_filename = benchmark-1.8.4.tar.gz
 source_hash = 3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45
-patch_filename = google-benchmark_1.8.4-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-1/get_patch
-patch_hash = 77cdae534fe12b6783c1267de3673d3462b229054519034710d581b419e73cca
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-1/benchmark-1.8.4.tar.gz
-wrapdb_version = 1.8.4-1
+patch_filename = google-benchmark_1.8.4-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-4/get_patch
+patch_hash = d1af464d29eb42442c41bc0629f94dbc2e390d9a8656461a14adfee84bcb6250
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-4/benchmark-1.8.4.tar.gz
+wrapdb_version = 1.8.4-4
 
 [provide]
-benchmark = google_benchmark_dep
-benchmark-main = google_benchmark_main_dep
+dependency_names = benchmark, benchmark_main

--- a/subprojects/libffi.wrap
+++ b/subprojects/libffi.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = libffi-3.4.6
-source_url = https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz
-source_filename = libffi-3.4.6.tar.gz
-source_hash = b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e
-patch_filename = libffi_3.4.6-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/libffi_3.4.6-3/get_patch
-patch_hash = 548eef573e8065df10dbd70b7394b4e30a89b627c734aae28e90244265d18b2d
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libffi_3.4.6-3/libffi-3.4.6.tar.gz
-wrapdb_version = 3.4.6-3
+directory = libffi-3.5.2
+source_url = https://github.com/libffi/libffi/releases/download/v3.5.2/libffi-3.5.2.tar.gz
+source_filename = libffi-3.5.2.tar.gz
+source_hash = f3a3082a23b37c293a4fcd1053147b371f2ff91fa7ea1b2a52e335676bac82dc
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libffi_3.5.2-2/libffi-3.5.2.tar.gz
+patch_filename = libffi_3.5.2-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libffi_3.5.2-2/get_patch
+patch_hash = 74ed624f74cd860be3bdf6d473b70ab88707bdf2f940191fbcb577e2a49a9710
+wrapdb_version = 3.5.2-2
 
 [provide]
 dependency_names = libffi


### PR DESCRIPTION
FreeType 2.14 loads HarfBuzz on runtime dynamically to simplify the circular dependencies, which is nice.