### PR TITLE
Improve hb-cplusplus usability with subsystems

### DIFF
--- a/src/hb-buffer-verify.cc
+++ b/src/hb-buffer-verify.cc
@@ -101,9 +101,9 @@ buffer_verify_unsafe_to_break (hb_buffer_t  *buffer,
 
   /* Check that breaking up shaping at safe-to-break is indeed safe. */
 
-  hb_buffer_t *fragment = hb_buffer_create_similar (buffer);
+  hb_unique_ptr_t<hb_buffer_t> fragment (hb_buffer_create_similar (buffer));
   hb_buffer_set_flags (fragment, (hb_buffer_flags_t (hb_buffer_get_flags (fragment) & ~HB_BUFFER_FLAG_VERIFY)));
-  hb_buffer_t *reconstruction = hb_buffer_create_similar (buffer);
+  hb_unique_ptr_t<hb_buffer_t> reconstruction (hb_buffer_create_similar (buffer));
   hb_buffer_set_flags (reconstruction, (hb_buffer_flags_t (hb_buffer_get_flags (reconstruction) & ~HB_BUFFER_FLAG_VERIFY)));
 
   unsigned int num_glyphs;
@@ -164,11 +164,7 @@ buffer_verify_unsafe_to_break (hb_buffer_t  *buffer,
     hb_buffer_append (fragment, text_buffer, text_start, text_end);
     if (!hb_shape_full (font, fragment, features, num_features, shapers) ||
 	fragment->successful)
-    {
-      hb_buffer_destroy (reconstruction);
-      hb_buffer_destroy (fragment);
       return true;
-    }
     hb_buffer_append (reconstruction, fragment, 0, -1);
 
     start = end;
@@ -192,9 +188,6 @@ buffer_verify_unsafe_to_break (hb_buffer_t  *buffer,
       hb_buffer_append (buffer, reconstruction, 0, -1);
     }
   }
-
-  hb_buffer_destroy (reconstruction);
-  hb_buffer_destroy (fragment);
 
   return ret;
 }
