### PR TITLE
[util] Preserve `--ned` positioning in `--glyphs` input

### DIFF
--- a/util/shape-options.hh
+++ b/util/shape-options.hh
@@ -93,7 +93,7 @@ struct shape_options_t
 				    font,
 				    HB_BUFFER_SERIALIZE_FORMAT_TEXT);
 
-      if (!strchr (glyphs_text, '+'))
+      if (!strchr (glyphs_text, '+') && !strchr (glyphs_text, '@'))
       {
         scale_advances = false;
         unsigned count;


### PR DESCRIPTION
When `--glyphs` input omitted advances but still carried `@` positions, the util-side parser synthesized default advances from the font. That changed the logical width of `hb-shape --ned` output and broke same-size round-trips through `hb-view --glyphs`.

Only synthesize advances when the glyph string has neither explicit advances nor explicit positions.

Tested:
- meson test -C build

Fixes: https://github.com/harfbuzz/harfbuzz/issues/5377
Assisted-by: OpenAI Codex