### PR TITLE
`hb-raster-gpu`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ set (raster_project_sources
      ${PROJECT_SOURCE_DIR}/src/hb-raster-image.hh
      ${PROJECT_SOURCE_DIR}/src/hb-raster-utils.hh
      ${PROJECT_SOURCE_DIR}/src/hb-raster-draw.cc
+     ${PROJECT_SOURCE_DIR}/src/hb-raster-gpu.cc
      ${PROJECT_SOURCE_DIR}/src/hb-raster-svg-base.cc
      ${PROJECT_SOURCE_DIR}/src/hb-raster-svg-base.hh
      ${PROJECT_SOURCE_DIR}/src/hb-raster-svg-defs.cc

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -155,6 +155,11 @@ fixed and called `config-override.h`, and was activated by defining the macro
 
 ## Notes
 
+Defining `HB_NO_RASTER_GPU` disables the
+`hb_raster_gpu_render_from_blob_or_fail()` helper in the
+`harfbuzz-raster` library. This only affects CPU rasterization
+of blobs produced by `hb_gpu_draw_encode()`.
+
 Note that the config option `HB_NO_CFF`, which is enabled by `HB_LEAN` and
 `HB_TINY` does *not* mean that the resulting library won't work with CFF fonts.
 The library can shape valid CFF fonts just fine, with or without this option.

--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,7 @@ Wednesday, April 1, 2026
   + hb_gpu_shader_lang_t
   + hb_gpu_shader_fragment_source()
   + hb_gpu_shader_vertex_source()
+  + hb_raster_gpu_render_from_blob_or_fail()
 
 
 Overview of changes leading to 13.2.1
@@ -4232,5 +4233,4 @@ Summary of API changes follows.
     hb_version()
     hb_version_string()
     hb_version_check()
-
 

--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -1035,6 +1035,7 @@ hb_raster_draw_get_funcs
 hb_raster_draw_glyph
 hb_raster_draw_render
 hb_raster_draw_recycle_image
+hb_raster_gpu_render_from_blob_or_fail
 hb_raster_paint_t
 hb_raster_paint_create_or_fail
 hb_raster_paint_reference

--- a/src/harfbuzz-world.cc
+++ b/src/harfbuzz-world.cc
@@ -114,6 +114,7 @@
 
 #ifdef HB_HAS_RASTER
 #include "hb-raster-draw.cc"
+#include "hb-raster-gpu.cc"
 #include "hb-raster-image.cc"
 #include "hb-raster-paint.cc"
 #include "hb-raster-svg-base.cc"

--- a/src/hb-config.hh
+++ b/src/hb-config.hh
@@ -79,6 +79,7 @@
 #define HB_NO_OPEN
 #define HB_NO_OT_FONT_GLYPH_NAMES
 #define HB_NO_PAINT
+#define HB_NO_RASTER_GPU
 #define HB_NO_SETLOCALE
 #define HB_NO_STYLE
 #define HB_NO_SUBSET_LAYOUT

--- a/src/hb-gpu.cc
+++ b/src/hb-gpu.cc
@@ -69,6 +69,10 @@
  * allow buffer reuse; call hb_gpu_draw_reset() before each new
  * glyph.
  *
+ * For CPU-side validation, fallback rendering, or offline image
+ * generation, blobs produced here can also be rasterized with
+ * hb_raster_gpu_render_from_blob_or_fail() from `harfbuzz-raster`.
+ *
  * # Atlas setup
  *
  * All encoded blobs are uploaded into a single GL_TEXTURE_BUFFER

--- a/src/hb-gpu.h
+++ b/src/hb-gpu.h
@@ -64,6 +64,10 @@ hb_gpu_shader_vertex_source (hb_gpu_shader_lang_t lang);
  * callbacks, then encodes them into a compact blob for GPU
  * rendering.
  *
+ * Encoded blobs are typically uploaded for shader-based rendering,
+ * but can also be rasterized on the CPU with
+ * hb_raster_gpu_render_from_blob_or_fail() from `harfbuzz-raster`.
+ *
  * Since: 14.0.0
  */
 typedef struct hb_gpu_draw_t hb_gpu_draw_t;

--- a/src/hb-raster-gpu.cc
+++ b/src/hb-raster-gpu.cc
@@ -1,0 +1,533 @@
+/*
+ * Copyright © 2026  Behdad Esfahbod
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Author(s): Behdad Esfahbod
+ */
+
+#include "hb.hh"
+
+#include "hb-raster.h"
+#include "hb-raster-image.hh"
+#include "hb-gpu-draw.hh"
+
+#include <math.h>
+
+
+#ifndef HB_NO_RASTER_GPU
+
+struct hb_raster_gpu_texel_t
+{
+  int16_t r, g, b, a;
+};
+
+struct hb_raster_gpu_blob_t
+{
+  const char *data = nullptr;
+  unsigned texel_count = 0;
+
+  float min_x = 0.f;
+  float min_y = 0.f;
+  float max_x = 0.f;
+  float max_y = 0.f;
+
+  int num_hbands = 0;
+  int num_vbands = 0;
+  float scale_x = 0.f;
+  float scale_y = 0.f;
+
+  float band_scale_x = 0.f;
+  float band_scale_y = 0.f;
+  float band_offset_x = 0.f;
+  float band_offset_y = 0.f;
+  unsigned band_base = 2;
+};
+
+static constexpr float HB_RASTER_GPU_INV_UNITS = 1.f / HB_GPU_UNITS_PER_EM;
+static constexpr float HB_RASTER_GPU_EPSILON = 1.f / 65536.f;
+
+static HB_ALWAYS_INLINE unsigned
+hb_raster_gpu_decode_offset (int16_t v)
+{
+  return (unsigned) ((int) v + 32768);
+}
+
+static HB_ALWAYS_INLINE float
+hb_raster_gpu_clamp01 (float v)
+{
+  return hb_clamp (v, 0.f, 1.f);
+}
+
+static HB_ALWAYS_INLINE float
+hb_raster_gpu_smoothstep (float edge0,
+			  float edge1,
+			  float x)
+{
+  float t = hb_raster_gpu_clamp01 ((x - edge0) / (edge1 - edge0));
+  return t * t * (3.f - 2.f * t);
+}
+
+static HB_ALWAYS_INLINE uint32_t
+hb_raster_gpu_float_bits_to_uint (float v)
+{
+  uint32_t u = 0;
+  hb_memcpy (&u, &v, sizeof (u));
+  return u;
+}
+
+static HB_ALWAYS_INLINE uint32_t
+hb_raster_gpu_calc_root_code (float y1,
+			      float y2,
+			      float y3)
+{
+  uint32_t i1 = hb_raster_gpu_float_bits_to_uint (y1) >> 31U;
+  uint32_t i2 = hb_raster_gpu_float_bits_to_uint (y2) >> 30U;
+  uint32_t i3 = hb_raster_gpu_float_bits_to_uint (y3) >> 29U;
+
+  uint32_t shift = (i2 & 2U) | (i1 & ~2U);
+  shift = (i3 & 4U) | (shift & ~4U);
+
+  return (0x2E74U >> shift) & 0x0101U;
+}
+
+static HB_ALWAYS_INLINE bool
+hb_raster_gpu_read_texel (const hb_raster_gpu_blob_t *blob,
+			  unsigned                    offset,
+			  hb_raster_gpu_texel_t      *out)
+{
+  if (unlikely (offset >= blob->texel_count))
+    return false;
+
+  hb_memcpy (out, blob->data + offset * sizeof (*out), sizeof (*out));
+  return true;
+}
+
+static HB_ALWAYS_INLINE void
+hb_raster_gpu_solve_horiz_poly (float  ax,
+				float  ay,
+				float  bx,
+				float  by,
+				float  p1x,
+				float  p1y,
+				float *r0,
+				float *r1)
+{
+  float ra = 1.f / ay;
+  float rb = 0.5f / by;
+
+  float d = sqrtf (hb_max (by * by - ay * p1y, 0.f));
+  float t1 = (by - d) * ra;
+  float t2 = (by + d) * ra;
+
+  if (ay == 0.f)
+    t1 = t2 = p1y * rb;
+
+  *r0 = (ax * t1 - bx * 2.f) * t1 + p1x;
+  *r1 = (ax * t2 - bx * 2.f) * t2 + p1x;
+}
+
+static HB_ALWAYS_INLINE void
+hb_raster_gpu_solve_vert_poly (float  ax,
+			       float  ay,
+			       float  bx,
+			       float  by,
+			       float  p1x,
+			       float  p1y,
+			       float *r0,
+			       float *r1)
+{
+  float ra = 1.f / ax;
+  float rb = 0.5f / bx;
+
+  float d = sqrtf (hb_max (bx * bx - ax * p1x, 0.f));
+  float t1 = (bx - d) * ra;
+  float t2 = (bx + d) * ra;
+
+  if (ax == 0.f)
+    t1 = t2 = p1x * rb;
+
+  *r0 = (ay * t1 - by * 2.f) * t1 + p1y;
+  *r1 = (ay * t2 - by * 2.f) * t2 + p1y;
+}
+
+static HB_ALWAYS_INLINE float
+hb_raster_gpu_calc_coverage (float xcov,
+			     float ycov,
+			     float xwgt,
+			     float ywgt)
+{
+  float coverage = hb_max (fabsf (xcov * xwgt + ycov * ywgt) /
+			   hb_max (xwgt + ywgt, HB_RASTER_GPU_EPSILON),
+			   hb_min (fabsf (xcov), fabsf (ycov)));
+
+  return hb_raster_gpu_clamp01 (coverage);
+}
+
+static bool
+hb_raster_gpu_decode_blob (const char           *data,
+			   unsigned              texel_count,
+			   hb_raster_gpu_blob_t *blob)
+{
+  if (unlikely (texel_count < 2))
+    return false;
+
+  blob->data = data;
+  blob->texel_count = texel_count;
+
+  hb_raster_gpu_texel_t header0;
+  hb_raster_gpu_texel_t header1;
+  if (unlikely (!hb_raster_gpu_read_texel (blob, 0, &header0) ||
+		!hb_raster_gpu_read_texel (blob, 1, &header1)))
+    return false;
+
+  blob->min_x = header0.r * HB_RASTER_GPU_INV_UNITS;
+  blob->min_y = header0.g * HB_RASTER_GPU_INV_UNITS;
+  blob->max_x = header0.b * HB_RASTER_GPU_INV_UNITS;
+  blob->max_y = header0.a * HB_RASTER_GPU_INV_UNITS;
+  blob->num_hbands = header1.r;
+  blob->num_vbands = header1.g;
+  blob->scale_x = (float) header1.b;
+  blob->scale_y = (float) header1.a;
+
+  if (unlikely (blob->num_hbands <= 0 || blob->num_vbands <= 0 ||
+		blob->max_x < blob->min_x ||
+		blob->max_y < blob->min_y))
+    return false;
+
+  unsigned band_headers = (unsigned) blob->num_hbands + (unsigned) blob->num_vbands;
+  if (unlikely (blob->band_base + band_headers > texel_count))
+    return false;
+
+  float ext_size_x = blob->max_x - blob->min_x;
+  float ext_size_y = blob->max_y - blob->min_y;
+
+  blob->band_scale_x = (float) blob->num_vbands /
+		       hb_max (ext_size_x, HB_RASTER_GPU_EPSILON);
+  blob->band_scale_y = (float) blob->num_hbands /
+		       hb_max (ext_size_y, HB_RASTER_GPU_EPSILON);
+  blob->band_offset_x = -blob->min_x * blob->band_scale_x;
+  blob->band_offset_y = -blob->min_y * blob->band_scale_y;
+  return true;
+}
+
+static bool
+hb_raster_gpu_render_single (const hb_raster_gpu_blob_t *blob,
+			     float                       render_x,
+			     float                       render_y,
+			     float                       pixels_per_em_x,
+			     float                       pixels_per_em_y,
+			     float                      *coverage)
+{
+  int band_index_x = hb_clamp ((int) (render_x * blob->band_scale_x + blob->band_offset_x),
+			       0, blob->num_vbands - 1);
+  int band_index_y = hb_clamp ((int) (render_y * blob->band_scale_y + blob->band_offset_y),
+			       0, blob->num_hbands - 1);
+
+  float xcov = 0.f;
+  float xwgt = 0.f;
+
+  hb_raster_gpu_texel_t hband_data;
+  if (unlikely (!hb_raster_gpu_read_texel (blob, blob->band_base + (unsigned) band_index_y, &hband_data) ||
+		hband_data.r < 0))
+    return false;
+
+  int h_curve_count = hband_data.r;
+  float h_split = hband_data.a * HB_RASTER_GPU_INV_UNITS;
+  bool h_left_ray = render_x < h_split;
+  unsigned h_data_offset = hb_raster_gpu_decode_offset (h_left_ray ? hband_data.b : hband_data.g);
+
+  for (int ci = 0; ci < h_curve_count; ci++)
+  {
+    hb_raster_gpu_texel_t curve_index;
+    if (unlikely (!hb_raster_gpu_read_texel (blob, h_data_offset + (unsigned) ci, &curve_index)))
+      return false;
+
+    unsigned curve_offset = hb_raster_gpu_decode_offset (curve_index.r);
+    hb_raster_gpu_texel_t raw12;
+    hb_raster_gpu_texel_t raw3;
+    if (unlikely (!hb_raster_gpu_read_texel (blob, curve_offset, &raw12) ||
+		  !hb_raster_gpu_read_texel (blob, curve_offset + 1u, &raw3)))
+      return false;
+
+    float q12x = raw12.r * HB_RASTER_GPU_INV_UNITS;
+    float q12y = raw12.g * HB_RASTER_GPU_INV_UNITS;
+    float q12z = raw12.b * HB_RASTER_GPU_INV_UNITS;
+    float q12w = raw12.a * HB_RASTER_GPU_INV_UNITS;
+    float q3x = raw3.r * HB_RASTER_GPU_INV_UNITS;
+    float q3y = raw3.g * HB_RASTER_GPU_INV_UNITS;
+
+    float p12x = q12x - render_x;
+    float p12y = q12y - render_y;
+    float p12z = q12z - render_x;
+    float p12w = q12w - render_y;
+    float p3x = q3x - render_x;
+    float p3y = q3y - render_y;
+
+    if (h_left_ray)
+    {
+      if (hb_min (hb_min (p12x, p12z), p3x) * pixels_per_em_x > 0.5f)
+	break;
+    }
+    else
+    {
+      if (hb_max (hb_max (p12x, p12z), p3x) * pixels_per_em_x < -0.5f)
+	break;
+    }
+
+    uint32_t code = hb_raster_gpu_calc_root_code (p12y, p12w, p3y);
+    if (!code)
+      continue;
+
+    float ax = q12x - q12z * 2.f + q3x;
+    float ay = q12y - q12w * 2.f + q3y;
+    float bx = q12x - q12z;
+    float by = q12y - q12w;
+    float r0, r1;
+    hb_raster_gpu_solve_horiz_poly (ax, ay, bx, by, p12x, p12y, &r0, &r1);
+    r0 *= pixels_per_em_x;
+    r1 *= pixels_per_em_x;
+
+    float cov0 = h_left_ray ? hb_raster_gpu_clamp01 (0.5f - r0)
+			    : hb_raster_gpu_clamp01 (r0 + 0.5f);
+    float cov1 = h_left_ray ? hb_raster_gpu_clamp01 (0.5f - r1)
+			    : hb_raster_gpu_clamp01 (r1 + 0.5f);
+
+    if (code & 1U)
+    {
+      xcov += cov0;
+      xwgt = hb_max (xwgt, hb_raster_gpu_clamp01 (1.f - fabsf (r0) * 2.f));
+    }
+
+    if (code > 1U)
+    {
+      xcov -= cov1;
+      xwgt = hb_max (xwgt, hb_raster_gpu_clamp01 (1.f - fabsf (r1) * 2.f));
+    }
+  }
+
+  float ycov = 0.f;
+  float ywgt = 0.f;
+
+  hb_raster_gpu_texel_t vband_data;
+  if (unlikely (!hb_raster_gpu_read_texel (blob,
+					   blob->band_base + (unsigned) blob->num_hbands + (unsigned) band_index_x,
+					   &vband_data) ||
+		vband_data.r < 0))
+    return false;
+
+  int v_curve_count = vband_data.r;
+  float v_split = vband_data.a * HB_RASTER_GPU_INV_UNITS;
+  bool v_left_ray = render_y < v_split;
+  unsigned v_data_offset = hb_raster_gpu_decode_offset (v_left_ray ? vband_data.b : vband_data.g);
+
+  for (int ci = 0; ci < v_curve_count; ci++)
+  {
+    hb_raster_gpu_texel_t curve_index;
+    if (unlikely (!hb_raster_gpu_read_texel (blob, v_data_offset + (unsigned) ci, &curve_index)))
+      return false;
+
+    unsigned curve_offset = hb_raster_gpu_decode_offset (curve_index.r);
+    hb_raster_gpu_texel_t raw12;
+    hb_raster_gpu_texel_t raw3;
+    if (unlikely (!hb_raster_gpu_read_texel (blob, curve_offset, &raw12) ||
+		  !hb_raster_gpu_read_texel (blob, curve_offset + 1u, &raw3)))
+      return false;
+
+    float q12x = raw12.r * HB_RASTER_GPU_INV_UNITS;
+    float q12y = raw12.g * HB_RASTER_GPU_INV_UNITS;
+    float q12z = raw12.b * HB_RASTER_GPU_INV_UNITS;
+    float q12w = raw12.a * HB_RASTER_GPU_INV_UNITS;
+    float q3x = raw3.r * HB_RASTER_GPU_INV_UNITS;
+    float q3y = raw3.g * HB_RASTER_GPU_INV_UNITS;
+
+    float p12x = q12x - render_x;
+    float p12y = q12y - render_y;
+    float p12z = q12z - render_x;
+    float p12w = q12w - render_y;
+    float p3x = q3x - render_x;
+    float p3y = q3y - render_y;
+
+    if (v_left_ray)
+    {
+      if (hb_min (hb_min (p12y, p12w), p3y) * pixels_per_em_y > 0.5f)
+	break;
+    }
+    else
+    {
+      if (hb_max (hb_max (p12y, p12w), p3y) * pixels_per_em_y < -0.5f)
+	break;
+    }
+
+    uint32_t code = hb_raster_gpu_calc_root_code (p12x, p12z, p3x);
+    if (!code)
+      continue;
+
+    float ax = q12x - q12z * 2.f + q3x;
+    float ay = q12y - q12w * 2.f + q3y;
+    float bx = q12x - q12z;
+    float by = q12y - q12w;
+    float r0, r1;
+    hb_raster_gpu_solve_vert_poly (ax, ay, bx, by, p12x, p12y, &r0, &r1);
+    r0 *= pixels_per_em_y;
+    r1 *= pixels_per_em_y;
+
+    float cov0 = v_left_ray ? hb_raster_gpu_clamp01 (0.5f - r0)
+			    : hb_raster_gpu_clamp01 (r0 + 0.5f);
+    float cov1 = v_left_ray ? hb_raster_gpu_clamp01 (0.5f - r1)
+			    : hb_raster_gpu_clamp01 (r1 + 0.5f);
+
+    if (code & 1U)
+    {
+      ycov -= cov0;
+      ywgt = hb_max (ywgt, hb_raster_gpu_clamp01 (1.f - fabsf (r0) * 2.f));
+    }
+
+    if (code > 1U)
+    {
+      ycov += cov1;
+      ywgt = hb_max (ywgt, hb_raster_gpu_clamp01 (1.f - fabsf (r1) * 2.f));
+    }
+  }
+
+  *coverage = hb_raster_gpu_calc_coverage (xcov, ycov, xwgt, ywgt);
+  return true;
+}
+
+static bool
+hb_raster_gpu_render_coverage (const hb_raster_gpu_blob_t *blob,
+			       float                       render_x,
+			       float                       render_y,
+			       float                      *coverage)
+{
+  float c = 0.f;
+  if (unlikely (!hb_raster_gpu_render_single (blob, render_x, render_y,
+					      1.f, 1.f, &c)))
+    return false;
+
+#ifndef HB_GPU_NO_MSAA
+  float ppem = hb_min (blob->scale_x, blob->scale_y);
+  if (ppem < 16.f)
+  {
+    float c0, c1, c2, c3;
+    if (unlikely (!hb_raster_gpu_render_single (blob, render_x - 1.f / 3.f, render_y - 1.f / 3.f, 1.f, 1.f, &c0) ||
+		  !hb_raster_gpu_render_single (blob, render_x + 1.f / 3.f, render_y - 1.f / 3.f, 1.f, 1.f, &c1) ||
+		  !hb_raster_gpu_render_single (blob, render_x - 1.f / 3.f, render_y + 1.f / 3.f, 1.f, 1.f, &c2) ||
+		  !hb_raster_gpu_render_single (blob, render_x + 1.f / 3.f, render_y + 1.f / 3.f, 1.f, 1.f, &c3)))
+      return false;
+
+    float msaa = 0.25f * (c0 + c1 + c2 + c3);
+    c = c + (msaa - c) * hb_raster_gpu_smoothstep (16.f, 8.f, ppem);
+  }
+#endif
+
+  *coverage = c;
+  return true;
+}
+
+static hb_raster_image_t *
+hb_raster_gpu_render_from_blob_data_or_fail (const char *data,
+					     unsigned    texel_count)
+{
+  hb_raster_gpu_blob_t blob;
+  if (unlikely (!hb_raster_gpu_decode_blob (data, texel_count, &blob)))
+    return nullptr;
+
+  constexpr float pad = 0.5f;
+  hb_raster_extents_t ext;
+  ext.x_origin = (int) floorf (blob.min_x - pad);
+  ext.y_origin = (int) floorf (blob.min_y - pad);
+  ext.width = (unsigned) hb_max (0, (int) ceilf (blob.max_x + pad) - ext.x_origin);
+  ext.height = (unsigned) hb_max (0, (int) ceilf (blob.max_y + pad) - ext.y_origin);
+  ext.stride = (ext.width + 3u) & ~3u;
+
+  hb_raster_image_t *image = hb_raster_image_create_or_fail ();
+  if (unlikely (!image))
+    return nullptr;
+
+  if (unlikely (!image->configure (HB_RASTER_FORMAT_A8, ext)))
+    goto fail;
+  image->clear ();
+
+  for (unsigned y = 0; y < ext.height; y++)
+    for (unsigned x = 0; x < ext.width; x++)
+    {
+      float render_x = (float) ext.x_origin + (float) x + 0.5f;
+      float render_y = (float) ext.y_origin + (float) y + 0.5f;
+      float coverage;
+      if (unlikely (!hb_raster_gpu_render_coverage (&blob,
+						    render_x,
+						    render_y,
+						    &coverage)))
+	goto fail;
+
+      image->buffer.arrayZ[y * ext.stride + x] =
+	(uint8_t) (hb_raster_gpu_clamp01 (coverage) * 255.f + 0.5f);
+    }
+
+  return image;
+
+fail:
+  hb_raster_image_destroy (image);
+  return nullptr;
+}
+
+#endif /* !HB_NO_RASTER_GPU */
+
+
+/**
+ * hb_raster_gpu_render_from_blob_or_fail:
+ * @blob: a blob produced by hb_gpu_draw_encode()
+ *
+ * Decodes a glyph blob produced by hb_gpu_draw_encode() and rasterizes
+ * it into a new @HB_RASTER_FORMAT_A8 image using the same coverage
+ * algorithm as hb_gpu_render().
+ *
+ * Return value: (transfer full):
+ * A rendered #hb_raster_image_t, or `NULL` on malformed input or
+ * allocation failure. An empty blob returns an empty image.
+ *
+ * XSince: REPLACEME
+ **/
+hb_raster_image_t *
+hb_raster_gpu_render_from_blob_or_fail (hb_blob_t *blob)
+{
+#ifdef HB_NO_RASTER_GPU
+  return nullptr;
+#else
+  if (unlikely (!blob))
+    return nullptr;
+
+  unsigned length = hb_blob_get_length (blob);
+  if (!length)
+    return hb_raster_image_create_or_fail ();
+
+  if (unlikely (length % sizeof (hb_raster_gpu_texel_t)))
+    return nullptr;
+
+  const char *data = hb_blob_get_data (blob, nullptr);
+  if (unlikely (!data))
+    return nullptr;
+
+  return hb_raster_gpu_render_from_blob_data_or_fail (data,
+						      length / sizeof (hb_raster_gpu_texel_t));
+#endif
+}

--- a/src/hb-raster.cc
+++ b/src/hb-raster.cc
@@ -48,6 +48,10 @@
  * hb_raster_image_t *mask = hb_raster_draw_render (draw);
  * ]|
  *
