### PR TITLE
[message] Improve recursing message

### DIFF
--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -1865,22 +1865,24 @@ static inline void apply_lookup (hb_ot_apply_context_t *c,
       if (buffer->have_output)
         c->buffer->sync_so_far ();
       c->buffer->message (c->font,
-			  "recursing to lookup %u at %u",
+			  "start recursing to lookup %u at %u",
 			  (unsigned) lookupRecord[i].lookupListIndex,
 			  buffer->idx);
     }
 
-    if (!c->recurse (lookupRecord[i].lookupListIndex))
-      continue;
+    bool ret = c->recurse (lookupRecord[i].lookupListIndex);
 
     if (HB_BUFFER_MESSAGE_MORE && c->buffer->messaging ())
     {
       if (buffer->have_output)
         c->buffer->sync_so_far ();
       c->buffer->message (c->font,
-			  "recursed to lookup %u",
+			  "end recursing to lookup %u",
 			  (unsigned) lookupRecord[i].lookupListIndex);
     }
+
+    if (!ret)
+      continue;
 
     unsigned int new_len = buffer->backtrack_len () + buffer->lookahead_len ();
     int delta = new_len - orig_len;


### PR DESCRIPTION
Currently if recursed is skipped, no message is shown:
```
start lookup 56 feature 'rlig'
recursing to lookup 43 at 8
replacing glyph at 8 (single substitution)
replaced glyph at 8 (single substitution)
recursed to lookup 43
recursing to lookup 51 at 10
end lookup 56 feature 'rlig'
```

With this change we always show `recursed to` messaged, and show `skipped lookup` message is recursed lookup is skipped:
```
start lookup 56 feature 'rlig'
recursing to lookup 43 at 8
replacing glyph at 8 (single substitution)
replaced glyph at 8 (single substitution)
recursed to lookup 43
recursing to lookup 51 at 10
skipped lookup 51
recursed to lookup 51
end lookup 56 feature 'rlig'
```