### PR TITLE
[vector/raster/gpu] Add *_glyph_or_fail() variants across all three

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -82,16 +82,20 @@ Overview of changes leading to NEXT (REPLACEME)
   +hb_gpu_paint_reset()
   +hb_gpu_paint_recycle_blob()
   +hb_gpu_paint_shader_source()
+  +hb_gpu_paint_glyph_or_fail()
   +HB_GPU_SHADER_STAGE_VERTEX
   +HB_GPU_SHADER_STAGE_FRAGMENT
   +hb_gpu_shader_source()
   +hb_gpu_draw_shader_source()
   +hb_gpu_draw_clear()
   +hb_gpu_draw_get_scale()
+  +hb_gpu_draw_glyph_or_fail()
 
 - New API, Raster library:
   +hb_raster_draw_clear()
+  +hb_raster_draw_glyph_or_fail()
   +hb_raster_paint_clear()
+  +hb_raster_paint_glyph_or_fail()
   +hb_raster_paint_set_palette()
   +hb_raster_paint_get_palette()
   +hb_raster_paint_get_foreground()
@@ -100,12 +104,14 @@ Overview of changes leading to NEXT (REPLACEME)
   +HB_VECTOR_FORMAT_PDF
   +hb_vector_draw_clear()
   +hb_vector_draw_get_precision()
+  +hb_vector_draw_glyph_or_fail()
   +hb_vector_draw_set_svg_prefix()
   +hb_vector_draw_get_svg_prefix()
   +hb_vector_paint_clear()
   +hb_vector_paint_get_precision()
   +hb_vector_paint_get_foreground()
   +hb_vector_paint_get_palette()
+  +hb_vector_paint_glyph_or_fail()
   +hb_vector_paint_set_svg_prefix()
   +hb_vector_paint_get_svg_prefix()
 
@@ -121,7 +127,18 @@ Overview of changes leading to NEXT (REPLACEME)
   -hb_vector_paint_get_flat()
 
 - Changed API, GPU library:
-  * hb_gpu_draw_glyph() now returns hb_bool_t instead of void.
+  * hb_gpu_draw_glyph() now returns void (was hb_bool_t).  Use
+    hb_gpu_draw_glyph_or_fail() if you need the success status.
+  * hb_gpu_paint_glyph() now returns void (was hb_bool_t) and
+    internally synthesizes a foreground-colored layer for
+    non-color glyphs via hb_font_paint_glyph(), so every glyph
+    with an outline produces output.  Use
+    hb_gpu_paint_glyph_or_fail() -- which delegates to
+    hb_font_paint_glyph_or_fail() -- if you need to distinguish
+    color vs synthesized paint.  Encoder-level limits
+    (unsupported ops, group-stack overflow) no longer fail
+    paint_glyph; they surface from hb_gpu_paint_encode()
+    returning NULL.
   * hb_gpu_draw_encode() now takes an extents out-parameter and
     auto-clears the encoder on return.
   * hb_gpu_draw_darken() renamed to hb_gpu_stem_darken().
@@ -130,9 +147,16 @@ Overview of changes leading to NEXT (REPLACEME)
   * hb_vector_svg_set_precision() and its paint counterpart renamed
     to hb_vector_draw_set_precision() / hb_vector_paint_set_precision()
     (SVG-specific naming is inaccurate with the PDF backend added).
+  * hb_vector_draw_glyph() / hb_vector_paint_glyph() now return
+    void (were hb_bool_t).  Paint additionally gains a draw
+    fallback for non-color glyphs.  Use the matching _or_fail()
+    variants for the bool return.
 
 - Changed API, Raster library:
-  * hb_raster_draw_glyph() now returns hb_bool_t instead of void.
+  * hb_raster_draw_glyph() / hb_raster_paint_glyph() now return
+    void (were hb_bool_t).  Paint additionally gains a draw
+    fallback for non-color glyphs.  Use the matching _or_fail()
+    variants for the bool return.
 
 - Changed API, general:
   * Many read-only getters gained const on their object argument.

--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -1041,6 +1041,7 @@ hb_raster_draw_clear
 hb_raster_draw_reset
 hb_raster_draw_get_funcs
 hb_raster_draw_glyph
+hb_raster_draw_glyph_or_fail
 hb_raster_draw_render
 hb_raster_draw_recycle_image
 hb_raster_paint_t
@@ -1064,6 +1065,7 @@ hb_raster_paint_clear_custom_palette_colors
 hb_raster_paint_set_custom_palette_color
 hb_raster_paint_get_funcs
 hb_raster_paint_glyph
+hb_raster_paint_glyph_or_fail
 hb_raster_paint_render
 hb_raster_paint_clear
 hb_raster_paint_reset
@@ -1090,6 +1092,7 @@ hb_vector_draw_get_extents
 hb_vector_draw_set_glyph_extents
 hb_vector_draw_get_funcs
 hb_vector_draw_glyph
+hb_vector_draw_glyph_or_fail
 hb_vector_draw_set_precision
 hb_vector_draw_get_precision
 hb_vector_draw_set_svg_prefix
@@ -1119,6 +1122,7 @@ hb_vector_paint_set_custom_palette_color
 hb_vector_paint_clear_custom_palette_colors
 hb_vector_paint_get_funcs
 hb_vector_paint_glyph
+hb_vector_paint_glyph_or_fail
 hb_vector_paint_set_precision
 hb_vector_paint_get_precision
 hb_vector_paint_set_svg_prefix
@@ -1145,6 +1149,7 @@ hb_gpu_draw_get_funcs
 hb_gpu_draw_set_scale
 hb_gpu_draw_get_scale
 hb_gpu_draw_glyph
+hb_gpu_draw_glyph_or_fail
 hb_gpu_draw_encode
 hb_gpu_draw_clear
 hb_gpu_draw_reset
@@ -1163,6 +1168,7 @@ hb_gpu_paint_set_custom_palette_color
 hb_gpu_paint_set_scale
 hb_gpu_paint_get_scale
 hb_gpu_paint_glyph
+hb_gpu_paint_glyph_or_fail
 hb_gpu_paint_encode
 hb_gpu_paint_clear
 hb_gpu_paint_reset

