### PR TITLE
[varStore] Handle >65535 items per encoding

### DIFF
--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -1707,6 +1707,16 @@ struct item_variations_t
   const hb_map_t& get_varidx_map () const
   { return varidx_map; }
 
+  bool add_vardata_encoding_for_testing (hb_vector_t<const hb_vector_t<int>*> &&rows,
+                                         unsigned num_cols)
+  {
+    encodings.push (delta_row_encoding_t (std::move (rows), num_cols));
+    return !encodings.in_error ();
+  }
+
+  bool compile_varidx_map_for_testing (const hb_hashmap_t<unsigned, const hb_vector_t<int>*>& front_mapping)
+  { return compile_varidx_map (front_mapping); }
+
   bool instantiate (const ItemVariationStore& varStore,
                     const hb_subset_plan_t *plan,
                     bool optimize=true,
@@ -2053,26 +2063,45 @@ struct item_variations_t
   {
     /* full encoding_row -> new VarIdxes mapping */
     hb_hashmap_t<const hb_vector_t<int>*, unsigned> back_mapping;
+    hb_vector_t<delta_row_encoding_t> split_encodings;
 
-    for (unsigned major = 0; major < encodings.length; major++)
+    for (unsigned i = 0; i < encodings.length; i++)
     {
-      delta_row_encoding_t& encoding = encodings[major];
+      delta_row_encoding_t& encoding = encodings[i];
       /* just sanity check, this shouldn't happen */
       if (encoding.is_empty ())
         return false;
 
       unsigned num_rows = encoding.items.length;
+      unsigned num_cols = encoding.chars.length;
 
       /* sort rows, make result deterministic */
       encoding.items.qsort (_cmp_row);
 
-      /* compile old to new var_idxes mapping */
-      for (unsigned minor = 0; minor < num_rows; minor++)
+      for (unsigned start = 0; start < num_rows; start += 0xFFFFu)
       {
-        unsigned new_varidx = (major << 16) + minor;
-        back_mapping.set (encoding.items.arrayZ[minor], new_varidx);
+        unsigned chunk_len = hb_min (num_rows - start, 0xFFFFu);
+        hb_vector_t<const hb_vector_t<int>*> rows;
+
+        if (!rows.alloc (chunk_len))
+          return false;
+
+        unsigned major = split_encodings.length;
+        for (unsigned minor = 0; minor < chunk_len; minor++)
+        {
+          const hb_vector_t<int> *row = encoding.items.arrayZ[start + minor];
+          rows.push (row);
+          if (!back_mapping.set (row, (major << 16) + minor))
+            return false;
+        }
+
+        split_encodings.push (delta_row_encoding_t (std::move (rows), num_cols));
       }
     }
+
+    encodings = std::move (split_encodings);
+    if (encodings.in_error () || back_mapping.in_error ())
+      return false;
 
     for (auto _ : front_mapping.iter ())
     {

--- a/src/test-item-varstore.cc
+++ b/src/test-item-varstore.cc
@@ -59,8 +59,79 @@ test_item_variations ()
   hb_always_assert (item_vars.get_region_list().length == 8);
 }
 
+static void
+test_item_variations_overflow ()
+{
+  hb_vector_t<hb_vector_t<int>> row_storage;
+  hb_hashmap_t<unsigned, const hb_vector_t<int>*> front_mapping;
+  OT::item_variations_t item_vars;
+  unsigned old_varidx = 0;
+  const unsigned total_count = 0xFFFFu * 2u;
+
+  const unsigned counts[] = {
+    128u,                 /* 0..127: 1-byte deltas */
+    32768u - 128u,        /* 128..32767: 2-byte deltas */
+    0xFFFFu * 2u - 32768u /* 32768..131069: 4-byte deltas */
+  };
+  const int starts[] = {
+    0,
+    128,
+    32768
+  };
+
+  hb_always_assert (row_storage.alloc (total_count));
+
+  for (unsigned bucket = 0; bucket < 3; bucket++)
+  {
+    hb_vector_t<const hb_vector_t<int>*> rows;
+    hb_always_assert (rows.alloc (counts[bucket]));
+
+    for (unsigned i = 0; i < counts[bucket]; i++)
+    {
+      hb_vector_t<int> row;
+      hb_always_assert (row.resize (1));
+      row[0] = starts[bucket] + i;
+      row_storage.push (std::move (row));
+    }
+
+    hb_always_assert (!row_storage.in_error ());
+
+    unsigned base = row_storage.length - counts[bucket];
+    for (unsigned i = 0; i < counts[bucket]; i++)
+    {
+      const hb_vector_t<int> *row = &row_storage.arrayZ[base + i];
+      rows.push (row);
+      front_mapping.set (old_varidx++, row);
+    }
+
+    hb_always_assert (!rows.in_error ());
+    hb_always_assert (item_vars.add_vardata_encoding_for_testing (std::move (rows), 1));
+  }
+
+  hb_always_assert (!front_mapping.in_error ());
+  hb_always_assert (item_vars.compile_varidx_map_for_testing (front_mapping));
+
+  const auto& encodings = item_vars.get_vardata_encodings ();
+  hb_always_assert (encodings.length == 4);
+  hb_always_assert (encodings[0].items.length == 128u);
+  hb_always_assert (encodings[1].items.length == 32768u - 128u);
+  hb_always_assert (encodings[2].items.length == 0xFFFFu);
+  hb_always_assert (encodings[3].items.length == 32767u);
+
+  const hb_map_t& varidx_map = item_vars.get_varidx_map ();
+  hb_always_assert (varidx_map.get (0) == 0);
+  hb_always_assert (varidx_map.get (127) == 127);
+  hb_always_assert (varidx_map.get (128) == 0x00010000u);
+  hb_always_assert (varidx_map.get (32767) == 0x00017F7Fu);
+  hb_always_assert (varidx_map.get (32768) == 0x00020000u);
+  hb_always_assert (varidx_map.get (98302) == 0x0002FFFEu);
+  hb_always_assert (varidx_map.get (98303) == 0x00030000u);
+  hb_always_assert (varidx_map.get (131069) == 0x00037FFEu);
+}
+
 int
 main (int argc, char **argv)
 {
   test_item_variations ();
+  test_item_variations_overflow ();
 }


### PR DESCRIPTION
Split optimized encodings into multiple VarData subtables before rebuilding VariationIndex mappings. This keeps itemCount within the 16-bit limit when the optimizer produces more than 65535 rows for a single encoding.

Add a regression test that mirrors the FontTools overflow case and checks the split boundaries in the remapped VarIdx output.

Testing: meson compile -C build test-item-varstore
Testing: ./build/src/test-item-varstore
Fixes: #5839
Assisted-by: OpenAI Codex