### PR TITLE
Fix potential buffer overwrite in CFF/CFF2.

### DIFF
--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -1275,11 +1275,21 @@ struct CFFIndex
     if (unlikely (!serialize_header (c, +it, data_size, min_off_size))) return_trace (false);
     unsigned char *ret = c->allocate_size<unsigned char> (data_size, false);
     if (unlikely (!ret)) return_trace (false);
+    unsigned total_bytes = 0;
     for (const auto &_ : +it)
     {
       unsigned len = _.length;
+
       if (!len)
 	continue;
+
+      total_bytes += len;
+
+      if (unlikely (total_bytes > data_size))
+        // We have more bytes to write then the computed data size, so the size calculation
+        // must have encountered overflow.
+        return_trace (c->check_success (false, HB_SERIALIZE_ERROR_INT_OVERFLOW));
+
       if (len <= 1)
       {
 	*ret++ = *_.arrayZ;


### PR DESCRIPTION
Caused by integer overflow in the total_size() calculation.

Based on fix provided by Quang Luong <oss@engineer.ink>

@quangIO 