### PR TITLE
[rust] Bulk-populate HarfRust input buffer

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -4,10 +4,10 @@ edition = "2021"
 rust-version = "1.87.0"
 
 [dependencies]
-skrifa = { version = "0.*", optional = true }
-read-fonts = "0.39.*"
-harfrust = { version = "0.8.2", optional = true }
+harfrust = { version = "0.8.3", optional = true }
 # harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
+read-fonts = "0.39.*"
+skrifa = { version = "0.*", optional = true }
 smallvec = "1.*"
 
 [lib]

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -366,14 +366,9 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     // Populate buffer
     let count = hb_buffer_get_length(buffer);
     let infos = hb_buffer_get_glyph_infos(buffer, null_mut());
-
-    hr_buffer.reserve(count as usize);
-
-    for i in 0..count {
-        let info = &*infos.add(i as usize);
-        let unicode = info.codepoint;
-        let cluster = info.cluster;
-        hr_buffer.add(char::from_u32_unchecked(unicode), cluster);
+    let infos = std::slice::from_raw_parts(infos.cast(), count as usize);
+    if !hr_buffer.push_glyph_infos(infos) {
+        return false as hb_bool_t;
     }
 
     let pre_context = std::slice::from_raw_parts(pre_context, pre_context_length as usize);


### PR DESCRIPTION
Use the HarfRust bulk UnicodeBuffer glyph-info append API to populate the shaping buffer from HarfBuzz glyph infos after one slice cast. This avoids per-codepoint add calls in the HarfBuzz-to-HarfRust bridge.

Point the temporary HarfRust dependency at the branch carrying the new buffer API.

Testing: ninja -C build src/rust/libharfbuzz_rust.a

Assisted-by: OpenAI Codex

Depends on https://github.com/harfbuzz/harfrust/pull/378