### PR TITLE
[rust] Use SmallVec for HarfRust features

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -8,6 +8,7 @@ skrifa = { version = "0.*", optional = true }
 read-fonts = "0.39.*"
 harfrust = { version = "0.8.2", optional = true }
 # harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
+smallvec = "1.*"
 
 [lib]
 name = "harfbuzz_rust"

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -16,6 +16,9 @@ use harfrust::{
     ShaperInstance, Tag,
 };
 use read_fonts::types::GlyphId;
+use smallvec::SmallVec;
+
+type HRFeatureVec = SmallVec<[harfrust::Feature; 4]>;
 
 const _: () = {
     assert!(size_of::<hb_glyph_info_t>() == size_of::<HRGlyphInfo>());
@@ -236,12 +239,9 @@ pub unsafe extern "C" fn _hb_harfrust_buffer_destroy_rs(data: *mut c_void) {
     let _hr_buffer = Box::from_raw(data);
 }
 
-fn hb_feature_to_hr_feature(
-    features: *const hb_feature_t,
-    num_features: u32,
-) -> Vec<harfrust::Feature> {
+fn hb_feature_to_hr_feature(features: *const hb_feature_t, num_features: u32) -> HRFeatureVec {
     if features.is_null() {
-        Vec::new()
+        SmallVec::new()
     } else {
         let features = unsafe { std::slice::from_raw_parts(features, num_features as usize) };
         features
@@ -258,7 +258,7 @@ fn hb_feature_to_hr_feature(
                     end,
                 }
             })
-            .collect::<Vec<_>>()
+            .collect()
     }
 }
 


### PR DESCRIPTION
Most shaping calls pass maximum a couple of user features. Store the converted HarfRust feature list in a SmallVec with the same inline capacity that HarfRust uses for shape-plan user features, avoiding a heap allocation for common cases.

Testing: ninja -C build src/rust/libharfbuzz_rust.a

Assisted-by: OpenAI Codex