### PR TITLE
[raster] Use png_jmpbuf in PNG error callback

### DIFF
--- a/src/hb-raster-image.cc
+++ b/src/hb-raster-image.cc
@@ -46,7 +46,9 @@ static void
 hb_raster_png_error (png_structp png,
 		     png_const_charp msg HB_UNUSED)
 {
-  png_longjmp (png, 1);
+#ifdef PNG_SETJMP_SUPPORTED
+  longjmp (png_jmpbuf (png), 1);
+#endif
 }
 
 static void


### PR DESCRIPTION
hb_raster_png_error() switched to png_longjmp() when raster PNG error handling was hardened. That symbol is only available with newer libpng headers, but HarfBuzz does not require a minimum libpng version.

Follow cairo-png.c and jump through png_jmpbuf() instead. This keeps the error path working with older libpng headers, including macOS framework builds that pick up pre-1.5 libpng.

Testing:
meson test -C build

Fixes: https://github.com/harfbuzz/harfbuzz/issues/5867
Assisted-by: OpenAI Codex