### PR TITLE
Add start/end compose/decompose messages

### DIFF
--- a/src/hb-ot-shape-normalize.cc
+++ b/src/hb-ot-shape-normalize.cc
@@ -322,6 +322,7 @@ _hb_ot_shape_normalize (const hb_ot_shape_plan_t *plan,
   /* First round, decompose */
 
   bool all_simple = true;
+  if (buffer->message (font, "start decompose"))
   {
     buffer->clear_output ();
     count = buffer->len;
@@ -364,6 +365,7 @@ _hb_ot_shape_normalize (const hb_ot_shape_plan_t *plan,
     }
     while (buffer->idx < count && buffer->successful);
     buffer->sync ();
+    (void) buffer->message (font, "end decompose");
   }
 
 
@@ -420,7 +422,8 @@ _hb_ot_shape_normalize (const hb_ot_shape_plan_t *plan,
   if (!all_simple &&
       buffer->successful &&
       (mode == HB_OT_SHAPE_NORMALIZATION_MODE_COMPOSED_DIACRITICS ||
-       mode == HB_OT_SHAPE_NORMALIZATION_MODE_COMPOSED_DIACRITICS_NO_SHORT_CIRCUIT))
+       mode == HB_OT_SHAPE_NORMALIZATION_MODE_COMPOSED_DIACRITICS_NO_SHORT_CIRCUIT) &&
+      buffer->message (font, "start compose"))
   {
     /* As noted in the comment earlier, we don't try to combine
      * ccc=0 chars with their previous Starter. */
@@ -470,6 +473,7 @@ _hb_ot_shape_normalize (const hb_ot_shape_plan_t *plan,
 	starter = buffer->out_len - 1;
     }
     buffer->sync ();
+    (void) buffer->message (font, "end compose");
   }
 }
 


### PR DESCRIPTION
Similar to start/end reorder messages. It does not give details on what have been composed or decomposed as this seems to be tricky and one can always deduce that from the changes to buffer contents.

* Fixes #5853
