### PR TITLE
Fix two bugs in hb_set_is_subset().

### DIFF
--- a/src/hb-bit-set-invertible.hh
+++ b/src/hb-bit-set-invertible.hh
@@ -173,7 +173,14 @@ struct hb_bit_set_invertible_t
   bool is_subset (const hb_bit_set_invertible_t &larger_set) const
   {
     if (unlikely (inverted != larger_set.inverted))
-      return hb_all (hb_iter (s) | hb_map (larger_set.s));
+    {
+      if (inverted)
+	return hb_all (iter (), larger_set.s);
+      else
+        // larger set is inverted so larger_set.s is the set of things that are not present
+        // in larger_set, therefore if s has any of those it can't be a subset.
+	return !s.intersects (larger_set.s);
+    }
     else
       return unlikely (inverted) ? larger_set.s.is_subset (s) : s.is_subset (larger_set.s);
   }

--- a/src/hb-bit-set.hh
+++ b/src/hb-bit-set.hh
@@ -438,23 +438,31 @@ struct hb_bit_set_t
       return false;
 
     uint32_t spi = 0;
-    for (uint32_t lpi = 0; spi < page_map.length && lpi < larger_set.page_map.length; lpi++)
+    uint32_t lpi = 0;
+    while (spi < page_map.length && lpi < larger_set.page_map.length)
     {
       uint32_t spm = page_map.arrayZ[spi].major;
       uint32_t lpm = larger_set.page_map.arrayZ[lpi].major;
       auto sp = page_at (spi);
 
-      if (spm < lpm && !sp.is_empty ())
-        return false;
-
-      if (lpm < spm)
+      if (spm < lpm) {
+        if (!sp.is_empty ())
+          return false;
+        spi++;
         continue;
+      }
+
+      if (lpm < spm) {
+        lpi++;
+        continue;
+      }
 
       auto lp = larger_set.page_at (lpi);
       if (!sp.is_subset (lp))
         return false;
 
       spi++;
+      lpi++;
     }
 
     while (spi < page_map.length)


### PR DESCRIPTION
1. If smaller set has empty pages the subset checking logic was incorrectly incrementing the larger page index after skipping the empty smaller page index.
2. The logic for is_subset() on mixed inverted/not inverted sets was wrong.