### PR TITLE
[COLR] Propagate clip extents failures

### DIFF
--- a/src/OT/Color/COLR/COLR.hh
+++ b/src/OT/Color/COLR/COLR.hh
@@ -1814,10 +1814,7 @@ struct ClipList
   {
     auto *rec = clips.as_array ().bsearch (gid);
     if (rec)
-    {
-      rec->get_extents (extents, this, instancer);
-      return true;
-    }
+      return rec->get_extents (extents, this, instancer);
     return false;
   }
 


### PR DESCRIPTION
ClipList::get_extents() returned true for any matching clip record, even when the underlying ClipBox rejected the request.

That left the output extents uninitialized and the paint path could pass them to scale_glyph_extents(), which shows up under MemorySanitizer in clipped COLRv1 raster painting.

Return the ClipRecord result directly so invalid clip boxes fail cleanly instead of exposing uninitialized extents.

Fixes: https://oss-fuzz.com/testcase-detail/4659742604853248
Assisted-by: OpenAI Codex