+ * #hb_raster_gpu_render_from_blob_or_fail() decodes blobs produced by
+ * hb_gpu_draw_encode() and rasterizes them with the same coverage
+ * algorithm used by the GPU fragment shader.
+ *
  * #hb_raster_paint_t renders color paint graphs and always outputs
  * @HB_RASTER_FORMAT_BGRA32. Typical flow:
  *

--- a/src/hb-raster.h
+++ b/src/hb-raster.h
@@ -212,6 +212,23 @@ HB_EXTERN void
 hb_raster_draw_recycle_image (hb_raster_draw_t  *draw,
 			      hb_raster_image_t *image);
 
+/**
+ * hb_raster_gpu_render_from_blob_or_fail:
+ * @blob: a blob produced by hb_gpu_draw_encode()
+ *
+ * Decodes a glyph blob produced by hb_gpu_draw_encode() and rasterizes
+ * it into a new @HB_RASTER_FORMAT_A8 image using the same coverage
+ * algorithm as hb_gpu_render().
+ *
+ * Return value: (transfer full):
+ * A rendered #hb_raster_image_t, or `NULL` on malformed input or
+ * allocation failure. An empty blob returns an empty image.
+ *
+ * XSince: REPLACEME
+ **/
+HB_EXTERN hb_raster_image_t *
+hb_raster_gpu_render_from_blob_or_fail (hb_blob_t *blob);
+
 
 
 /* hb_raster_paint_t */

