### PR TITLE
Revert back from using std::sort

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -1325,7 +1325,7 @@ template <typename T, typename Compar>
 static inline void
 hb_qsort_loop (T *base, size_t nel, Compar compar)
 {
-  while (nel > 32)
+  while (nel > 24)
   {
     T *last = base + nel - 1;
     T *mid = base + nel / 2;

--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -1305,17 +1305,27 @@ hb_bsearch (const K& key, V* base,
 }
 
 
-/* Quicksort with median-of-three pivot, two-way Hoare partition,
- * tail-call elimination on the larger side, and insertion-sort
- * fall-through for small ranges.  Comparator follows C qsort
- * convention (negative / zero / positive int).
+/* Quicksort partitioning loop: median-of-three pivot, two-way
+ * Hoare partition, tail-call elimination on the larger side.
+ * Stops partitioning when subranges shrink below the threshold;
+ * a single insertion-sort pass over the whole array (run by the
+ * caller) finishes the job.  Same structure libstdc++ uses for
+ * std::sort.
+ *
+ * Not stable; equivalent values may be swapped. */
+/* Quicksort partitioning loop: median-of-three pivot, two-way
+ * Hoare partition, tail-call elimination on the larger side.
+ * Stops partitioning when subranges shrink below the threshold;
+ * a single insertion-sort pass over the whole array (run by
+ * hb_qsort_inline below) finishes the job.  Same shape libstdc++
+ * uses for std::sort.
  *
  * Not stable; equivalent values may be swapped. */
 template <typename T, typename Compar>
 static inline void
-hb_qsort_inline (T *base, size_t nel, Compar compar)
+hb_qsort_loop (T *base, size_t nel, Compar compar)
 {
-  while (nel > 16)
+  while (nel > 32)
   {
     T *last = base + nel - 1;
     T *mid = base + nel / 2;
@@ -1330,8 +1340,9 @@ hb_qsort_inline (T *base, size_t nel, Compar compar)
     hb_swap (*mid, *(last - 1));
     T &pivot = *(last - 1);
 
-    /* Two-way Hoare partition.  base and last are sentinels
-     * (already <= and >= pivot respectively). */
+    /* Two-way Hoare partition.  Inner loops are unguarded:
+     * median-of-three left *base <= pivot and *last >= pivot,
+     * which act as sentinels. */
     T *i = base, *j = last - 1;
     while (true)
     {
@@ -1348,18 +1359,27 @@ hb_qsort_inline (T *base, size_t nel, Compar compar)
     size_t right = nel - left - 1;
     if (left < right)
     {
-      hb_qsort_inline (base, left, compar);
+      hb_qsort_loop (base, left, compar);
       base = i + 1;
       nel  = right;
     }
     else
     {
-      hb_qsort_inline (i + 1, right, compar);
+      hb_qsort_loop (i + 1, right, compar);
       nel  = left;
     }
   }
+}
 
-  /* Insertion sort for small inputs. */
+template <typename T, typename Compar>
+static inline void
+hb_qsort_inline (T *base, size_t nel, Compar compar)
+{
+  hb_qsort_loop (base, nel, compar);
+
+  /* Single final insertion sort over the whole array.  After
+   * the partitioning loop, every element is within the threshold
+   * of its sorted position, so this pass is O(n * threshold). */
   T *end = base + nel;
   for (T *pi = base + 1; pi < end; pi++)
     for (T *pj = pi; pj > base && compar (pj[-1], pj[0]) > 0; pj--)

--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -1305,141 +1305,65 @@ hb_bsearch (const K& key, V* base,
 }
 
 
-/* From https://github.com/noporpoise/sort_r
-   Feb 5, 2019 (c8c65c1e)
-   Modified to support optional argument using templates */
-
-/* Isaac Turner 29 April 2014 Public Domain */
-
-/*
-hb_qsort function to be exported.
-Parameters:
-  base is the array to be sorted
-  nel is the number of elements in the array
-  width is the size in bytes of each element of the array
-  compar is the comparison function
-  arg (optional) is a pointer to be passed to the comparison function
-
-void hb_qsort(void *base, size_t nel, size_t width,
-              int (*compar)(const void *_a, const void *_b, [void *_arg]),
-              [void *arg]);
-*/
-
-#define SORT_R_SWAP(a,b,tmp) ((void) ((tmp) = (a)), (void) ((a) = (b)), (b) = (tmp))
-
-/* swap a and b */
-/* a and b must not be equal! */
-static inline void sort_r_swap(char *__restrict a, char *__restrict b,
-                               size_t w)
+/* Quicksort with median-of-three pivot, two-way Hoare partition,
+ * tail-call elimination on the larger side, and insertion-sort
+ * fall-through for small ranges.  Comparator follows C qsort
+ * convention (negative / zero / positive int).
+ *
+ * Not stable; equivalent values may be swapped. */
+template <typename T, typename Compar>
+static inline void
+hb_qsort_inline (T *base, size_t nel, Compar compar)
 {
-  char tmp, *end = a+w;
-  for(; a < end; a++, b++) { SORT_R_SWAP(*a, *b, tmp); }
-}
-
-/* swap a, b iff a>b */
-/* a and b must not be equal! */
-/* __restrict is same as restrict but better support on old machines */
-template <typename Compar>
-static inline int sort_r_cmpswap(char *__restrict a,
-                                 char *__restrict b, size_t w,
-                                 Compar compar)
-{
-  if(compar(a, b) > 0) {
-    sort_r_swap(a, b, w);
-    return 1;
-  }
-  return 0;
-}
-
-/*
-Swap consecutive blocks of bytes of size na and nb starting at memory addr ptr,
-with the smallest swap so that the blocks are in the opposite order. Blocks may
-be internally re-ordered e.g.
-  12345ab  ->   ab34512
-  123abc   ->   abc123
-  12abcde  ->   deabc12
-*/
-static inline void sort_r_swap_blocks(char *ptr, size_t na, size_t nb)
-{
-  if(na > 0 && nb > 0) {
-    if(na > nb) { sort_r_swap(ptr, ptr+na, nb); }
-    else { sort_r_swap(ptr, ptr+nb, na); }
-  }
-}
-
-/* Implement recursive quicksort ourselves */
-/* Note: quicksort is not stable, equivalent values may be swapped */
-template <typename Compar>
-static inline void sort_r_simple(void *base, size_t nel, size_t w,
-                                 Compar compar)
-{
-  char *b = (char *)base, *end = b + nel*w;
-
-  if(nel < 10) {
-    /* Insertion sort for arbitrarily small inputs */
-    char *pi, *pj;
-    for(pi = b+w; pi < end; pi += w) {
-      for(pj = pi; pj > b && sort_r_cmpswap(pj-w,pj,w,compar); pj -= w) {}
-    }
-  }
-  else
+  while (nel > 16)
   {
-    /* nel > 9; Quicksort */
+    T *last = base + nel - 1;
+    T *mid = base + nel / 2;
 
-    int cmp;
-    char *pl, *ple, *pr, *pre, *pivot;
-    char *last = b+w*(nel-1), *tmp;
-
-    char *l[3];
-    l[0] = b + w;
-    l[1] = b+w*(nel/2);
-    l[2] = last - w;
-
-    if(compar(l[0],l[1]) > 0) { SORT_R_SWAP(l[0], l[1], tmp); }
-    if(compar(l[1],l[2]) > 0) {
-      SORT_R_SWAP(l[1], l[2], tmp);
-      if(compar(l[0],l[1]) > 0) { SORT_R_SWAP(l[0], l[1], tmp); }
+    /* Median-of-three pivot, parked at last-1. */
+    if (compar (*base, *mid) > 0) hb_swap (*base, *mid);
+    if (compar (*mid, *last) > 0)
+    {
+      hb_swap (*mid, *last);
+      if (compar (*base, *mid) > 0) hb_swap (*base, *mid);
     }
+    hb_swap (*mid, *(last - 1));
+    T &pivot = *(last - 1);
 
-    if(l[1] != last) { sort_r_swap(l[1], last, w); }
-
-    pivot = last;
-    ple = pl = b;
-    pre = pr = last;
-
-    while(pl < pr) {
-      for(; pl < pr; pl += w) {
-        cmp = compar(pl, pivot);
-        if(cmp > 0) { break; }
-        else if(cmp == 0) {
-          if(ple < pl) { sort_r_swap(ple, pl, w); }
-          ple += w;
-        }
-      }
-      if(pl >= pr) { break; }
-      for(; pl < pr; ) {
-        pr -= w;
-        cmp = compar(pr, pivot);
-        if(cmp == 0) {
-          pre -= w;
-          if(pr < pre) { sort_r_swap(pr, pre, w); }
-        }
-        else if(cmp < 0) {
-          if(pl < pr) { sort_r_swap(pl, pr, w); }
-          pl += w;
-          break;
-        }
-      }
+    /* Two-way Hoare partition.  base and last are sentinels
+     * (already <= and >= pivot respectively). */
+    T *i = base, *j = last - 1;
+    while (true)
+    {
+      while (compar (*++i, pivot) < 0) {}
+      while (compar (*--j, pivot) > 0) {}
+      if (i >= j) break;
+      hb_swap (*i, *j);
     }
+    hb_swap (*i, *(last - 1));
 
-    pl = pr;
-
-    sort_r_swap_blocks(b, ple-b, pl-ple);
-    sort_r_swap_blocks(pr, pre-pr, end-pre);
-
-    sort_r_simple(b, (pl-ple)/w, w, compar);
-    sort_r_simple(end-(pre-pr), (pre-pr)/w, w, compar);
+    /* Recurse on smaller side, loop on larger — bounds stack
+     * depth at O(log n). */
+    size_t left  = (size_t) (i - base);
+    size_t right = nel - left - 1;
+    if (left < right)
+    {
+      hb_qsort_inline (base, left, compar);
+      base = i + 1;
+      nel  = right;
+    }
+    else
+    {
+      hb_qsort_inline (i + 1, right, compar);
+      nel  = left;
+    }
   }
+
+  /* Insertion sort for small inputs. */
+  T *end = base + nel;
+  for (T *pi = base + 1; pi < end; pi++)
+    for (T *pj = pi; pj > base && compar (pj[-1], pj[0]) > 0; pj--)
+      hb_swap (pj[-1], pj[0]);
 }
 
 static inline void

--- a/src/hb-array.hh
+++ b/src/hb-array.hh
@@ -32,8 +32,6 @@
 #include "hb-iter.hh"
 #include "hb-null.hh"
 
-#include <algorithm>
-
 
 template <typename Type>
 struct hb_sorted_array_t;
@@ -227,22 +225,16 @@ struct hb_array_t : hb_iter_with_fallback_t<hb_array_t<Type>, Type&>
       hb_qsort (arrayZ, length, this->get_item_size (), cmp);
     return hb_sorted_array_t<Type> (*this);
   }
-  /* std::sort wants a strict-weak `a < b` boolean, but our other
-   * qsort overload (and most existing call sites) follow the C
-   * qsort convention of returning negative / zero / positive ints.
-   * Adapt to either via overload resolution: bool passes through;
-   * any other arithmetic return type is treated as the int signed
-   * comparator. */
-  template <typename T> static bool _qsort_lt (T v) { return v < 0; }
-  static bool _qsort_lt (bool v) { return v; }
 
+  /* Comparator follows the C qsort convention: returns
+   * negative / zero / positive int. */
   template <typename Compar>
   hb_sorted_array_t<Type> qsort (Compar compar)
   {
     if (likely (length))
-      std::sort (arrayZ, arrayZ + length,
-		 [&] (const Type &a, const Type &b)
-		 { return _qsort_lt (compar (a, b)); });
+      sort_r_simple (arrayZ, length, sizeof (Type),
+		     [&] (const void *a, const void *b)
+		     { return compar (*(const Type *) a, *(const Type *) b); });
     return hb_sorted_array_t<Type> (*this);
   }
 
@@ -251,7 +243,7 @@ struct hb_array_t : hb_iter_with_fallback_t<hb_array_t<Type>, Type&>
 	    hb_enable_if (std::is_move_assignable<T>::value)>
   hb_sorted_array_t<Type> _qsort (hb_priority<1>)
   {
-    return qsort ([] (const Type &a, const Type &b) { return Type::cmp (&a, &b) < 0; });
+    return qsort ([] (const Type &a, const Type &b) { return Type::cmp (&a, &b); });
   }
   hb_sorted_array_t<Type> _qsort (hb_priority<0>)
   {

--- a/src/hb-array.hh
+++ b/src/hb-array.hh
@@ -232,9 +232,7 @@ struct hb_array_t : hb_iter_with_fallback_t<hb_array_t<Type>, Type&>
   hb_sorted_array_t<Type> qsort (Compar compar)
   {
     if (likely (length))
-      sort_r_simple (arrayZ, length, sizeof (Type),
-		     [&] (const void *a, const void *b)
-		     { return compar (*(const Type *) a, *(const Type *) b); });
+      hb_qsort_inline (arrayZ, length, compar);
     return hb_sorted_array_t<Type> (*this);
   }
 

--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -579,7 +579,7 @@ _hb_cairo_paint_sweep_gradient (hb_cairo_context_t *c,
 
   hb_array_t<hb_color_stop_t> (stops, len)
     .qsort ([] (const hb_color_stop_t &a, const hb_color_stop_t &b) {
-      return a.offset < b.offset;
+      return (a.offset > b.offset) - (a.offset < b.offset);
     });
 
   cairo_clip_extents (cr, &x1, &y1, &x2, &y2);

--- a/src/hb-face-builder.cc
+++ b/src/hb-face-builder.cc
@@ -181,7 +181,7 @@ _hb_face_builder_get_table_tags (const hb_face_t *face HB_UNUSED,
     // Not much to do...
   }
   sorted_tags.qsort ([] (const hb_tag_t &a, const hb_tag_t &b) {
-    return a < b;
+    return (a > b) - (a < b);
   });
 
   auto array = sorted_tags.as_array ().sub_array (start_offset, table_count);

--- a/src/hb-gpu-draw.cc
+++ b/src/hb-gpu-draw.cc
@@ -579,11 +579,13 @@ hb_gpu_draw_encode (hb_gpu_draw_t      *draw,
     unsigned count = s.hband_curve_counts.arrayZ[b];
     s.hband_curves.as_array ().sub_array (off, count)
       .qsort ([infos] (const unsigned &a, const unsigned &b) {
-	return infos[a].max_x > infos[b].max_x;
+	auto av = infos[a].max_x, bv = infos[b].max_x;
+	return (av < bv) - (av > bv);
       });
     s.hband_curves_asc.as_array ().sub_array (off, count)
       .qsort ([infos] (const unsigned &a, const unsigned &b) {
-	return infos[a].min_x < infos[b].min_x;
+	auto av = infos[a].min_x, bv = infos[b].min_x;
+	return (av > bv) - (av < bv);
       });
   }
 
@@ -593,11 +595,13 @@ hb_gpu_draw_encode (hb_gpu_draw_t      *draw,
     unsigned count = s.vband_curve_counts.arrayZ[b];
     s.vband_curves.as_array ().sub_array (off, count)
       .qsort ([infos] (const unsigned &a, const unsigned &b) {
-	return infos[a].max_y > infos[b].max_y;
+	auto av = infos[a].max_y, bv = infos[b].max_y;
+	return (av < bv) - (av > bv);
       });
     s.vband_curves_asc.as_array ().sub_array (off, count)
       .qsort ([infos] (const unsigned &a, const unsigned &b) {
-	return infos[a].min_y < infos[b].min_y;
+	auto av = infos[a].min_y, bv = infos[b].min_y;
+	return (av > bv) - (av < bv);
       });
   }
 

--- a/src/hb-ot-post-table.hh
+++ b/src/hb-ot-post-table.hh
@@ -197,7 +197,7 @@ struct post
 	auto thiz = this;
 	hb_array_t<uint16_t> (gids, count)
 	  .qsort ([thiz] (const uint16_t &a, const uint16_t &b) {
-	    return thiz->find_glyph_name (a).cmp (thiz->find_glyph_name (b)) > 0;
+	    return thiz->find_glyph_name (a).cmp (thiz->find_glyph_name (b));
 	  });
 
 	if (unlikely (!gids_sorted_by_name.cmpexch (nullptr, gids)))

--- a/src/hb-ot-post-table.hh
+++ b/src/hb-ot-post-table.hh
@@ -197,7 +197,10 @@ struct post
 	auto thiz = this;
 	hb_array_t<uint16_t> (gids, count)
 	  .qsort ([thiz] (const uint16_t &a, const uint16_t &b) {
-	    return thiz->find_glyph_name (a).cmp (thiz->find_glyph_name (b));
+	    /* hb_array_t::cmp has reversed argument order, so
+	     * x.cmp(y) returns sign of (y - x).  Pass (b, a) to
+	     * get standard "negative when a < b" ordering. */
+	    return thiz->find_glyph_name (b).cmp (thiz->find_glyph_name (a));
 	  });
 
 	if (unlikely (!gids_sorted_by_name.cmpexch (nullptr, gids)))

--- a/src/hb-paint.cc
+++ b/src/hb-paint.cc
@@ -939,7 +939,7 @@ hb_paint_normalize_color_line (hb_color_stop_t *stops,
 
   hb_array_t<hb_color_stop_t> (stops, len)
     .qsort ([] (const hb_color_stop_t &a, const hb_color_stop_t &b) {
-      return a.offset < b.offset;
+      return (a.offset > b.offset) - (a.offset < b.offset);
     });
 
   float mn = stops[0].offset, mx = stops[0].offset;

--- a/src/hb-vector-paint-pdf.cc
+++ b/src/hb-vector-paint-pdf.cc
@@ -892,7 +892,7 @@ hb_pdf_build_gradient_function_from_stops (hb_pdf_resources_t *res,
   /* Sort by offset. */
   paint->color_stops_scratch.as_array ().qsort (
     [] (const hb_color_stop_t &a, const hb_color_stop_t &b)
-    { return a.offset < b.offset; });
+    { return (a.offset > b.offset) - (a.offset < b.offset); });
 
   if (count == 2)
   {
@@ -1342,7 +1342,7 @@ hb_pdf_paint_sweep_gradient (hb_paint_funcs_t *,
   hb_vector_t<hb_color_stop_t> &stops = paint->color_stops_scratch;
   stops.as_array ().qsort (
     [] (const hb_color_stop_t &a, const hb_color_stop_t &b)
-    { return a.offset < b.offset; });
+    { return (a.offset > b.offset) - (a.offset < b.offset); });
 
   hb_paint_extend_t extend = hb_color_line_get_extend (color_line);
 


### PR DESCRIPTION
std::sort leaks weak symbols. This switches to a templated qsort loop with a final insertion sort path. Still slower than std::sort in the `hb-gpu-encode-all` benchmark for me by 7%.

Fixes https://github.com/harfbuzz/harfbuzz/issues/5895