### PR TITLE
Allow line-ending changes in gen-gpu-shader-artifacts.py

### DIFF
--- a/src/gen-gpu-shader-artifacts.py
+++ b/src/gen-gpu-shader-artifacts.py
@@ -38,6 +38,7 @@ src_copy = os.path.join(CURRENT_SOURCE_DIR, hh)
 try:
     shutil.copyfile(OUTPUT, src_copy)
 except OSError:
-    import filecmp
-    if not filecmp.cmp(OUTPUT, src_copy, shallow=False):
-        sys.exit(f'{src_copy} is out of date; regenerate with a writable source tree')
+    # Read as text to ignore line-ending changes
+    with open(OUTPUT, 'r') as f1, open(src_copy, 'r') as f2:
+        if f1.read() != f2.read():
+            sys.exit(f'{src_copy} is out of date; regenerate with a writable source tree')


### PR DESCRIPTION
Fixes #5967

Avoids failing the build when the repository is checked out with non-native line endings and the source tree is non-writable. An alternative strategy might be to detect the line endings from the source and use that to write the output, but that feels unnecessarily complex.