### PR TITLE
[subset-repack] add additional sorting after extension promotion

### DIFF
--- a/src/hb-repacker.hh
+++ b/src/hb-repacker.hh
@@ -379,6 +379,17 @@ hb_resolve_graph_overflows (hb_tag_t table_tag,
         DEBUG_MSG (SUBSET_REPACK, nullptr, "Extensions promotion failed.");
         return false;
       }
+
+      // an additional sorting is needed before assign_spaces () which requires
+      // correct topological ordering to find space roots
+      sorted_graph.sort_shortest_distance_if_needed ();
+      if (sorted_graph.in_error ())
+      {
+        DEBUG_MSG (SUBSET_REPACK, nullptr, "Sorted graph in error state.");
+        return false;
+      }
+
+      if (!graph::will_overflow (sorted_graph)) return true;
     }
 
     DEBUG_MSG (SUBSET_REPACK, nullptr, "Assigning spaces to 32 bit subgraphs.");


### PR DESCRIPTION
assign_spaces() requires correct topological ordering to find space roots, so add an additional topo sorting after extension promotion and table splitting to keep thing sorted.

This bug is triggered in Skera, sorry I tried but couldn't make a small testcase in HB.