### PR TITLE
Skip adjusting glyph offsets when all origin values are zero

### DIFF
--- a/src/hb-font.hh
+++ b/src/hb-font.hh
@@ -903,15 +903,11 @@ struct hb_font_t
 	}
 	else
 	{
-	  for (unsigned j = 0; j < n; j++)
-	  {
-	    origins[j].x = 0;
-	    origins[j].y = 0;
-	  }
+	  mult = 0; /* Indicates all origins[].x and origins[].y values are 0, therefore we can skip adjusting offsets below */
 	}
       }
 
-      assert (mult == -1 || mult == +1);
+      assert (mult == -1 || mult == +1 || mult == 0);
       if (mult == +1)
         for (unsigned j = 0; j < n; j++)
 	{
@@ -919,13 +915,14 @@ struct hb_font_t
 	  add_offset (&pos->x_offset, &pos->y_offset,
 		      origins[j].x, origins[j].y);
 	}
-      else /* mult == -1 */
+      else if (mult == -1)
 	for (unsigned j = 0; j < n; j++)
 	{
 	  hb_glyph_position_t *pos = &buf->pos[offset + j];
 	  subtract_offset (&pos->x_offset, &pos->y_offset,
 			   origins[j].x, origins[j].y);
 	}
+      /* else if (mult == 0) --> Do nothing */
 
       offset += n;
     }
@@ -970,15 +967,11 @@ struct hb_font_t
 	}
 	else
 	{
-	  for (unsigned j = 0; j < n; j++)
-	  {
-	    origins[j].x = 0;
-	    origins[j].y = 0;
-	  }
+	  mult = 0; /* Indicates all origins[].x and origins[].y values are 0, therefore we can skip adjusting offsets below */
 	}
       }
 
-      assert (mult == -1 || mult == +1);
+      assert (mult == -1 || mult == +1 || mult == 0);
       if (mult == +1)
         for (unsigned j = 0; j < n; j++)
 	{
@@ -986,13 +979,14 @@ struct hb_font_t
 	  add_offset (&pos->x_offset, &pos->y_offset,
 		      origins[j].x, origins[j].y);
 	}
-      else /* mult == -1 */
+      else if (mult == -1)
 	for (unsigned j = 0; j < n; j++)
 	{
 	  hb_glyph_position_t *pos = &buf->pos[offset + j];
 	  subtract_offset (&pos->x_offset, &pos->y_offset,
 			   origins[j].x, origins[j].y);
 	}
+      /* else if (mult == 0) --> Do nothing */
 
       offset += n;
     }


### PR DESCRIPTION
This issue is not **directly** related to #5847 but was discovered at the same time and makes sense to include in this branch. The fix affects the apply_glyph_h_origins_with_fallback() and apply_glyph_v_origins_with_fallback() functions in hb-font.hh.

There is a potential code path in these functions where origins[].x and origins[].y could remain uninitialized. This fix solves this and also offers a minor performance optimization by completely skipping adjusting glyph offsets when all origins[].x and origins[].y values are zero.

The proposed fix minimizes changes to existing code.