### PR TITLE
[algs] Saturating arithmetic for get_size() on 32-bit

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -1215,6 +1215,62 @@ hb_unsigned_add_overflows (unsigned int a, unsigned int b, unsigned *result = nu
   return b > (unsigned int) -1 - a;
 }
 
+/* Saturating arithmetic on size_t.  On platforms where size_t is wider than
+ * unsigned int (i.e. 64-bit), the inputs to get_size()-style computations
+ * (counts and static_sizes which are at most 32-bit) cannot overflow size_t,
+ * so these reduce to plain arithmetic.  On 32-bit platforms (size_t is
+ * unsigned int), they saturate to SIZE_MAX so sanitize/serialize callers
+ * naturally reject the resulting size as out-of-range. */
+
+static inline size_t
+hb_unsigned_mul_saturate (size_t a, size_t b)
+{
+  if (sizeof (size_t) > sizeof (unsigned int))
+    return a * b;
+#if hb_has_builtin(__builtin_mul_overflow)
+  size_t result;
+  if (__builtin_mul_overflow (a, b, &result))
+    return (size_t) -1;
+  return result;
+#else
+  if (b > 0 && a > ((size_t) -1) / b) return (size_t) -1;
+  return a * b;
+#endif
+}
+
+static inline size_t
+hb_unsigned_add_saturate (size_t a, size_t b)
+{
+  if (sizeof (size_t) > sizeof (unsigned int))
+    return a + b;
+#if hb_has_builtin(__builtin_add_overflow)
+  size_t result;
+  if (__builtin_add_overflow (a, b, &result))
+    return (size_t) -1;
+  return result;
+#else
+  if (b > ((size_t) -1) - a) return (size_t) -1;
+  return a + b;
+#endif
+}
+
+/* Variadic forms: fold left across all arguments. */
+template <typename ...Ts>
+static inline size_t
+hb_unsigned_mul_saturate (size_t a, size_t b, size_t c, Ts... rest)
+{ return hb_unsigned_mul_saturate (hb_unsigned_mul_saturate (a, b), c, rest...); }
+
+template <typename ...Ts>
+static inline size_t
+hb_unsigned_add_saturate (size_t a, size_t b, size_t c, Ts... rest)
+{ return hb_unsigned_add_saturate (hb_unsigned_add_saturate (a, b), c, rest...); }
+
+/* Saturating mul-add: a * b + c.  Covers the dominant get_size() pattern
+ * `count * static_size + min_size`. */
+static inline size_t
+hb_unsigned_mul_add_saturate (size_t a, size_t b, size_t c)
+{ return hb_unsigned_add_saturate (hb_unsigned_mul_saturate (a, b), c); }
+
 
 /*
  * Sort and search.

--- a/src/hb-open-type.hh
+++ b/src/hb-open-type.hh
@@ -564,7 +564,7 @@ struct UnsizedArrayOf
   }
 
   static size_t get_size (unsigned int len)
-  { return len * Type::static_size; }
+  { return hb_unsigned_mul_saturate (len, Type::static_size); }
 
   template <typename T> operator T * () { return arrayZ; }
   template <typename T> operator const T * () const { return arrayZ; }
@@ -726,7 +726,7 @@ struct ArrayOf
   }
 
   size_t get_size () const
-  { return len.static_size + len * Type::static_size; }
+  { return hb_unsigned_mul_add_saturate (len, Type::static_size, len.static_size); }
 
   explicit operator bool () const { return len; }
 
@@ -910,7 +910,7 @@ struct HeadlessArrayOf
     return arrayZ[i-1];
   }
   size_t get_size () const
-  { return lenP1.static_size + get_length () * Type::static_size; }
+  { return hb_unsigned_mul_add_saturate (get_length (), Type::static_size, lenP1.static_size); }
 
   unsigned get_length () const { return lenP1 ? lenP1 - 1 : 0; }
 
@@ -1004,7 +1004,7 @@ struct ArrayOfM1
     return arrayZ[i];
   }
   size_t get_size () const
-  { return lenM1.static_size + (lenM1 + 1) * Type::static_size; }
+  { return hb_unsigned_mul_add_saturate (lenM1 + 1, Type::static_size, lenM1.static_size); }
 
   template <typename ...Ts>
   HB_ALWAYS_INLINE
@@ -1198,7 +1198,7 @@ struct VarSizedBinSearchArrayOf
   unsigned int get_length () const
   { return header.nUnits - last_is_terminator (); }
   size_t get_size () const
-  { return header.static_size + header.nUnits * header.unitSize; }
+  { return hb_unsigned_mul_add_saturate (header.nUnits, header.unitSize, header.static_size); }
 
   template <typename ...Ts>
   HB_ALWAYS_INLINE
@@ -1464,7 +1464,8 @@ struct CFFIndex
   size_t get_size () const
   {
     if (count)
-      return min_size + offSize.static_size + offset_array_size () + (offset_at (count) - 1);
+      return hb_unsigned_add_saturate (min_size, offSize.static_size,
+				       offset_array_size (), offset_at (count) - 1);
     return min_size;  /* empty CFFIndex contains count only */
   }
 

