### PR TITLE
[ft] Bump minimum freetype version to 2.8.0 (20.0.14)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ if (HB_HAVE_FREETYPE AND NOT TARGET freetype)
 endif ()
 
 if (HB_HAVE_FREETYPE)
-  list(APPEND PC_REQUIRES_PRIV "freetype2 >= 12.0.6")
+  list(APPEND PC_REQUIRES_PRIV "freetype2 >= 20.0.14")
 endif ()
 
 if (HB_HAVE_GRAPHITE2)

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ cairo_min_version = '>= 1.10.0'
 chafa_min_version = '>= 1.6.0'
 icu_min_version = '>= 49.0'
 graphite2_min_version = '>= 1.2.0'
-freetype_min_version = '>= 12.0.6'
+freetype_min_version = '>= 20.0.14'
 
 hb_version_arr = meson.project_version().split('.')
 hb_version_major = hb_version_arr[0].to_int()


### PR DESCRIPTION
e31ea830c8dbcbc9e81772e8113a9f9f8418f2ce added use of FT_Set_Default_Properties, which was introduced in FreeType 2.8.

Reference: https://freetype.org/freetype2/docs/reference/ft2-module_management.html#ft_set_default_properties