### PR TITLE
Pass codepoints for context directly to HarfRust shaper

### DIFF
--- a/src/hb-harfrust.cc
+++ b/src/hb-harfrust.cc
@@ -115,9 +115,9 @@ _hb_harfrust_shape_rs (const void         *font_data,
 		       const void         *rs_buffer,
 		       hb_font_t          *font,
 		       hb_buffer_t        *buffer,
-		       const uint8_t      *pre_context,
+		       const hb_codepoint_t *pre_context,
 		       uint32_t            pre_context_len,
-		       const uint8_t      *post_context,
+		       const hb_codepoint_t *post_context,
 		       uint32_t            post_context_len,
 		       const hb_feature_t *features,
 		       unsigned int        num_features);
@@ -175,30 +175,15 @@ retry_shape_plan:
     }
   }
 
-  // Encode buffer pre/post-context as UTF-8, so that HarfRust can use it.
-  constexpr int CONTEXT_BYTE_SIZE = 4 * hb_buffer_t::CONTEXT_LENGTH;
-  uint8_t pre_context[CONTEXT_BYTE_SIZE];
-  unsigned pre_context_len = 0;
-  for (unsigned i = buffer->context_len[0]; i; i--)
-    pre_context_len = hb_utf8_t::encode (pre_context + pre_context_len,
-					 pre_context + CONTEXT_BYTE_SIZE,
-					 buffer->context[0][i - 1]) - pre_context;
-  uint8_t post_context[CONTEXT_BYTE_SIZE];
-  unsigned post_context_len = 0;
-  for (unsigned i = 0; i < buffer->context_len[1]; i++)
-    post_context_len = hb_utf8_t::encode (post_context + post_context_len,
-					  post_context + CONTEXT_BYTE_SIZE,
-					  buffer->context[1][i]) - post_context;
-
   return _hb_harfrust_shape_rs (font_data,
 				hr_shape_plan,
 				hr_buffer,
 				font,
 				buffer,
-				pre_context,
-				pre_context_len,
-				post_context,
-				post_context_len,
+				buffer->context[0],
+				buffer->context_len[0],
+				buffer->context[1],
+				buffer->context_len[1],
 				features,
 				num_features);
 }

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -271,9 +271,9 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     hr_buffer_box: *const c_void,
     font: *mut hb_font_t,
     buffer: *mut hb_buffer_t,
-    pre_context: *const u8,
+    pre_context: *const u32,
     pre_context_length: u32,
-    post_context: *const u8,
+    post_context: *const u32,
     post_context_length: u32,
     features: *const hb_feature_t,
     num_features: u32,
@@ -345,9 +345,9 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     }
 
     let pre_context = std::slice::from_raw_parts(pre_context, pre_context_length as usize);
-    hr_buffer.set_pre_context(str::from_utf8(pre_context).unwrap());
+    hr_buffer.set_pre_context_codepoints(pre_context);
     let post_context = std::slice::from_raw_parts(post_context, post_context_length as usize);
-    hr_buffer.set_post_context(str::from_utf8(post_context).unwrap());
+    hr_buffer.set_post_context_codepoints(post_context);
 
     let ptem = hb_font_get_ptem(font);
     let ptem = if ptem > 0.0 { Some(ptem) } else { None };


### PR DESCRIPTION
Avoid unnecessary round-trip of converting pre- and post-context from Unicode codepoints to UTF-8 in C++ (hb-harfrust.cc) and back to Rust &str (and eventually back to codepoints) in Rust (shape.rs). Instead, use the new codepoint-based context setters in HarfRust.

Verified locally against CJK_article.html blink_perf menchmark to gain approximately 2-4%.

Requires https://github.com/harfbuzz/harfrust/pull/371 and a newly released HarfRust version.

Assisted-by: Google Antigravity