### PR TITLE
[meson] Set CMake import libraries for Windows DLLs

### DIFF
--- a/src/harfbuzz-config.cmake.in
+++ b/src/harfbuzz-config.cmake.in
@@ -4,31 +4,40 @@ set_and_check(HARFBUZZ_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 
 set(HARFBUZZ_VERSION "@HARFBUZZ_VERSION@")
 
+function(_harfbuzz_set_imported_library target library_name)
+  set_target_properties("${target}" PROPERTIES
+    IMPORTED_LOCATION "@HB_LIB_DIR@/@HB_LIB_PREFIX@${library_name}@HB_LIB_SUFFIX@")
+  if (@HB_HAS_IMPORT_LIBRARY@)
+    set_target_properties("${target}" PROPERTIES
+      IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@HB_IMPLIB_PREFIX@${library_name}@HB_IMPLIB_SUFFIX@")
+  endif ()
+endfunction()
+
 # Add the libraries.
 add_library(harfbuzz::harfbuzz @HB_LIBRARY_TYPE@ IMPORTED)
 set_target_properties(harfbuzz::harfbuzz PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_INCLUDE_INSTALL_DIR@"
-  IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@HB_LIB_PREFIX@harfbuzz@HB_LIB_SUFFIX@")
+  INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_INCLUDE_INSTALL_DIR@")
+_harfbuzz_set_imported_library(harfbuzz::harfbuzz harfbuzz)
 
 add_library(harfbuzz::icu @HB_LIBRARY_TYPE@ IMPORTED)
 set_target_properties(harfbuzz::icu PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_INCLUDE_INSTALL_DIR@"
-  INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
-  IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@HB_LIB_PREFIX@harfbuzz-icu@HB_LIB_SUFFIX@")
+  INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz")
+_harfbuzz_set_imported_library(harfbuzz::icu harfbuzz-icu)
 
 add_library(harfbuzz::subset @HB_LIBRARY_TYPE@ IMPORTED)
 set_target_properties(harfbuzz::subset PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_INCLUDE_INSTALL_DIR@"
-  INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
-  IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@HB_LIB_PREFIX@harfbuzz-subset@HB_LIB_SUFFIX@")
+  INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz")
+_harfbuzz_set_imported_library(harfbuzz::subset harfbuzz-subset)
 
 # Only add the gobject library if it was built.
 if (@HB_HAVE_GOBJECT@)
   add_library(harfbuzz::gobject @HB_LIBRARY_TYPE@ IMPORTED)
   set_target_properties(harfbuzz::gobject PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "@PACKAGE_INCLUDE_INSTALL_DIR@"
-    INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz"
-    IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@HB_LIB_PREFIX@harfbuzz-gobject@HB_LIB_SUFFIX@")
+    INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz")
+  _harfbuzz_set_imported_library(harfbuzz::gobject harfbuzz-gobject)
 endif ()
 
 check_required_components(harfbuzz)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1111,6 +1111,16 @@ if fs.is_absolute(cmake_install_libdir)
   endif
 endif
 
+cmake_install_bindir = get_option('bindir')
+
+if fs.is_absolute(cmake_install_bindir)
+  if meson.version().version_compare('>=1.3.0')
+    cmake_install_bindir = fs.relative_to(cmake_install_bindir, get_option('prefix'))
+  else
+    cmake_install_bindir = run_command(relative_to, cmake_install_bindir, get_option('prefix'), check: true).stdout().strip()
+  endif
+endif
+
 cmake_config.set('PACKAGE_INIT', '''
 get_filename_component(PACKAGE_PREFIX_DIR "@0@" ABSOLUTE)
 
@@ -1134,21 +1144,36 @@ endmacro()
 
 cmake_config.set('PACKAGE_CMAKE_INSTALL_INCLUDEDIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_includedir))
 cmake_config.set('PACKAGE_CMAKE_INSTALL_LIBDIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_libdir))
+cmake_config.set('PACKAGE_CMAKE_INSTALL_BINDIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_bindir))
 cmake_config.set('PACKAGE_INCLUDE_INSTALL_DIR', '${PACKAGE_PREFIX_DIR}/@0@/@1@'.format(cmake_install_includedir, meson.project_name()))
 cmake_config.set('HARFBUZZ_VERSION', meson.project_version())
 cmake_config.set('HB_HAVE_GOBJECT', have_gobject ? 'YES' : 'NO')
 cmake_config.set('HB_LIBRARY_TYPE', get_option('default_library') == 'static' ? 'STATIC' : 'SHARED')
+cmake_config.set('HB_HAS_IMPORT_LIBRARY', 'NO')
+cmake_config.set('HB_IMPLIB_PREFIX', '')
+cmake_config.set('HB_IMPLIB_SUFFIX', '')
 
 if get_option('default_library') == 'static'
+  cmake_config.set('HB_LIB_DIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_libdir))
   cmake_config.set('HB_LIB_PREFIX', '${CMAKE_STATIC_LIBRARY_PREFIX}')
   cmake_config.set('HB_LIB_SUFFIX', '${CMAKE_STATIC_LIBRARY_SUFFIX}')
 elif host_machine.system() == 'darwin'
+  cmake_config.set('HB_LIB_DIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_libdir))
   cmake_config.set('HB_LIB_PREFIX', '${CMAKE_SHARED_LIBRARY_PREFIX}')
   cmake_config.set('HB_LIB_SUFFIX', '.@0@${CMAKE_SHARED_LIBRARY_SUFFIX}'.format(hb_so_version))
 elif host_machine.system() == 'windows'
-  cmake_config.set('HB_LIB_PREFIX', '${CMAKE_IMPORT_LIBRARY_PREFIX}')
-  cmake_config.set('HB_LIB_SUFFIX', '${CMAKE_IMPORT_LIBRARY_SUFFIX}')
+  cmake_config.set('HB_HAS_IMPORT_LIBRARY', 'YES')
+  cmake_config.set('HB_LIB_DIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_bindir))
+  cmake_config.set('HB_LIB_PREFIX', '${CMAKE_SHARED_LIBRARY_PREFIX}')
+  if hb_so_version == ''
+    cmake_config.set('HB_LIB_SUFFIX', '${CMAKE_SHARED_LIBRARY_SUFFIX}')
+  else
+    cmake_config.set('HB_LIB_SUFFIX', '-@0@${CMAKE_SHARED_LIBRARY_SUFFIX}'.format(hb_so_version))
+  endif
+  cmake_config.set('HB_IMPLIB_PREFIX', '${CMAKE_IMPORT_LIBRARY_PREFIX}')
+  cmake_config.set('HB_IMPLIB_SUFFIX', '${CMAKE_IMPORT_LIBRARY_SUFFIX}')
 else
+  cmake_config.set('HB_LIB_DIR', '${PACKAGE_PREFIX_DIR}/@0@'.format(cmake_install_libdir))
   cmake_config.set('HB_LIB_PREFIX', '${CMAKE_SHARED_LIBRARY_PREFIX}')
   cmake_config.set('HB_LIB_SUFFIX', '${CMAKE_SHARED_LIBRARY_SUFFIX}.@0@'.format(version))
 endif


### PR DESCRIPTION
The Meson-generated CMake package described Windows shared-library targets with IMPORTED_LOCATION pointing at the import library. CMake expects DLL imported targets to put the runtime DLL in IMPORTED_LOCATION and the import library in IMPORTED_IMPLIB.

Generate bindir-aware paths for Windows CMake packages and set both target properties for all HarfBuzz imported targets. Static and non-Windows shared builds keep their existing single-location behavior.

Fixes: https://github.com/harfbuzz/harfbuzz/issues/6026

Testing:
meson setup build --reconfigure
meson compile -C build
meson test -C build
MinGW cross configure/build/install in /private/tmp CMake consumer configure/build against harfbuzz::harfbuzz and harfbuzz::subset

Assisted-by: OpenAI Codex