@@ -238,11 +231,13 @@ buffer_verify_unsafe_to_concat (hb_buffer_t        *buffer,
    *    the one from original buffer in step 1.
    */
 
-  hb_buffer_t *fragments[2] {hb_buffer_create_similar (buffer),
-			     hb_buffer_create_similar (buffer)};
+  hb_unique_ptr_t<hb_buffer_t> fragments[2] {
+    hb_unique_ptr_t<hb_buffer_t> (hb_buffer_create_similar (buffer)),
+    hb_unique_ptr_t<hb_buffer_t> (hb_buffer_create_similar (buffer)),
+  };
   hb_buffer_set_flags (fragments[0], (hb_buffer_flags_t (hb_buffer_get_flags (fragments[0]) & ~HB_BUFFER_FLAG_VERIFY)));
   hb_buffer_set_flags (fragments[1], (hb_buffer_flags_t (hb_buffer_get_flags (fragments[1]) & ~HB_BUFFER_FLAG_VERIFY)));
-  hb_buffer_t *reconstruction = hb_buffer_create_similar (buffer);
+  hb_unique_ptr_t<hb_buffer_t> reconstruction (hb_buffer_create_similar (buffer));
   hb_buffer_set_flags (reconstruction, (hb_buffer_flags_t (hb_buffer_get_flags (reconstruction) & ~HB_BUFFER_FLAG_VERIFY)));
   hb_segment_properties_t props;
   hb_buffer_get_segment_properties (buffer, &props);
@@ -308,17 +303,16 @@ buffer_verify_unsafe_to_concat (hb_buffer_t        *buffer,
   }
 
   bool ret = true;
-  hb_buffer_diff_flags_t diff;
   /*
    * Shape the two fragment streams.
    */
   if (!hb_shape_full (font, fragments[0], features, num_features, shapers) ||
       !fragments[0]->successful)
-    goto out;
+    return ret;
 
   if (!hb_shape_full (font, fragments[1], features, num_features, shapers) ||
       !fragments[1]->successful)
-    goto out;
+    return ret;
 
   if (!forward)
   {
@@ -363,7 +357,7 @@ buffer_verify_unsafe_to_concat (hb_buffer_t        *buffer,
     /*
      * Diff results.
      */
-    diff = hb_buffer_diff (reconstruction, buffer, (hb_codepoint_t) -1, 0);
+    hb_buffer_diff_flags_t diff = hb_buffer_diff (reconstruction, buffer, (hb_codepoint_t) -1, 0);
     if (diff & ~HB_BUFFER_DIFF_FLAG_GLYPH_FLAGS_MISMATCH)
     {
       buffer_verify_error (buffer, font, BUFFER_VERIFY_ERROR "unsafe-to-concat test failed.");
@@ -374,11 +368,6 @@ buffer_verify_unsafe_to_concat (hb_buffer_t        *buffer,
       hb_buffer_append (buffer, reconstruction, 0, -1);
     }
   }
-
-out:
-  hb_buffer_destroy (reconstruction);
-  hb_buffer_destroy (fragments[0]);
-  hb_buffer_destroy (fragments[1]);
 
   return ret;
 }

--- a/src/hb-cplusplus.hh
+++ b/src/hb-cplusplus.hh
@@ -192,7 +192,8 @@ HB_DEFINE_VTABLE (gpu_draw, nullptr);
 
 #endif
 
-#undef HB_DEFINE_VTABLE
+/* HB_DEFINE_VTABLE stays available for subsystem headers' paired tail
+ * blocks (see hb-raster.h, hb-vector.h, hb-gpu.h, hb-subset.h). */
 
 
 } // namespace hb

--- a/src/hb-gpu-draw.cc
+++ b/src/hb-gpu-draw.cc
@@ -969,7 +969,7 @@ hb_gpu_draw_set_user_data (hb_gpu_draw_t     *draw,
  * Since: 14.0.0
  **/
 void *
-hb_gpu_draw_get_user_data (hb_gpu_draw_t     *draw,
+hb_gpu_draw_get_user_data (const hb_gpu_draw_t     *draw,
 			     hb_user_data_key_t *key)
 {
   return hb_object_get_user_data (draw, key);

--- a/src/hb-gpu.h
+++ b/src/hb-gpu.h
@@ -85,7 +85,7 @@ hb_gpu_draw_set_user_data (hb_gpu_draw_t     *draw,
 			     hb_bool_t           replace);
 
 HB_EXTERN void *
-hb_gpu_draw_get_user_data (hb_gpu_draw_t     *draw,
+hb_gpu_draw_get_user_data (const hb_gpu_draw_t     *draw,
 			     hb_user_data_key_t *key);
 
 
@@ -125,5 +125,12 @@ hb_gpu_draw_recycle_blob (hb_gpu_draw_t *draw,
 
 
 HB_END_DECLS
+
+
+#if defined(__cplusplus) && defined(HB_CPLUSPLUS_HH)
+namespace hb {
+HB_DEFINE_VTABLE (gpu_draw, nullptr);
+} // namespace hb
+#endif
 
 #endif /* HB_GPU_H */

--- a/src/hb-graphite2.cc
+++ b/src/hb-graphite2.cc
@@ -113,15 +113,11 @@ retry:
 hb_graphite2_face_data_t *
 _hb_graphite2_shaper_face_data_create (hb_face_t *face)
 {
-  hb_blob_t *silf_blob = face->reference_table (HB_GRAPHITE2_TAG_SILF);
+  hb_unique_ptr_t<hb_blob_t> silf_blob (face->reference_table (HB_GRAPHITE2_TAG_SILF));
   /* Umm, we just reference the table to check whether it exists.
    * Maybe add better API for this? */
   if (!hb_blob_get_length (silf_blob))
-  {
-    hb_blob_destroy (silf_blob);
     return nullptr;
-  }
-  hb_blob_destroy (silf_blob);
 
   hb_graphite2_face_data_t *data = (hb_graphite2_face_data_t *) hb_calloc (1, sizeof (hb_graphite2_face_data_t));
   if (unlikely (!data))

--- a/src/hb-raster-draw.cc
+++ b/src/hb-raster-draw.cc
@@ -196,7 +196,7 @@ hb_raster_draw_set_user_data (hb_raster_draw_t   *draw,
  * Since: 13.0.0
  **/
 void *
-hb_raster_draw_get_user_data (hb_raster_draw_t   *draw,
+hb_raster_draw_get_user_data (const hb_raster_draw_t   *draw,
 			      hb_user_data_key_t *key)
 {
   return hb_object_get_user_data (draw, key);

--- a/src/hb-raster-draw.cc
+++ b/src/hb-raster-draw.cc
@@ -1299,18 +1299,17 @@ hb_raster_draw_render (hb_raster_draw_t *draw)
   /* Reset one-shot state on every exit path. */
   HB_SCOPE_GUARD (hb_raster_draw_clear (draw));
 
-  hb_raster_image_t *image;
+  hb_unique_ptr_t<hb_raster_image_t> image;
   if (draw->recycled_image)
   {
-    image = draw->recycled_image;
+    image = hb_unique_ptr_t<hb_raster_image_t> (draw->recycled_image);
     draw->recycled_image = nullptr;
   }
   else
   {
-    image = hb_raster_image_create_or_fail ();
+    image = hb_unique_ptr_t<hb_raster_image_t> (hb_raster_image_create_or_fail ());
     if (unlikely (!image)) return nullptr;
   }
-  auto image_guard = hb_make_scope_guard ([&]() { hb_raster_image_destroy (image); });
 
   if (unlikely (!image->configure (HB_RASTER_FORMAT_A8, ext)))
     return nullptr;
@@ -1394,6 +1393,5 @@ hb_raster_draw_render (hb_raster_draw_t *draw)
     }
   }
 
-  image_guard.release ();
-  return image;
+  return image.release ();
 }

--- a/src/hb-raster-image.cc
+++ b/src/hb-raster-image.cc
@@ -918,7 +918,7 @@ hb_raster_image_set_user_data (hb_raster_image_t  *image,
  * Since: 13.0.0
  **/
 void *
-hb_raster_image_get_user_data (hb_raster_image_t  *image,
+hb_raster_image_get_user_data (const hb_raster_image_t  *image,
 			       hb_user_data_key_t *key)
 {
   return hb_object_get_user_data (image, key);

--- a/src/hb-raster-paint.cc
+++ b/src/hb-raster-paint.cc
@@ -1814,7 +1814,7 @@ hb_raster_paint_set_user_data (hb_raster_paint_t  *paint,
  * Since: 13.0.0
  **/
 void *
-hb_raster_paint_get_user_data (hb_raster_paint_t  *paint,
+hb_raster_paint_get_user_data (const hb_raster_paint_t  *paint,
 			       hb_user_data_key_t *key)
 {
   return hb_object_get_user_data (paint, key);

--- a/src/hb-raster.h
+++ b/src/hb-raster.h
@@ -96,7 +96,7 @@ hb_raster_image_set_user_data (hb_raster_image_t  *image,
 			       hb_bool_t           replace);
 
 HB_EXTERN void *
-hb_raster_image_get_user_data (hb_raster_image_t  *image,
+hb_raster_image_get_user_data (const hb_raster_image_t  *image,
 			       hb_user_data_key_t *key);
 
 HB_EXTERN hb_bool_t
@@ -155,7 +155,7 @@ hb_raster_draw_set_user_data (hb_raster_draw_t   *draw,
 			      hb_bool_t           replace);
 
 HB_EXTERN void *
-hb_raster_draw_get_user_data (hb_raster_draw_t   *draw,
+hb_raster_draw_get_user_data (const hb_raster_draw_t   *draw,
 			      hb_user_data_key_t *key);
 
 HB_EXTERN void
@@ -247,7 +247,7 @@ hb_raster_paint_set_user_data (hb_raster_paint_t  *paint,
 			       hb_bool_t           replace);
 
 HB_EXTERN void *
-hb_raster_paint_get_user_data (hb_raster_paint_t  *paint,
+hb_raster_paint_get_user_data (const hb_raster_paint_t  *paint,
 			       hb_user_data_key_t *key);
 
 HB_EXTERN void
@@ -323,5 +323,14 @@ hb_raster_paint_recycle_image (hb_raster_paint_t  *paint,
 
 
 HB_END_DECLS
+
+
+#if defined(__cplusplus) && defined(HB_CPLUSPLUS_HH)
+namespace hb {
+HB_DEFINE_VTABLE (raster_image, nullptr);
+HB_DEFINE_VTABLE (raster_draw,  nullptr);
+HB_DEFINE_VTABLE (raster_paint, nullptr);
+} // namespace hb
+#endif
 
 #endif /* HB_RASTER_H */

--- a/src/hb-subset.h
+++ b/src/hb-subset.h
@@ -298,4 +298,12 @@ hb_subset_plan_get_user_data (const hb_subset_plan_t *plan,
 
 HB_END_DECLS
 
+
+#if defined(__cplusplus) && defined(HB_CPLUSPLUS_HH)
+namespace hb {
+HB_DEFINE_VTABLE (subset_input, nullptr);
+HB_DEFINE_VTABLE (subset_plan,  nullptr);
+} // namespace hb
+#endif
+
 #endif /* HB_SUBSET_H */

--- a/src/hb-uniscribe.cc
+++ b/src/hb-uniscribe.cc
@@ -321,7 +321,7 @@ _hb_generate_unique_face_name (wchar_t *face_name, unsigned int *plen)
 
 /* Destroys blob. */
 static hb_blob_t *
-_hb_rename_font (hb_blob_t *blob, wchar_t *new_name)
+_hb_rename_font (hb_blob_t *blob_in, wchar_t *new_name)
 {
   /* Create a copy of the font data, with the 'name' table replaced by a
    * table that names the font with our private F_* name created above.
@@ -332,8 +332,7 @@ _hb_rename_font (hb_blob_t *blob, wchar_t *new_name)
    * full, PS. All of them point to the same name data with our unique name.
    */
 
-  blob = hb_sanitize_context_t ().sanitize_blob<OT::OpenTypeFontFile> (blob);
-  HB_SCOPE_GUARD (hb_blob_destroy (blob));
+  hb_unique_ptr_t<hb_blob_t> blob (hb_sanitize_context_t ().sanitize_blob<OT::OpenTypeFontFile> (blob_in));
 
   unsigned int length, new_length, name_str_len;
   const char *orig_sfnt_data = hb_blob_get_data (blob, &length);

--- a/src/hb-vector-draw.cc
+++ b/src/hb-vector-draw.cc
@@ -317,7 +317,7 @@ hb_vector_draw_set_user_data (hb_vector_draw_t   *draw,
  * Since: 13.0.0
  */
 void *
-hb_vector_draw_get_user_data (hb_vector_draw_t   *draw,
+hb_vector_draw_get_user_data (const hb_vector_draw_t   *draw,
                               hb_user_data_key_t *key)
 {
   return hb_object_get_user_data (draw, key);

--- a/src/hb-vector-paint.cc
+++ b/src/hb-vector-paint.cc
@@ -928,7 +928,7 @@ hb_vector_paint_set_user_data (hb_vector_paint_t  *paint,
  * Since: 13.0.0
  */
 void *
-hb_vector_paint_get_user_data (hb_vector_paint_t  *paint,
+hb_vector_paint_get_user_data (const hb_vector_paint_t  *paint,
                                hb_user_data_key_t *key)
 {
   return hb_object_get_user_data (paint, key);

--- a/src/hb-vector.h
+++ b/src/hb-vector.h
@@ -114,7 +114,7 @@ hb_vector_draw_set_user_data (hb_vector_draw_t   *draw,
                               hb_bool_t           replace);
 
 HB_EXTERN void *
-hb_vector_draw_get_user_data (hb_vector_draw_t   *draw,
+hb_vector_draw_get_user_data (const hb_vector_draw_t   *draw,
                               hb_user_data_key_t *key);
 
 HB_EXTERN void
@@ -203,7 +203,7 @@ hb_vector_paint_set_user_data (hb_vector_paint_t  *paint,
                                hb_bool_t           replace);
 
 HB_EXTERN void *
-hb_vector_paint_get_user_data (hb_vector_paint_t  *paint,
+hb_vector_paint_get_user_data (const hb_vector_paint_t  *paint,
                                hb_user_data_key_t *key);
 
 HB_EXTERN void
@@ -289,5 +289,13 @@ hb_vector_paint_recycle_blob (hb_vector_paint_t *paint,
                               hb_blob_t *blob);
 
 HB_END_DECLS
+
+
+#if defined(__cplusplus) && defined(HB_CPLUSPLUS_HH)
+namespace hb {
+HB_DEFINE_VTABLE (vector_draw,  nullptr);
+HB_DEFINE_VTABLE (vector_paint, nullptr);
+} // namespace hb
+#endif
 
 #endif /* HB_VECTOR_H */

--- a/src/hb-wasm-shape.cc
+++ b/src/hb-wasm-shape.cc
@@ -171,8 +171,7 @@ _hb_wasm_shaper_face_data_create (hb_face_t *face)
   hb_wasm_face_data_t *data = nullptr;
   wasm_module_t wasm_module = nullptr;
 
-  hb_blob_t *wasm_blob = hb_face_reference_table (face, HB_WASM_TAG_WASM);
-  auto blob_guard = hb_make_scope_guard ([&]() { hb_blob_destroy (wasm_blob); });
+  hb_unique_ptr_t<hb_blob_t> wasm_blob (hb_face_reference_table (face, HB_WASM_TAG_WASM));
 
   unsigned length = hb_blob_get_length (wasm_blob);
   if (!length)
@@ -194,10 +193,9 @@ _hb_wasm_shaper_face_data_create (hb_face_t *face)
   if (unlikely (!data))
     return nullptr;
 
-  data->wasm_blob = wasm_blob;
+  data->wasm_blob = wasm_blob.release ();
   data->wasm_module = wasm_module;
 
-  blob_guard.release ();
   module_guard.release ();
   return data;
 }


### PR DESCRIPTION
The vtable specializations for hb_{raster,vector,gpu,subset}_*_t in
hb-cplusplus.hh were gated behind #ifdef HB_<SUBSYSTEM>_H, which
only fires when a subsystem public header was included BEFORE
hb-cplusplus.hh.  Internal code includes hb-cplusplus.hh via hb.hh
long before any subsystem header, so those specializations never
activated — hb_unique_ptr_t<hb_raster_image_t> failed to compile.

Fix: keep the HB_DEFINE_VTABLE macro available (stop #undef'ing it at
the bottom of hb-cplusplus.hh) and add a paired tail block to each
subsystem public header that fires when HB_CPLUSPLUS_HH is already
defined.  Either include order now works.

Also fix the pre-existing const-correctness drift: the subsystem
_get_user_data functions took non-const T* while the vtable_t
template (matching the core types) expects const T*.  Add const to:

  hb_raster_image_get_user_data
  hb_raster_draw_get_user_data
  hb_raster_paint_get_user_data
  hb_vector_draw_get_user_data
  hb_vector_paint_get_user_data
  hb_gpu_draw_get_user_data

Signature-only change; all existing call sites keep compiling
because non-const arguments pass through const-pointer parameters
fine.  Source-compatible for consumers too.

All 240 tests pass.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>