### PR TITLE
[subset-repack] increase the MAX_SPACES limit

### DIFF
--- a/src/hb-limits.hh
+++ b/src/hb-limits.hh
@@ -134,7 +134,7 @@
 #endif
 
 #ifndef HB_REPACKER_MAX_SPACES
-#define HB_REPACKER_MAX_SPACES 1024
+#define HB_REPACKER_MAX_SPACES 8000
 #endif
 
 


### PR DESCRIPTION
This fixes #5980 , in which the total num of spaces >1500