### PR TITLE
[TupleValues] Inline decompile_deltas

### DIFF
--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -1711,6 +1711,9 @@ struct TupleValues
   }
 
   template <typename T>
+#ifndef HB_OPTIMIZE_SIZE
+  HB_ALWAYS_INLINE
+#endif
   static bool decompile (const HBUINT8 *&p /* IN/OUT */,
 			 hb_vector_t<T> &values /* IN/OUT */,
 			 const HBUINT8 *end,

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -1534,6 +1534,7 @@ struct TupleVariationData
   }
 
   template <typename T>
+  HB_ALWAYS_INLINE
   static bool decompile_deltas (const HBUINT8 *&p /* IN/OUT */,
 				hb_vector_t<T> &deltas /* IN/OUT */,
 				const HBUINT8 *end,


### PR DESCRIPTION
8% speedup in GoogleSansFlex heavy variations test.

$ b/perf/benchmark-font GSF.ttf --benchmark_filter=draw.*var/ot --variations=ROND=40,wght=500,wdth=50,opsz=54,slnt=-10,GRAD=50