### PR TITLE
Fix integer overflow in _add_loca_and_head function

### DIFF
--- a/src/OT/glyf/glyf-helpers.hh
+++ b/src/OT/glyf/glyf-helpers.hh
@@ -94,12 +94,12 @@ _add_loca_and_head (hb_subset_context_t *c,
   unsigned num_offsets = c->plan->num_output_glyphs () + 1;
   unsigned entry_size = use_short_loca ? 2 : 4;
 
-  char *loca_prime_data = (char *) hb_malloc (entry_size * num_offsets);
+  char *loca_prime_data = (char *) hb_malloc (entry_size * (size_t)num_offsets);
 
   if (unlikely (!loca_prime_data)) return false;
 
-  DEBUG_MSG (SUBSET, nullptr, "loca entry_size %u num_offsets %u size %u",
-	     entry_size, num_offsets, entry_size * num_offsets);
+  DEBUG_MSG (SUBSET, nullptr, "loca entry_size %u num_offsets %u size %zu",
+	     entry_size, num_offsets, entry_size * (size_t)num_offsets);
 
   if (use_short_loca)
     _write_loca (padded_offsets, c->plan->new_to_old_gid_list, true, (HBUINT16 *) loca_prime_data, num_offsets);


### PR DESCRIPTION
In the `_add_loca_and_head` function, the expression `entry_size * num_offsets` is computed and passed directly to `hb_malloc`:

```c
unsigned num_offsets = c->plan->num_output_glyphs () + 1;
unsigned entry_size = use_short_loca ? 2 : 4;
char *loca_prime_data = (char *) hb_malloc (entry_size * num_offsets);
```

Since the multiplication is performed using the `unsigned int` type, an integer overflow may occur, causing the result to wrap around to a much smaller value. This leads to allocating an undersized buffer, which can result in out-of-bounds writes.

The `hb_malloc` function (defined in `/src/hb-common.cc`) takes a parameter of type `size_t`:

```c
void* hb_malloc(size_t size) { return hb_malloc_impl(size); }
```

To avoid the overflow, an explicit cast should be added so that `num_offsets` is converted to `size_t` before the multiplication. This ensures that the product is calculated in the `size_t` domain instead of the `unsigned int` domain, preventing the integer overflow vulnerability.