### PR TITLE
[harfrust] Honor hb font funcs during shaping

### DIFF
--- a/src/hb-harfrust.cc
+++ b/src/hb-harfrust.cc
@@ -96,7 +96,10 @@ extern "C" void *
 _hb_harfrust_shape_plan_create_rs (const void *font_data,
 				   hb_script_t script,
 				   hb_language_t language,
-				   hb_direction_t direction);
+				   hb_direction_t direction,
+				   const hb_feature_t *features,
+				   unsigned int        num_features);
+
 
 extern "C" void
 _hb_harfrust_shape_plan_destroy_rs (void *data);
@@ -151,26 +154,24 @@ retry_buffer:
 
   void *hr_shape_plan = nullptr;
 
-  if (!num_features)
+retry_shape_plan:
+  hr_shape_plan = hb_shape_plan_get_user_data (shape_plan, &hb_object_key);
+  if (unlikely (!hr_shape_plan))
   {
-  retry_shape_plan:
-    hr_shape_plan = hb_shape_plan_get_user_data (shape_plan, &hb_object_key);
-    if (unlikely (!hr_shape_plan))
+    hr_shape_plan = _hb_harfrust_shape_plan_create_rs (font_data,
+						       shape_plan->key.props.script,
+						       shape_plan->key.props.language,
+						       shape_plan->key.props.direction,
+						       features, num_features);
+    if (hr_shape_plan &&
+	!hb_shape_plan_set_user_data (shape_plan,
+				     &hb_object_key,
+				     hr_shape_plan,
+				     _hb_harfrust_shape_plan_destroy_rs,
+				     false))
     {
-      hr_shape_plan = _hb_harfrust_shape_plan_create_rs (font_data,
-							 shape_plan->key.props.script,
-							 shape_plan->key.props.language,
-							 shape_plan->key.props.direction);
-      if (hr_shape_plan &&
-	  !hb_shape_plan_set_user_data (shape_plan,
-				       &hb_object_key,
-				       hr_shape_plan,
-				       _hb_harfrust_shape_plan_destroy_rs,
-				       false))
-      {
-        _hb_harfrust_shape_plan_destroy_rs (hr_shape_plan);
-	goto retry_shape_plan;
-      }
+      _hb_harfrust_shape_plan_destroy_rs (hr_shape_plan);
+      goto retry_shape_plan;
     }
   }
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.87.0"
 skrifa = { version = "0.*", optional = true }
 read-fonts = "0.39.*"
 # harfrust = { version = "0.8.*", optional = true }
-harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
+harfrust = { git = "https://github.com/harfbuzz/harfrust", branch = "scale-it", optional = true }
 
 [lib]
 name = "harfbuzz_rust"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.87.0"
 skrifa = { version = "0.*", optional = true }
 read-fonts = "0.39.*"
 # harfrust = { version = "0.8.*", optional = true }
-harfrust = { git = "https://github.com/harfbuzz/harfrust", branch = "scale-it", optional = true }
+harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
 
 [lib]
 name = "harfbuzz_rust"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.87.0"
 skrifa = { version = "0.*", optional = true }
 read-fonts = "0.39.*"
 # harfrust = { version = "0.8.*", optional = true }
-harfrust = { git = "https://github.com/harfbuzz/harfrust", branch = "font-funcs", optional = true }
+harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
 
 [lib]
 name = "harfbuzz_rust"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -5,8 +5,9 @@ rust-version = "1.87.0"
 
 [dependencies]
 skrifa = { version = "0.*", optional = true }
-harfrust = { version = "0.8.*", optional = true }
-# harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
+read-fonts = "0.39.*"
+# harfrust = { version = "0.8.*", optional = true }
+harfrust = { git = "https://github.com/harfbuzz/harfrust", branch = "font-funcs", optional = true }
 
 [lib]
 name = "harfbuzz_rust"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -6,8 +6,7 @@ rust-version = "1.87.0"
 [dependencies]
 skrifa = { version = "0.*", optional = true }
 read-fonts = "0.39.*"
