### PR TITLE
[vector] Use clear() instead of resize(0)/shrink(0)

### DIFF
--- a/src/OT/Color/svg/svg.hh
+++ b/src/OT/Color/svg/svg.hh
@@ -605,7 +605,7 @@ SVG::accelerator_t::accelerator_t (hb_face_t *face)
   doc_caches.init ();
   unsigned doc_count = table->get_document_count ();
   if (doc_count && unlikely (!doc_caches.resize (doc_count)))
-    doc_caches.resize (0);
+    doc_caches.clear ();
   for (unsigned i = 0; i < doc_caches.length; i++)
     doc_caches.arrayZ[i].set_relaxed (nullptr);
 }

--- a/src/OT/glyf/glyf.hh
+++ b/src/OT/glyf/glyf.hh
@@ -121,7 +121,7 @@ struct glyf
 
     if (!use_short_loca)
     {
-      padded_offsets.resize (0);
+      padded_offsets.clear ();
       for (auto &g : glyphs)
 	padded_offsets.push (g.length ());
     }
@@ -226,7 +226,7 @@ struct glyf_accelerator_t
     if (gid >= num_glyphs) return false;
 
     auto &all_points = scratch.all_points;
-    all_points.resize (0);
+    all_points.clear ();
 
     bool phantom_only = !consumer.is_consuming_contour_points ();
     if (unlikely (!glyph_for_gid (gid).get_points (font, *this, all_points, scratch, nullptr, nullptr, nullptr, true, true, phantom_only, coords, gvar_cache)))

--- a/src/hb-bimap.hh
+++ b/src/hb-bimap.hh
@@ -115,7 +115,7 @@ struct hb_inc_bimap_t
   void clear ()
   {
     forw_map.clear ();
-    back_map.resize (0);
+    back_map.clear ();
   }
 
   /* Add a mapping from lhs to rhs with a unique value if lhs is unknown.

--- a/src/hb-cff-specializer.hh
+++ b/src/hb-cff-specializer.hh
@@ -134,7 +134,7 @@ generalize_commands (hb_vector_t<cs_command_t> &commands)
   }
 
   /* Replace commands with generalized result */
-  commands.resize (0);
+  commands.clear ();
   for (unsigned i = 0; i < result.length; i++)
     commands.push (result[i]);
 }

--- a/src/hb-cff2-interp-cs.hh
+++ b/src/hb-cff2-interp-cs.hh
@@ -55,7 +55,7 @@ struct blend_arg_t : number_t
   void reset_blends ()
   {
     numValues = valueIndex = 0;
-    deltas.shrink (0);
+    deltas.clear ();
   }
 
   unsigned int numValues;

--- a/src/hb-ms-feature-ranges.hh
+++ b/src/hb-ms-feature-ranges.hh
@@ -86,8 +86,8 @@ hb_ms_setup_features (const hb_feature_t                *features,
 		      hb_vector_t<hb_ms_feature_t>      &feature_records, /* OUT */
 		      hb_vector_t<hb_ms_range_record_t> &range_records /* OUT */)
 {
-  feature_records.shrink(0);
-  range_records.shrink(0);
+  feature_records.clear ();
+  range_records.clear ();
 
   /* Sort features by start/end events. */
   hb_vector_t<hb_ms_feature_event_t> feature_events;
@@ -195,8 +195,8 @@ hb_ms_make_feature_ranges (hb_vector_t<hb_ms_feature_t>      &feature_records,
 			   hb_vector_t<hb_ms_features_t*>    &range_features, /* OUT */
 			   hb_vector_t<uint32_t>             &range_counts /* OUT */)
 {
-  range_features.shrink (0);
-  range_counts.shrink (0);
+  range_features.clear ();
+  range_counts.clear ();
 
   auto *last_range = &range_records[0];
   for (unsigned int i = chars_offset; i < chars_len; i++)
@@ -213,8 +213,8 @@ hb_ms_make_feature_ranges (hb_vector_t<hb_ms_feature_t>      &feature_records,
       auto *c = range_counts.push ();
       if (unlikely (!features || !c))
       {
-        range_features.shrink (0);
-        range_counts.shrink (0);
+        range_features.clear ();
+        range_counts.clear ();
         break;
       }
       *features = &range->features;

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -262,7 +262,7 @@ struct Encoding
 
   void get_supplement_codes (hb_codepoint_t sid, hb_vector_t<hb_codepoint_t> &codes) const
   {
-    codes.resize (0);
+    codes.clear ();
     if (has_supplement ())
       suppEncData().get_codes (sid, codes);
   }

--- a/src/hb-outline.hh
+++ b/src/hb-outline.hh
@@ -65,7 +65,7 @@ struct hb_outline_vector_t
 
 struct hb_outline_t
 {
-  void reset () { points.shrink (0, false); contours.resize (0); }
+  void reset () { points.clear (); contours.clear (); }
 
   HB_INTERNAL void replay (hb_draw_funcs_t *pen, void *pen_data) const;
   HB_INTERNAL float control_area () const;

--- a/src/hb-priority-queue.hh
+++ b/src/hb-priority-queue.hh
@@ -61,7 +61,7 @@ struct hb_priority_queue_t
       bubble_down (i);
   }
 
-  void reset () { heap.resize (0); }
+  void reset () { heap.clear (); }
 
   bool in_error () const { return heap.in_error (); }
 

--- a/src/hb-subset-cff1.cc
+++ b/src/hb-subset-cff1.cc
@@ -431,7 +431,8 @@ struct cff1_subset_plan
     unsigned code, last_code = CFF_UNDEF_CODE - 1;
     hb_vector_t<hb_codepoint_t> supp_codes;
 
-    if (unlikely (!subset_enc_code_ranges.resize (0)))
+    subset_enc_code_ranges.clear ();
+    if (unlikely (subset_enc_code_ranges.in_error ()))
     {
       plan->check_success (false);
       return;
@@ -496,7 +497,8 @@ struct cff1_subset_plan
     unsigned int  size0, size_ranges;
     unsigned last_sid = CFF_UNDEF_CODE - 1;
 
-    if (unlikely (!subset_charset_ranges.resize (0)))
+    subset_charset_ranges.clear ();
+    if (unlikely (subset_charset_ranges.in_error ()))
     {
       plan->check_success (false);
       return false;

--- a/src/hb-vector.hh
+++ b/src/hb-vector.hh
@@ -577,8 +577,7 @@ struct hb_vector_t
   HB_ALWAYS_INLINE_VECTOR_ALLOCS
   void clear ()
   {
-    if (!resize (0))
-      shrink_vector (0); /* If resize fails (e.g. vector in error state), still destruct items and clear length. */
+    shrink_vector (0);
   }
 
   template <typename allocator_t>


### PR DESCRIPTION
Also simplify clear() itself to just call shrink_vector(0) directly, avoiding the resize() -> alloc() path which both fails in error state and requires Type to be default-constructible.