### PR TITLE
build: Fix building hb-gpu on Windows

### DIFF
--- a/util/gpu/meson.build
+++ b/util/gpu/meson.build
@@ -64,6 +64,6 @@ if not gpu_demo_opt.disabled()
     metal_dep = disabler()
   endif
   d3d11_dep = meson.get_compiler('cpp').find_library('d3d11', required: false)
-  d3dcompiler_dep = meson.get_compiler('cpp').find_library('d3dcompiler_47', required: false)
+  d3dcompiler_dep = meson.get_compiler('cpp').find_library('d3dcompiler', required: false)
   have_gpu_demo_deps = glew_dep.found() and glfw_dep.found() and gl_dep.found()
 endif


### PR DESCRIPTION
Hi,

This attempts to update the Meson build files to fix building `hb-gpu` on Windows:

* Use `-DNOMINMAX` when building on Visual Studio-style compilers, so that `std::min` and `std::max` can be used properly.
* Correct the dependency for linking to `D3DCompiler_47.dll`-the library to look for should be `D3DCompiler.lib` (or so for MinGW).

With blessings, thank you!