### PR TITLE
Force gen-harfbuzzcc.py to generate POSIX-style paths to avoid annoying git diffs

### DIFF
--- a/src/gen-harfbuzzcc.py
+++ b/src/gen-harfbuzzcc.py
@@ -2,7 +2,7 @@
 
 "This tool is intended to be used from meson"
 
-import os, sys, shutil
+import os, sys, shutil, pathlib
 
 if len (sys.argv) < 3:
 	sys.exit (__doc__)
@@ -14,7 +14,7 @@ CURRENT_SOURCE_DIR = sys.argv[2]
 sources = sorted(set(sys.argv[3:]))
 
 with open (OUTPUT, "wb") as f:
-	f.write ("".join ('#include "{}"\n'.format (os.path.relpath (os.path.abspath (x), CURRENT_SOURCE_DIR)) for x in sources if x.endswith (".cc")).encode ())
+	f.write ("".join ('#include "{}"\n'.format (pathlib.Path( os.path.relpath (os.path.abspath (x), CURRENT_SOURCE_DIR) ).as_posix()) for x in sources if x.endswith (".cc")).encode ())
 
 # copy it also to the source tree, but only if it has changed
 baseline_filename = os.path.join (CURRENT_SOURCE_DIR, os.path.basename (OUTPUT))


### PR DESCRIPTION
Windows uses backslashes as path separators, causing annoying git diffs every time Meson is run.

I also checked the other c/c++ source code and confirmed that the paths in `#include` directives are in POSIX style.

`pathlib` was introduced into Python in version 3.4, and the minimum Python version used in CI and GitHub Actions is 3.10, so I it's safe to use the `pathlib` module.

```diff
PS D:\Project\github-fork\harfbuzz> git diff
diff --git a/src/harfbuzz-subset.cc b/src/harfbuzz-subset.cc
index f6a5a319c..7acbe4e9f 100644
--- a/src/harfbuzz-subset.cc
+++ b/src/harfbuzz-subset.cc
@@ -1,5 +1,5 @@
-#include "OT/Var/VARC/VARC.cc"
-#include "graph/gsubgpos-context.cc"
+#include "OT\Var\VARC\VARC.cc"
+#include "graph\gsubgpos-context.cc"
 #include "hb-aat-layout.cc"
 #include "hb-aat-map.cc"
 #include "hb-blob.cc"
diff --git a/src/harfbuzz.cc b/src/harfbuzz.cc
index 471942c55..c0e2acc0b 100644
--- a/src/harfbuzz.cc
+++ b/src/harfbuzz.cc
@@ -1,4 +1,4 @@
-#include "OT/Var/VARC/VARC.cc"
+#include "OT\Var\VARC\VARC.cc"
 #include "hb-aat-layout.cc"
 #include "hb-aat-map.cc"
 #include "hb-blob.cc"
```



