### PR TITLE
[font] Fix typo in setting design coords

### DIFF
--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -3185,7 +3185,7 @@ hb_font_set_var_coords_design (hb_font_t    *font,
   for (unsigned int i = input_coords_length; i < coords_length; i++)
     design_coords[i] = axes[i].get_default ();
 
-  hb_ot_var_normalize_coords (font->face, coords_length, coords, normalized);
+  hb_ot_var_normalize_coords (font->face, coords_length, design_coords, normalized);
   _hb_font_adopt_var_coords (font, normalized, design_coords, coords_length);
 }
 


### PR DESCRIPTION
Fixes https://github.com/harfbuzz/harfbuzz/security/advisories/GHSA-8p7p-f952-473p