### PR TITLE
[cmake] Fix missing hb-static.cc in gpu target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,7 @@ set (gpu_project_sources
      ${PROJECT_SOURCE_DIR}/src/hb-gpu.cc
      ${PROJECT_SOURCE_DIR}/src/hb-gpu-draw.cc
      ${PROJECT_SOURCE_DIR}/src/hb-gpu-paint.cc
+     ${PROJECT_SOURCE_DIR}/src/hb-static.cc
 )
 set (gpu_project_headers
      ${PROJECT_SOURCE_DIR}/src/hb-gpu.h


### PR DESCRIPTION
After comparing with the Meson scripts, I confirmed that `hb-static.cc` is missing.

Build fail example:

```
alpha@alpha-pc:~/project/harfbuzz$ cmake --build build
[1/1] Linking C shared library libharfbuzz-gpu.so
FAILED: libharfbuzz-gpu.so
: && /usr/bin/cc -fPIC    -shared -Wl,-soname,libharfbuzz-gpu.so -o libharfbuzz-gpu.so CMakeFiles/harfbuzz-gpu.dir/src/hb-gpu.cc.o CMakeFiles/harfbuzz-gpu.dir/src/hb-gpu-draw.cc.o CMakeFiles/harfbuzz-gpu.dir/src/hb-gpu-paint.cc.o  -Wl,-rpath,/home/alpha/project/harfbuzz/build:  libharfbuzz.so  /usr/lib/x86_64-linux-gnu/libfreetype.so  /usr/lib/x86_64-linux-gnu/libicuuc.so  -ldl  -lm && :
/usr/bin/ld: CMakeFiles/harfbuzz-gpu.dir/src/hb-gpu-draw.cc.o: in function `hb_gpu_curve_t& Crap<hb_gpu_curve_t>()':
hb-gpu-draw.cc:(.text._Z4CrapI14hb_gpu_curve_tERT_v[_ZN10CrapHelperI14hb_gpu_curve_tE8get_crapEv]+0xb): undefined reference to `_hb_CrapPool'
/usr/bin/ld: CMakeFiles/harfbuzz-gpu.dir/src/hb-gpu-draw.cc.o: relocation R_X86_64_PC32 against undefined hidden symbol `_hb_CrapPool' can not be used when making a shared object
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

```
PS D:\Project\github-fork\harfbuzz> cmake --build cmake-build-amd64 --config Release
适用于 .NET Framework MSBuild 版本 18.5.4+cb4e32d21

  harfbuzz.vcxproj -> D:\Project\github-fork\harfbuzz\cmake-build-amd64\Release\harfbuzz.dll
     Creating library D:/Project/github-fork/harfbuzz/cmake-build-amd64/Release/harfbuzz-gpu.lib and object D:/Project/github-fork/harfbuzz/cmake-build-amd64/Releas
  e/harfbuzz-gpu.exp
hb-gpu-draw.obj : error LNK2019: unresolved external symbol "unsigned __int64 const * const _hb_NullPool" (?_hb_NullPool@@3QB_KB) referenced in function "struct hb_
gpu_curve_t & __cdecl Crap<struct hb_gpu_curve_t>(void)" (??$Crap@Uhb_gpu_curve_t@@@@YAAEAUhb_gpu_curve_t@@XZ) [D:\Project\github-fork\harfbuzz\cmake-build-amd64\ha
rfbuzz-gpu.vcxproj]
hb-gpu-paint.obj : error LNK2001: unresolved external symbol "unsigned __int64 const * const _hb_NullPool" (?_hb_NullPool@@3QB_KB) [D:\Project\github-fork\harfbuzz\
cmake-build-amd64\harfbuzz-gpu.vcxproj]
hb-gpu-draw.obj : error LNK2019: unresolved external symbol "unsigned __int64 * _hb_CrapPool" (?_hb_CrapPool@@3PA_KA) referenced in function "struct hb_gpu_curve_t 
& __cdecl Crap<struct hb_gpu_curve_t>(void)" (??$Crap@Uhb_gpu_curve_t@@@@YAAEAUhb_gpu_curve_t@@XZ) [D:\Project\github-fork\harfbuzz\cmake-build-amd64\harfbuzz-gpu.v
cxproj]
hb-gpu-paint.obj : error LNK2001: unresolved external symbol "unsigned __int64 * _hb_CrapPool" (?_hb_CrapPool@@3PA_KA) [D:\Project\github-fork\harfbuzz\cmake-build-
amd64\harfbuzz-gpu.vcxproj]
D:\Project\github-fork\harfbuzz\cmake-build-amd64\Release\harfbuzz-gpu.dll : fatal error LNK1120: 2 unresolved externals [D:\Project\github-fork\harfbuzz\cmake-buil
d-amd64\harfbuzz-gpu.vcxproj]
  harfbuzz-icu.vcxproj -> D:\Project\github-fork\harfbuzz\cmake-build-amd64\Release\harfbuzz-icu.dll
  harfbuzz-raster.vcxproj -> D:\Project\github-fork\harfbuzz\cmake-build-amd64\Release\harfbuzz-raster.dll
  harfbuzz-subset.vcxproj -> D:\Project\github-fork\harfbuzz\cmake-build-amd64\Release\harfbuzz-subset.dll
  harfbuzz-vector.vcxproj -> D:\Project\github-fork\harfbuzz\cmake-build-amd64\Release\harfbuzz-vector.dll
```