--- a/src/hb-cairo.cc
+++ b/src/hb-cairo.cc
@@ -645,8 +645,12 @@ hb_cairo_render_color_glyph (cairo_scaled_font_t  *scaled_font,
   c.cr = cr;
   c.color_cache = (hb_map_t *) cairo_scaled_font_get_user_data (scaled_font, &color_cache_key);
 
-  if (!hb_font_paint_glyph_or_fail (font, glyph, hb_cairo_paint_get_funcs (), &c, palette, color))
-    return CAIRO_STATUS_USER_FONT_NOT_IMPLEMENTED;
+  /* Synthesizing variant: mono glyphs render here too via the
+   * push_clip_glyph + foreground-fill fallback inside
+   * hb_font_paint_glyph.  Callers that want the cheaper
+   * outline path for mono fonts set CAIRO_COLOR_MODE_NO_COLOR
+   * on the font options instead. */
+  hb_font_paint_glyph (font, glyph, hb_cairo_paint_get_funcs (), &c, palette, color);
 
   return CAIRO_STATUS_SUCCESS;
 }

--- a/src/hb-gpu-draw.cc
+++ b/src/hb-gpu-draw.cc
@@ -966,24 +966,25 @@ hb_gpu_draw_get_scale (const hb_gpu_draw_t *draw,
 }
 
 /**
- * hb_gpu_draw_glyph:
+ * hb_gpu_draw_glyph_or_fail:
  * @draw: a GPU shape encoder
  * @font: font to draw from
  * @glyph: glyph ID to draw
  *
  * Convenience wrapper that draws a single glyph outline into the
- * encoder using hb_font_draw_glyph().  Calls hb_gpu_draw_set_scale()
- * with the font's scale before walking the outline.
+ * encoder using hb_font_draw_glyph_or_fail().  Calls
+ * hb_gpu_draw_set_scale() with the font's scale before walking the
+ * outline.
  *
  * Return value: `true` if the glyph was drawn, `false` if the font
  * has no outlines for @glyph.
  *
- * Since: 14.0.0
+ * XSince: REPLACEME
  **/
 hb_bool_t
