### PR TITLE
Speedometer hb backport

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,403 @@
+# Copyright 2014 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/buildflags_paint_preview.gni")
+import("//build/config/chrome_build.gni")
+import("//build/config/ui.gni")
+import("//testing/libfuzzer/fuzzer_test.gni")
+import("//third_party/harfbuzz-ng/harfbuzz.gni")
+
+if (use_system_harfbuzz) {
+  import("//build/config/linux/pkg_config.gni")
+  pkg_config("harfbuzz_from_pkgconfig") {
+    visibility = [
+      "//third_party/freetype",
+      "//third_party/harfbuzz-ng",
+    ]
+    packages = [
+      "harfbuzz",
+      "harfbuzz-subset",
+    ]
+  }
+
+  component("harfbuzz-ng") {
+    public_configs = [ ":harfbuzz_from_pkgconfig" ]
+  }
+} else {
+  config("harfbuzz_config") {
+    include_dirs = [ "src/src" ]
+  }
+
+  config("harfbuzz_warnings") {
+    if (is_win) {
+      # Result of 32-bit shift implicitly converted to 64 bits.
+      cflags = [ "/wd4334" ]
+    }
+  }
+
+  component("harfbuzz-ng") {
+    public = [
+      "src/src/hb-blob.h",
+      "src/src/hb-buffer.h",
+      "src/src/hb-common.h",
+      "src/src/hb-cplusplus.hh",
+      "src/src/hb-deprecated.h",
+      "src/src/hb-face.h",
+      "src/src/hb-font.h",
+      "src/src/hb-icu.h",
+      "src/src/hb-map.h",
+      "src/src/hb-ot-color.h",
+      "src/src/hb-ot-font.h",
+      "src/src/hb-ot-layout.h",
+      "src/src/hb-ot-math.h",
+      "src/src/hb-ot-shape.h",
+      "src/src/hb-ot-var.h",
+      "src/src/hb-ot.h",
+      "src/src/hb-set.h",
+      "src/src/hb-shape-plan.h",
+      "src/src/hb-shape.h",
+      "src/src/hb-subset.h",
+      "src/src/hb-unicode.h",
+      "src/src/hb-version.h",
+      "src/src/hb.h",
+    ]
+
+    sources = [
+      "src/src/hb-aat-layout-ankr-table.hh",
+      "src/src/hb-aat-layout-bsln-table.hh",
+      "src/src/hb-aat-layout-common.hh",
+      "src/src/hb-aat-layout-feat-table.hh",
+      "src/src/hb-aat-layout-just-table.hh",
+      "src/src/hb-aat-layout-kerx-table.hh",
+      "src/src/hb-aat-layout-morx-table.hh",
+      "src/src/hb-aat-layout-opbd-table.hh",
+      "src/src/hb-aat-layout-trak-table.hh",
+      "src/src/hb-aat-layout.cc",
+      "src/src/hb-aat-layout.h",
+      "src/src/hb-aat-layout.hh",
+      "src/src/hb-aat-ltag-table.hh",
+      "src/src/hb-aat-map.cc",
+      "src/src/hb-aat-map.hh",
+      "src/src/hb-aat.h",
+      "src/src/hb-algs.hh",
+      "src/src/hb-array.hh",
+      "src/src/hb-atomic.hh",
+      "src/src/hb-bimap.hh",
+      "src/src/hb-bit-page.hh",
+      "src/src/hb-bit-set-invertible.hh",
+      "src/src/hb-bit-set.hh",
+      "src/src/hb-blob.cc",
+      "src/src/hb-blob.hh",
+      "src/src/hb-buffer-deserialize-json.hh",
+      "src/src/hb-buffer-deserialize-text.hh",
+      "src/src/hb-buffer-serialize.cc",
+      "src/src/hb-buffer.cc",
+      "src/src/hb-buffer.hh",
+      "src/src/hb-cache.hh",
+      "src/src/hb-cff-interp-common.hh",
+      "src/src/hb-cff-interp-cs-common.hh",
+      "src/src/hb-cff-interp-dict-common.hh",
+      "src/src/hb-cff1-interp-cs.hh",
+      "src/src/hb-cff2-interp-cs.hh",
+      "src/src/hb-common.cc",
+      "src/src/hb-config.hh",
+      "src/src/hb-debug.hh",
+      "src/src/hb-dispatch.hh",
+      "src/src/hb-draw.cc",
+      "src/src/hb-draw.h",
+      "src/src/hb-draw.hh",
+      "src/src/hb-face.cc",
+      "src/src/hb-face.hh",
+      "src/src/hb-font.cc",
+      "src/src/hb-font.hh",
+      "src/src/hb-ft.cc",
+      "src/src/hb-icu.cc",
+      "src/src/hb-iter.hh",
+      "src/src/hb-kern.hh",
+      "src/src/hb-machinery.hh",
+      "src/src/hb-map.cc",
+      "src/src/hb-map.hh",
+      "src/src/hb-meta.hh",
+      "src/src/hb-ms-feature-ranges.cc",
+      "src/src/hb-ms-feature-ranges.hh",
+      "src/src/hb-mutex.hh",
+      "src/src/hb-null.hh",
+      "src/src/hb-number-parser.hh",
+      "src/src/hb-number.cc",
+      "src/src/hb-number.hh",
+      "src/src/hb-object.hh",
+      "src/src/hb-open-file.hh",
+      "src/src/hb-open-type.hh",
+      "src/src/hb-ot-cff-common.hh",
+      "src/src/hb-ot-cff1-std-str.hh",
+      "src/src/hb-ot-cff1-table.cc",
+      "src/src/hb-ot-cff1-table.hh",
+      "src/src/hb-ot-cff2-table.cc",
+      "src/src/hb-ot-cff2-table.hh",
+      "src/src/hb-ot-cmap-table.hh",
+      "src/src/hb-ot-color-cbdt-table.hh",
+      "src/src/hb-ot-color-colr-table.hh",
+      "src/src/hb-ot-color-colrv1-closure.hh",
+      "src/src/hb-ot-color-cpal-table.hh",
+      "src/src/hb-ot-color-sbix-table.hh",
+      "src/src/hb-ot-color-svg-table.hh",
+      "src/src/hb-ot-color.cc",
+      "src/src/hb-ot-deprecated.h",
+      "src/src/hb-ot-face-table-list.hh",
+      "src/src/hb-ot-face.cc",
+      "src/src/hb-ot-face.hh",
+      "src/src/hb-ot-font.cc",
+      "src/src/hb-ot-gasp-table.hh",
+      "src/src/hb-ot-glyf-table.hh",
+      "src/src/hb-ot-hdmx-table.hh",
+      "src/src/hb-ot-head-table.hh",
+      "src/src/hb-ot-hhea-table.hh",
+      "src/src/hb-ot-hmtx-table.hh",
+      "src/src/hb-ot-kern-table.hh",
+      "src/src/hb-ot-layout-base-table.hh",
+      "src/src/hb-ot-layout-common.hh",
+      "src/src/hb-ot-layout-gdef-table.hh",
+      "src/src/hb-ot-layout-gpos-table.hh",
+      "src/src/hb-ot-layout-gsub-table.hh",
+      "src/src/hb-ot-layout-gsubgpos.hh",
+      "src/src/hb-ot-layout-jstf-table.hh",
+      "src/src/hb-ot-layout.cc",
+      "src/src/hb-ot-layout.hh",
+      "src/src/hb-ot-map.cc",
+      "src/src/hb-ot-map.hh",
+      "src/src/hb-ot-math-table.hh",
+      "src/src/hb-ot-math.cc",
+      "src/src/hb-ot-maxp-table.hh",
+      "src/src/hb-ot-meta-table.hh",
+      "src/src/hb-ot-meta.cc",
+      "src/src/hb-ot-meta.h",
+      "src/src/hb-ot-metrics.cc",
+      "src/src/hb-ot-metrics.h",
+      "src/src/hb-ot-metrics.hh",
+      "src/src/hb-ot-name-language-static.hh",
+      "src/src/hb-ot-name-language.hh",
+      "src/src/hb-ot-name-table.hh",
+      "src/src/hb-ot-name.cc",
+      "src/src/hb-ot-name.h",
+      "src/src/hb-ot-os2-table.hh",
+      "src/src/hb-ot-os2-unicode-ranges.hh",
+      "src/src/hb-ot-post-macroman.hh",
+      "src/src/hb-ot-post-table-v2subset.hh",
+      "src/src/hb-ot-post-table.hh",
+      "src/src/hb-ot-shape-complex-arabic-fallback.hh",
+      "src/src/hb-ot-shape-complex-arabic-joining-list.hh",
+      "src/src/hb-ot-shape-complex-arabic-table.hh",
+      "src/src/hb-ot-shape-complex-arabic.cc",
+      "src/src/hb-ot-shape-complex-arabic.hh",
+      "src/src/hb-ot-shape-complex-default.cc",
+      "src/src/hb-ot-shape-complex-hangul.cc",
+      "src/src/hb-ot-shape-complex-hebrew.cc",
+      "src/src/hb-ot-shape-complex-indic-machine.hh",
+      "src/src/hb-ot-shape-complex-indic-table.cc",
+      "src/src/hb-ot-shape-complex-indic.cc",
+      "src/src/hb-ot-shape-complex-indic.hh",
+      "src/src/hb-ot-shape-complex-khmer-machine.hh",
+      "src/src/hb-ot-shape-complex-khmer.cc",
+      "src/src/hb-ot-shape-complex-khmer.hh",
+      "src/src/hb-ot-shape-complex-myanmar-machine.hh",
+      "src/src/hb-ot-shape-complex-myanmar.cc",
+      "src/src/hb-ot-shape-complex-myanmar.hh",
+      "src/src/hb-ot-shape-complex-syllabic.cc",
+      "src/src/hb-ot-shape-complex-syllabic.hh",
+      "src/src/hb-ot-shape-complex-thai.cc",
+      "src/src/hb-ot-shape-complex-use-machine.hh",
+      "src/src/hb-ot-shape-complex-use-table.hh",
+      "src/src/hb-ot-shape-complex-use.cc",
+      "src/src/hb-ot-shape-complex-vowel-constraints.cc",
+      "src/src/hb-ot-shape-complex-vowel-constraints.hh",
+      "src/src/hb-ot-shape-complex.hh",
+      "src/src/hb-ot-shape-fallback.cc",
+      "src/src/hb-ot-shape-fallback.hh",
+      "src/src/hb-ot-shape-normalize.cc",
+      "src/src/hb-ot-shape-normalize.hh",
+      "src/src/hb-ot-shape.cc",
+      "src/src/hb-ot-shape.hh",
+      "src/src/hb-ot-stat-table.hh",
+      "src/src/hb-ot-tag-table.hh",
+      "src/src/hb-ot-tag.cc",
+      "src/src/hb-ot-var-avar-table.hh",
+      "src/src/hb-ot-var-fvar-table.hh",
+      "src/src/hb-ot-var-gvar-table.hh",
+      "src/src/hb-ot-var-hvar-table.hh",
+      "src/src/hb-ot-var-mvar-table.hh",
+      "src/src/hb-ot-var.cc",
+      "src/src/hb-ot-vorg-table.hh",
+      "src/src/hb-pool.hh",
+      "src/src/hb-priority-queue.hh",
+      "src/src/hb-repacker.hh",
+      "src/src/hb-sanitize.hh",
+      "src/src/hb-serialize.hh",
+      "src/src/hb-set-digest.hh",
+      "src/src/hb-set.cc",
+      "src/src/hb-set.hh",
+      "src/src/hb-shape-plan.cc",
+      "src/src/hb-shape-plan.hh",
+      "src/src/hb-shape.cc",
+      "src/src/hb-shaper-impl.hh",
+      "src/src/hb-shaper-list.hh",
+      "src/src/hb-shaper.cc",
+      "src/src/hb-shaper.hh",
+      "src/src/hb-static.cc",
+      "src/src/hb-string-array.hh",
+      "src/src/hb-subset-cff-common.cc",
+      "src/src/hb-subset-cff-common.hh",
+      "src/src/hb-subset-cff1.cc",
+      "src/src/hb-subset-cff1.hh",
+      "src/src/hb-subset-cff2.cc",
+      "src/src/hb-subset-cff2.hh",
+      "src/src/hb-subset-input.cc",
+      "src/src/hb-subset-input.hh",
+      "src/src/hb-subset-plan.cc",
+      "src/src/hb-subset-plan.hh",
+      "src/src/hb-subset.cc",
+      "src/src/hb-subset.hh",
+      "src/src/hb-ucd-table.hh",
+      "src/src/hb-ucd.cc",
+      "src/src/hb-unicode-emoji-table.hh",
+      "src/src/hb-unicode.cc",
+      "src/src/hb-unicode.hh",
+      "src/src/hb-utf.hh",
+      "src/src/hb-vector.hh",
+      "src/src/hb.hh",
+    ]
+
+    # The following sources are explictly not used.
+    # They are referenced to aid in detecting previously uncategorized files.
+    unused_sources = [
+      "src/src/hb-coretext.cc",
+      "src/src/hb-coretext.h",
+      "src/src/hb-directwrite.cc",
+      "src/src/hb-directwrite.h",
+      "src/src/hb-fallback-shape.cc",
+      "src/src/hb-gdi.cc",
+      "src/src/hb-gdi.h",
+      "src/src/hb-gobject-structs.cc",
+      "src/src/hb-gobject-structs.h",
+      "src/src/hb-gobject.h",
+      "src/src/hb-graphite2.cc",
+      "src/src/hb-graphite2.h",
+      "src/src/hb-ot-shape-complex-arabic-win1256.hh",
+      "src/src/hb-style.cc",
+      "src/src/hb-style.h",
+      "src/src/hb-uniscribe.cc",
+      "src/src/hb-uniscribe.h",
+    ]
+    assert(unused_sources != [])
+
+    defines = [
+      "HAVE_OT",
+      "HAVE_ICU",
+      "HAVE_ICU_BUILTIN",
+      "HB_NO_MMAP",
+      "HB_NO_RESOURCE_FORK",
+
+      # Use assignment to empty value to work around a build failure.
+      "HB_NO_PAINT=",
+
+      # Size reductions by disabling parts that we do not currently require:
+
+      # SkPDF needs subsetting but does not require subsetting of layout or CFF tables.
+      "HB_NO_SUBSET_LAYOUT",
+      "HB_NO_SUBSET_CFF",
+
+      # Fallback shaper not required, we only use the HarfBuzz internal OT shaper.
+      "HB_NO_FALLBACK_SHAPE",
+
+      # Tells HarfBuzz to use ICU instead of the own mini UCDN implementation
+      # that is part of HarfBuzz.
+      "HB_NO_UCD",
+
+      # Disable .fon file support, not needed for Chrome, and code behind this
+      # flag produces warnings in Clang. Compare https://crbug.com/1002945.
+      "HB_NO_WIN1256",
+
+      # TODO(https://crbug.com/949962): Remove once this is fixed upstream.
+      "U_DISABLE_VERSION_SUFFIX=0",
+
+      # Buffer verification not used in production build.
+      "HB_NO_BUFFER_VERIFY",
+
+      # We're not using HarfBuzz' drawing functions or debug tools in this build.
+      "HB_NO_DRAW",
+
+      # Don't ship experimental extensions.
+      "HB_NO_BORING_EXPANSION",
+
+      # Don't ship AVAR2 yet.
+      "HB_NO_AVAR2",
+
+    ]
+
+    if (!is_win && !is_mac) {
+      # Needed for HarfBuzz mutex implementation, see hb-mutex.hh
+      defines += [ "HAVE_PTHREAD" ]
+    }
+
+    if (enable_paint_preview) {
+      # Paint Previews make use of CFF subsetting. However, enabling this is
+      # expensive for binary size so only compile it when Paint Previews are
+      # compiled.
+      defines -= [ "HB_NO_SUBSET_CFF" ]
+    }
+
+    if (is_component_build) {
+      if (is_win) {
+        defines += [ "HB_EXTERN=__declspec(dllexport)" ]
+      } else {
+        defines += [ "HB_EXTERN=__attribute__((visibility(\"default\")))" ]
+      }
+    }
+
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [
+      "//build/config/compiler:no_chromium_code",
+
+      # Must be after no_chromium_code for warning flags to be ordered
+      # correctly.
+      ":harfbuzz_warnings",
+    ]
+
+    # This allows the compiler to do further optimizations in the code.
+    if (!is_debug) {
+      configs -= [ "//build/config/compiler:default_optimization" ]
+      configs += [ "//build/config/compiler:optimize_speed" ]
+    }
+
+    public_configs = [ ":harfbuzz_config" ]
+
+    deps = [ "//third_party/icu:icuuc" ]
+
+    if (use_glib) {
+      configs += [ "//build/config/linux:glib" ]
+      public += [ "src/src/hb-glib.h" ]
+      sources += [ "src/src/hb-glib.cc" ]
+    }
+  }
+}
+
+# Not all checkouts have a //base directory.
+if (build_with_chromium) {
+  fuzzer_test("hb_shape_fuzzer") {
+    sources = [ "fuzz/hb_shape_fuzzer.cc" ]
+    deps = [
+      "//base",
+      "//third_party/harfbuzz-ng",
+    ]
+    seed_corpus = "fuzz/seed_corpus"
+  }
+
+  fuzzer_test("hb_subset_fuzzer") {
+    sources = [ "fuzz/hb_subset_fuzzer.cc" ]
+    deps = [
+      "//base",
+      "//third_party/harfbuzz-ng",
+    ]
+    seed_corpus = "fuzz/seed_corpus"
+  }
+}

