### PR TITLE
[gpu] Validate extents fit i16 before quantizing

### DIFF
--- a/src/hb-gpu-draw.cc
+++ b/src/hb-gpu-draw.cc
@@ -446,6 +446,16 @@ hb_gpu_draw_encode (hb_gpu_draw_t      *draw,
   if (unlikely (!s.curve_infos.resize (num_curves)))
     return nullptr;
 
+  /* Validate the extents fit in i16 before quantizing: the casts in
+   * quantize_down()/quantize_up() are undefined for out-of-range
+   * values, and every later i16 conversion of a curve point is bounded
+   * by these extents. */
+  if (!quantize_down_fits_i16 (draw->ext_min_x) ||
+      !quantize_down_fits_i16 (draw->ext_min_y) ||
+      !quantize_up_fits_i16 (draw->ext_max_x) ||
+      !quantize_up_fits_i16 (draw->ext_max_y))
+    return nullptr;
+
   int16_t min_x_q = quantize_down (draw->ext_min_x);
   int16_t min_y_q = quantize_down (draw->ext_min_y);
   int16_t max_x_q = quantize_up (draw->ext_max_x);
@@ -651,12 +661,6 @@ hb_gpu_draw_encode (hb_gpu_draw_t      *draw,
 
   /* Validate fits in uint16 offsets (stored as int16 with bias) */
   if (total_len > (unsigned) UINT16_MAX + 1u)
-    return nullptr;
-
-  if (!quantize_down_fits_i16 (draw->ext_min_x) ||
-      !quantize_down_fits_i16 (draw->ext_min_y) ||
-      !quantize_up_fits_i16 (draw->ext_max_x) ||
-      !quantize_up_fits_i16 (draw->ext_max_y))
     return nullptr;
 
   /* Allocate or reuse encode buffer */


### PR DESCRIPTION
hb_gpu_draw_encode quantizes the accumulated outline extents to int16 at the top of the function, but the quantize_down_fits_i16/quantize_up_fits_i16 checks that guard those casts only run a couple hundred lines further down. Anything that pushes the extents past the i16 range trips the conversion first: with HB_GPU_UNITS_PER_EM at 4 that means |v| > 8191, so drawing a font at a 16.16 scale is enough, and the shape already used by test_extents_saturate_overflow reports `float-cast-overflow` at hb-gpu-draw.cc:449 under the asan-ubsan config the sanitizers workflow builds. Hoisting the check above the quantize calls keeps the rejected case returning NULL exactly as before, and once the extents are known to fit, every later i16 conversion of a curve point is bounded by them.