### PR TITLE
Guard VarData itemCount overflow

### DIFF
--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -2971,7 +2971,9 @@ struct VarData
     }
 
     if (unlikely (!c->extend_min (this))) return_trace (false);
-    itemCount = row_count;
+    if (unlikely (!c->check_assign (itemCount, row_count,
+                                    HB_SERIALIZE_ERROR_INT_OVERFLOW)))
+      return_trace (false);
 
     int min_threshold = has_long ? -65536 : -128;
     int max_threshold = has_long ? +65535 : +127;


### PR DESCRIPTION
Reject oversized merged VarData row sets before assigning them to the 16-bit itemCount field. This avoids truncating the serialized allocation size and prevents the subsequent row write loop from running out of bounds.

 src/hb-ot-layout-common.hh | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)