-# harfrust = { version = "0.8.*", optional = true }
-harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
+harfrust = { version = "0.8.*", optional = true }
 
 [lib]
 name = "harfbuzz_rust"

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -200,12 +200,40 @@ pub unsafe extern "C" fn _hb_harfrust_buffer_destroy_rs(data: *mut c_void) {
     let _hr_buffer = Box::from_raw(data);
 }
 
+fn hb_feature_to_hr_feature(
+    features: *const hb_feature_t,
+    num_features: u32,
+) -> Vec<harfrust::Feature> {
+    if features.is_null() {
+        Vec::new()
+    } else {
+        let features = unsafe { std::slice::from_raw_parts(features, num_features as usize) };
+        features
+            .iter()
+            .map(|f| {
+                let tag = f.tag;
+                let value = f.value;
+                let start = f.start;
+                let end = f.end;
+                harfrust::Feature {
+                    tag: Tag::from_u32(tag),
+                    value,
+                    start,
+                    end,
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _hb_harfrust_shape_plan_create_rs(
     font_data: *const c_void,
     script: hb_script_t,
     language: hb_language_t,
     direction: hb_direction_t,
+    features: *const hb_feature_t,
+    num_features: u32,
 ) -> *mut c_void {
     let font_data = font_data as *const HBHarfRustFontData;
 
@@ -220,10 +248,12 @@ pub unsafe extern "C" fn _hb_harfrust_shape_plan_create_rs(
         hb_direction_t_HB_DIRECTION_BTT => harfrust::Direction::BottomToTop,
         _ => harfrust::Direction::Invalid,
     };
+    let features = hb_feature_to_hr_feature(features, num_features);
 
     let shaper = &(*font_data).shaper;
 
-    let hr_shape_plan = harfrust::ShapePlan::new(shaper, direction, script, language.as_ref(), &[]);
+    let hr_shape_plan =
+        harfrust::ShapePlan::new(shaper, direction, script, language.as_ref(), &features);
     let hr_shape_plan = Box::new(hr_shape_plan);
     Box::into_raw(hr_shape_plan) as *mut c_void
 }
@@ -322,33 +352,8 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     let ptem = hb_font_get_ptem(font);
     let ptem = if ptem > 0.0 { Some(ptem) } else { None };
 
-    let features = if features.is_null() {
-        Vec::new()
-    } else {
-        let features = std::slice::from_raw_parts(features, num_features as usize);
-        features
-            .iter()
-            .map(|f| {
-                let tag = f.tag;
-                let value = f.value;
-                let start = f.start;
-                let end = f.end;
-                harfrust::Feature {
-                    tag: Tag::from_u32(tag),
-                    value,
-                    start,
-                    end,
-                }
-            })
-            .collect::<Vec<_>>()
-    };
-
-    let shape_plan = if shape_plan.is_null() {
-        None
-    } else {
-        let shape_plan = shape_plan as *const harfrust::ShapePlan;
-        shape_plan.as_ref()
-    };
+    let features = hb_feature_to_hr_feature(features, num_features);
+    let shape_plan = (shape_plan as *const harfrust::ShapePlan).as_ref();
     let mut x_scale = 0;
     let mut y_scale = 0;
     hb_font_get_scale(font, &mut x_scale, &mut y_scale);

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -7,7 +7,11 @@ use std::mem::transmute;
 use std::ptr::null_mut;
 use std::str::FromStr;
 
-use harfrust::{FontRef, NormalizedCoord, ShapeOptions, Shaper, ShaperData, ShaperInstance, Tag};
+use harfrust::{
+    funcs::{AdvanceWidthBatch, BuiltinFontFuncs, FontFuncs},
+    FontRef, GlyphExtents, NormalizedCoord, ShapeOptions, Shaper, ShaperData, ShaperInstance, Tag,
+};
+use read_fonts::types::GlyphId;
 
 pub struct HBHarfRustFaceData<'a> {
     face_blob: *mut hb_blob_t,
@@ -55,6 +59,80 @@ pub struct HBHarfRustFontData {
     // Keep the instance alive because `shaper` borrows variation data from it.
     _shaper_instance: Box<ShaperInstance>,
     shaper: Shaper<'static>,
+}
+
+struct HBHarfBuzzFontFuncs {
+    font: *mut hb_font_t,
+}
+
+impl FontFuncs for HBHarfBuzzFontFuncs {
+    fn nominal_glyph(&mut self, _: &BuiltinFontFuncs, c: u32) -> Option<GlyphId> {
+        let mut glyph = 0;
+        if unsafe { hb_font_get_nominal_glyph(self.font, c, &mut glyph) } != 0 {
+            Some(GlyphId::new(glyph))
+        } else {
+            None
+        }
+    }
+
+    fn variant_glyph(&mut self, _: &BuiltinFontFuncs, c: u32, vs: u32) -> Option<GlyphId> {
+        let mut glyph = 0;
+        if unsafe { hb_font_get_variation_glyph(self.font, c, vs, &mut glyph) } != 0 {
+            Some(GlyphId::new(glyph))
+        } else {
+            None
+        }
+    }
+
+    fn advance_width(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+        unsafe { hb_font_get_glyph_h_advance(self.font, glyph.to_u32()) }
+    }
+
+    fn populate_advance_widths(&mut self, _: &BuiltinFontFuncs, batch: AdvanceWidthBatch<'_>) {
+        let raw = batch.into_raw();
+        unsafe {
+            hb_font_get_glyph_h_advances(
+                self.font,
+                raw.len as u32,
+                raw.gids,
+                raw.gid_stride as u32,
+                raw.advances,
+                raw.advance_stride as u32,
+            );
+        }
+    }
+
+    fn advance_height(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+        unsafe { hb_font_get_glyph_v_advance(self.font, glyph.to_u32()) }
+    }
+
+    fn vertical_origin(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+        let mut x = 0;
+        let mut y = 0;
+        unsafe {
+            hb_font_get_glyph_v_origin(self.font, glyph.to_u32(), &mut x, &mut y);
+        }
+        y
+    }
+
+    fn extents(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> Option<GlyphExtents> {
+        let mut extents = hb_glyph_extents_t {
+            x_bearing: 0,
+            y_bearing: 0,
+            width: 0,
+            height: 0,
+        };
+        if unsafe { hb_font_get_glyph_extents(self.font, glyph.to_u32(), &mut extents) } != 0 {
+            Some(GlyphExtents {
+                x_bearing: extents.x_bearing,
+                y_bearing: extents.y_bearing,
+                width: extents.width,
+                height: extents.height,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 fn font_to_shaper_instance(font: *mut hb_font_t, font_ref: &FontRef<'_>) -> ShaperInstance {
@@ -271,12 +349,14 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
         let shape_plan = shape_plan as *const harfrust::ShapePlan;
         shape_plan.as_ref()
     };
+    let mut font_funcs = HBHarfBuzzFontFuncs { font };
     let glyphs = (*font_data).shaper.shape(
         hr_buffer,
         ShapeOptions::new()
             .plan(shape_plan)
             .point_size(ptem)
-            .features(&features),
+            .features(&features)
+            .font_funcs(Some(&mut font_funcs)),
     );
 
     let count = glyphs.len();

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -63,31 +63,6 @@ pub struct HBHarfRustFontData {
 
 struct HBHarfBuzzFontFuncs {
     font: *mut hb_font_t,
-    x_mult_inv: i64,
-    y_mult_inv: i64,
-}
-
-impl HBHarfBuzzFontFuncs {
-    // HarfRust currently expects font-func metrics in UPEM units, but
-    // hb_font_get_* returns values in the hb_font_t scale. Convert back here
-    // and let the existing bridge scaling convert shaped output again.
-    fn inv_mult(scale: i32, upem: i32) -> i64 {
-        if upem <= 0 {
-            return 1 << 16;
-        }
-
-        let scale = if scale == 0 { 1 } else { scale } as i64;
-        let upem = upem as i64;
-        if scale < 0 {
-            -(((-upem) << 16) / scale)
-        } else {
-            (upem << 16) / scale
-        }
-    }
-
-    fn to_upem(value: i32, mult_inv: i64) -> i32 {
-        ((value as i64 * mult_inv + 32768) >> 16) as i32
-    }
 }
 
 impl FontFuncs for HBHarfBuzzFontFuncs {
@@ -110,8 +85,7 @@ impl FontFuncs for HBHarfBuzzFontFuncs {
     }
 
     fn advance_width(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
-        let advance = unsafe { hb_font_get_glyph_h_advance(self.font, glyph.to_u32()) };
-        Self::to_upem(advance, self.x_mult_inv)
+        unsafe { hb_font_get_glyph_h_advance(self.font, glyph.to_u32()) }
     }
 
     fn populate_advance_widths(&mut self, _: &BuiltinFontFuncs, batch: AdvanceWidthBatch<'_>) {
@@ -125,20 +99,11 @@ impl FontFuncs for HBHarfBuzzFontFuncs {
                 raw.advances,
                 raw.advance_stride as u32,
             );
-            for i in 0..raw.len {
-                let advance = raw
-                    .advances
-                    .byte_offset(i as isize * raw.advance_stride)
-                    .as_mut()
-                    .unwrap();
-                *advance = Self::to_upem(*advance, self.x_mult_inv);
-            }
         }
     }
 
     fn advance_height(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
-        let advance = unsafe { hb_font_get_glyph_v_advance(self.font, glyph.to_u32()) };
-        Self::to_upem(advance, self.y_mult_inv)
+        unsafe { hb_font_get_glyph_v_advance(self.font, glyph.to_u32()) }
     }
 
     fn vertical_origin(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> (i32, i32) {
@@ -147,10 +112,7 @@ impl FontFuncs for HBHarfBuzzFontFuncs {
         unsafe {
             hb_font_get_glyph_v_origin(self.font, glyph.to_u32(), &mut x, &mut y);
         }
-        (
-            Self::to_upem(x, self.x_mult_inv),
-            Self::to_upem(y, self.y_mult_inv),
-        )
+        (x, y)
     }
 
     fn extents(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> Option<GlyphExtents> {
@@ -162,10 +124,10 @@ impl FontFuncs for HBHarfBuzzFontFuncs {
         };
         if unsafe { hb_font_get_glyph_extents(self.font, glyph.to_u32(), &mut extents) } != 0 {
             Some(GlyphExtents {
-                x_bearing: Self::to_upem(extents.x_bearing, self.x_mult_inv),
-                y_bearing: Self::to_upem(extents.y_bearing, self.y_mult_inv),
-                width: Self::to_upem(extents.width, self.x_mult_inv),
-                height: Self::to_upem(extents.height, self.y_mult_inv),
+                x_bearing: extents.x_bearing,
+                y_bearing: extents.y_bearing,
+                width: extents.width,
+                height: extents.height,
             })
         } else {
             None
@@ -390,17 +352,12 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     let mut x_scale = 0;
     let mut y_scale = 0;
     hb_font_get_scale(font, &mut x_scale, &mut y_scale);
-    let upem = (*font_data).shaper.units_per_em();
-    let upem = if upem > 0 { upem } else { 1000 };
-    let mut font_funcs = HBHarfBuzzFontFuncs {
-        font,
-        x_mult_inv: HBHarfBuzzFontFuncs::inv_mult(x_scale, upem),
-        y_mult_inv: HBHarfBuzzFontFuncs::inv_mult(y_scale, upem),
-    };
+    let mut font_funcs = HBHarfBuzzFontFuncs { font };
     let glyphs = (*font_data).shaper.shape(
         hr_buffer,
         ShapeOptions::new()
             .plan(shape_plan)
+            .scale_separate(Some((x_scale, y_scale)))
             .point_size(ptem)
             .features(&features)
             .font_funcs(Some(&mut font_funcs)),
@@ -419,20 +376,6 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     if count != count_out as usize {
         return false as hb_bool_t;
     }
-
-    let x_mult = if x_scale < 0 {
-        -((-x_scale as i64) << 16)
-    } else {
-        (x_scale as i64) << 16
-    } / upem as i64;
-    let y_mult = if y_scale < 0 {
-        -((-y_scale as i64) << 16)
-    } else {
-        (y_scale as i64) << 16
-    } / upem as i64;
-
-    let em_mult =
-        |v: i32, mult: i64| -> hb_position_t { ((v as i64 * mult + 32768) >> 16) as hb_position_t };
 
     for (i, (hr_info, hr_pos)) in glyphs
         .glyph_infos()
@@ -459,10 +402,10 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
                 info.mask |= hb_glyph_flags_t_HB_GLYPH_FLAG_SAFE_TO_INSERT_TATWEEL as u32;
             }
         }
-        pos.x_advance = em_mult(hr_pos.x_advance, x_mult);
-        pos.y_advance = em_mult(hr_pos.y_advance, y_mult);
-        pos.x_offset = em_mult(hr_pos.x_offset, x_mult);
-        pos.y_offset = em_mult(hr_pos.y_offset, y_mult);
+        pos.x_advance = hr_pos.x_advance;
+        pos.y_advance = hr_pos.y_advance;
+        pos.x_offset = hr_pos.x_offset;
+        pos.y_offset = hr_pos.y_offset;
     }
 
     let hr_buffer = glyphs.clear();

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -63,6 +63,31 @@ pub struct HBHarfRustFontData {
 
 struct HBHarfBuzzFontFuncs {
     font: *mut hb_font_t,
+    x_mult_inv: i64,
+    y_mult_inv: i64,
+}
+
+impl HBHarfBuzzFontFuncs {
+    // HarfRust currently expects font-func metrics in UPEM units, but
+    // hb_font_get_* returns values in the hb_font_t scale. Convert back here
+    // and let the existing bridge scaling convert shaped output again.
+    fn inv_mult(scale: i32, upem: i32) -> i64 {
+        if upem <= 0 {
+            return 1 << 16;
+        }
+
+        let scale = if scale == 0 { 1 } else { scale } as i64;
+        let upem = upem as i64;
+        if scale < 0 {
+            -(((-upem) << 16) / scale)
+        } else {
+            (upem << 16) / scale
+        }
+    }
+
+    fn to_upem(value: i32, mult_inv: i64) -> i32 {
+        ((value as i64 * mult_inv + 32768) >> 16) as i32
+    }
 }
 
 impl FontFuncs for HBHarfBuzzFontFuncs {
@@ -85,7 +110,8 @@ impl FontFuncs for HBHarfBuzzFontFuncs {
     }
 
     fn advance_width(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
-        unsafe { hb_font_get_glyph_h_advance(self.font, glyph.to_u32()) }
+        let advance = unsafe { hb_font_get_glyph_h_advance(self.font, glyph.to_u32()) };
+        Self::to_upem(advance, self.x_mult_inv)
     }
 
     fn populate_advance_widths(&mut self, _: &BuiltinFontFuncs, batch: AdvanceWidthBatch<'_>) {
@@ -99,20 +125,32 @@ impl FontFuncs for HBHarfBuzzFontFuncs {
                 raw.advances,
                 raw.advance_stride as u32,
             );
+            for i in 0..raw.len {
+                let advance = raw
+                    .advances
+                    .byte_offset(i as isize * raw.advance_stride)
+                    .as_mut()
+                    .unwrap();
+                *advance = Self::to_upem(*advance, self.x_mult_inv);
+            }
         }
     }
 
     fn advance_height(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
-        unsafe { hb_font_get_glyph_v_advance(self.font, glyph.to_u32()) }
+        let advance = unsafe { hb_font_get_glyph_v_advance(self.font, glyph.to_u32()) };
+        Self::to_upem(advance, self.y_mult_inv)
     }
 
-    fn vertical_origin(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+    fn vertical_origin(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> (i32, i32) {
         let mut x = 0;
         let mut y = 0;
         unsafe {
             hb_font_get_glyph_v_origin(self.font, glyph.to_u32(), &mut x, &mut y);
         }
-        y
+        (
+            Self::to_upem(x, self.x_mult_inv),
+            Self::to_upem(y, self.y_mult_inv),
+        )
     }
 
     fn extents(&mut self, _: &BuiltinFontFuncs, glyph: GlyphId) -> Option<GlyphExtents> {
@@ -124,10 +162,10 @@ impl FontFuncs for HBHarfBuzzFontFuncs {
         };
         if unsafe { hb_font_get_glyph_extents(self.font, glyph.to_u32(), &mut extents) } != 0 {
             Some(GlyphExtents {
-                x_bearing: extents.x_bearing,
-                y_bearing: extents.y_bearing,
-                width: extents.width,
-                height: extents.height,
+                x_bearing: Self::to_upem(extents.x_bearing, self.x_mult_inv),
+                y_bearing: Self::to_upem(extents.y_bearing, self.y_mult_inv),
+                width: Self::to_upem(extents.width, self.x_mult_inv),
+                height: Self::to_upem(extents.height, self.y_mult_inv),
             })
         } else {
             None
@@ -349,7 +387,16 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
         let shape_plan = shape_plan as *const harfrust::ShapePlan;
         shape_plan.as_ref()
     };
-    let mut font_funcs = HBHarfBuzzFontFuncs { font };
+    let mut x_scale = 0;
+    let mut y_scale = 0;
+    hb_font_get_scale(font, &mut x_scale, &mut y_scale);
+    let upem = (*font_data).shaper.units_per_em();
+    let upem = if upem > 0 { upem } else { 1000 };
+    let mut font_funcs = HBHarfBuzzFontFuncs {
+        font,
+        x_mult_inv: HBHarfBuzzFontFuncs::inv_mult(x_scale, upem),
+        y_mult_inv: HBHarfBuzzFontFuncs::inv_mult(y_scale, upem),
+    };
     let glyphs = (*font_data).shaper.shape(
         hr_buffer,
         ShapeOptions::new()
@@ -373,11 +420,6 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
         return false as hb_bool_t;
     }
 
-    let mut x_scale: i32 = 0;
-    let mut y_scale: i32 = 0;
-    hb_font_get_scale(font, &mut x_scale, &mut y_scale);
-    let upem = (*font_data).shaper.units_per_em();
-    let upem = if upem > 0 { upem } else { 1000 };
     let x_mult = if x_scale < 0 {
         -((-x_scale as i64) << 16)
     } else {

--- a/test/api/meson.build
+++ b/test/api/meson.build
@@ -130,6 +130,25 @@ foreach source : tests
     suite: suite)
 endforeach
 
+if get_option('harfrust').enabled()
+  harfrust_shape_env = environment()
+  harfrust_shape_env.set('MALLOC_CHECK_', '1')
+  harfrust_shape_env.set('G_DEBUG', 'gc-friendly')
+  harfrust_shape_env.set('G_TEST_SRCDIR', meson.current_source_dir())
+  harfrust_shape_env.set('G_TEST_BUILDDIR', meson.current_build_dir())
+  harfrust_shape_env.set('HB_SHAPER_LIST', 'harfrust')
+
+  test('test-shape-harfrust',
+    executable('test-shape-harfrust', 'test-shape.c',
+      include_directories: [incconfig],
+      dependencies: [libharfbuzz_dep, libharfbuzz_cairo_dep, libharfbuzz_icu_dep],
+      install: false,
+    ),
+    protocol: 'tap',
+    env: harfrust_shape_env,
+    suite: ['api', 'harfrust'])
+endif
+
 if not get_option('raster').disabled()
   test('test-raster',
     executable('test-raster', 'test-raster.cc',


### PR DESCRIPTION
Wire the HarfRust shaper through the active hb_font_t callback surface so custom hb_font_funcs_t are respected during shaping. Add a harfrust-specific test-shape invocation to cover that path.

Tested: meson test -C build test-shape-harfrust
Tested: HB_SHAPER_LIST=harfrust meson test -C build harfbuzz:shape_threads
Tested: HB_SHAPER_LIST=harfrust meson test -C build test-shape
Assisted-by: OpenAI Codex