### PR TITLE
Make Rust global_allocator mapping optional

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,11 +14,12 @@ path = "lib.rs"
 crate-type = ["staticlib"]
 
 [features]
-default = ["paint", "draw"]
+default = ["paint", "draw", "hb-allocator"]
 font = ["dep:skrifa"]
 shape = ["dep:harfrust"]
 paint = []
 draw = []
+hb-allocator = []
 
 [profile.release]
 strip = true

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -1,4 +1,5 @@
 mod hb;
+#[allow(unused_imports)]
 use hb::*;
 
 #[cfg(feature = "font")]
@@ -6,11 +7,15 @@ mod font;
 #[cfg(feature = "shape")]
 mod shape;
 
+#[cfg(feature = "hb-allocator")]
 use std::alloc::{GlobalAlloc, Layout};
+#[cfg(feature = "hb-allocator")]
 use std::os::raw::c_void;
 
+#[cfg(feature = "hb-allocator")]
 struct MyAllocator;
 
+#[cfg(feature = "hb-allocator")]
 unsafe impl GlobalAlloc for MyAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         assert!(layout.align() <= 2 * std::mem::size_of::<*mut u8>());
@@ -33,5 +38,6 @@ unsafe impl GlobalAlloc for MyAllocator {
     }
 }
 
+#[cfg(feature = "hb-allocator")]
 #[global_allocator]
 static GLOBAL: MyAllocator = MyAllocator;


### PR DESCRIPTION
In embedding projects, the global_allocator might already have been overriden. There is no known way to keep the allocator library-local, and allocator-bound containers are not a stable Rust feature yet.

Add an option to disable the allocator mapping to hb_malloc and friends, so that an embedder can keep their own allocator.