### PR TITLE
[gvar] Avoid null checks in tuple scalar cache path

### DIFF
--- a/src/hb-ot-var-common.hh
+++ b/src/hb-ot-var-common.hh
@@ -112,7 +112,7 @@ struct TupleVariationHeader
   HB_ALWAYS_INLINE
   double calculate_scalar (hb_array_t<const int> coords, unsigned int coord_count,
 			   const hb_array_t<const F2DOT14> shared_tuples,
-			   hb_scalar_cache_t *shared_tuple_scalar_cache = nullptr) const
+			   hb_scalar_cache_t *shared_tuple_scalar_cache = (hb_scalar_cache_t *) &Null(hb_scalar_cache_t)) const
   {
     unsigned tuple_index = tupleIndex;
     unsigned int index = tuple_index & TupleIndex::TupleIndexMask;
@@ -121,8 +121,7 @@ struct TupleVariationHeader
      * Only PrivatePointNumbers may accompany a cached shared-tuple index; any
      * other flag sets a bit at or above 0x1000, making this range test fail.
      */
-    bool plain_shared_tuple = shared_tuple_scalar_cache &&
-			      (tuple_index & ~TupleIndex::PrivatePointNumbers) < shared_tuple_scalar_cache->length;
+    bool plain_shared_tuple = (tuple_index & ~TupleIndex::PrivatePointNumbers) < shared_tuple_scalar_cache->length;
     if (likely (plain_shared_tuple))
     {
       float scalar;
@@ -143,7 +142,7 @@ struct TupleVariationHeader
     {
       float scalar;
       if (!plain_shared_tuple &&
-	  shared_tuple_scalar_cache &&
+	  shared_tuple_scalar_cache->length &&
 	  shared_tuple_scalar_cache->get (index, &scalar))
       {
         if (has_interm && (scalar != 0 && scalar != 1.f))

--- a/src/hb-ot-var-gvar-table.hh
+++ b/src/hb-ot-var-gvar-table.hh
@@ -722,6 +722,9 @@ struct gvar_GVAR
 				 bool phantom_only = false) const
     {
       if (unlikely (glyph >= glyphCount)) return true;
+      hb_scalar_cache_t *scalar_cache = gvar_cache ?
+					gvar_cache :
+					(hb_scalar_cache_t *) &Null(hb_scalar_cache_t);
 
       hb_bytes_t var_data_bytes = table->get_glyph_var_data_bytes (table.get_blob (), glyphCount, glyph);
       if (!var_data_bytes.as<GlyphVariationData> ()->has_data ()) return true;
@@ -761,7 +764,7 @@ struct gvar_GVAR
       do
       {
 	float scalar = iterator.current_tuple->calculate_scalar (coords, num_coords, shared_tuples,
-								 gvar_cache);
+								 scalar_cache);
 
 	if (scalar == 0.f) continue;
 


### PR DESCRIPTION
Normalize a missing gvar scalar cache to the Null cache before the tuple loop, so calculate_scalar can use the cache length directly in its fast path.

Keep the fallback from querying a zero-length cache, since that would otherwise be interpreted as a cached zero scalar.

~4% speedup in GoogleSansFlex benchmark draw.