### PR TITLE
[gpu] encode() returns extents + auto-clears; drop get_extents()

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -1131,7 +1131,6 @@ hb_gpu_draw_get_funcs
 hb_gpu_draw_set_scale
 hb_gpu_draw_glyph
 hb_gpu_draw_encode
-hb_gpu_draw_get_extents
 hb_gpu_draw_clear
 hb_gpu_draw_reset
 hb_gpu_draw_recycle_blob

--- a/src/hb-gpu-draw.cc
+++ b/src/hb-gpu-draw.cc
@@ -355,13 +355,18 @@ encode_curve_info (const hb_gpu_curve_t *c)
 /**
  * hb_gpu_draw_encode:
  * @draw: a GPU shape encoder
+ * @extents: (out) (nullable): where to store the computed glyph
+ *           extents (in font units, Y-up).  Pass `NULL` if not
+ *           needed.
  *
  * Encodes the accumulated outlines into a compact blob
  * suitable for GPU rendering.  The blob data is an array of
  * RGBA16I texels (8 bytes each) to be uploaded to a texture
  * buffer object.
  *
- * The returned blob owns its own copy of the data.
+ * The returned blob owns its own copy of the data.  On success
+ * @draw is auto-cleared so it can be reused for the next glyph;
+ * user configuration (font scale) is preserved.
  *
  * Return value: (transfer full):
  * An #hb_blob_t containing the encoded data, or
@@ -369,14 +374,18 @@ encode_curve_info (const hb_gpu_curve_t *c)
  *
  * Since: 14.0.0
  **/
+static void
+_hb_gpu_draw_get_extents (hb_gpu_draw_t      *draw,
+			  hb_glyph_extents_t *extents);
+
 hb_blob_t *
-hb_gpu_draw_encode (hb_gpu_draw_t *draw)
+hb_gpu_draw_encode (hb_gpu_draw_t      *draw,
+                    hb_glyph_extents_t *extents)
 {
-  /* Unlike hb_vector_*_render and hb_raster_*_render, encode() does
-   * NOT auto-clear — the encoded extents live on @draw (not on the
-   * returned blob) and callers typically read them via
-   * hb_gpu_draw_get_extents() after encode().  Call
-   * hb_gpu_draw_clear() explicitly before the next glyph. */
+  /* Capture computed extents before auto-clear wipes them. */
+  if (extents)
+    _hb_gpu_draw_get_extents (draw, extents);
+  HB_SCOPE_GUARD (hb_gpu_draw_clear (draw));
 
   if (unlikely (!draw->success))
     return nullptr;
@@ -1031,18 +1040,9 @@ hb_gpu_draw_glyph (hb_gpu_draw_t *draw,
 		       draw);
 }
 
