### PR TITLE
[hb-directwrite] Fix building with `HB_DISABLE_DEPRECATED`

### DIFF
--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -452,6 +452,7 @@ hb_directwrite_font_get_dw_font_face (hb_font_t *font)
   return (IDWriteFontFace *) (const void *) font->data.directwrite;
 }
 
+#ifndef HB_DISABLE_DEPRECATED
 
 /**
 * hb_directwrite_font_get_dw_font:
@@ -469,5 +470,7 @@ hb_directwrite_font_get_dw_font (hb_font_t *font)
 {
   return nullptr;
 }
+
+#endif
 
 #endif


### PR DESCRIPTION
Fix the following build error with `HB_DISABLE_DEPRECATED`:

```
In file included from harfbuzz\src\harfbuzz.cc:14:
harfbuzz\src\hb-directwrite.cc(468,1): error : no previous prototype for function 'hb_directwrite_font_get_dw_font' [-Werror,-Wmissing-prototypes]
    468 | hb_directwrite_font_get_dw_font (hb_font_t *font)
        | ^
```

`hb_directwrite_font_get_dw_font()` is guarded with `HB_DISABLE_DEPRECATED` only in the header file, but not in the .cc.