### PR TITLE
[arabic] Improve stch measurement pass

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -1200,6 +1200,21 @@ hb_unsigned_mul_overflows (unsigned int count, unsigned int size, unsigned *resu
   return (size > 0) && (count >= ((unsigned int) -1) / size);
 }
 
+static inline bool
+hb_unsigned_add_overflows (unsigned int a, unsigned int b, unsigned *result = nullptr)
+{
+#if hb_has_builtin(__builtin_add_overflow)
+  unsigned stack_result;
+  if (!result)
+    result = &stack_result;
+  return __builtin_add_overflow (a, b, result);
+#endif
+
+  if (result)
+    *result = a + b;
+  return b > (unsigned int) -1 - a;
+}
+
 
 /*
  * Sort and search.

--- a/src/hb-ot-shaper-arabic.cc
+++ b/src/hb-ot-shaper-arabic.cc
@@ -584,7 +584,10 @@ apply_stch (const hb_ot_shape_plan_t *plan HB_UNUSED,
 
       if (step == MEASURE)
       {
-	extra_glyphs_needed += n_copies * n_repeating;
+	unsigned int added_glyphs = 0;
+	if (unlikely (hb_unsigned_mul_overflows (n_copies, n_repeating, &added_glyphs) ||
+		      hb_unsigned_add_overflows (extra_glyphs_needed, added_glyphs, &extra_glyphs_needed)))
+	  break;
 	DEBUG_MSG (ARABIC, nullptr, "will add extra %d copies of repeating tiles", n_copies);
       }
       else
@@ -629,7 +632,9 @@ apply_stch (const hb_ot_shape_plan_t *plan HB_UNUSED,
 
     if (step == MEASURE)
     {
-      if (unlikely (!buffer->ensure (count + extra_glyphs_needed)))
+      unsigned int total_glyphs = 0;
+      if (unlikely (hb_unsigned_add_overflows (count, extra_glyphs_needed, &total_glyphs) ||
+		    !buffer->ensure (total_glyphs)))
 	break;
     }
     else


### PR DESCRIPTION
Use checked arithmetic when calculating the number of extra glyphs needed during stch processing. Includes a new hb_unsigned_add_overflows helper in hb-algs.hh.