### PR TITLE
[arabic] Cap stch expansion per run

### DIFF
--- a/src/hb-ot-shaper-arabic.cc
+++ b/src/hb-ot-shaper-arabic.cc
@@ -561,20 +561,29 @@ apply_stch (const hb_ot_shape_plan_t *plan HB_UNUSED,
       DEBUG_MSG (ARABIC, nullptr, "fixed tiles:     count=%d width=%" PRId32, n_fixed, w_fixed);
       DEBUG_MSG (ARABIC, nullptr, "repeating tiles: count=%d width=%" PRId32, n_repeating, w_repeating);
 
-      /* Number of additional times to repeat each repeating tile. */
-      int n_copies = 0;
+      static constexpr unsigned STCH_MAX_GLYPHS = 256;
 
-      hb_position_t w_remaining = w_total - w_fixed;
-      if (sign * w_remaining > sign * w_repeating && sign * w_repeating > 0)
-	n_copies = (sign * w_remaining) / (sign * w_repeating) - 1;
+      /* Number of additional times to repeat each repeating tile. */
+      unsigned int n_copies = 0;
+
+      int64_t w_remaining_signed = (int64_t) w_total - w_fixed;
+      int64_t w_repeating_signed = w_repeating;
+      if (sign < 0)
+      {
+	w_remaining_signed = -w_remaining_signed;
+	w_repeating_signed = -w_repeating_signed;
+      }
+      hb_position_t w_remaining = (hb_position_t) (w_total - w_fixed);
+      if (w_remaining_signed > w_repeating_signed && w_repeating_signed > 0)
+	n_copies = w_remaining_signed / w_repeating_signed - 1;
 
       /* See if we can improve the fit by adding an extra repeat and squeezing them together a bit. */
       hb_position_t extra_repeat_overlap = 0;
-      hb_position_t shortfall = sign * w_remaining - sign * w_repeating * (n_copies + 1);
+      int64_t shortfall = w_remaining_signed - w_repeating_signed * (n_copies + 1);
       if (shortfall > 0 && n_repeating > 0)
       {
 	++n_copies;
-	hb_position_t excess = (n_copies + 1) * sign * w_repeating - sign * w_remaining;
+	int64_t excess = (n_copies + 1) * w_repeating_signed - w_remaining_signed;
 	if (excess > 0)
 	{
 	  extra_repeat_overlap = excess / (n_copies * n_repeating);
@@ -582,13 +591,22 @@ apply_stch (const hb_ot_shape_plan_t *plan HB_UNUSED,
 	}
       }
 
+      unsigned int max_copies = 0;
+      if (n_repeating > 0)
+      {
+	unsigned int base_glyphs = n_fixed + n_repeating;
+	if (base_glyphs < STCH_MAX_GLYPHS)
+	  max_copies = (STCH_MAX_GLYPHS - base_glyphs) / n_repeating;
+      }
+      n_copies = hb_min (n_copies, max_copies);
+
       if (step == MEASURE)
       {
 	unsigned int added_glyphs = 0;
 	if (unlikely (hb_unsigned_mul_overflows (n_copies, n_repeating, &added_glyphs) ||
 		      hb_unsigned_add_overflows (extra_glyphs_needed, added_glyphs, &extra_glyphs_needed)))
 	  break;
-	DEBUG_MSG (ARABIC, nullptr, "will add extra %d copies of repeating tiles", n_copies);
+	DEBUG_MSG (ARABIC, nullptr, "will add extra %u copies of repeating tiles", n_copies);
       }
       else
       {


### PR DESCRIPTION
Cap each stch run to at most 256 output glyphs.

This keeps pathological stretch runs from expanding to unbounded sizes, and switches the repeat-count math to 64-bit intermediates so the cap is applied before 32-bit arithmetic can wrap.

The existing checked accumulation and buffer growth logic stays in place, covering both the per-run overflow and multi-run accumulation cases reported in the recent stch advisories.

Tested: meson test -C build --suite shape
Assisted-by: OpenAI Codex