### PR TITLE
[subset-repack] dont duplicate node that might be shared

### DIFF
--- a/src/graph/markbasepos-graph.hh
+++ b/src/graph/markbasepos-graph.hh
@@ -430,7 +430,6 @@ struct MarkBasePosFormat1 : public OT::Layout::GPOS_impl::MarkBasePosFormat1_2<S
     unsigned base_coverage_id =
         graph.index_for_offset (sc.this_index, &baseCoverage);
     graph.add_link (&(prime->baseCoverage), prime_id, base_coverage_id);
-    graph.duplicate (prime_id, base_coverage_id);
 
     auto mark_coverage = sc.c.graph.as_table<Coverage> (this_index,
                                                         &markCoverage);

--- a/src/graph/pairpos-graph.hh
+++ b/src/graph/pairpos-graph.hh
@@ -422,7 +422,6 @@ struct PairPosFormat2 : public OT::Layout::GPOS_impl::PairPosFormat2_4<SmallType
     class_def_link->objidx = class_def_2_id;
     class_def_link->position = 10;
     graph.vertices_[class_def_2_id].add_parent (pair_pos_prime_id, false);
-    graph.duplicate (pair_pos_prime_id, class_def_2_id);
 
     return pair_pos_prime_id;
   }


### PR DESCRIPTION
PairPos is split by class1_def, thus class2_def could be shared by all new subtables.
MarkBase is split by mark classes, baseCoverage could be shared.
If an overflow is introduced due to shared table, the usual overflow resolution handling should be able to duplicate it if actually needed.