-hb_gpu_draw_glyph (hb_gpu_draw_t  *draw,
-		   hb_font_t      *font,
-		   hb_codepoint_t  glyph)
+hb_gpu_draw_glyph_or_fail (hb_gpu_draw_t  *draw,
+			   hb_font_t      *font,
+			   hb_codepoint_t  glyph)
 {
   int x_scale, y_scale;
   hb_font_get_scale (font, &x_scale, &y_scale);
@@ -992,6 +993,25 @@ hb_gpu_draw_glyph (hb_gpu_draw_t  *draw,
   return hb_font_draw_glyph_or_fail (font, glyph,
 				     hb_gpu_draw_get_funcs (),
 				     draw);
+}
+
+/**
+ * hb_gpu_draw_glyph:
+ * @draw: a GPU shape encoder
+ * @font: font to draw from
+ * @glyph: glyph ID to draw
+ *
+ * Draws a single glyph outline into the encoder.  Equivalent to
+ * hb_gpu_draw_glyph_or_fail() with the return value ignored.
+ *
+ * Since: 14.0.0
+ **/
+void
+hb_gpu_draw_glyph (hb_gpu_draw_t  *draw,
+		   hb_font_t      *font,
+		   hb_codepoint_t  glyph)
+{
+  hb_gpu_draw_glyph_or_fail (draw, font, glyph);
 }
 
 

--- a/src/hb-gpu-paint.cc
+++ b/src/hb-gpu-paint.cc
@@ -348,7 +348,7 @@ emit_clip_sub_blob (hb_gpu_paint_t *c,
   {
     /* Fast path: feed the glyph outline straight into the draw
      * encoder with no adapter. */
-    ok = hb_gpu_draw_glyph (c->scratch_draw, clip.font, clip.glyph);
+    ok = hb_gpu_draw_glyph_or_fail (c->scratch_draw, clip.font, clip.glyph);
   }
   else
   {
@@ -1156,27 +1156,57 @@ hb_gpu_paint_get_scale (const hb_gpu_paint_t *paint,
 }
 
 /**
+ * hb_gpu_paint_glyph_or_fail:
+ * @paint: a GPU color-glyph paint encoder
+ * @font: font to paint from
+ * @glyph: glyph ID to paint
+ *
+ * Feeds @glyph's paint tree into the encoder.  Fails (returns
+ * `false`) if @font has no paint data for @glyph; encoder-level
+ * limitations (unsupported paint ops, group-stack overflow) do
+ * NOT fail here -- they surface later from
+ * hb_gpu_paint_encode() which returns `NULL`.
+ *
+ * Return value: `true` if the font had paint data for @glyph,
+ * `false` otherwise.
+ *
+ * XSince: REPLACEME
+ **/
+hb_bool_t
+hb_gpu_paint_glyph_or_fail (hb_gpu_paint_t *paint,
+			    hb_font_t      *font,
+			    hb_codepoint_t  glyph)
+{
+  int x_scale, y_scale;
+  hb_font_get_scale (font, &x_scale, &y_scale);
+  hb_gpu_paint_set_scale (paint, x_scale, y_scale);
+  return hb_font_paint_glyph_or_fail (font, glyph,
+				      hb_gpu_paint_get_funcs (), paint,
+				      paint->palette,
+				      /* Foreground value is never read
+				       * from our encoded blob -- the
+				       * is_foreground flag routes to the
+				       * shader's foreground uniform at
+				       * render time -- so any sentinel
+				       * works here. */
+				      HB_COLOR (0, 0, 0, 0xff));
+}
+
+/**
  * hb_gpu_paint_glyph:
  * @paint: a GPU color-glyph paint encoder
  * @font: font to paint from
  * @glyph: glyph ID to paint
  *
- * Convenience wrapper that feeds @glyph's paint tree into the
- * encoder via hb_font_paint_glyph().  Non-color glyphs are handled
+ * Feeds @glyph into the encoder.  Unlike
+ * hb_gpu_paint_glyph_or_fail(), non-color glyphs are handled
  * transparently: harfbuzz synthesizes a single foreground-colored
  * layer from the outline, which our callbacks turn into a single
- * LAYER_SOLID op.  The font's scale is stashed on @paint via
- * hb_gpu_paint_set_scale() for use by hb_gpu_paint_encode().
+ * LAYER_SOLID op.
  *
- * Return value: `true` if the paint walk completed without hitting
- * an encoder limitation; `false` if some part of the paint tree
- * used a feature this encoder does not support (e.g. PaintImage,
- * group-stack overflow), in which case hb_gpu_paint_encode() will
- * return `NULL`.
- *
- * XSince: REPLACEME
+ * Since: 14.0.0
  **/
-hb_bool_t
+void
 hb_gpu_paint_glyph (hb_gpu_paint_t *paint,
 		    hb_font_t      *font,
 		    hb_codepoint_t  glyph)
@@ -1184,19 +1214,10 @@ hb_gpu_paint_glyph (hb_gpu_paint_t *paint,
   int x_scale, y_scale;
   hb_font_get_scale (font, &x_scale, &y_scale);
   hb_gpu_paint_set_scale (paint, x_scale, y_scale);
-  /* Use hb_font_paint_glyph (not _or_fail) so that non-color
-   * glyphs still produce a blob: harfbuzz synthesizes
-   * push_clip_glyph + color(is_foreground=true) + pop_clip, which
-   * our callbacks turn into a single LAYER_SOLID op. */
   hb_font_paint_glyph (font, glyph,
 		       hb_gpu_paint_get_funcs (), paint,
 		       paint->palette,
-		       /* Foreground value is never read from our encoded
-			* blob -- the is_foreground flag routes to the
-			* shader's foreground uniform at render time -- so
-			* any sentinel works here. */
 		       HB_COLOR (0, 0, 0, 0xff));
-  return !paint->unsupported;
 }
 
 /**

--- a/src/hb-gpu.h
+++ b/src/hb-gpu.h
@@ -122,10 +122,15 @@ hb_gpu_draw_get_scale (const hb_gpu_draw_t *draw,
 HB_EXTERN hb_draw_funcs_t *
 hb_gpu_draw_get_funcs (void);
 
-HB_EXTERN hb_bool_t
+HB_EXTERN void
 hb_gpu_draw_glyph (hb_gpu_draw_t  *draw,
 		   hb_font_t      *font,
 		   hb_codepoint_t  glyph);
+
+HB_EXTERN hb_bool_t
+hb_gpu_draw_glyph_or_fail (hb_gpu_draw_t  *draw,
+			   hb_font_t      *font,
+			   hb_codepoint_t  glyph);
 
 /* For arbitrary shapes beyond a single glyph, callers feed
  * outlines straight into the draw encoder via hb_draw_move_to()
@@ -229,10 +234,15 @@ hb_gpu_paint_get_scale (const hb_gpu_paint_t *paint,
 			int                  *x_scale,
 			int                  *y_scale);
 
-HB_EXTERN hb_bool_t
+HB_EXTERN void
 hb_gpu_paint_glyph (hb_gpu_paint_t *paint,
 		    hb_font_t      *font,
 		    hb_codepoint_t  glyph);
+
+HB_EXTERN hb_bool_t
+hb_gpu_paint_glyph_or_fail (hb_gpu_paint_t *paint,
+			    hb_font_t      *font,
+			    hb_codepoint_t  glyph);
 
 HB_EXTERN hb_blob_t *
 hb_gpu_paint_encode (hb_gpu_paint_t     *paint,

--- a/src/hb-raster-draw.cc
+++ b/src/hb-raster-draw.cc
@@ -952,7 +952,7 @@ hb_raster_draw_get_funcs (void)
 }
 
 /**
- * hb_raster_draw_glyph:
+ * hb_raster_draw_glyph_or_fail:
  * @draw: a rasterizer
  * @font: font to draw from
  * @glyph: glyph ID to draw
@@ -966,14 +966,14 @@ hb_raster_draw_get_funcs (void)
  * Return value: `true` if the glyph was drawn, `false` if the font has
  * no outlines for @glyph.
  *
- * Since: 13.0.0
+ * XSince: REPLACEME
  **/
 hb_bool_t
-hb_raster_draw_glyph (hb_raster_draw_t *draw,
-		      hb_font_t       *font,
-		      hb_codepoint_t   glyph,
-		      float            pen_x,
-		      float            pen_y)
+hb_raster_draw_glyph_or_fail (hb_raster_draw_t *draw,
+			      hb_font_t       *font,
+			      hb_codepoint_t   glyph,
+			      float            pen_x,
+			      float            pen_y)
 {
   float xx = draw->transform.xx;
   float yx = draw->transform.yx;
@@ -990,6 +990,30 @@ hb_raster_draw_glyph (hb_raster_draw_t *draw,
 					      hb_raster_draw_get_funcs (), draw);
   hb_raster_draw_set_transform (draw, xx, yx, xy, yy, dx, dy);
   return ret;
+}
+
+/**
+ * hb_raster_draw_glyph:
+ * @draw: a rasterizer
+ * @font: font to draw from
+ * @glyph: glyph ID to draw
+ * @pen_x: glyph origin x in font coordinates (pre-transform)
+ * @pen_y: glyph origin y in font coordinates (pre-transform)
+ *
+ * Draws one glyph at (@pen_x, @pen_y) using the rasterizer's current
+ * transform.  Equivalent to hb_raster_draw_glyph_or_fail() with the
+ * return value ignored.
+ *
+ * Since: 13.0.0
+ **/
+void
+hb_raster_draw_glyph (hb_raster_draw_t *draw,
+		      hb_font_t       *font,
+		      hb_codepoint_t   glyph,
+		      float            pen_x,
+		      float            pen_y)
+{
+  hb_raster_draw_glyph_or_fail (draw, font, glyph, pen_x, pen_y);
 }
 
 

--- a/src/hb-raster-paint.cc
+++ b/src/hb-raster-paint.cc
@@ -2120,31 +2120,13 @@ hb_raster_paint_get_funcs (void)
   return static_raster_paint_funcs.get_unconst ();
 }
 
-/**
- * hb_raster_paint_glyph:
- * @paint: a paint context
- * @font: font to paint from
- * @glyph: glyph ID to paint
- * @pen_x: glyph origin x in font coordinates (pre-transform)
- * @pen_y: glyph origin y in font coordinates (pre-transform)
- *
- * Convenience wrapper to paint one color glyph at (@pen_x, @pen_y) using
- * the paint context's current transform, palette, and foreground color.
- * The pen coordinates are applied before minification and transformed by
- * the current affine transform.  Configure palette and foreground via
- * hb_raster_paint_set_palette() and hb_raster_paint_set_foreground()
- * before calling.
- *
- * Return value: `true` if painting succeeded, `false` otherwise.
- *
- * XSince: REPLACEME
- **/
-hb_bool_t
-hb_raster_paint_glyph (hb_raster_paint_t *paint,
-		       hb_font_t        *font,
-		       hb_codepoint_t    glyph,
-		       float             pen_x,
-		       float             pen_y)
+static hb_bool_t
+hb_raster_paint_glyph_impl (hb_raster_paint_t *paint,
+			    hb_font_t        *font,
+			    hb_codepoint_t    glyph,
+			    float             pen_x,
+			    float             pen_y,
+			    hb_bool_t         fallible)
 {
   float xx = paint->base_transform.xx;
   float yx = paint->base_transform.yx;
@@ -2167,11 +2149,67 @@ hb_raster_paint_glyph (hb_raster_paint_t *paint,
   }
 
   hb_raster_paint_set_transform (paint, xx, yx, xy, yy, tx, ty);
-  hb_bool_t ret = hb_font_paint_glyph_or_fail (font, glyph,
-						hb_raster_paint_get_funcs (), paint,
-						paint->palette, paint->foreground);
+  hb_bool_t ret = true;
+  if (fallible)
+    ret = hb_font_paint_glyph_or_fail (font, glyph,
+				       hb_raster_paint_get_funcs (), paint,
+				       paint->palette, paint->foreground);
+  else
+    hb_font_paint_glyph (font, glyph,
+			 hb_raster_paint_get_funcs (), paint,
+			 paint->palette, paint->foreground);
   hb_raster_paint_set_transform (paint, xx, yx, xy, yy, dx, dy);
   return ret;
+}
+
+/**
+ * hb_raster_paint_glyph_or_fail:
+ * @paint: a paint context
+ * @font: font to paint from
+ * @glyph: glyph ID to paint
+ * @pen_x: glyph origin x in font coordinates (pre-transform)
+ * @pen_y: glyph origin y in font coordinates (pre-transform)
+ *
+ * Paints one color glyph at (@pen_x, @pen_y).  Fails (returns
+ * `false`) if @font has no paint data for @glyph.
+ *
+ * Return value: `true` if painting succeeded, `false` otherwise.
+ *
+ * XSince: REPLACEME
+ **/
+hb_bool_t
+hb_raster_paint_glyph_or_fail (hb_raster_paint_t *paint,
+			       hb_font_t        *font,
+			       hb_codepoint_t    glyph,
+			       float             pen_x,
+			       float             pen_y)
+{
+  return hb_raster_paint_glyph_impl (paint, font, glyph, pen_x, pen_y, true);
+}
+
+/**
+ * hb_raster_paint_glyph:
+ * @paint: a paint context
+ * @font: font to paint from
+ * @glyph: glyph ID to paint
+ * @pen_x: glyph origin x in font coordinates (pre-transform)
+ * @pen_y: glyph origin y in font coordinates (pre-transform)
+ *
+ * Paints one glyph at (@pen_x, @pen_y).  Unlike
+ * hb_raster_paint_glyph_or_fail(), glyphs with no color paint data
+ * fall back to a synthesized foreground-colored outline, so any
+ * glyph with an outline or bitmap image produces output.
+ *
+ * Since: 13.0.0
+ **/
+void
+hb_raster_paint_glyph (hb_raster_paint_t *paint,
+		       hb_font_t        *font,
+		       hb_codepoint_t    glyph,
+		       float             pen_x,
+		       float             pen_y)
+{
+  hb_raster_paint_glyph_impl (paint, font, glyph, pen_x, pen_y, false);
 }
 
 /**

--- a/src/hb-raster.h
+++ b/src/hb-raster.h
@@ -195,12 +195,19 @@ hb_raster_draw_set_glyph_extents (hb_raster_draw_t          *draw,
 HB_EXTERN hb_draw_funcs_t *
 hb_raster_draw_get_funcs (void);
 
-HB_EXTERN hb_bool_t
+HB_EXTERN void
 hb_raster_draw_glyph (hb_raster_draw_t *draw,
 		      hb_font_t       *font,
 		      hb_codepoint_t   glyph,
 		      float            pen_x,
 		      float            pen_y);
+
+HB_EXTERN hb_bool_t
+hb_raster_draw_glyph_or_fail (hb_raster_draw_t *draw,
+			      hb_font_t       *font,
+			      hb_codepoint_t   glyph,
+			      float            pen_x,
+			      float            pen_y);
 
 HB_EXTERN hb_raster_image_t *
 hb_raster_draw_render (hb_raster_draw_t *draw);
@@ -309,12 +316,19 @@ hb_raster_paint_set_custom_palette_color (hb_raster_paint_t *paint,
 HB_EXTERN hb_paint_funcs_t *
 hb_raster_paint_get_funcs (void);
 
-HB_EXTERN hb_bool_t
+HB_EXTERN void
 hb_raster_paint_glyph (hb_raster_paint_t *paint,
 		       hb_font_t        *font,
 		       hb_codepoint_t    glyph,
 		       float             pen_x,
 		       float             pen_y);
+
+HB_EXTERN hb_bool_t
+hb_raster_paint_glyph_or_fail (hb_raster_paint_t *paint,
+			       hb_font_t        *font,
+			       hb_codepoint_t    glyph,
+			       float             pen_x,
+			       float             pen_y);
 
 HB_EXTERN hb_raster_image_t *
 hb_raster_paint_render (hb_raster_paint_t *paint);

--- a/src/hb-vector-draw.cc
+++ b/src/hb-vector-draw.cc
@@ -526,7 +526,7 @@ hb_vector_draw_get_funcs (void)
 }
 
 /**
- * hb_vector_draw_glyph:
+ * hb_vector_draw_glyph_or_fail:
  * @draw: a draw context.
  * @font: font object.
  * @glyph: glyph ID.
@@ -538,10 +538,10 @@ hb_vector_draw_get_funcs (void)
  *
  * Return value: `true` if glyph data was emitted, `false` otherwise.
  *
- * Since: 13.0.0
+ * XSince: REPLACEME
  */
 hb_bool_t
-hb_vector_draw_glyph (hb_vector_draw_t *draw,
+hb_vector_draw_glyph_or_fail (hb_vector_draw_t *draw,
                       hb_font_t *font,
                       hb_codepoint_t glyph,
                       float pen_x,
@@ -644,6 +644,31 @@ hb_vector_draw_glyph (hb_vector_draw_t *draw,
     case HB_VECTOR_FORMAT_INVALID: default:
       return false;
   }
+}
+
+/**
+ * hb_vector_draw_glyph:
+ * @draw: a draw context.
+ * @font: font object.
+ * @glyph: glyph ID.
+ * @pen_x: glyph x origin before context transform.
+ * @pen_y: glyph y origin before context transform.
+ * @extents_mode: extents update mode.
+ *
+ * Draws one glyph into @draw.  Equivalent to
+ * hb_vector_draw_glyph_or_fail() with the return value ignored.
+ *
+ * Since: 13.0.0
+ */
+void
+hb_vector_draw_glyph (hb_vector_draw_t *draw,
+                      hb_font_t *font,
+                      hb_codepoint_t glyph,
+                      float pen_x,
+                      float pen_y,
+                      hb_vector_extents_mode_t extents_mode)
+{
+  hb_vector_draw_glyph_or_fail (draw, font, glyph, pen_x, pen_y, extents_mode);
 }
 
 /**

--- a/src/hb-vector-paint.cc
+++ b/src/hb-vector-paint.cc
@@ -1316,7 +1316,7 @@ hb_vector_paint_custom_palette_color (hb_paint_funcs_t *pfuncs HB_UNUSED,
 }
 
 /**
- * hb_vector_paint_glyph:
+ * hb_vector_paint_glyph_or_fail:
  * @paint: a paint context.
  * @font: font object.
  * @glyph: glyph ID.
@@ -1328,15 +1328,16 @@ hb_vector_paint_custom_palette_color (hb_paint_funcs_t *pfuncs HB_UNUSED,
  *
  * Return value: `true` if glyph paint data was emitted, `false` otherwise.
  *
- * Since: 13.0.0
+ * XSince: REPLACEME
  */
-hb_bool_t
-hb_vector_paint_glyph (hb_vector_paint_t *paint,
-		       hb_font_t         *font,
-		       hb_codepoint_t     glyph,
-		       float              pen_x,
-		       float              pen_y,
-		       hb_vector_extents_mode_t extents_mode)
+static hb_bool_t
+hb_vector_paint_glyph_impl (hb_vector_paint_t *paint,
+			    hb_font_t         *font,
+			    hb_codepoint_t     glyph,
+			    float              pen_x,
+			    float              pen_y,
+			    hb_vector_extents_mode_t extents_mode,
+			    hb_bool_t          fallible)
 {
   float xx = paint->transform.xx;
   float yx = paint->transform.yx;
@@ -1387,10 +1388,17 @@ hb_vector_paint_glyph (hb_vector_paint_t *paint,
       hb_buf_append_num (&body, ty, paint->precision);
       hb_buf_append_str (&body, " cm\n");
 
-      hb_bool_t ret = hb_font_paint_glyph_or_fail (font, glyph,
-						    hb_vector_paint_pdf_funcs_get (), paint,
-						    (unsigned) paint->palette,
-						    paint->foreground);
+      hb_bool_t ret = true;
+      if (fallible)
+	ret = hb_font_paint_glyph_or_fail (font, glyph,
+					   hb_vector_paint_pdf_funcs_get (), paint,
+					   (unsigned) paint->palette,
+					   paint->foreground);
+      else
+	hb_font_paint_glyph (font, glyph,
+			     hb_vector_paint_pdf_funcs_get (), paint,
+			     (unsigned) paint->palette,
+			     paint->foreground);
       hb_buf_append_str (&body, "Q\n");
       return ret;
     }
@@ -1423,10 +1431,17 @@ hb_vector_paint_glyph (hb_vector_paint_t *paint,
 	if (unlikely (!paint->group_stack.push_or_fail (hb_vector_t<char> {})))
 	  return false;
 
-	hb_bool_t ret = hb_font_paint_glyph_or_fail (font, glyph,
-						      hb_vector_paint_get_funcs (), paint,
-						      (unsigned) paint->palette,
-						      paint->foreground);
+	hb_bool_t ret = true;
+	if (fallible)
+	  ret = hb_font_paint_glyph_or_fail (font, glyph,
+					     hb_vector_paint_get_funcs (), paint,
+					     (unsigned) paint->palette,
+					     paint->foreground);
+	else
+	  hb_font_paint_glyph (font, glyph,
+			       hb_vector_paint_get_funcs (), paint,
+			       (unsigned) paint->palette,
+			       paint->foreground);
 	if (unlikely (!ret))
 	{
 	  paint->group_stack.pop ();
@@ -1465,26 +1480,67 @@ hb_vector_paint_glyph (hb_vector_paint_t *paint,
 	hb_buf_append_str (&body, "\"/>\n");
 	return !paint->defs.in_error () && !body.in_error ();
       }
-
-      hb_buf_append_str (&paint->current_body (), "<g transform=\"");
-      hb_vector_svg_append_instance_transform (&paint->current_body (), paint->precision,
-					paint->x_scale_factor,
-					paint->y_scale_factor,
-					xx, yx, xy, yy, tx, ty);
-      hb_buf_append_str (&paint->current_body (), "\">\n");
-      hb_bool_t ret = hb_font_paint_glyph_or_fail (font, glyph,
-						    hb_vector_paint_get_funcs (), paint,
-						    (unsigned) paint->palette,
-						    paint->foreground);
-      hb_buf_append_str (&paint->current_body (), "</g>\n");
-      return ret &&
-	     !paint->defs.in_error () &&
-	     !paint->current_body ().in_error ();
     }
 
     case HB_VECTOR_FORMAT_INVALID: default:
       return false;
   }
+}
+
+/**
+ * hb_vector_paint_glyph_or_fail:
+ * @paint: a paint context.
+ * @font: font object.
+ * @glyph: glyph ID.
+ * @pen_x: glyph x origin before context transform.
+ * @pen_y: glyph y origin before context transform.
+ * @extents_mode: extents update mode.
+ *
+ * Paints one color glyph into @paint.  Fails (returns
+ * `false`) if @font has no paint data for @glyph.
+ *
+ * Return value: `true` if glyph paint data was emitted, `false` otherwise.
+ *
+ * XSince: REPLACEME
+ */
+hb_bool_t
+hb_vector_paint_glyph_or_fail (hb_vector_paint_t *paint,
+			       hb_font_t         *font,
+			       hb_codepoint_t     glyph,
+			       float              pen_x,
+			       float              pen_y,
+			       hb_vector_extents_mode_t extents_mode)
+{
+  return hb_vector_paint_glyph_impl (paint, font, glyph, pen_x, pen_y,
+				     extents_mode, true);
+}
+
+/**
+ * hb_vector_paint_glyph:
+ * @paint: a paint context.
+ * @font: font object.
+ * @glyph: glyph ID.
+ * @pen_x: glyph x origin before context transform.
+ * @pen_y: glyph y origin before context transform.
+ * @extents_mode: extents update mode.
+ *
+ * Paints one glyph into @paint.  Unlike
+ * hb_vector_paint_glyph_or_fail(), glyphs with no color paint
+ * data fall back to a synthesized foreground-colored outline,
+ * so any glyph with an outline or bitmap image produces output.
+ *
+ * Since: 13.0.0
+ */
+void
+hb_vector_paint_glyph (hb_vector_paint_t *paint,
+		       hb_font_t         *font,
+		       hb_codepoint_t     glyph,
+		       float              pen_x,
+		       float              pen_y,
+		       hb_vector_extents_mode_t extents_mode)
+{
+  hb_vector_paint_glyph_impl (paint, font, glyph, pen_x, pen_y,
+			      extents_mode, false);
 }
 
 /**

--- a/src/hb-vector.h
+++ b/src/hb-vector.h
@@ -154,13 +154,21 @@ hb_vector_draw_set_glyph_extents (hb_vector_draw_t *draw,
 HB_EXTERN hb_draw_funcs_t *
 hb_vector_draw_get_funcs (void);
 
-HB_EXTERN hb_bool_t
+HB_EXTERN void
 hb_vector_draw_glyph (hb_vector_draw_t *draw,
                       hb_font_t *font,
                       hb_codepoint_t glyph,
                       float pen_x,
                       float pen_y,
                       hb_vector_extents_mode_t extents_mode);
+
+HB_EXTERN hb_bool_t
+hb_vector_draw_glyph_or_fail (hb_vector_draw_t *draw,
+                              hb_font_t *font,
+                              hb_codepoint_t glyph,
+                              float pen_x,
+                              float pen_y,
+                              hb_vector_extents_mode_t extents_mode);
 
 HB_EXTERN void
 hb_vector_draw_set_precision (hb_vector_draw_t *draw,
@@ -271,13 +279,21 @@ hb_vector_paint_clear_custom_palette_colors (hb_vector_paint_t *paint);
 HB_EXTERN hb_paint_funcs_t *
 hb_vector_paint_get_funcs (void);
 
-HB_EXTERN hb_bool_t
+HB_EXTERN void
 hb_vector_paint_glyph (hb_vector_paint_t *paint,
 		       hb_font_t         *font,
 		       hb_codepoint_t     glyph,
 		       float              pen_x,
 		       float              pen_y,
 		       hb_vector_extents_mode_t extents_mode);
+
+HB_EXTERN hb_bool_t
+hb_vector_paint_glyph_or_fail (hb_vector_paint_t *paint,
+			       hb_font_t         *font,
+			       hb_codepoint_t     glyph,
+			       float              pen_x,
+			       float              pen_y,
+			       hb_vector_extents_mode_t extents_mode);
 
 HB_EXTERN void
 hb_vector_paint_set_precision (hb_vector_paint_t *paint,

--- a/test/api/test-gpu.cc
+++ b/test/api/test-gpu.cc
@@ -381,7 +381,9 @@ test_paint_encode_monochrome (void)
 
   hb_codepoint_t gid;
   g_assert_true (hb_font_get_nominal_glyph (font, 'a', &gid));
-  g_assert_true (hb_gpu_paint_glyph (p, font, gid));
+  /* Use hb_gpu_paint_glyph (not _or_fail) so that non-color
+   * glyphs still produce a blob via the synthesize fallback. */
+  hb_gpu_paint_glyph (p, font, gid);
 
   hb_glyph_extents_t ext;
   hb_blob_t *blob = hb_gpu_paint_encode (p, &ext);

--- a/util/gpu-output.hh
+++ b/util/gpu-output.hh
@@ -56,8 +56,6 @@ struct gpu_output_t
   hb_bool_t use_d3d11 = false;
   hb_bool_t demo = false;
   hb_bool_t bench = false;
-  hb_bool_t force_draw  = false;  /* --draw   : use monochrome draw path */
-  hb_bool_t force_paint = false;  /* --paint  : use paint path */
   hb_bool_t show_extents = false; /* --show-extents */
   /* Initial state for interactive toggles; each corresponds to
    * a keyboard shortcut in demo_view_t. */
@@ -92,8 +90,8 @@ struct gpu_output_t
       {"bench",		0, G_OPTION_FLAG_NO_ARG,
 				G_OPTION_ARG_CALLBACK,	(gpointer) &parse_bench,"Demo in fullscreen benchmark mode",	nullptr},
       {"type",		'T', 0, G_OPTION_ARG_STRING,	&this->type_text,	"Type these keystrokes on start",	"keys"},
-      {"draw",		0, 0, G_OPTION_ARG_NONE,	&this->force_draw,	"Force monochrome draw path",		nullptr},
-      {"paint",		0, 0, G_OPTION_ARG_NONE,	&this->force_paint,	"Force color paint path",		nullptr},
+      {"draw",		0, 0, G_OPTION_ARG_NONE,	&this->view.force_draw,	"Force monochrome draw path",		nullptr},
+      {"paint",		0, 0, G_OPTION_ARG_NONE,	&this->view.force_paint,	"Force color paint path",		nullptr},
       {"output-file",	'o', 0, G_OPTION_ARG_STRING,	&this->output_file,	"Render one frame to PPM file (\"-\" for stdout) and exit","filename"},
       {"show-extents",	0, 0, G_OPTION_ARG_NONE,	&this->show_extents,	"Draw a frame around each glyph's ink extents",	nullptr},
       /* Interactive-toggle defaults.  Each mirrors a keybinding
@@ -153,8 +151,8 @@ struct gpu_output_t
      * otherwise auto: fonts without color paint get the draw path
      * (smaller shader, better perf).  A mismatched pair of flags
      * is a user error; prefer paint. */
-    draw_only = force_paint ? false
-	      : force_draw  ? true
+    draw_only = view.force_paint ? false
+	      : view.force_draw  ? true
 	      : !hb_ot_color_has_paint (face);
 
     if (use_metal)

--- a/util/hb-raster-all.cc
+++ b/util/hb-raster-all.cc
@@ -165,7 +165,7 @@ main (int argc, char **argv)
 	    hb_raster_paint_set_glyph_extents (pnt, &gext))
 	{
 	  hb_raster_paint_set_transform (pnt, 1.f, 0.f, 0.f, 1.f, 0.f, 0.f);
-	  hb_bool_t painted = hb_raster_paint_glyph (pnt, font, gid, 0.f, 0.f);
+	  hb_bool_t painted = hb_raster_paint_glyph_or_fail (pnt, font, gid, 0.f, 0.f);
 	  if (painted)
 	    img = hb_raster_paint_render (pnt);
 	}

--- a/util/hb-vector-svg-all.c
+++ b/util/hb-vector-svg-all.c
@@ -56,7 +56,7 @@ main (int argc, char **argv)
   for (unsigned gid = 0; gid < glyph_count; gid++)
   {
     hb_vector_paint_set_transform (paint, 1.f, 0.f, 0.f, 1.f, 0.f, 0.f);
-    if (hb_vector_paint_glyph (paint, font, gid, 0.f, 0.f,
+    if (hb_vector_paint_glyph_or_fail (paint, font, gid, 0.f, 0.f,
                                HB_VECTOR_EXTENTS_MODE_EXPAND))
     {
       hb_blob_t *blob = hb_vector_paint_render (paint);
@@ -65,7 +65,7 @@ main (int argc, char **argv)
     }
 
     hb_vector_draw_set_transform (draw, 1.f, 0.f, 0.f, 1.f, 0.f, 0.f);
-    if (hb_vector_draw_glyph (draw, font, gid, 0.f, 0.f,
+    if (hb_vector_draw_glyph_or_fail (draw, font, gid, 0.f, 0.f,
                               HB_VECTOR_EXTENTS_MODE_EXPAND))
     {
       hb_blob_t *blob = hb_vector_draw_render (draw);

--- a/util/helper-cairo.hh
+++ b/util/helper-cairo.hh
@@ -37,6 +37,7 @@
 #include <cairo.h>
 #include <hb.h>
 #include <hb-cairo.h>
+#include <hb-ot.h>
 
 #include "helper-cairo-ansi.hh"
 #ifdef CAIRO_HAS_SVG_SURFACE
@@ -119,6 +120,24 @@ helper_cairo_create_scaled_font (const font_options_t *font_opts,
   font_options = cairo_font_options_create ();
   cairo_font_options_set_hint_style (font_options, CAIRO_HINT_STYLE_NONE);
   cairo_font_options_set_hint_metrics (font_options, CAIRO_HINT_METRICS_OFF);
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1,18,0)
+  /* Pick draw vs paint mode.  --paint wins over --draw;
+   * otherwise auto-detect: route mono fonts through the
+   * cheaper outline path (NO_COLOR) and color fonts through
+   * the paint pipeline (cairo's default color mode). */
+  hb_face_t *hb_face = hb_font_get_face (font);
+  bool font_has_color = hb_ot_color_has_paint (hb_face) ||
+			hb_ot_color_has_layers (hb_face) ||
+#ifndef HB_NO_SVG
+			hb_ot_color_has_svg (hb_face) ||
+#endif
+			hb_ot_color_has_png (hb_face);
+  bool use_paint = view_opts->force_paint ? true
+		 : view_opts->force_draw  ? false
+		 : font_has_color;
+  if (!use_paint)
+    cairo_font_options_set_color_mode (font_options, CAIRO_COLOR_MODE_NO_COLOR);
+#endif
 #ifdef CAIRO_COLOR_PALETTE_DEFAULT
   cairo_font_options_set_color_palette (font_options, view_opts->palette);
 #endif

--- a/util/raster-output.hh
+++ b/util/raster-output.hh
@@ -81,12 +81,18 @@ struct raster_output_t : output_options_t<true>, view_options_t
     subpixel_bits = font_opts->subpixel_bits;
 
     hb_face_t *face = hb_font_get_face (font);
-    has_color = hb_ot_color_has_paint (face) ||
-		hb_ot_color_has_layers (face) ||
+    bool font_has_color = hb_ot_color_has_paint (face) ||
+			  hb_ot_color_has_layers (face) ||
 #ifndef HB_NO_SVG
-		hb_ot_color_has_svg (face) ||
+			  hb_ot_color_has_svg (face) ||
 #endif
-		hb_ot_color_has_png (face);
+			  hb_ot_color_has_png (face);
+    /* --paint wins over --draw; otherwise auto-detect.
+     * hb_raster_paint_glyph synthesizes paint from outlines
+     * for mono fonts, so --paint works even without color. */
+    has_color = force_paint ? true
+	      : force_draw  ? false
+	      : font_has_color;
 
     fg_color = HB_COLOR ((uint8_t) foreground_color.b,
 			 (uint8_t) foreground_color.g,

--- a/util/vector-output.hh
+++ b/util/vector-output.hh
@@ -234,6 +234,21 @@ struct vector_output_t : output_options_t<>, view_options_t
       foreground_use_palette && foreground_palette && foreground_palette->len;
     unsigned palette_glyph_index = 0;
 
+    /* Pick draw vs paint mode.  --paint wins over --draw;
+     * otherwise auto-detect via the font's color tables.
+     * hb_vector_paint_glyph synthesizes paint from outlines
+     * for mono fonts, so --paint works even without color. */
+    hb_face_t *face = hb_font_get_face (font);
+    bool font_has_color = hb_ot_color_has_paint (face) ||
+			  hb_ot_color_has_layers (face) ||
+#ifndef HB_NO_SVG
+			  hb_ot_color_has_svg (face) ||
+#endif
+			  hb_ot_color_has_png (face);
+    bool use_paint = force_paint ? true
+		   : force_draw  ? false
+		   : font_has_color;
+
     hb_direction_t dir = direction;
     if (dir == HB_DIRECTION_INVALID)
       dir = HB_DIRECTION_LTR;
@@ -256,7 +271,7 @@ struct vector_output_t : output_options_t<>, view_options_t
         float pen_x = g.x + off_x;
         float pen_y = g.y + off_y;
 
-        if (paint)
+        if (use_paint && paint)
         {
           if (use_foreground_palette)
           {
@@ -267,17 +282,16 @@ struct vector_output_t : output_options_t<>, view_options_t
           }
 
           hb_vector_paint_set_transform (paint, 1.f, 0.f, 0.f, 1.f, 0.f, 0.f);
-          if (hb_vector_paint_glyph_or_fail (paint, upem_font, g.gid, pen_x, pen_y,
-                                     extents_mode))
-          {
-            had_paint = true;
-            continue;
-          }
+          hb_vector_paint_glyph (paint, upem_font, g.gid, pen_x, pen_y,
+                                 extents_mode);
+          had_paint = true;
         }
-
-        if (hb_vector_draw_glyph_or_fail (draw, upem_font, g.gid, pen_x, pen_y,
-                                  extents_mode))
+        else
+        {
+          hb_vector_draw_glyph (draw, upem_font, g.gid, pen_x, pen_y,
+                                extents_mode);
           had_draw = true;
+        }
       }
     }
 

--- a/util/vector-output.hh
+++ b/util/vector-output.hh
@@ -267,7 +267,7 @@ struct vector_output_t : output_options_t<>, view_options_t
           }
 
           hb_vector_paint_set_transform (paint, 1.f, 0.f, 0.f, 1.f, 0.f, 0.f);
-          if (hb_vector_paint_glyph (paint, upem_font, g.gid, pen_x, pen_y,
+          if (hb_vector_paint_glyph_or_fail (paint, upem_font, g.gid, pen_x, pen_y,
                                      extents_mode))
           {
             had_paint = true;
@@ -275,7 +275,7 @@ struct vector_output_t : output_options_t<>, view_options_t
           }
         }
 
-        if (hb_vector_draw_glyph (draw, upem_font, g.gid, pen_x, pen_y,
+        if (hb_vector_draw_glyph_or_fail (draw, upem_font, g.gid, pen_x, pen_y,
                                   extents_mode))
           had_draw = true;
       }

--- a/util/view-options.hh
+++ b/util/view-options.hh
@@ -242,6 +242,8 @@ struct view_options_t
   hb_bool_t logical = false;
   hb_bool_t ink = false;
   hb_bool_t show_extents = false;
+  hb_bool_t force_draw = false;   /* --draw  : use mono outline path */
+  hb_bool_t force_paint = false;  /* --paint : use color paint path */
 
   bool parse_custom_palette_entries (GError **error)
   {
@@ -375,6 +377,8 @@ view_options_t::add_options (option_parser_t *parser)
     {"logical",		0, 0, G_OPTION_ARG_NONE,	&this->logical,		"Render to logical box instead of union of logical and ink boxes",	nullptr},
     {"ink",		0, 0, G_OPTION_ARG_NONE,	&this->ink,			"Render to ink box instead of union of logical and ink boxes",	nullptr},
     {"show-extents",	0, 0, G_OPTION_ARG_NONE,	&this->show_extents,		"Draw glyph extents",							nullptr},
+    {"draw",		0, 0, G_OPTION_ARG_NONE,	&this->force_draw,		"Force monochrome draw path (overrides auto-detect)",	nullptr},
+    {"paint",		0, 0, G_OPTION_ARG_NONE,	&this->force_paint,		"Force color paint path (overrides auto-detect)",	nullptr},
     {nullptr}
   };
   parser->add_group (entries,


### PR DESCRIPTION
Consolidate the {vector,raster,gpu}_{draw,paint}_glyph APIs to match the hb_font_{draw,paint}_glyph / _or_fail pattern:

  * Each existing *_glyph() public function now returns void. For the draw variants this is purely a return-value drop. For the paint variants the void entry additionally gains a synthesize fallback for non-color glyphs (calls hb_font_paint_glyph instead of _or_fail) so a mono glyph still produces output via a foreground-colored outline.

  * New *_glyph_or_fail() variants return hb_bool_t, reporting exactly what hb_font_{draw,paint}_glyph_or_fail() would. Callers that care about distinguishing color paint from synthesized outline now have a clean boolean signal.

Refactors the internal impls behind a shared static helper parameterised by a `fallible` flag; the two public entries delegate, passing true (for _or_fail) or false (for the void alias).

For GPU specifically, paint_glyph_or_fail no longer folds the encoder's unsupported flag into its return -- that state was always better reported from hb_gpu_paint_encode() (which returns NULL), and conflating the two prevented callers from telling "font has no paint data" from "encoder hit a limit".

While in there, remove a dead branch at the end of hb_vector_paint_glyph's SVG case (both inner blocks had already returned; the tail was unreachable).

Updates docs/harfbuzz-sections.txt with the six new symbols and the NEWS note with the Changed API callouts.  Updates in-tree callers (hb-vector-svg-all, hb-raster-all, test-gpu, util/vector-output.hh) to the _or_fail variants where they previously read the return value.

Fixes: https://github.com/harfbuzz/harfbuzz/issues/5926

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>