### PR TITLE
[repacker] bug fix for splitting shared subtables

### DIFF
--- a/src/graph/graph.hh
+++ b/src/graph/graph.hh
@@ -1104,24 +1104,6 @@ struct graph_t
    *
    * Returns the index of the newly created duplicate.
    *
-   * If the child_idx only has incoming edges from parent_idx, this
-   * will do nothing and return the original child_idx.
-   */
-  unsigned duplicate_if_shared (unsigned parent_idx, unsigned child_idx)
-  {
-    unsigned new_idx = duplicate (parent_idx, child_idx);
-    if (new_idx == (unsigned) -1) return child_idx;
-    return new_idx;
-  }
-
-
-  /*
-   * Creates a copy of child and re-assigns the link from
-   * parent to the clone. The copy is a shallow copy, objects
-   * linked from child are not duplicated.
-   *
-   * Returns the index of the newly created duplicate.
-   *
    * If the child_idx only has incoming edges from parent_idx,
    * duplication isn't possible and this will return -1.
    */
@@ -1256,6 +1238,34 @@ struct graph_t
     clone->space = 0;
 
     return clone_idx;
+  }
+
+  /*
+   * Creates a new child node and remap the old child to it.
+   *
+   * Returns the index of the newly created child.
+   *
+   */
+  unsigned remap_child (unsigned parent_idx, unsigned old_child_idx)
+  {
+    unsigned new_child_idx = duplicate (old_child_idx);
+    if (new_child_idx == (unsigned) -1) return -1;
+
+    auto& parent = vertices_[parent_idx];
+    for (auto& l : parent.obj.real_links)
+    {
+      if (l.objidx != old_child_idx)
+        continue;
+      reassign_link (l, parent_idx, new_child_idx, false);
+    }
+
+    for (auto& l : parent.obj.virtual_links)
+    {
+      if (l.objidx != old_child_idx)
+        continue;
+      reassign_link (l, parent_idx, new_child_idx, true);
+    }
+    return new_child_idx;
   }
 
   /*

--- a/src/graph/gsubgpos-context.hh
+++ b/src/graph/gsubgpos-context.hh
@@ -41,6 +41,7 @@ struct gsubgpos_graph_context_t
   unsigned lookup_list_index;
   hb_hashmap_t<unsigned, graph::Lookup*> lookups;
   hb_hashmap_t<unsigned, unsigned> subtable_to_extension;
+  hb_hashmap_t<unsigned, hb_vector_t<unsigned>> split_subtables;
 
   HB_INTERNAL gsubgpos_graph_context_t (hb_tag_t table_tag_,
                                         graph_t& graph_);

--- a/src/graph/gsubgpos-graph.hh
+++ b/src/graph/gsubgpos-graph.hh
@@ -138,10 +138,8 @@ struct Lookup : public OT::Lookup
     for (unsigned i = 0; i < subTable.len; i++)
     {
       unsigned subtable_index = c.graph.index_for_offset (this_index, &subTable[i]);
-      unsigned parent_index = this_index;
       if (is_ext) {
         unsigned ext_subtable_index = subtable_index;
-        parent_index = ext_subtable_index;
         ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>* extension =
             (ExtensionFormat1<OT::Layout::GSUB_impl::ExtensionSubst>*)
             c.graph.object (ext_subtable_index).head;
@@ -154,31 +152,43 @@ struct Lookup : public OT::Lookup
           continue;
       }
 
-      hb_vector_t<unsigned> new_sub_tables;
-
-      if (c.table_tag == HB_OT_TAG_GPOS) {
-        switch (type)
-        {
-        case 2:
-          new_sub_tables = split_subtable<PairPos> (c, parent_index, subtable_index); break;
-        case 4:
-          new_sub_tables = split_subtable<MarkBasePos> (c, parent_index, subtable_index); break;
-        default:
-          break;
-        }
-      } else if (c.table_tag == HB_OT_TAG_GSUB) {
-        switch (type)
-        {
-        case 4:
-          new_sub_tables = split_subtable<graph::LigatureSubst> (c, parent_index, subtable_index); break;
-        default:
-          break;
-        }
+      hb_vector_t<unsigned>* split_result;
+      if (c.split_subtables.has (subtable_index, &split_result))
+      {
+        if (split_result->length == 0)
+          continue;
+        all_new_subtables.push (hb_pair(i, *split_result));
       }
+      else
+      {
+        hb_vector_t<unsigned> new_sub_tables;
 
-      if (new_sub_tables.in_error ()) return false;
-      if (!new_sub_tables) continue;
-      all_new_subtables.push (hb_pair (i, std::move (new_sub_tables)));
+        if (c.table_tag == HB_OT_TAG_GPOS) {
+          switch (type)
+          {
+          case 2:
+            new_sub_tables = split_subtable<PairPos> (c, subtable_index); break;
+          case 4:
+            new_sub_tables = split_subtable<MarkBasePos> (c, subtable_index); break;
+          default:
+            break;
+          }
+        } else if (c.table_tag == HB_OT_TAG_GSUB) {
+          switch (type)
+          {
+          case 4:
+            new_sub_tables = split_subtable<graph::LigatureSubst> (c, subtable_index); break;
+          default:
+            break;
+          }
+        }
+
+        if (new_sub_tables.in_error ()) return false;
+
+        c.split_subtables.set (subtable_index, new_sub_tables);
+        if (new_sub_tables)
+          all_new_subtables.push (hb_pair (i, std::move (new_sub_tables)));
+      }
     }
 
     if (all_new_subtables) {
@@ -190,14 +200,13 @@ struct Lookup : public OT::Lookup
 
   template<typename T>
   hb_vector_t<unsigned> split_subtable (gsubgpos_graph_context_t& c,
-                                        unsigned parent_idx,
                                         unsigned objidx)
   {
     T* sub_table = (T*) c.graph.object (objidx).head;
     if (!sub_table || !sub_table->sanitize (c.graph.vertices_[objidx]))
       return hb_vector_t<unsigned> ();
 
-    return sub_table->split_subtables (c, parent_idx, objidx);
+    return sub_table->split_subtables (c, objidx);
   }
 
   bool add_sub_tables (gsubgpos_graph_context_t& c,

--- a/src/graph/ligature-graph.hh
+++ b/src/graph/ligature-graph.hh
@@ -67,14 +67,13 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
   }
 
   hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
-                                         unsigned parent_index,
                                          unsigned this_index)
   {
-    auto split_points = compute_split_points(c, parent_index, this_index);
+    auto split_points = compute_split_points(c, this_index);
     split_context_t split_context {
       c,
       this,
-      c.graph.duplicate_if_shared (parent_index, this_index),
+      this_index,
       total_number_ligas(c, this_index),
       liga_counts(c, this_index),
     };
@@ -123,7 +122,6 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
   }
 
   hb_vector_t<unsigned> compute_split_points(gsubgpos_graph_context_t& c,
-                                             unsigned parent_index,
                                              unsigned this_index) const
   {
     // For ligature subst coverage is always packed last, and as a result is where an overflow
@@ -441,26 +439,35 @@ struct LigatureSubstFormat1 : public OT::Layout::GSUB_impl::LigatureSubstFormat1
     }
 
     // Adjust liga set array
-    c.graph.vertices_[this_index].obj.tail -= (ligatureSet.len - new_liga_set_count) * SmallTypes::size;
+    auto& this_vertex = c.graph.vertices_[this_index];
+    this_vertex.obj.tail -= (ligatureSet.len - new_liga_set_count) * SmallTypes::size;
     ligatureSet.len = new_liga_set_count;
 
     // Coverage matches the number of liga sets so rebuild as needed
-    auto coverage = c.graph.as_mutable_table<Coverage> (this_index, &this->coverage);
-    if (!coverage) return false;
+    unsigned coverage_idx = c.graph.index_for_offset (this_index, &this->coverage);
+    if (coverage_idx == (unsigned) -1) return false;
+
+    auto& coverage_v = c.graph.vertices_[coverage_idx];
+    if (coverage_v.is_shared ())
+    {
+      coverage_idx = c.graph.remap_child (this_index, coverage_idx);
+      if (coverage_idx == (unsigned) -1) return false;
+    }
 
     for (unsigned i : retained_indices.iter())
-      add_virtual_link(c, i, coverage.index);
+      add_virtual_link(c, i, coverage_idx);
 
-    unsigned coverage_size = coverage.vertex->table_size ();
+    unsigned coverage_size = coverage_v.table_size ();
+    Coverage* coverage_table = (Coverage*) coverage_v.obj.head;
     auto new_coverage =
-        + hb_zip (coverage.table->iter (), hb_range ())
+        + hb_zip (coverage_table->iter (), hb_range ())
         | hb_filter ([&] (hb_pair_t<unsigned, unsigned> p) {
           return p.second < new_liga_set_count;
         })
         | hb_map_retains_sorting (hb_first)
         ;
 
-    return Coverage::make_coverage (c, new_coverage, coverage.index, coverage_size);
+    return Coverage::make_coverage (c, new_coverage, coverage_idx, coverage_size);
   }
 };
 
@@ -468,12 +475,11 @@ struct LigatureSubst : public OT::Layout::GSUB_impl::LigatureSubst
 {
 
   hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
-                                         unsigned parent_index,
                                          unsigned this_index)
   {
     switch (u.format.v) {
     case 1:
-      return ((LigatureSubstFormat1*)(&u.format1))->split_subtables (c, parent_index, this_index);
+      return ((LigatureSubstFormat1*)(&u.format1))->split_subtables (c, this_index);
 #ifndef HB_NO_BEYOND_64K
     case 2: HB_FALLTHROUGH;
       // Don't split 24bit Ligature Subs

--- a/src/graph/markbasepos-graph.hh
+++ b/src/graph/markbasepos-graph.hh
@@ -212,7 +212,6 @@ struct MarkBasePosFormat1 : public OT::Layout::GPOS_impl::MarkBasePosFormat1_2<S
   }
 
   hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
-                                         unsigned parent_index,
                                          unsigned this_index)
   {
     hb_set_t visited;
@@ -265,7 +264,7 @@ struct MarkBasePosFormat1 : public OT::Layout::GPOS_impl::MarkBasePosFormat1_2<S
     split_context_t split_context {
       c,
       this,
-      c.graph.duplicate_if_shared (parent_index, this_index),
+      this_index,
       std::move (class_to_info),
       c.graph.vertices_[mark_array_id].position_to_index_map (),
     };
@@ -478,12 +477,11 @@ struct MarkBasePosFormat1 : public OT::Layout::GPOS_impl::MarkBasePosFormat1_2<S
 struct MarkBasePos : public OT::Layout::GPOS_impl::MarkBasePos
 {
   hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
-                                         unsigned parent_index,
                                          unsigned this_index)
   {
     switch (u.format.v) {
     case 1:
-      return ((MarkBasePosFormat1*)(&u.format1))->split_subtables (c, parent_index, this_index);
+      return ((MarkBasePosFormat1*)(&u.format1))->split_subtables (c, this_index);
 #ifndef HB_NO_BEYOND_64K
     case 2: HB_FALLTHROUGH;
       // Don't split 24bit MarkBasePos's.

--- a/src/graph/pairpos-graph.hh
+++ b/src/graph/pairpos-graph.hh
@@ -49,7 +49,6 @@ struct PairPosFormat1 : public OT::Layout::GPOS_impl::PairPosFormat1_3<SmallType
   }
 
   hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
-                                         unsigned parent_index,
                                          unsigned this_index)
   {
     hb_set_t visited;
@@ -84,7 +83,7 @@ struct PairPosFormat1 : public OT::Layout::GPOS_impl::PairPosFormat1_3<SmallType
     split_context_t split_context {
       c,
       this,
-      c.graph.duplicate_if_shared (parent_index, this_index),
+      this_index,
     };
 
     return actuate_subtable_split<split_context_t> (split_context, split_points);
@@ -207,7 +206,6 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
   }
 
   hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
-                                         unsigned parent_index,
                                          unsigned this_index)
   {
     const unsigned base_size = OT::Layout::GPOS_impl::PairPosFormat2_4<SmallTypes>::min_size;
@@ -291,7 +289,7 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
     split_context_t split_context {
       c,
       this,
-      c.graph.duplicate_if_shared (parent_index, this_index),
+      this_index,
       class1_record_size,
       total_value_len,
       value_1_len,
@@ -607,14 +605,13 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
 struct PairPos : public OT::Layout::GPOS_impl::PairPos
 {
   hb_vector_t<unsigned> split_subtables (gsubgpos_graph_context_t& c,
-                                         unsigned parent_index,
                                          unsigned this_index)
   {
     switch (u.format.v) {
     case 1:
-      return ((PairPosFormat1*)(&u.format1))->split_subtables (c, parent_index, this_index);
+      return ((PairPosFormat1*)(&u.format1))->split_subtables (c, this_index);
     case 2:
-      return ((PairPosFormat2*)(&u.format2))->split_subtables (c, parent_index, this_index);
+      return ((PairPosFormat2*)(&u.format2))->split_subtables (c, this_index);
 #ifndef HB_NO_BEYOND_64K
     case 3: HB_FALLTHROUGH;
     case 4: HB_FALLTHROUGH;


### PR DESCRIPTION
And also fixed splitting for ligatureSubst table with shared coverage table. LigatureSubst table is special because there're virtual links to the coverage table so [as_mutable_table()](https://github.com/harfbuzz/harfbuzz/blob/5ef5240e94de5cbeeb57caf9e57c946b17c9290f/src/graph/ligature-graph.hh#L448) is not duplicating coverage table when it's shared.
