### PR TITLE
[util] Fix Unicode command line arguments on Windows

### DIFF
--- a/util/hb-ft-raster.cc
+++ b/util/hb-ft-raster.cc
@@ -332,5 +332,12 @@ int
 main (int argc, char **argv)
 {
   using main_t = main_font_text_t<shape_consumer_t<ft_raster_output_t>, font_options_t, shape_text_options_t>;
+#ifdef _WIN32
+  gchar **argv_utf8 = g_win32_get_command_line ();
+  int ret = batch_main<main_t, true> ((int) g_strv_length (argv_utf8), argv_utf8);
+  g_strfreev (argv_utf8);
+  return ret;
+#else
   return batch_main<main_t, true> (argc, argv);
+#endif
 }

--- a/util/hb-info.cc
+++ b/util/hb-info.cc
@@ -1437,5 +1437,12 @@ retry:
 int
 main (int argc, char **argv)
 {
+#ifdef _WIN32
+  gchar **argv_utf8 = g_win32_get_command_line ();
+  int ret = batch_main<info_t> ((int) g_strv_length (argv_utf8), argv_utf8);
+  g_strfreev (argv_utf8);
+  return ret;
+#else
   return batch_main<info_t> (argc, argv);
+#endif
 }

--- a/util/hb-raster.cc
+++ b/util/hb-raster.cc
@@ -38,5 +38,12 @@ int
 main (int argc, char **argv)
 {
   using main_t = main_font_text_t<shape_consumer_t<raster_output_t>, font_options_t, shape_text_options_t>;
+#ifdef _WIN32
+  gchar **argv_utf8 = g_win32_get_command_line ();
+  int ret = batch_main<main_t, true> ((int) g_strv_length (argv_utf8), argv_utf8);
+  g_strfreev (argv_utf8);
+  return ret;
+#else
   return batch_main<main_t, true> (argc, argv);
+#endif
 }

--- a/util/hb-shape.cc
+++ b/util/hb-shape.cc
@@ -39,5 +39,12 @@ int
 main (int argc, char **argv)
 {
   using main_t = main_font_text_t<shape_consumer_t<shape_output_t>, font_options_t, shape_text_options_t>;
+#ifdef _WIN32
+  gchar **argv_utf8 = g_win32_get_command_line ();
+  int ret = batch_main<main_t> ((int) g_strv_length (argv_utf8), argv_utf8);
+  g_strfreev (argv_utf8);
+  return ret;
+#else
   return batch_main<main_t> (argc, argv);
+#endif
 }

--- a/util/hb-subset.cc
+++ b/util/hb-subset.cc
@@ -1034,5 +1034,12 @@ subset_main_t::add_options ()
 int
 main (int argc, char **argv)
 {
+#ifdef _WIN32
+  gchar **argv_utf8 = g_win32_get_command_line ();
+  int ret = batch_main<subset_main_t, true> ((int) g_strv_length (argv_utf8), argv_utf8);
+  g_strfreev (argv_utf8);
+  return ret;
+#else
   return batch_main<subset_main_t, true> (argc, argv);
+#endif
 }

--- a/util/hb-vector.cc
+++ b/util/hb-vector.cc
@@ -36,5 +36,12 @@ int
 main (int argc, char **argv)
 {
   using main_t = main_font_text_t<shape_consumer_t<vector_output_t>, font_options_t, shape_text_options_t>;
+#ifdef _WIN32
+  gchar **argv_utf8 = g_win32_get_command_line ();
+  int ret = batch_main<main_t, true> ((int) g_strv_length (argv_utf8), argv_utf8);
+  g_strfreev (argv_utf8);
+  return ret;
+#else
   return batch_main<main_t, true> (argc, argv);
+#endif
 }

--- a/util/hb-view.cc
+++ b/util/hb-view.cc
@@ -39,5 +39,12 @@ int
 main (int argc, char **argv)
 {
   using main_t = main_font_text_t<shape_consumer_t<view_cairo_t>, font_options_t, shape_text_options_t>;
+#ifdef _WIN32
+  gchar **argv_utf8 = g_win32_get_command_line ();
+  int ret = batch_main<main_t, true> ((int) g_strv_length (argv_utf8), argv_utf8);
+  g_strfreev (argv_utf8);
+  return ret;
+#else
   return batch_main<main_t, true> (argc, argv);
+#endif
 }

--- a/util/main-font-text.hh
+++ b/util/main-font-text.hh
@@ -70,7 +70,7 @@ struct main_font_text_t :
 
     GOptionEntry entries[] =
     {
-      {G_OPTION_REMAINING,	0, G_OPTION_FLAG_IN_MAIN,
+      {G_OPTION_REMAINING,	0, G_OPTION_FLAG_IN_MAIN | G_OPTION_FLAG_FILENAME,
 				G_OPTION_ARG_CALLBACK,	(gpointer) &collect_rest,	nullptr,	"[FONT-FILE] [TEXT]"},
       {nullptr}
     };

--- a/util/options.hh
+++ b/util/options.hh
@@ -266,7 +266,21 @@ option_parser_t::parse (int *argc, char ***argv, bool ignore_error)
   set_full_description ();
 
   GError *parse_error = nullptr;
-  if (!g_option_context_parse (context, argc, argv, &parse_error))
+  bool parse_ok;
+#ifdef G_OS_WIN32
+  /* g_option_context_parse() on Windows converts argv from the ACP via
+   * g_locale_to_utf8(), but argv is already in UTF-8.
+   * Use g_option_context_parse_strv() to skip the locale conversion. */
+  gchar **win32_argv = g_new (gchar *, *argc + 1);
+  for (int i = 0; i < *argc; i++)
+    win32_argv[i] = g_strdup ((*argv)[i]);
+  win32_argv[*argc] = nullptr;
+  parse_ok = g_option_context_parse_strv (context, &win32_argv, &parse_error);
+  g_strfreev (win32_argv);
+#else
+  parse_ok = g_option_context_parse (context, argc, argv, &parse_error);
+#endif
+  if (!parse_ok)
   {
     if (parse_error)
     {


### PR DESCRIPTION
GLib g_option_context_parse() converts argv strings from the system ACP via g_locale_to_utf8(), but Windows cmd deliver arguments encoded in the system codepage (ex: CP1252), which cannot represent most Unicode codepoints. This caused non ascii character to be corrupted

For example, for this command, it rendered garbage instead of the emoji:
```
hb-view.exe "C:\Windows\Fonts\seguiemj.ttf" "😋" --output-file=output.png
```

Fix this in all util binaries (hb-ft-raster, hb-info, hb-raster, hb-shape, hb-subset, hb-vector, hb-view) by:
1. Calling g_win32_get_command_line() to obtain correctly UTF-8-encoded arguments from GetCommandLineW().
2. Parsing with g_option_context_parse_strv() which skips the g_locale_to_utf8() conversion for G_OPTION_ARG_STRING entries.
3. Adding G_OPTION_FLAG_FILENAME to the G_OPTION_REMAINING callback entry in main-font-text.hh, so the callback path also skips the locale conversion in strv_mode (see https://gitlab.gnome.org/GNOME/glib/-/blob/8ef2f3ad402daf9fb94615ddef63ceef978fd76f/glib/goption.c#L1305).