### PR TITLE
Fix for AIX shared library name change

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -640,6 +640,10 @@ else
   hb_so_version = '0'
 endif
 
+if host_machine.system() == 'aix'
+  version = '0'
+endif
+
 if get_option('fuzzer_ldflags') != ''
   extra_hb_cpp_args += ['-DHB_CUSTOM_MALLOC']
   hb_sources += hb_failing_alloc_sources


### PR DESCRIPTION
#5788 

Reason:

Due to the naming change, resulting from minor version increments, causes failures in runtime dependency resolution. 
Earlier: libharfbuzz.a(libharfbuzz.so.0)
Now: libharfbuzz.a(libharfbuzz.so.0.61230.0)

Fix:

hardcoded version string to lock shared library object name for aix platform 