### PR TITLE
test: strengthen buffer and map API coverage

### DIFF
--- a/test/api/test-buffer.c
+++ b/test/api/test-buffer.c
@@ -180,6 +180,73 @@ test_buffer_properties (gpointer fixture_, gconstpointer user_data HB_UNUSED)
 }
 
 static void
+test_buffer_create_similar (void)
+{
+  hb_buffer_t *b;
+  hb_buffer_t *similar;
+  hb_unicode_funcs_t *ufuncs;
+
+  b = hb_buffer_create ();
+  ufuncs = hb_unicode_funcs_create (NULL);
+  hb_buffer_set_unicode_funcs (b, ufuncs);
+  hb_unicode_funcs_destroy (ufuncs);
+
+  hb_buffer_set_flags (b, HB_BUFFER_FLAG_BOT | HB_BUFFER_FLAG_EOT);
+  hb_buffer_set_cluster_level (b, HB_BUFFER_CLUSTER_LEVEL_CHARACTERS);
+  hb_buffer_set_replacement_codepoint (b, 0x25CCu);
+  hb_buffer_set_invisible_glyph (b, 3);
+  hb_buffer_set_not_found_glyph (b, 4);
+  hb_buffer_set_not_found_variation_selector_glyph (b, 5);
+  hb_buffer_set_random_state (b, 23);
+  hb_buffer_add_utf8 (b, "abc", -1, 0, -1);
+
+  similar = hb_buffer_create_similar (b);
+
+  g_assert_true (similar != b);
+  g_assert_cmpint (hb_buffer_get_length (similar), ==, 0);
+  g_assert_true (hb_buffer_get_content_type (similar) == HB_BUFFER_CONTENT_TYPE_INVALID);
+
+  g_assert_true (hb_buffer_get_unicode_funcs (similar) == ufuncs);
+  g_assert_true (hb_buffer_get_flags (similar) == (HB_BUFFER_FLAG_BOT | HB_BUFFER_FLAG_EOT));
+  g_assert_true (hb_buffer_get_cluster_level (similar) == HB_BUFFER_CLUSTER_LEVEL_CHARACTERS);
+  g_assert_cmphex (hb_buffer_get_replacement_codepoint (similar), ==, 0x25CCu);
+  g_assert_cmphex (hb_buffer_get_invisible_glyph (similar), ==, 3);
+  g_assert_cmphex (hb_buffer_get_not_found_glyph (similar), ==, 4);
+  g_assert_cmphex (hb_buffer_get_not_found_variation_selector_glyph (similar), ==, 5);
+  g_assert_cmpint (hb_buffer_get_random_state (similar), ==, 1);
+
+  hb_buffer_clear_contents (b);
+
+  g_assert_cmpint (hb_buffer_get_length (b), ==, 0);
+  g_assert_true (hb_buffer_get_content_type (b) == HB_BUFFER_CONTENT_TYPE_INVALID);
+  g_assert_true (hb_buffer_get_unicode_funcs (b) == ufuncs);
+  g_assert_true (hb_buffer_get_flags (b) == (HB_BUFFER_FLAG_BOT | HB_BUFFER_FLAG_EOT));
+  g_assert_true (hb_buffer_get_cluster_level (b) == HB_BUFFER_CLUSTER_LEVEL_CHARACTERS);
+  g_assert_cmphex (hb_buffer_get_replacement_codepoint (b), ==, 0x25CCu);
+  g_assert_cmphex (hb_buffer_get_invisible_glyph (b), ==, 3);
+  g_assert_cmphex (hb_buffer_get_not_found_glyph (b), ==, 4);
+  g_assert_cmphex (hb_buffer_get_not_found_variation_selector_glyph (b), ==, 5);
+  g_assert_cmpint (hb_buffer_get_random_state (b), ==, 1);
+
+  hb_buffer_set_random_state (b, 23);
+  hb_buffer_reset (b);
+
+  g_assert_cmpint (hb_buffer_get_length (b), ==, 0);
+  g_assert_true (hb_buffer_get_content_type (b) == HB_BUFFER_CONTENT_TYPE_INVALID);
+  g_assert_true (hb_buffer_get_unicode_funcs (b) == hb_unicode_funcs_get_default ());
+  g_assert_true (hb_buffer_get_flags (b) == HB_BUFFER_FLAG_DEFAULT);
+  g_assert_true (hb_buffer_get_cluster_level (b) == HB_BUFFER_CLUSTER_LEVEL_DEFAULT);
+  g_assert_cmphex (hb_buffer_get_replacement_codepoint (b), ==, HB_BUFFER_REPLACEMENT_CODEPOINT_DEFAULT);
+  g_assert_cmphex (hb_buffer_get_invisible_glyph (b), ==, 0);
+  g_assert_cmphex (hb_buffer_get_not_found_glyph (b), ==, 0);
+  g_assert_cmphex (hb_buffer_get_not_found_variation_selector_glyph (b), ==, HB_CODEPOINT_INVALID);
+  g_assert_cmpint (hb_buffer_get_random_state (b), ==, 1);
+
+  hb_buffer_destroy (similar);
+  hb_buffer_destroy (b);
+}
+
+static void
 test_buffer_contents (gpointer fixture_, gconstpointer user_data)
 {
   fixture_t *fixture = fixture_;
@@ -1027,6 +1094,7 @@ main (int argc, char **argv)
   hb_test_add (test_buffer_utf16_conversion);
   hb_test_add (test_buffer_utf32_conversion);
   hb_test_add (test_buffer_empty);
+  hb_test_add (test_buffer_create_similar);
   hb_test_add (test_buffer_serialize_deserialize);
   hb_test_add (test_buffer_serialize_no_advances);
 

--- a/test/api/test-map.c
+++ b/test/api/test-map.c
@@ -28,6 +28,13 @@
 
 
 static void
+assert_map_has (const hb_map_t *m, hb_codepoint_t key, hb_codepoint_t value)
+{
+  g_assert_true (hb_map_has (m, key));
+  g_assert_cmpint (hb_map_get (m, key), ==, value);
+}
+
+static void
 test_map_basic (void)
 {
   hb_map_t *empty = hb_map_get_empty ();
@@ -59,6 +66,92 @@ test_map_basic (void)
   g_assert_true (!hb_map_has (m, 643));
   g_assert_cmpint (hb_map_get_population (m), ==, 0);
 
+  hb_map_destroy (m);
+}
+
+static void
+test_map_copy_equal_hash_update (void)
+{
+  hb_map_t *m = hb_map_create ();
+  hb_map_t *copy;
+  hb_map_t *updated;
+
+  hb_map_set (m, 11, 101);
+  hb_map_set (m, 22, 202);
+
+  copy = hb_map_copy (m);
+  g_assert_true (hb_map_allocation_successful (copy));
+  g_assert_true (hb_map_is_equal (m, copy));
+  g_assert_true (hb_map_is_equal (copy, m));
+  g_assert_cmpint (hb_map_hash (m), ==, hb_map_hash (copy));
+
+  hb_map_set (m, 33, 303);
+  g_assert_true (!hb_map_is_equal (m, copy));
+  g_assert_true (!hb_map_has (copy, 33));
+  assert_map_has (copy, 11, 101);
+  assert_map_has (copy, 22, 202);
+
+  updated = hb_map_create ();
+  hb_map_set (updated, 22, 222);
+  hb_map_set (updated, 44, 404);
+  hb_map_update (copy, updated);
+
+  g_assert_cmpint (hb_map_get_population (copy), ==, 3);
+  assert_map_has (copy, 11, 101);
+  assert_map_has (copy, 22, 222);
+  assert_map_has (copy, 44, 404);
+  assert_map_has (m, 22, 202);
+
+  hb_map_destroy (updated);
+  hb_map_destroy (copy);
+  hb_map_destroy (m);
+}
+
+static void
+test_map_next_keys_values (void)
+{
+  hb_map_t *m = hb_map_create ();
+  hb_set_t *iter_keys = hb_set_create ();
+  hb_set_t *iter_values = hb_set_create ();
+  hb_set_t *keys = hb_set_create ();
+  hb_set_t *values = hb_set_create ();
+  hb_codepoint_t key;
+  hb_codepoint_t value;
+  unsigned int count = 0;
+  int idx = -1;
+
+  hb_map_set (m, 7, 70);
+  hb_map_set (m, 19, 190);
+  hb_map_set (m, 23, 190);
+
+  while (hb_map_next (m, &idx, &key, &value))
+  {
+    g_assert_true (!hb_set_has (iter_keys, key));
+    assert_map_has (m, key, value);
+    hb_set_add (iter_keys, key);
+    hb_set_add (iter_values, value);
+    count++;
+  }
+
+  g_assert_cmpint (count, ==, hb_map_get_population (m));
+  g_assert_cmpint (hb_set_get_population (iter_keys), ==, 3);
+  g_assert_true (hb_set_has (iter_keys, 7));
+  g_assert_true (hb_set_has (iter_keys, 19));
+  g_assert_true (hb_set_has (iter_keys, 23));
+  g_assert_cmpint (hb_set_get_population (iter_values), ==, 2);
+  g_assert_true (hb_set_has (iter_values, 70));
+  g_assert_true (hb_set_has (iter_values, 190));
+
+  hb_map_keys (m, keys);
+  hb_map_values (m, values);
+
+  g_assert_true (hb_set_is_equal (keys, iter_keys));
+  g_assert_true (hb_set_is_equal (values, iter_values));
+
+  hb_set_destroy (values);
+  hb_set_destroy (keys);
+  hb_set_destroy (iter_values);
+  hb_set_destroy (iter_keys);
   hb_map_destroy (m);
 }
 
@@ -137,6 +230,8 @@ main (int argc, char **argv)
   hb_test_init (&argc, &argv);
 
   hb_test_add (test_map_basic);
+  hb_test_add (test_map_copy_equal_hash_update);
+  hb_test_add (test_map_next_keys_values);
   hb_test_add (test_map_userdata);
   hb_test_add (test_map_refcount);
   hb_test_add (test_map_get_population);


### PR DESCRIPTION
## Summary

Test-only patch closing public-API coverage gaps:

- `test/api/test-buffer.c`: `test_buffer_create_similar` pins `hb_buffer_create_similar` option-copy semantics, `hb_buffer_clear_contents` preserving user-set options, and `hb_buffer_reset` restoring defaults.
- `test/api/test-map.c`: `test_map_copy_equal_hash_update` and `test_map_next_keys_values` cover `hb_map_copy`, `hb_map_is_equal`, `hb_map_hash`, `hb_map_update`, `hb_map_next`, `hb_map_keys`, `hb_map_values`. Iteration assertions are order-independent.

The existing API tests did not exercise these public wrappers directly; internal C++ tests don't substitute for public-API coverage.

## Coverage delta (vs baseline `5062828615`, same `-Db_coverage=true` config, only `test-buffer` and `test-map` run)

| File | Lines | Functions |
|---|---|---|
| `src/hb-map.cc` | 59.3% → **96.3%** (+20, +37.0pp) | 66.7% → **100.0%** (+7, +33.3pp) |
| `src/hb-map.hh` | 62.4% → **89.8%** (+54, +27.4pp) | 14.0% → **33.3%** (+18, +19.3pp) |
| `src/hb-buffer.cc` | 40.4% → **46.4%** (+41, +6.0pp) | 48.9% → **62.8%** (+13, +13.9pp) |
| `src/hb-buffer.hh` | unchanged | unchanged |

Net: +115 lines, +38 functions across the four files.

## Validation

```sh
meson test -C build --print-errorlogs --suite api test-buffer test-map
# test-buffer  24 subtests passed
# test-map      6 subtests passed
```

Also clean under `-Db_sanitize=address,undefined -Db_lundef=false`. `git diff --check` passes; only the two test files are touched.