### PR TITLE
[paint] pass color_glyph its own user_data

### DIFF
--- a/src/hb-paint.hh
+++ b/src/hb-paint.hh
@@ -93,7 +93,7 @@ struct hb_paint_funcs_t
   { return func.color_glyph (this, paint_data,
                              glyph,
                              font,
-                             !user_data ? nullptr : user_data->push_clip_glyph); }
+                             !user_data ? nullptr : user_data->color_glyph); }
   void push_clip_glyph (void *paint_data,
                         hb_codepoint_t glyph,
                         hb_font_t *font)

--- a/test/api/test-paint.c
+++ b/test/api/test-paint.c
@@ -875,6 +875,42 @@ test_fill_glyph_nil_decomposes (void)
   hb_paint_funcs_destroy (funcs);
 }
 
+static void *color_glyph_user_data_seen;
+
+static hb_bool_t
+color_glyph_record_user_data (hb_paint_funcs_t *funcs HB_UNUSED,
+                              void *paint_data HB_UNUSED,
+                              hb_codepoint_t glyph HB_UNUSED,
+                              hb_font_t *font HB_UNUSED,
+                              void *user_data)
+{
+  color_glyph_user_data_seen = user_data;
+  return TRUE;
+}
+
+/* Each callback must be handed the user_data it was registered with,
+ * not another callback's. */
+static void
+test_color_glyph_user_data (void)
+{
+  char color_glyph_ctx = 0;
+  char push_clip_glyph_ctx = 0;
+
+  hb_paint_funcs_t *funcs = hb_paint_funcs_create ();
+  hb_paint_funcs_set_color_glyph_func (funcs, color_glyph_record_user_data,
+                                       &color_glyph_ctx, NULL);
+  hb_paint_funcs_set_push_clip_glyph_func (funcs, push_clip_glyph,
+                                           &push_clip_glyph_ctx, NULL);
+  hb_paint_funcs_make_immutable (funcs);
+
+  color_glyph_user_data_seen = NULL;
+  hb_paint_color_glyph (funcs, NULL, 42, hb_font_get_empty ());
+
+  g_assert_true (color_glyph_user_data_seen == &color_glyph_ctx);
+
+  hb_paint_funcs_destroy (funcs);
+}
+
 
 int
 main (int argc, char **argv)
@@ -888,6 +924,7 @@ main (int argc, char **argv)
   hb_test_add (test_push_clip_path_nil_returns_null);
   hb_test_add (test_push_clip_path_round_trip);
   hb_test_add (test_fill_glyph_nil_decomposes);
+  hb_test_add (test_color_glyph_user_data);
 
   for (unsigned int i = 0; i < G_N_ELEMENTS (paint_tests); i++)
   {


### PR DESCRIPTION
hb_paint_funcs_t::color_glyph dispatches with user_data->push_clip_glyph where every other wrapper in the file passes its own slot, so a client that registers color_glyph and push_clip_glyph with different context objects has the push_clip_glyph context delivered to its color_glyph callback and casts it to the wrong type. Both COLR.hh:2874 and hb-ft-colr.hh:417 reach it, so it fires on any color glyph paint; hb_paint_funcs_destroy already reads user_data->color_glyph, so the slot is allocated and freed correctly and just never handed to the callback. I swept the other 17 wrappers here plus hb-draw.hh and hb-font.hh and this is the only mismatch. The added test registers the two callbacks with distinct contexts and aborts on the unpatched tree.