### PR TITLE
[util/gpu] Guard D3D11 atlas allocation

### DIFF
--- a/util/gpu/demo-renderer-d3d11.cc
+++ b/util/gpu/demo-renderer-d3d11.cc
@@ -167,6 +167,8 @@ struct demo_renderer_d3d11_t : demo_renderer_t
     backend.alloc = [](void *ctx_, const char *data, unsigned len_bytes) -> unsigned {
       auto *self = (demo_renderer_d3d11_t *) ctx_;
       unsigned len_texels = len_bytes / 8;
+      if (self->atlas.cursor + len_texels > self->atlas.capacity)
+	die ("Ran out of atlas memory");
       unsigned offset = self->atlas.cursor;
       self->atlas.cursor += len_texels;
       const int16_t *src = (const int16_t *) data;


### PR DESCRIPTION
The D3D11 demo atlas backend advanced its cursor and copied glyph data into the shadow buffer without checking the fixed atlas capacity. Long sessions could therefore write past the end of the shadow buffer once the atlas filled.

Match the other demo atlas backends by failing before advancing the cursor when the requested glyph data does not fit.

Testing: meson test -C build
Assisted-by: OpenAI Codex <codex@openai.com>