### PR TITLE
[fuzzer] Fix hb-set-fuzzer reading pointer address instead of input data

### DIFF
--- a/test/fuzzing/hb-set-fuzzer.cc
+++ b/test/fuzzing/hb-set-fuzzer.cc
@@ -47,10 +47,7 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   if (size > MAX_INPUT_SIZE)
     return 0;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-  const instructions_t &instructions = reinterpret_cast<const instructions_t &> (data);
-#pragma GCC diagnostic pop
+  const instructions_t &instructions = reinterpret_cast<const instructions_t &> (*data);
   data += sizeof (instructions_t);
   size -= sizeof (instructions_t);
 


### PR DESCRIPTION
## Summary

`hb-set-fuzzer` has a `reinterpret_cast` bug that causes it to read the **address of the `data` pointer** (determined by ASLR) instead of the actual fuzzer input. This makes `operation` and `first_set_size` uncontrollable by the fuzzer, rendering it nearly useless.

This is **not** a bug in harfbuzz itself — it is a bug in the fuzzer harness.

Fixes #5787

## What's Wrong

```cpp
const instructions_t &instructions = reinterpret_cast<const instructions_t &> (data);
```

In C++, `reinterpret_cast<T&>(x)` is equivalent to `*reinterpret_cast<T*>(&x)`. Since `data` is a `const uint8_t *`, this reads bytes from `&data` (the pointer variable on the stack), not from the buffer `data` points to.

The compiler warned about this (`-Wstrict-aliasing`), but the warning was suppressed with `#pragma` in commit a470b0b2 instead of fixing the root cause.

## Fix

```diff
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-  const instructions_t &instructions = reinterpret_cast<const instructions_t &> (data);
-#pragma GCC diagnostic pop
+  const instructions_t &instructions = reinterpret_cast<const instructions_t &> (*data);
```

Dereference `data` so the cast reads from the input buffer. The `#pragma` is no longer needed.

## Evidence

10-minute fuzzing coverage comparison:

| Version | Lines Covered | Line Coverage | Functions Covered | Function Coverage |
|---------|--------------|---------------|-------------------|-------------------|
| Original | 15 | 0.05% | 2 | 0.04% |
| Fixed | 486 | 1.47% | 144 | 2.68% |
| **Improvement** | **+471** | **29x** | **+142** | **72x** |

## Related

- #2544 noted the fuzzer was inefficient but did not identify this `reinterpret_cast` bug as the root cause.