--- a/src/hb-cplusplus.hh
+++ b/src/hb-cplusplus.hh
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2022 Behdad Esfahbod
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#ifndef HB_CPLUSPLUS_HH
+#define HB_CPLUSPLUS_HH
+
+#include "hb.h"
+
+#ifdef __cplusplus
+
+#include <functional>
+#include <utility>
+
+#if 0
+#if !(__cplusplus >= 201103L)
+#error "HarfBuzz C++ helpers require C++11"
+#endif
+#endif
+
+namespace hb {
+
+
+template <typename T>
+struct vtable;
+
+template <typename T>
+struct shared_ptr
+{
+  using element_type = T;
+
+  using v = vtable<T>;
+
+  explicit shared_ptr (T *p = nullptr) : p (p) {}
+  shared_ptr (const shared_ptr &o) : p (v::reference (o.p)) {}
+  shared_ptr (shared_ptr &&o)  noexcept : p (o.p) { o.p = nullptr; }
+  shared_ptr& operator = (const shared_ptr &o) { if (p != o.p) { destroy (); p = o.p; reference (); } return *this; }
+  shared_ptr& operator = (shared_ptr &&o)  noexcept { v::destroy (p); p = o.p; o.p = nullptr; return *this; }
+  ~shared_ptr () { v::destroy (p); p = nullptr; }
+
+  T* get() const { return p; }
+
+  void swap (shared_ptr &o)  noexcept { std::swap (p, o.p); }
+  friend void swap (shared_ptr &a, shared_ptr &b)  noexcept { std::swap (a.p, b.p); }
+
+  operator T * () const { return p; }
+  T& operator * () const { return *get (); }
+  T* operator -> () const { return get (); }
+  operator bool () const { return p; }
+  bool operator == (const shared_ptr &o) const { return p == o.p; }
+  bool operator != (const shared_ptr &o) const { return p != o.p; }
+
+  static T* get_empty() { return v::get_empty (); }
+  T* reference() { return v::reference (p); }
+  void destroy() { v::destroy (p); }
+
+  private:
+  T *p;
+};
+
+template<typename T> struct is_shared_ptr : std::false_type {};
+template<typename T> struct is_shared_ptr<shared_ptr<T>> : std::true_type {};
+
+template <typename T>
+struct unique_ptr
+{
+  using element_type = T;
+
+  using v = vtable<T>;
+
+  explicit unique_ptr (T *p = nullptr) : p (p) {}
+  unique_ptr (const unique_ptr &o) = delete;
+  unique_ptr (unique_ptr &&o)  noexcept : p (o.p) { o.p = nullptr; }
+  unique_ptr& operator = (const unique_ptr &o) = delete;
+  unique_ptr& operator = (unique_ptr &&o)  noexcept { v::destroy (p); p = o.p; o.p = nullptr; return *this; }
+  ~unique_ptr () { v::destroy (p); p = nullptr; }
+
+  T* get() const { return p; }
+  T* release () { T* v = p; p = nullptr; return v; }
+
+  void swap (unique_ptr &o)  noexcept { std::swap (p, o.p); }
+  friend void swap (unique_ptr &a, unique_ptr &b)  noexcept { std::swap (a.p, b.p); }
+
+  operator T * () const { return p; }
+  T& operator * () const { return *get (); }
+  T* operator -> () const { return get (); }
+  operator bool () { return p; }
+
+  private:
+  T *p;
+};
+
+template<typename T> struct is_unique_ptr : std::false_type {};
+template<typename T> struct is_unique_ptr<unique_ptr<T>> : std::true_type {};
+
+template <typename T,
+	  T * (*_get_empty) (void),
+	  T * (*_reference) (T *),
+	  void (*_destroy) (T *)>
+struct vtable_t
+{
+  static constexpr auto get_empty = _get_empty;
+  static constexpr auto reference = _reference;
+  static constexpr auto destroy = _destroy;
+};
+
+#define HB_DEFINE_VTABLE(name) \
+	template<> \
+	struct vtable<hb_##name##_t> \
+	     : vtable_t<hb_##name##_t, \
+			&hb_##name##_get_empty, \
+			&hb_##name##_reference, \
+			&hb_##name##_destroy> {}
+
+HB_DEFINE_VTABLE (buffer);
+HB_DEFINE_VTABLE (blob);
+HB_DEFINE_VTABLE (face);
+HB_DEFINE_VTABLE (font);
+HB_DEFINE_VTABLE (font_funcs);
+HB_DEFINE_VTABLE (map);
+HB_DEFINE_VTABLE (set);
+HB_DEFINE_VTABLE (shape_plan);
+HB_DEFINE_VTABLE (unicode_funcs);
+
+#undef HB_DEFINE_VTABLE
+
+
+#ifdef HB_SUBSET_H
+
+#define HB_DEFINE_VTABLE(name) \
+	template<> \
+	struct vtable<hb_##name##_t> \
+	     : vtable_t<hb_##name##_t, \
+			nullptr, \
+			&hb_##name##_reference, \
+			&hb_##name##_destroy> {}
+
+
+HB_DEFINE_VTABLE (subset_input);
+
+#undef HB_DEFINE_VTABLE
+
+#endif
+
+
+} // namespace hb
+
+/* Workaround for GCC < 7, see:
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
+ * https://stackoverflow.com/a/25594741 */
+namespace std {
+
+
+template<typename T>
+struct hash<hb::shared_ptr<T>>
+{
+    std::size_t operator()(const hb::shared_ptr<T>& v) const noexcept
+    {
+        std::size_t h = std::hash<decltype (v.get ())>{}(v.get ());
+        return h;
+    }
+};
+
+template<typename T>
+struct hash<hb::unique_ptr<T>>
+{
+    std::size_t operator()(const hb::unique_ptr<T>& v) const noexcept
+    {
+        std::size_t h = std::hash<decltype (v.get ())>{}(v.get ());
+        return h;
+    }
+};
+
+
+} // namespace std
+
+#endif /* __cplusplus */
+
+#endif /* HB_CPLUSPLUS_HH */


### PR DESCRIPTION
This is a fork from HB 3.0.0 tag, with backported `hb-cplusplus.hh`, to build a Chrome with and do performance testing against current HB.