-/**
- * hb_gpu_draw_get_extents:
- * @draw: a GPU shape encoder
- * @extents: (out): glyph extents
- *
- * Fetches the extents of the accumulated outlines.
- *
- * Since: 14.0.0
- **/
-void
-hb_gpu_draw_get_extents (hb_gpu_draw_t     *draw,
-			   hb_glyph_extents_t *extents)
+static void
+_hb_gpu_draw_get_extents (hb_gpu_draw_t      *draw,
+			  hb_glyph_extents_t *extents)
 {
   if (unlikely (!draw->success) ||
       draw->num_curves == 0 ||

--- a/src/hb-gpu.h
+++ b/src/hb-gpu.h
@@ -110,11 +110,8 @@ hb_gpu_draw_glyph (hb_gpu_draw_t *draw,
 /* Encode */
 
 HB_EXTERN hb_blob_t *
-hb_gpu_draw_encode (hb_gpu_draw_t *draw);
-
-HB_EXTERN void
-hb_gpu_draw_get_extents (hb_gpu_draw_t     *draw,
-			   hb_glyph_extents_t *extents);
+hb_gpu_draw_encode (hb_gpu_draw_t      *draw,
+                    hb_glyph_extents_t *extents);
 
 HB_EXTERN void
 hb_gpu_draw_clear (hb_gpu_draw_t *draw);

--- a/test/api/test-gpu.cc
+++ b/test/api/test-gpu.cc
@@ -83,15 +83,13 @@ test_empty_encode (void)
   hb_gpu_draw_t *draw = hb_gpu_draw_create_or_fail ();
   g_assert_nonnull (draw);
 
-  /* Encode with no curves should return empty blob. */
-  hb_blob_t *blob = hb_gpu_draw_encode (draw);
+  /* Encode with no curves should return empty blob and zero extents. */
+  hb_glyph_extents_t ext;
+  hb_blob_t *blob = hb_gpu_draw_encode (draw, &ext);
   g_assert_nonnull (blob);
   g_assert_cmpuint (hb_blob_get_length (blob), ==, 0);
   hb_blob_destroy (blob);
 
-  /* Extents should be zero. */
-  hb_glyph_extents_t ext;
-  hb_gpu_draw_get_extents (draw, &ext);
   g_assert_cmpint (ext.x_bearing, ==, 0);
   g_assert_cmpint (ext.y_bearing, ==, 0);
   g_assert_cmpint (ext.width, ==, 0);
@@ -117,17 +115,15 @@ test_encode_glyph (void)
 
   hb_gpu_draw_glyph (draw, font, gid);
 
-  /* Encode should produce non-empty blob. */
-  hb_blob_t *blob = hb_gpu_draw_encode (draw);
+  /* Encode should produce non-empty blob with non-zero extents. */
+  hb_glyph_extents_t ext;
+  hb_blob_t *blob = hb_gpu_draw_encode (draw, &ext);
   g_assert_nonnull (blob);
   g_assert_cmpuint (hb_blob_get_length (blob), >, 0);
 
   /* Blob size should be a multiple of 8 (RGBA16I texels). */
   g_assert_cmpuint (hb_blob_get_length (blob) % 8, ==, 0);
 
-  /* Extents should be non-zero. */
-  hb_glyph_extents_t ext;
-  hb_gpu_draw_get_extents (draw, &ext);
   g_assert_cmpint (ext.width, >, 0);
   g_assert_cmpint (ext.height, <, 0); /* height is negative (y-down) */
 
@@ -151,20 +147,20 @@ test_reset (void)
 
   /* Draw, encode, reset, encode again — should work. */
   hb_gpu_draw_glyph (draw, font, gid);
-  hb_blob_t *blob1 = hb_gpu_draw_encode (draw);
+  hb_blob_t *blob1 = hb_gpu_draw_encode (draw, nullptr);
   g_assert_cmpuint (hb_blob_get_length (blob1), >, 0);
   hb_blob_destroy (blob1);
 
   hb_gpu_draw_reset (draw);
 
   /* After reset, encode should be empty. */
-  hb_blob_t *blob2 = hb_gpu_draw_encode (draw);
+  hb_blob_t *blob2 = hb_gpu_draw_encode (draw, nullptr);
   g_assert_cmpuint (hb_blob_get_length (blob2), ==, 0);
   hb_blob_destroy (blob2);
 
   /* Draw again after reset. */
   hb_gpu_draw_glyph (draw, font, gid);
-  hb_blob_t *blob3 = hb_gpu_draw_encode (draw);
+  hb_blob_t *blob3 = hb_gpu_draw_encode (draw, nullptr);
   g_assert_cmpuint (hb_blob_get_length (blob3), >, 0);
   hb_blob_destroy (blob3);
 
@@ -203,7 +199,7 @@ test_encode_quantizes_extents_outward (void)
   hb_draw_line_to (funcs, draw, &st, 0.76f, 0.76f);
   hb_draw_close_path (funcs, draw, &st);
 
-  hb_blob_t *blob = hb_gpu_draw_encode (draw);
+  hb_blob_t *blob = hb_gpu_draw_encode (draw, nullptr);
   g_assert_nonnull (blob);
 
   unsigned texel_count;
@@ -236,7 +232,7 @@ test_encode_preserves_touching_contours (void)
   hb_draw_quadratic_to (funcs, draw, &st, -0.75f, 0.25f, -0.25f, -1.f);
   hb_draw_close_path (funcs, draw, &st);
 
-  hb_blob_t *blob = hb_gpu_draw_encode (draw);
+  hb_blob_t *blob = hb_gpu_draw_encode (draw, nullptr);
   g_assert_nonnull (blob);
 
   g_assert_true (blob_has_texel (blob, {0, 0, -3, 1}));
@@ -259,7 +255,7 @@ test_recycle_blob (void)
   hb_draw_line_to (funcs, draw, &st, 0.f, 1.f);
   hb_draw_close_path (funcs, draw, &st);
 
-  hb_blob_t *blob = hb_gpu_draw_encode (draw);
+  hb_blob_t *blob = hb_gpu_draw_encode (draw, nullptr);
   g_assert_nonnull (blob);
   unsigned first_length = hb_blob_get_length (blob);
   g_assert_cmpuint (first_length, >, 0);
@@ -278,7 +274,7 @@ test_recycle_blob (void)
   hb_draw_quadratic_to (funcs, draw, &st, 1.f, -0.5f, 0.25f, 0.25f);
   hb_draw_close_path (funcs, draw, &st);
 
-  hb_blob_t *blob2 = hb_gpu_draw_encode (draw);
+  hb_blob_t *blob2 = hb_gpu_draw_encode (draw, nullptr);
   g_assert_nonnull (blob2);
   g_assert_cmpuint (hb_blob_get_length (blob2), >, first_length);
 
@@ -301,7 +297,8 @@ test_extents_saturate_overflow (void)
   hb_draw_close_path (funcs, draw, &st);
 
   hb_glyph_extents_t ext;
-  hb_gpu_draw_get_extents (draw, &ext);
+  hb_blob_t *blob = hb_gpu_draw_encode (draw, &ext);
+  hb_blob_destroy (blob);
 
   g_assert_cmpint (ext.x_bearing, ==, G_MININT32);
   g_assert_cmpint (ext.y_bearing, ==, 1);

--- a/test/fuzzing/hb-gpu-fuzzer.cc
+++ b/test/fuzzing/hb-gpu-fuzzer.cc
@@ -25,10 +25,8 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
     hb_gpu_draw_glyph (draw, input.font, gid);
 
     hb_glyph_extents_t extents;
-    hb_gpu_draw_get_extents (draw, &extents);
+    hb_blob_t *blob = hb_gpu_draw_encode (draw, &extents);
     counter += extents.width;
-
-    hb_blob_t *blob = hb_gpu_draw_encode (draw);
     if (blob)
     {
       unsigned length = 0;

--- a/util/gpu/demo-font.cc
+++ b/util/gpu/demo-font.cc
@@ -71,15 +71,13 @@ _demo_font_upload_glyph (demo_font_t  *font,
 
   hb_gpu_draw_glyph (font->g, font->font, glyph_index);
 
-  hb_blob_t *blob = hb_gpu_draw_encode (font->g);
+  /* Get extents in font design units */
+  hb_glyph_extents_t hb_ext;
+  hb_blob_t *blob = hb_gpu_draw_encode (font->g, &hb_ext);
   if (!blob)
     die ("Failed encoding glyph");
 
   unsigned int len = hb_blob_get_length (blob);
-
-  /* Get extents in font design units */
-  hb_glyph_extents_t hb_ext;
-  hb_gpu_draw_get_extents (font->g, &hb_ext);
 
   glyph_info->extents.min_x = hb_ext.x_bearing;
   glyph_info->extents.max_x = hb_ext.x_bearing + hb_ext.width;

--- a/util/hb-gpu-encode-all.cc
+++ b/util/hb-gpu-encode-all.cc
@@ -112,7 +112,7 @@ main (int argc, char **argv)
     hb_gpu_draw_glyph (draw, font, gid);
     clock::time_point t1 = clock::now ();
 
-    hb_blob_t *encoded = hb_gpu_draw_encode (draw);
+    hb_blob_t *encoded = hb_gpu_draw_encode (draw, nullptr);
     clock::time_point t2 = clock::now ();
 
     outline_ns += std::chrono::duration_cast<std::chrono::nanoseconds> (t1 - t0).count ();


### PR DESCRIPTION
Bring hb_gpu_draw_encode into line with the rest of the render APIs: auto-clear on success, and return the computed glyph extents to the caller via a new out-parameter (nullable).

  HB_EXTERN hb_blob_t *
  hb_gpu_draw_encode (hb_gpu_draw_t      *draw,
                      hb_glyph_extents_t *extents);

Consumers typically need both the encoded blob and the glyph's extents to size the quad they'll draw into in the vertex shader; returning them together removes a redundant trip through the draw state and lets encode() auto-clear like hb_vector_*_render() and hb_raster_*_render() do.

Drop hb_gpu_draw_get_extents() from the public API — its only role was reading extents out of the draw state post-encode, which the new encode() signature makes redundant.  The computation stays (moved to a static _hb_gpu_draw_get_extents helper) so encode() can call it before auto-clear wipes the state.

ABI break for anyone who had already wired up against the 14.0.0 hb_gpu_draw_encode signature or hb_gpu_draw_get_extents, but the library is new/experimental and the two in-tree consumers (test/api/test-gpu.cc, util/gpu/demo-font.cc, util/hb-gpu-encode-all.cc, test/fuzzing/hb-gpu-fuzzer.cc) are updated here.

All 240 tests pass.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>