### PR TITLE
[rust] Update harfrust to 0.12.0, read-fonts to 0.41.*

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -4,9 +4,9 @@ edition = "2021"
 rust-version = "1.87.0"
 
 [dependencies]
-harfrust = { version = "0.11.0", features = ["experimental_font_api"], optional = true }
+harfrust = { version = "0.12.0", features = ["experimental_font_api"], optional = true }
 # harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
-read-fonts = "0.40.*"
+read-fonts = "0.41.*"
 skrifa = { version = "0.*", optional = true }
 smallvec = "1.*"
 


### PR DESCRIPTION
Updates the Rust shaper dependencies to their latest releases.

## Why

`harfrust` 0.12.0 fixes sub-font-unit GPOS advance/placement and AAT `trak`
tracking differences against the `ot` shaper on variable fonts
(harfbuzz/harfrust#402, #403, #404). Both bugs were double-rounding a
fractional delta (variation-index deltas, and interpolated `trak` values) to
whole font units before scaling, instead of keeping it fractional and
rounding once at the end like HarfBuzz does.

`read-fonts` is bumped to `0.41.*` to match harfrust's requirement. The
currently released `skrifa` (0.44.0) already depends on `read-fonts ^0.41.0`,
so the whole dependency graph resolves to a single `read-fonts` version (no
duplicate-version split).

## Testing

Verified against the real published crates.io packages (harfrust 0.12.0,
read-fonts 0.41.0, skrifa 0.44.0), not just a local checkout:

- `meson test -C build --suite shape`: 3/3 OK, 8912 subtests passed.
- `meson test -C build --suite api`: 69/69 OK, including `test-shape-harfrust`.
- `hb-shape --shaper ot` vs `--shaper harfrust` on `SFNSItalic.ttf` across
  variable-font instances: now byte-identical (previously differed by
  sub-font-unit amounts, the harfrust#402 bug).
