### PR TITLE
[gobject] Drop const attribute from enum get_type declarations

### DIFF
--- a/src/hb-gobject-enums.h.tmpl
+++ b/src/hb-gobject-enums.h.tmpl
@@ -43,7 +43,7 @@ HB_BEGIN_DECLS
 
 /*** BEGIN value-header ***/
 HB_EXTERN GType
-@enum_name@_get_type (void) G_GNUC_CONST;
+@enum_name@_get_type (void);
 #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
 
 /*** END value-header ***/


### PR DESCRIPTION
## What changed

Removed `G_GNUC_CONST` from the generated GObject enum `*_get_type`
declarations in `src/hb-gobject-enums.h.tmpl`.

## Why

GLib removed this attribute from its generated `get_type` declarations because
GType registration can initialize state, and marking these functions as const
can trigger GCC trunk miscompilations.

Fixes https://github.com/harfbuzz/harfbuzz/issues/6060.

## Testing

- `meson setup build --reconfigure`
- `meson compile -C build`
- `meson test -C build`