--- a/src/hb-ot-cff-common.hh
+++ b/src/hb-ot-cff-common.hh
@@ -202,7 +202,7 @@ struct FDSelect0 {
   { return {fds[glyph], glyph + 1}; }
 
   size_t get_size (unsigned int num_glyphs) const
-  { return HBUINT8::static_size * num_glyphs; }
+  { return hb_unsigned_mul_saturate (HBUINT8::static_size, num_glyphs); }
 
   HBUINT8     fds[HB_VAR_ARRAY];
 
@@ -230,7 +230,7 @@ template <typename GID_TYPE, typename FD_TYPE>
 struct FDSelect3_4
 {
   size_t get_size () const
-  { return GID_TYPE::static_size * 2 + ranges.get_size (); }
+  { return hb_unsigned_add_saturate ((size_t) GID_TYPE::static_size * 2, ranges.get_size ()); }
 
   bool sanitize (hb_sanitize_context_t *c, unsigned int fdcount) const
   {
@@ -308,8 +308,8 @@ struct FDSelect
   {
     switch (format)
     {
-    case 0: hb_barrier (); return format.static_size + u.format0.get_size (num_glyphs);
-    case 3: hb_barrier (); return format.static_size + u.format3.get_size ();
+    case 0: hb_barrier (); return hb_unsigned_add_saturate (format.static_size, u.format0.get_size (num_glyphs));
+    case 3: hb_barrier (); return hb_unsigned_add_saturate (format.static_size, u.format3.get_size ());
     default:return 0;
     }
   }

--- a/src/hb-ot-cff1-table.hh
+++ b/src/hb-ot-cff1-table.hh
@@ -236,14 +236,14 @@ struct Encoding
 
   size_t get_size () const
   {
-    unsigned int size = min_size;
+    size_t size = min_size;
     switch (table_format ())
     {
-    case 0: hb_barrier (); size += u.format0.get_size (); break;
-    case 1: hb_barrier (); size += u.format1.get_size (); break;
+    case 0: hb_barrier (); size = hb_unsigned_add_saturate (size, u.format0.get_size ()); break;
+    case 1: hb_barrier (); size = hb_unsigned_add_saturate (size, u.format1.get_size ()); break;
     }
     if (has_supplement ())
-      size += suppEncData ().get_size ();
+      size = hb_unsigned_add_saturate (size, suppEncData ().get_size ());
     return size;
   }
 
@@ -567,9 +567,9 @@ struct Charset
   {
     switch (format)
     {
-    case 0: hb_barrier (); return min_size + u.format0.get_size (num_glyphs);
-    case 1: hb_barrier (); return min_size + u.format1.get_size (num_glyphs);
-    case 2: hb_barrier (); return min_size + u.format2.get_size (num_glyphs);
+    case 0: hb_barrier (); return hb_unsigned_add_saturate (min_size, u.format0.get_size (num_glyphs));
+    case 1: hb_barrier (); return hb_unsigned_add_saturate (min_size, u.format1.get_size (num_glyphs));
+    case 2: hb_barrier (); return hb_unsigned_add_saturate (min_size, u.format2.get_size (num_glyphs));
     default:return 0;
     }
   }

--- a/src/hb-ot-hdmx-table.hh
+++ b/src/hb-ot-hdmx-table.hh
@@ -42,7 +42,7 @@ namespace OT {
 struct DeviceRecord
 {
   static size_t get_size (unsigned count)
-  { return hb_ceil_to_4 (min_size + count * HBUINT8::static_size); }
+  { return hb_ceil_to_4 (hb_unsigned_mul_add_saturate (count, HBUINT8::static_size, min_size)); }
 
   template<typename Iterator,
 	   hb_requires (hb_is_iterator (Iterator))>
@@ -88,7 +88,7 @@ struct hdmx
   static constexpr hb_tag_t tableTag = HB_OT_TAG_hdmx;
 
   size_t get_size () const
-  { return min_size + numRecords * sizeDeviceRecord; }
+  { return hb_unsigned_mul_add_saturate (numRecords, sizeDeviceRecord, min_size); }
 
   template<typename Iterator,
 	   hb_requires (hb_is_iterator (Iterator))>

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -638,7 +638,7 @@ struct FeatureParamsCharacterVariants
   }
 
   size_t get_size () const
-  { return min_size + characters.len * HBUINT24::static_size; }
+  { return hb_unsigned_mul_add_saturate (characters.len, HBUINT24::static_size, min_size); }
 
   void collect_name_ids (hb_set_t *nameids_to_retain /* OUT */) const
   {
@@ -2791,7 +2791,10 @@ struct VarRegionList
     return !regions.in_error ();
   }
 
-  size_t get_size () const { return min_size + (size_t) VarRegionAxis::static_size * axisCount * regionCount; }
+  size_t get_size () const
+  { return hb_unsigned_add_saturate (min_size,
+				     hb_unsigned_mul_saturate (VarRegionAxis::static_size,
+							       axisCount, regionCount)); }
 
   public:
   HBUINT16	axisCount;
@@ -2872,10 +2875,9 @@ struct VarData
   { return (wordCount () + regionIndices.len) * (longWords () ? 2 : 1); }
 
   size_t get_size () const
-  { return min_size
-	 - regionIndices.min_size + regionIndices.get_size ()
-	 + itemCount * get_row_size ();
-  }
+  { return hb_unsigned_add_saturate (min_size - regionIndices.min_size,
+				     regionIndices.get_size (),
+				     hb_unsigned_mul_saturate (itemCount, get_row_size ())); }
 
   float _get_delta (unsigned int inner,
 		    const int *coords, unsigned int coord_count,
@@ -3244,10 +3246,9 @@ struct VarData
 struct MultiVarData
 {
   size_t get_size () const
-  { return min_size
-	 - regionIndices.min_size + regionIndices.get_size ()
-	 + StructAfter<CFF2Index> (regionIndices).get_size ();
-  }
+  { return hb_unsigned_add_saturate (min_size - regionIndices.min_size,
+				     regionIndices.get_size (),
+				     StructAfter<CFF2Index> (regionIndices).get_size ()); }
 
   void get_delta (unsigned int inner,
 		  const int *coords, unsigned int coord_count,
@@ -3639,7 +3640,7 @@ struct DeltaSetIndexMapFormat01
   friend struct DeltaSetIndexMap;
 
   size_t get_size () const
-  { return min_size + mapCount * get_width (); }
+  { return hb_unsigned_mul_add_saturate (mapCount, get_width (), min_size); }
 
   private:
   DeltaSetIndexMapFormat01* copy (hb_serialize_context_t *c) const

--- a/src/hb-ot-os2-table.hh
+++ b/src/hb-ot-os2-table.hh
@@ -346,10 +346,10 @@ struct OS2
 
   size_t get_size () const
   {
-    unsigned result = min_size;
-    if (version >= 1) result += v1X.get_size ();
-    if (version >= 2) result += v2X.get_size ();
-    if (version >= 5) result += v5X.get_size ();
+    size_t result = min_size;
+    if (version >= 1) result = hb_unsigned_add_saturate (result, v1X.get_size ());
+    if (version >= 2) result = hb_unsigned_add_saturate (result, v2X.get_size ());
+    if (version >= 5) result = hb_unsigned_add_saturate (result, v5X.get_size ());
     return result;
   }
 

--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -47,7 +47,7 @@ struct TupleVariationHeader
     if (unlikely ((ti & (TupleIndex::EmbeddedPeakTuple | TupleIndex::IntermediateRegion))))
     {
       unsigned count = ((ti & TupleIndex::EmbeddedPeakTuple) != 0) + ((ti & TupleIndex::IntermediateRegion) != 0) * 2;
-      return min_size + count * axis_count_times_2;
+      return hb_unsigned_mul_add_saturate (count, axis_count_times_2, min_size);
     }
     return min_size;
   }
@@ -936,12 +936,14 @@ struct TupleVariationData
 
   size_t get_size (unsigned axis_count_times_2) const
   {
-    unsigned total_size = min_size;
+    size_t total_size = min_size;
     unsigned count = tupleVarCount.get_count ();
     const TupleVariationHeader *tuple_var_header = &(get_tuple_var_header());
     for (unsigned i = 0; i < count; i++)
     {
-      total_size += tuple_var_header->get_size (axis_count_times_2) + tuple_var_header->get_data_size ();
+      total_size = hb_unsigned_add_saturate (total_size,
+					     tuple_var_header->get_size (axis_count_times_2),
+					     (size_t) tuple_var_header->get_data_size ());
       tuple_var_header = &tuple_var_header->get_next (axis_count_times_2);
     }
 

--- a/src/hb-ot-var-hvar-table.hh
+++ b/src/hb-ot-var-hvar-table.hh
@@ -181,7 +181,11 @@ struct index_map_subset_plan_t
   unsigned int get_map_count ()       const { return map_count; }
 
   size_t get_size () const
-  { return (map_count? (DeltaSetIndexMap::min_size + get_width () * map_count): 0); }
+  {
+    if (!map_count) return 0;
+    return hb_unsigned_mul_add_saturate (get_width (), map_count,
+					 DeltaSetIndexMap::min_size);
+  }
 
   bool is_identity () const { return get_output_map ().length == 0; }
   hb_array_t<const uint32_t> get_output_map () const { return output_map.as_array (); }

--- a/src/hb-vector.hh
+++ b/src/hb-vector.hh
@@ -272,7 +272,7 @@ struct hb_vector_t
   const Type& tail () const { return (*this)[length - 1]; }
 
   explicit operator bool () const { return length; }
-  size_t get_size () const { return length * item_size; }
+  size_t get_size () const { return hb_unsigned_mul_saturate (length, item_size); }
 
   /* Sink interface. */
   template <typename T>


### PR DESCRIPTION
On 32-bit platforms size_t is unsigned int, so the typical get_size() computation `min_size + count * static_size` silently wraps when the product exceeds UINT_MAX.  The truncated value then flows into sanitize / serialize as a small but plausible size, defeating bounds checks.

Add three helpers in hb-algs.hh:

  hb_unsigned_mul_saturate (a, b, ...)
  hb_unsigned_add_saturate (a, b, ...)
  hb_unsigned_mul_add_saturate (a, b, c)   /* a*b + c */

They saturate to SIZE_MAX on overflow.  Variadic overloads left-fold so 3+ arguments work.  On 64-bit (size_t wider than unsigned int), all three reduce to plain a*b / a+b — the inputs to size computations are at most unsigned int so the result fits in size_t without overflow.

Convert every get_size() that does arithmetic over variable inputs:

  hb-open-type.hh        UnsizedArrayOf, ArrayOf,
                         HeadlessArrayOf, ArrayOfM1,
                         sorted-array-with-header, CFFIndex
  hb-ot-layout-common.hh CmapSubtableFormat-style,
                         VarRegionList, VarData, MultiVarData,
                         DeltaSetIndexMapFormat01
  hb-ot-hdmx-table.hh    DeviceRecord, hdmx
  hb-ot-cff-common.hh    Charset0, Charset wrapper
  hb-ot-cff1-table.hh    Encoding, Charset wrapper
                         (also widened unsigned accumulator
                         to size_t)
  hb-ot-os2-table.hh     OS/2 (widened accumulator to size_t)
  hb-ot-var-common.hh    TupleVariationHeader,
                         TupleVariationData accumulator
  hb-ot-var-hvar-table.hh DeltaSetIndexMap
  hb-vector.hh           hb_vector_t::get_size

When saturation kicks in, check_range() and extend_size() naturally reject the resulting value (SIZE_MAX truncated to unsigned is UINT_MAX, far past any real blob; extend_size already rejects sizes >= INT_MAX).

Assisted-by: Claude <noreply@anthropic.com>