--- a/src/meson.build
+++ b/src/meson.build
@@ -716,6 +716,7 @@ hb_raster_sources = files(
   'hb-raster-image.hh',
   'hb-raster-utils.hh',
   'hb-raster-draw.cc',
+  'hb-raster-gpu.cc',
   'hb-raster-svg-base.cc',
   'hb-raster-svg-base.hh',
   'hb-raster-svg-defs.cc',

--- a/test/api/meson.build
+++ b/test/api/meson.build
@@ -153,3 +153,15 @@ if not get_option('gpu').disabled()
     env: env,
     suite: ['api', 'gpu'])
 endif
+
+if not get_option('raster').disabled() and not get_option('gpu').disabled()
+  test('test-raster-gpu',
+    executable('test-raster-gpu', 'test-raster-gpu.cc',
+      include_directories: [incconfig],
+      dependencies: [libharfbuzz_raster_dep, libharfbuzz_gpu_dep],
+      install: false,
+    ),
+    protocol: 'tap',
+    env: env,
+    suite: ['api', 'raster', 'gpu'])
+endif

--- a/test/api/test-raster-gpu.cc
+++ b/test/api/test-raster-gpu.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2026  Behdad Esfahbod
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Author(s): Behdad Esfahbod
+ */
+
+#include "hb-test.h"
+#include "hb-raster.h"
+#include "hb-gpu.h"
+
+
+static void
+draw_rect (hb_draw_funcs_t *funcs,
+	   void            *data,
+	   float            x0,
+	   float            y0,
+	   float            x1,
+	   float            y1)
+{
+  hb_draw_state_t st = HB_DRAW_STATE_DEFAULT;
+
+  hb_draw_move_to (funcs, data, &st, x0, y0);
+  hb_draw_line_to (funcs, data, &st, x1, y0);
+  hb_draw_line_to (funcs, data, &st, x1, y1);
+  hb_draw_line_to (funcs, data, &st, x0, y1);
+  hb_draw_close_path (funcs, data, &st);
+}
+
+static void
+draw_test_shape_gpu (hb_gpu_draw_t *draw)
+{
+  hb_draw_funcs_t *funcs = hb_gpu_draw_get_funcs ();
+
+  draw_rect (funcs, draw, 1.f, 1.f, 4.f, 3.f);
+  draw_rect (funcs, draw, 6.f, 0.f, 8.f, 2.f);
+}
+
+#ifndef HB_NO_RASTER_GPU
+static uint8_t
+pixel_at (hb_raster_image_t *img,
+	  int                x,
+	  int                y)
+{
+  hb_raster_extents_t ext;
+  hb_raster_image_get_extents (img, &ext);
+
+  int col = x - ext.x_origin;
+  int row = y - ext.y_origin;
+  if (col < 0 || row < 0 ||
+      (unsigned) col >= ext.width || (unsigned) row >= ext.height)
+    return 0;
+
+  return hb_raster_image_get_buffer (img)[row * ext.stride + col];
+}
+#endif
+
+static void
+test_render_from_gpu_empty (void)
+{
+#ifdef HB_NO_RASTER_GPU
+  g_assert_null (hb_raster_gpu_render_from_blob_or_fail (hb_blob_get_empty ()));
+#else
+  hb_raster_image_t *img = hb_raster_gpu_render_from_blob_or_fail (hb_blob_get_empty ());
+  g_assert_nonnull (img);
+
+  hb_raster_extents_t ext;
+  hb_raster_image_get_extents (img, &ext);
+  g_assert_cmpuint (ext.width, ==, 0);
+  g_assert_cmpuint (ext.height, ==, 0);
+
+  hb_raster_image_destroy (img);
+#endif
+}
+
+static void
+test_render_from_gpu_invalid (void)
+{
+  hb_blob_t *blob = hb_blob_create_or_fail ("\0\0\0", 3,
+					    HB_MEMORY_MODE_READONLY,
+					    nullptr, nullptr);
+  g_assert_nonnull (blob);
+  g_assert_null (hb_raster_gpu_render_from_blob_or_fail (blob));
+  hb_blob_destroy (blob);
+}
+
+static void
+test_render_from_gpu_roundtrip (void)
+{
+#ifdef HB_NO_RASTER_GPU
+  hb_gpu_draw_t *gpu = hb_gpu_draw_create_or_fail ();
+  g_assert_nonnull (gpu);
+  draw_test_shape_gpu (gpu);
+
+  hb_blob_t *blob = hb_gpu_draw_encode (gpu);
+  g_assert_nonnull (blob);
+  g_assert_null (hb_raster_gpu_render_from_blob_or_fail (blob));
+
+  hb_blob_destroy (blob);
+  hb_gpu_draw_destroy (gpu);
+#else
+  hb_gpu_draw_t *gpu = hb_gpu_draw_create_or_fail ();
+  g_assert_nonnull (gpu);
+
+  draw_test_shape_gpu (gpu);
+
+  hb_blob_t *blob = hb_gpu_draw_encode (gpu);
+  g_assert_nonnull (blob);
+
+  hb_raster_image_t *from_gpu = hb_raster_gpu_render_from_blob_or_fail (blob);
+  g_assert_nonnull (from_gpu);
+
+  hb_raster_extents_t ext;
+  hb_raster_image_get_extents (from_gpu, &ext);
+  g_assert_cmpint (ext.x_origin, ==, 0);
+  g_assert_cmpint (ext.y_origin, ==, -1);
+  g_assert_cmpuint (ext.width, ==, 9);
+  g_assert_cmpuint (ext.height, ==, 5);
+
+  static const uint8_t expected[5][9] = {
+    {0, 0, 0, 0, 0, 0, 43, 43, 0},
+    {0, 43, 43, 43, 0, 43, 191, 191, 42},
+    {43, 191, 213, 191, 43, 43, 191, 191, 42},
+    {43, 191, 213, 191, 43, 0, 42, 42, 0},
+    {0, 42, 42, 42, 0, 0, 0, 0, 0},
+  };
+
+  for (unsigned y = 0; y < ext.height; y++)
+    for (unsigned x = 0; x < ext.width; x++)
+      g_assert_cmpuint (pixel_at (from_gpu,
+				  ext.x_origin + x,
+				  ext.y_origin + y),
+			==,
+			expected[y][x]);
+
+  hb_raster_image_destroy (from_gpu);
+  hb_blob_destroy (blob);
+  hb_gpu_draw_destroy (gpu);
+#endif
+}
+
+int
+main (int argc, char **argv)
+{
+  hb_test_init (&argc, &argv);
+
+  hb_test_add (test_render_from_gpu_empty);
+  hb_test_add (test_render_from_gpu_invalid);
+  hb_test_add (test_render_from_gpu_roundtrip);
+
+  return hb_test_run ();
+}

