### PR TITLE
[config] Fix CFF closure with HB_NO_DRAW

### DIFF
--- a/src/hb-config.hh
+++ b/src/hb-config.hh
@@ -141,6 +141,10 @@
 #define HB_NO_PAINT
 #endif
 
+#if defined(HB_TINY) && defined(HB_NO_DRAW)
+#define HB_NO_CFF
+#endif
+
 #ifdef HB_NO_CFF
 #define HB_NO_OT_FONT_CFF
 #define HB_NO_SUBSET_CFF

--- a/src/hb-subset-plan-var.cc
+++ b/src/hb-subset-plan-var.cc
@@ -285,6 +285,7 @@ normalize_axes_location (hb_face_t *face, hb_subset_plan_t *plan)
   return true;
 }
 
+#ifndef HB_NO_OT_FONT_CFF
 void
 update_instance_metrics_map_from_cff2 (hb_subset_plan_t *plan)
 {
@@ -370,6 +371,7 @@ update_instance_metrics_map_from_cff2 (hb_subset_plan_t *plan)
   if (vvar_store_cache)
     _vmtx.var_table->get_var_store ().destroy_cache (vvar_store_cache);
 }
+#endif
 
 bool
 get_instance_glyphs_contour_points (hb_subset_plan_t *plan)

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -743,8 +743,10 @@ hb_subset_plan_t::hb_subset_plan_t (hb_face_t *face,
   if (unlikely (in_error ()))
     return;
 
-#ifndef HB_NO_VAR
+#if !defined(HB_NO_VAR) && !defined(HB_NO_OT_FONT_CFF)
   update_instance_metrics_map_from_cff2 (this);
+#endif
+#ifndef HB_NO_VAR
   if (!check_success (get_instance_glyphs_contour_points (this)))
       return;
 #endif


### PR DESCRIPTION
HB_NO_DRAW only disables the draw-dependent OT-font CFF extents path.  It should not imply full HB_NO_CFF for downstream builds that independently disable CFF subsetting.

Keep the HB_TINY behavior by making HB_NO_CFF conditional on the combination of HB_TINY and HB_NO_DRAW.  Also avoid calling the CFF2 instance-metrics helper when OT-font CFF support is disabled, since that helper needs the CFF2 extents implementation.

Context:
https://github.com/harfbuzz/harfbuzz/pull/5958#discussion_r3121421428 https://github.com/harfbuzz/harfbuzz/issues/5955#issuecomment-4289771142 https://github.com/harfbuzz/harfbuzz/issues/5955#issuecomment-4345573851

Tested by compiling src/harfbuzz-subset.cc directly with -DHB_NO_DRAW -DHB_NO_SUBSET_CFF and checking the CFF2 extents symbol is no longer undefined.  Also direct-compiled src/harfbuzz.cc with the same defines, plus src/harfbuzz-subset.cc for plain HB_TINY and HB_TINY with HAVE_CONFIG_OVERRIDE_H using util/gpu/web.

Assisted-by: OpenAI Codex <codex@openai.com>