### PR TITLE
[ot-font] Invalidate vertical origin cache on scale change

### DIFF
--- a/src/hb-ot-font.cc
+++ b/src/hb-ot-font.cc
@@ -289,7 +289,7 @@ struct hb_ot_font_t
 
   void check_serial (hb_font_t *font) const
   {
-    int font_serial = font->serial_coords.get_acquire ();
+    int font_serial = font->serial.get_acquire ();
     if (cached_serial.get_acquire () != font_serial)
     {
       /* These caches are dependent on scale and synthetic settings.
@@ -643,6 +643,8 @@ hb_ot_get_glyph_v_origins (hb_font_t *font,
 {
   const hb_ot_font_t *ot_font = (const hb_ot_font_t *) font_data;
   const hb_ot_face_t *ot_face = ot_font->ot_face;
+
+  ot_font->check_serial (font);
 
   /* First, set all the x values to half the advance width. */
   font->get_glyph_h_advances (count,

--- a/test/api/test-ot-face.c
+++ b/test/api/test-ot-face.c
@@ -215,6 +215,30 @@ test_ot_var_axis_on_zero_named_instance (void)
   hb_face_destroy (face);
 }
 
+#ifndef HB_NO_VERTICAL
+static void
+test_ot_font_v_origin_cache_invalidated_by_scale (void)
+{
+  hb_face_t *face = hb_test_open_font_file ("fonts/Mplus1p-Regular.660E.ttf");
+  hb_font_t *font = hb_font_create (face);
+  hb_codepoint_t glyph;
+  hb_position_t x, y1, y2;
+
+  g_assert_true (hb_font_get_nominal_glyph (font, 0x660E, &glyph));
+
+  hb_font_set_scale (font, 1000, 1000);
+  g_assert_true (hb_font_get_glyph_v_origin (font, glyph, &x, &y1));
+
+  hb_font_set_scale (font, 1000, 2000);
+  g_assert_true (hb_font_get_glyph_v_origin (font, glyph, &x, &y2));
+
+  g_assert_cmpint (y2, ==, y1 * 2);
+
+  hb_font_destroy (font);
+  hb_face_destroy (face);
+}
+#endif
+
 int
 main (int argc, char **argv)
 {
@@ -222,6 +246,9 @@ main (int argc, char **argv)
 
   hb_test_add (test_ot_face_empty);
   hb_test_add (test_ot_var_axis_on_zero_named_instance);
+#ifndef HB_NO_VERTICAL
+  hb_test_add (test_ot_font_v_origin_cache_invalidated_by_scale);
+#endif
 
   return hb_test_run();
 }


### PR DESCRIPTION
## What changed

Fix the OT font vertical-origin cache so scale-dependent cached values are invalidated when the font scale changes. `hb_ot_get_glyph_v_origins()` now checks the font serial before consulting the cache, and the scale-dependent cache serial uses the full font serial instead of the variation-coordinate serial.

## Why

`hb_font_set_scale()` updates `font->serial` but not `font->serial_coords`. The vertical-origin cache stores scaled y-origin values, so validating it against `serial_coords` could return stale vertical origins after a scale-only change.

## Test coverage

Added an API regression that changes `y_scale` on one `hb_font_t` and verifies the vertical origin is recomputed.

Validated with:

```sh
meson compile -C build test/api/test-ot-face
meson test -C build test-ot-face --print-errorlogs
meson test -C build --suite api --print-errorlogs
```

Fixes https://github.com/harfbuzz/harfbuzz/issues/6066