### PR TITLE
Fix for issue #5847 - Horizontal centering of glyphs in vertical runs

### DIFF
--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -406,14 +406,15 @@ hb_font_get_glyph_h_origins_default (hb_font_t *font HB_UNUSED,
 {
   if (font->has_glyph_h_origin_func_set ())
   {
+    hb_bool_t ret = true;
     for (unsigned int i = 0; i < count; i++)
     {
-      font->get_glyph_h_origin (*first_glyph, first_x, first_y, false);
+      ret &= font->get_glyph_h_origin (*first_glyph, first_x, first_y, false);
       first_glyph = &StructAtOffsetUnaligned<hb_codepoint_t> (first_glyph, glyph_stride);
       first_x = &StructAtOffsetUnaligned<hb_position_t> (first_x, x_stride);
       first_y = &StructAtOffsetUnaligned<hb_position_t> (first_y, y_stride);
     }
-    return true;
+    return ret;
   }
 
   hb_bool_t ret = font->parent->get_glyph_h_origins (count,
@@ -448,14 +449,15 @@ hb_font_get_glyph_v_origins_default (hb_font_t *font HB_UNUSED,
 {
   if (font->has_glyph_v_origin_func_set ())
   {
+    hb_bool_t ret = true;
     for (unsigned int i = 0; i < count; i++)
     {
-      font->get_glyph_v_origin (*first_glyph, first_x, first_y, false);
+      ret &= font->get_glyph_v_origin (*first_glyph, first_x, first_y, false);
       first_glyph = &StructAtOffsetUnaligned<hb_codepoint_t> (first_glyph, glyph_stride);
       first_x = &StructAtOffsetUnaligned<hb_position_t> (first_x, x_stride);
       first_y = &StructAtOffsetUnaligned<hb_position_t> (first_y, y_stride);
     }
-    return true;
+    return ret;
   }
 
   hb_bool_t ret = font->parent->get_glyph_v_origins (count,


### PR DESCRIPTION
A fix for issue #5847 that minimizes changes to existing code.

A small tweak to the hb_font_get_glyph_h_origins_default() and hb_font_get_glyph_v_origins_default() functions so their return value always matches the return value of their hb_font_get_glyph_h_origin_default() and hb_font_get_glyph_v_origin_default() counterparts. This ensures consistent behaviour in batch origin-changing callbacks, introduced on July 20, 2025 as part of commit https://github.com/harfbuzz/harfbuzz/commit/faa4472d44f43e39036f11ee38214d19c70a4034 ("Use batch origin-changing callbacks").

Without this fix, hb_font_get_glyph_h_origins_default() always returns true when font->has_glyph_h_origin_func_set() is true, and hb_font_get_glyph_v_origins_default() always returns true when font->has_glyph_v_origin_func_set() is true, which is not what their hb_font_get_glyph_h_origin_default() and hb_font_get_glyph_v_origin_default() counterparts do.

Fixes #5847