### PR TITLE
[atomic] Remove unused operator |=

### DIFF
--- a/src/hb-atomic.hh
+++ b/src/hb-atomic.hh
@@ -169,11 +169,6 @@ struct hb_atomic_t
 
   int operator++ (int) { return inc (); }
   int operator-- (int) { return dec (); }
-  long operator|= (long v_)
-  {
-    set_relaxed (get_relaxed () | v_);
-    return *this;
-  }
 
   friend void swap (hb_atomic_t &a, hb_atomic_t &b) noexcept
   {
@@ -236,7 +231,6 @@ struct hb_atomic_t
 
   int operator ++ (int) { return inc (); }
   int operator -- (int) { return dec (); }
-  long operator |= (long v_) { set_relaxed (get_relaxed () | v_); return *this; }
 
   T v = 0;
 };


### PR DESCRIPTION
Not sure why it was added.