### PR TITLE
Some CMake updates for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,7 +357,8 @@ if (HB_HAVE_ICU)
 
   list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-icu.h)
 
-  list(APPEND THIRD_PARTY_LIBS ICU::uc)
+  get_target_property(ICU_UC_LIBRARY ICU::uc IMPORTED_LOCATION)
+  list(APPEND THIRD_PARTY_LIBS ${ICU_UC_LIBRARY})
 endif ()
 
 if (APPLE AND HB_HAVE_CORETEXT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1060,6 +1060,15 @@ if (HB_BUILD_UTILS)
             "-framework Metal" "-framework QuartzCore"
             "-framework Foundation" "-framework AppKit")
       endif ()
+      if (WIN32)
+        find_library(D3D11_LIBRARY NAMES d3d11)
+        find_library(D3DCOMPILER_LIBRARY NAMES d3dcompiler)
+        target_sources(hb-gpu PRIVATE
+            ${PROJECT_SOURCE_DIR}/util/gpu/demo-renderer-d3d11.cc)
+        target_link_libraries(hb-gpu
+            "${D3D11_LIBRARY}"
+            "${D3DCOMPILER_LIBRARY}")
+      endif ()
     endif ()
   endif ()
 endif ()


### PR DESCRIPTION
Hi,

This attempts to fix up CMake builds, in particular for Windows, for the following:

* Fix up building `hb-cpu` on Windows by including the needed `demo-renderer-d3d11.cc` source file, and linking to `d3d11.lib` and `D3DCompiler.lib` (or so on MinGW).
* Fix up introspection builds when ICU is enabled, by grabbing the proper library name for ICU-UC, so that we can feed that into `g-ir-scanner`.

With blessings, thank you!