### PR TITLE
[COLR] Fix glyph extents for .notdef in COLRv1 fonts

### DIFF
--- a/src/OT/Color/COLR/COLR.hh
+++ b/src/OT/Color/COLR/COLR.hh
@@ -2411,10 +2411,11 @@ struct COLR
 
   const BaseGlyphPaintRecord* get_base_glyph_paintrecord (hb_codepoint_t gid) const
   {
-    const BaseGlyphPaintRecord* record = &(this+baseGlyphList).bsearch ((unsigned) gid);
-    if ((record && (hb_codepoint_t) record->glyphId != gid))
-      record = nullptr;
-    return record;
+    const BaseGlyphList &list = this+baseGlyphList;
+    unsigned int i;
+    if (!list.bfind ((unsigned) gid, &i))
+      return nullptr;
+    return &list[i];
   }
 
   bool downgrade_to_V0 (const hb_set_t &glyphset) const

--- a/test/api/test-extents.c
+++ b/test/api/test-extents.c
@@ -35,10 +35,11 @@ test_glyph_extents_color_v1 (void)
   hb_glyph_extents_t extents;
   hb_bool_t ret;
 
-  /* This font contains a COLRv1 glyph with a ClipBox,
-   * and various components without. The main thing
-   * we test here is that glyphs with no paint return
-   * 0,0,0,0 and not meaningless numbers.
+  /* This font contains COLRv1 glyphs with a ClipBox, as well as plain
+   * glyphs with no COLR paint. Extents resolve from COLR when the glyph
+   * has a paint, and otherwise fall back to the glyph outline. So glyph 0
+   * (.notdef), which has an outline, reports its outline extents, while
+   * the empty glyph 1 (.space) reports 0,0,0,0.
    */
 
   face = hb_test_open_font_file ("fonts/adwaita.ttf");
@@ -46,10 +47,10 @@ test_glyph_extents_color_v1 (void)
 
   ret = hb_font_get_glyph_extents (font, 0, &extents);
   g_assert_true (ret);
-  g_assert_true (extents.x_bearing == 0 &&
-                 extents.y_bearing == 0 &&
-                 extents.width     == 0 &&
-                 extents.height    == 0);
+  g_assert_true (extents.x_bearing ==    51 &&
+                 extents.y_bearing ==   950 &&
+                 extents.width     ==   410 &&
+                 extents.height    == -1200);
 
   ret = hb_font_get_glyph_extents (font, 1, &extents);
   g_assert_true (ret);


### PR DESCRIPTION
get_base_glyph_paintrecord() looked up the BaseGlyphList with the reference-returning bsearch(), which yields the all-zero Null object when the glyph is absent, and then rejected non-matches by comparing record->glyphId against the requested gid. For glyph 0 the Null object's glyphId (0) equals the requested gid, so the sentinel was taken for a real record. .notdef then resolved to a bogus empty paint, and COLR::get_extents() returned success with 0,0,0,0 instead of letting hb_ot_get_glyph_extents() fall back to the glyf outline.

Use bfind(), which reports presence directly, so a missing glyph (including glyph 0) returns nullptr and extents fall back correctly.

This surfaced as a mark-positioning difference: fallback mark positioning centers a mark using the base and mark glyph extents, so a .notdef mark over a space was positioned differently from shapers that report the real outline extents (e.g. fontations/HarfRust).

Testing:
- test/api/test-extents.c: glyph 0 (.notdef, has an outline) now reports its outline extents; updated the expectation accordingly.
- b/util/hb-shape Noto-COLRv1.ttf -u 0020,0650 now matches --font-funcs=fontations.
- meson test -C build  (246 passed, 1 skipped)