### PR TITLE
[subset] keep East Asian spacing palt by default

### DIFF
--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -128,6 +128,7 @@ hb_subset_input_t::hb_subset_input_t ()
     HB_TAG ('v', 'c', 'h', 'w'),
     HB_TAG ('h', 'a', 'l', 't'),
     HB_TAG ('v', 'h', 'a', 'l'),
+    HB_TAG ('p', 'a', 'l', 't'),
 
     //private
     HB_TAG ('H', 'a', 'r', 'f'),


### PR DESCRIPTION
## Summary

Add `palt` (Proportional Alternate Widths) to the default subset layout features. It is widely used in Japanese typography but was silently stripped by subsetting, unlike its vertical counterpart `vpal` and the related `halt` / `vhal` / `chws` / `vchw` which are already kept by default.

Same pattern as #4451 (which added `halt` / `vhal` / `chws` / `vchw`).

Fixes #6006.

## What was verified locally

Build / tests (macOS 15, arm64, clang):

```
meson setup build --buildtype=release
ninja -C build                        # 427/427 targets, no warnings introduced
meson test -C build                   # 240/240 OK, 0 failures
meson test -C build --suite subset    # 113/113 OK (subset of the above)
```

Empirical check on a `palt`-bearing font (NotoSansJP-Bold.ttf):

```
hb-subset --unicodes='U+3000-303F,U+4E00-4E0F,U+0041-0042' \
    NotoSansJP-Bold.ttf -o out.ttf
hb-info --list-features out.ttf | grep -E 'palt|halt|vpal|vhal'
```

| Build         | palt        | halt | vpal | vhal |
|---------------|-------------|------|------|------|
| main (before) | ❌ stripped | ✅   | ✅   | ✅   |
| with patch    | ✅ kept     | ✅   | ✅   | ✅   |

So the change does what it says and does not regress the other CJK spacing features.