--- a/util/hb-raster-gpu-all.cc
+++ b/util/hb-raster-gpu-all.cc
@@ -1,0 +1,274 @@
+/*
+ * Copyright © 2026  Behdad Esfahbod
+ *
+ *  This is part of HarfBuzz, a text shaping library.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Author(s): Behdad Esfahbod
+ */
+
+#include "hb.hh"
+#include <hb-gpu.h>
+#include <hb-raster.h>
+
+#include <chrono>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+static void
+write_ppm (hb_raster_image_t *img, const char *dir, unsigned gid)
+{
+  hb_raster_extents_t ext;
+  hb_raster_image_get_extents (img, &ext);
+  if (!ext.width || !ext.height) return;
+
+  char path[512];
+  snprintf (path, sizeof path, "%s/%05u.ppm", dir, gid);
+  FILE *f = fopen (path, "wb");
+  if (!f)
+  {
+    fprintf (stderr, "cannot write %s\n", path);
+    return;
+  }
+
+  const uint8_t *buf = hb_raster_image_get_buffer (img);
+  fprintf (f, "P6\n%u %u\n255\n", ext.width, ext.height);
+
+  uint8_t rgb[3];
+  for (unsigned row = 0; row < ext.height; row++)
+  {
+    const uint8_t *src = buf + (ext.height - 1 - row) * ext.stride;
+    for (unsigned x = 0; x < ext.width; x++)
+    {
+      rgb[0] = rgb[1] = rgb[2] = (uint8_t) (255 - src[x]);
+      fwrite (rgb, 1, 3, f);
+    }
+  }
+
+  fclose (f);
+}
+
+int
+main (int argc, char **argv)
+{
+#ifdef HB_NO_RASTER_GPU
+  fprintf (stderr, "%s was built with HB_NO_RASTER_GPU\n", argv[0]);
+  return 1;
+#else
+  unsigned num_iterations = 1;
+  int argi = 1;
+  for (; argi < argc; argi++)
+  {
+    const char *arg = argv[argi];
+    if (strcmp (arg, "--") == 0)
+    {
+      argi++;
+      break;
+    }
+    if (arg[0] != '-')
+      break;
+    if (strcmp (arg, "-h") == 0 || strcmp (arg, "--help") == 0)
+    {
+      fprintf (stderr, "Usage: %s [-n N|--num-iterations N] font-file [font-size] [output-dir]\n", argv[0]);
+      return 0;
+    }
+    if (strcmp (arg, "-n") == 0 || strcmp (arg, "--num-iterations") == 0)
+    {
+      if (++argi >= argc)
+      {
+	fprintf (stderr, "Missing value for %s\n", arg);
+	return 1;
+      }
+      char *end = nullptr;
+      long n = strtol (argv[argi], &end, 10);
+      if (!argv[argi][0] || end == argv[argi] || *end || n <= 0)
+      {
+	fprintf (stderr, "Invalid --num-iterations: %s\n", argv[argi]);
+	return 1;
+      }
+      num_iterations = (unsigned) n;
+      continue;
+    }
+
+    fprintf (stderr, "Unknown option: %s\n", arg);
+    return 1;
+  }
+
+  if (argc - argi < 1 || argc - argi > 3)
+  {
+    fprintf (stderr, "Usage: %s [-n N|--num-iterations N] font-file [font-size] [output-dir]\n", argv[0]);
+    return 1;
+  }
+
+  hb_face_t *face = hb_face_create_from_file_or_fail (argv[argi], 0);
+  if (!face)
+  {
+    fprintf (stderr, "Failed to open font\n");
+    return 1;
+  }
+
+  unsigned upem = hb_face_get_upem (face);
+  int font_size = (argc - argi > 1) ? atoi (argv[argi + 1]) : (int) upem;
+  if (font_size <= 0) font_size = (int) upem;
+  const char *outdir = (argc - argi > 2) ? argv[argi + 2] : nullptr;
+
+  hb_font_t *font = hb_font_create (face);
+  hb_font_set_scale (font, font_size, font_size);
+
+  hb_gpu_draw_t *draw = hb_gpu_draw_create_or_fail ();
+  if (!draw)
+  {
+    fprintf (stderr, "Failed to create GPU draw.\n");
+    hb_font_destroy (font);
+    hb_face_destroy (face);
+    return 1;
+  }
+
+  unsigned glyph_count = hb_face_get_glyph_count (face);
+  unsigned num_rendered = 0;
+  unsigned num_empty = 0;
+  unsigned num_failed = 0;
+  uint64_t total_blob_bytes = 0;
+  uint64_t total_pixels = 0;
+  unsigned max_blob_bytes = 0;
+  unsigned max_blob_gid = 0;
+  uint64_t outline_ns = 0;
+  uint64_t encode_ns = 0;
+  uint64_t render_ns = 0;
+  bool failed = false;
+
+  typedef std::chrono::steady_clock clock;
+  clock::time_point wall_start = clock::now ();
+
+  for (unsigned iter = 0; iter < num_iterations; iter++)
+    for (unsigned gid = 0; gid < glyph_count; gid++)
+    {
+      hb_gpu_draw_reset (draw);
+
+      clock::time_point t0 = clock::now ();
+      hb_gpu_draw_glyph (draw, font, gid);
+      clock::time_point t1 = clock::now ();
+
+      hb_blob_t *blob = hb_gpu_draw_encode (draw);
+      clock::time_point t2 = clock::now ();
+
+      outline_ns += std::chrono::duration_cast<std::chrono::nanoseconds> (t1 - t0).count ();
+      encode_ns  += std::chrono::duration_cast<std::chrono::nanoseconds> (t2 - t1).count ();
+
+      if (!blob)
+      {
+	if (iter == 0)
+	{
+	  fprintf (stderr, "gid %u: encode failed\n", gid);
+	  num_failed++;
+	}
+	failed = true;
+	continue;
+      }
+
+      unsigned blob_length = hb_blob_get_length (blob);
+      if (iter == 0)
+      {
+	total_blob_bytes += blob_length;
+	if (blob_length == 0)
+	  num_empty++;
+	else
+	{
+	  num_rendered++;
+	  if (blob_length > max_blob_bytes)
+	  {
+	    max_blob_bytes = blob_length;
+	    max_blob_gid = gid;
+	  }
+	}
+      }
+
+      clock::time_point t3 = clock::now ();
+      hb_raster_image_t *img = hb_raster_gpu_render_from_blob_or_fail (blob);
+      clock::time_point t4 = clock::now ();
+      render_ns += std::chrono::duration_cast<std::chrono::nanoseconds> (t4 - t3).count ();
+
+      hb_gpu_draw_recycle_blob (draw, blob);
+
+      if (!img)
+      {
+	if (iter == 0)
+	{
+	  fprintf (stderr, "gid %u: raster render failed\n", gid);
+	  num_failed++;
+	}
+	failed = true;
+	continue;
+      }
+
+      if (iter == 0)
+      {
+	hb_raster_extents_t ext;
+	hb_raster_image_get_extents (img, &ext);
+	total_pixels += (uint64_t) ext.width * ext.height;
+      }
+
+      if (outdir && iter + 1 == num_iterations)
+	write_ppm (img, outdir, gid);
+
+      hb_raster_image_destroy (img);
+    }
+
+  uint64_t wall_ns =
+    std::chrono::duration_cast<std::chrono::nanoseconds> (clock::now () - wall_start).count ();
+  uint64_t total_glyphs = (uint64_t) glyph_count * num_iterations;
+
+  printf ("font:     %s\n", argv[argi]);
+  printf ("glyphs:   %u\n", glyph_count);
+  printf ("rendered: %u\n", num_rendered);
+  printf ("empty:    %u\n", num_empty);
+  if (num_failed)
+    printf ("FAILED:   %u\n", num_failed);
+  printf ("blob:     %.2f KiB\n", total_blob_bytes / 1024.);
+  if (num_rendered)
+  {
+    printf ("avg:      %.2f KiB/glyph (non-empty)\n",
+	    total_blob_bytes / 1024. / num_rendered);
+    printf ("max:      %.2f KiB (gid %u)\n",
+	    max_blob_bytes / 1024., max_blob_gid);
+  }
+  printf ("pixels:   %.2f Mpx\n", total_pixels / 1000000.);
+  printf ("outline:  %.3fms (%.1fus/glyph)\n",
+	  outline_ns / 1e6 / num_iterations,
+	  total_glyphs ? outline_ns / 1e3 / total_glyphs : 0.);
+  printf ("encode:   %.3fms (%.1fus/glyph)\n",
+	  encode_ns / 1e6 / num_iterations,
+	  total_glyphs ? encode_ns / 1e3 / total_glyphs : 0.);
+  printf ("render:   %.3fms (%.1fus/glyph)\n",
+	  render_ns / 1e6 / num_iterations,
+	  total_glyphs ? render_ns / 1e3 / total_glyphs : 0.);
+  printf ("wall:     %.3fms (%.0f glyphs/s)\n",
+	  wall_ns / 1e6 / num_iterations,
+	  wall_ns ? total_glyphs * 1e9 / wall_ns : 0.);
+
+  hb_gpu_draw_destroy (draw);
+  hb_font_destroy (font);
+  hb_face_destroy (face);
+
+  return failed ? 1 : 0;
+#endif
+}

--- a/util/meson.build
+++ b/util/meson.build
@@ -152,6 +152,15 @@ if conf.get('HAVE_GLIB', 0) == 1
     )
   endif
 
+  if not get_option('raster').disabled() and not get_option('gpu').disabled()
+    hb_raster_gpu_all = executable('hb-raster-gpu-all', ['hb-raster-gpu-all.cc'],
+      cpp_args: cpp_args,
+      include_directories: [incconfig, incsrc],
+      link_with: [libharfbuzz, libharfbuzz_raster, libharfbuzz_gpu],
+      install: false,
+    )
+  endif
+
   hb_info = executable('hb-info', [hb_info_sources, gobject_enums_h],
     cpp_args: cpp_args,
     include_directories: [incconfig, incsrc],


### PR DESCRIPTION
This was just an experiment with implementing Slug shaders on the CPU and measure the rasterization performance compared to hb-raster.

In my limited testing this was 10x slower than hb-raster for NotoSerifCJK at 30ppem, and over 50x slower than hb-raster for Roboto-Regular at 100ppem.

Going to abandon because it would be a maintenance burden to keep it in the tree.