### PR TITLE
[buffer] Disallow hb_buffer_set_message_func during callback

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -2298,7 +2298,8 @@ hb_buffer_set_message_func (hb_buffer_t *buffer,
 			    hb_buffer_message_func_t func,
 			    void *user_data, hb_destroy_func_t destroy)
 {
-  if (unlikely (hb_object_is_immutable (buffer)))
+  if (unlikely (hb_object_is_immutable (buffer)) ||
+      unlikely (buffer->message_depth))
   {
     if (destroy)
       destroy (user_data);


### PR DESCRIPTION
## Summary

- Reject re-entrant calls to `hb_buffer_set_message_func()` when called from within a message callback (`message_depth > 0`)
- Previously, calling `hb_buffer_set_message_func()` from inside a message callback would destroy the old `user_data` via the destroy callback while the current callback still held a reference to it, leading to a use-after-free
- The fix checks `buffer->message_depth` alongside the existing immutability check; if non-zero, the new callback's `user_data` is destroyed immediately and the call is silently rejected

## Fixes

GHSA-h4c3-cvr5-ccq2

## Test plan

- [x] All 222 existing tests pass (`meson test -C build` - 0 failures)
- [x] Verified with AddressSanitizer: the UAF no longer triggers with the re-entrant PoC