### PR TITLE
[raster] Reject non-finite texel coords in hb_raster_paint_image

### DIFF
--- a/src/hb-raster-paint.cc
+++ b/src/hb-raster-paint.cc
@@ -946,7 +946,8 @@ hb_raster_paint_image (hb_paint_funcs_t *pfuncs HB_UNUSED,
 	float ix = (gx - img_x) / img_sx;
 	float iy = (float) (src_height - 1) - (gy - img_y) / img_sy;
 
-	if (ix < 0.f || iy < 0.f ||
+	if (unlikely (!std::isfinite (ix) || !std::isfinite (iy)) ||
+	    ix < 0.f || iy < 0.f ||
 	    ix > (float) (src_width - 1) || iy > (float) (src_height - 1))
 	{
 	  gx += inv_xx;
@@ -984,7 +985,8 @@ hb_raster_paint_image (hb_paint_funcs_t *pfuncs HB_UNUSED,
 	float ix = (gx - img_x) / img_sx;
 	float iy = (float) (src_height - 1) - (gy - img_y) / img_sy;
 
-	if (ix < 0.f || iy < 0.f ||
+	if (unlikely (!std::isfinite (ix) || !std::isfinite (iy)) ||
+	    ix < 0.f || iy < 0.f ||
 	    ix > (float) (src_width - 1) || iy > (float) (src_height - 1))
 	{
 	  gx += inv_xx;

--- a/test/api/test-raster.cc
+++ b/test/api/test-raster.cc
@@ -225,6 +225,43 @@ test_set_glyph_extents_with_transform (void)
   hb_raster_draw_destroy (rdr);
 }
 
+/* ── Test 6: image paint under an overflowing transform ──────────── */
+
+/* Nested scales, each representable, whose product overflows to infinity.
+ * The inverse transform then carries NaN into the image sampler's texel
+ * coordinates.  Exercised for the float-to-int conversion, so this needs a
+ * sanitizer build to catch a regression. */
+static void
+test_image_nonfinite_transform (void)
+{
+  hb_raster_paint_t *paint = hb_raster_paint_create_or_fail ();
+  g_assert_nonnull (paint);
+
+  hb_raster_extents_t ext = {0, 0, 32, 32, 0};
+  hb_raster_paint_set_extents (paint, &ext);
+
+  hb_paint_funcs_t *funcs = hb_raster_paint_get_funcs (paint);
+
+  hb_paint_push_transform (funcs, paint, 1e30f, 0.f, 0.f, 1e30f, 0.f, 0.f);
+  hb_paint_push_transform (funcs, paint, 1e30f, 0.f, 0.f, 1e30f, 0.f, 0.f);
+
+  const unsigned w = 4, h = 4;
+  char pixels[w * h * 4];
+  memset (pixels, 0, sizeof (pixels));
+  hb_blob_t *blob = hb_blob_create (pixels, sizeof (pixels),
+				    HB_MEMORY_MODE_READONLY, nullptr, nullptr);
+
+  hb_glyph_extents_t gext = {0, 32, 32, -32};
+  hb_paint_image (funcs, paint, blob, w, h,
+		  HB_PAINT_IMAGE_FORMAT_BGRA, 0.f, &gext);
+
+  hb_paint_pop_transform (funcs, paint);
+  hb_paint_pop_transform (funcs, paint);
+
+  hb_blob_destroy (blob);
+  hb_raster_paint_destroy (paint);
+}
+
 /* ── main ────────────────────────────────────────────────────────── */
 
 int
@@ -237,6 +274,7 @@ main (int argc, char **argv)
   hb_test_add (test_subpixel_edge);
   hb_test_add (test_transform);
   hb_test_add (test_set_glyph_extents_with_transform);
+  hb_test_add (test_image_nonfinite_transform);
 
   return hb_test_run ();
 }


### PR DESCRIPTION
both pixel loops in hb_raster_paint_image gate the sampler with a plain range test on ix/iy, and every comparison in it is false for NaN, so NaN coordinates walk straight into hb_raster_sample_bilinear_premul and hit (int) floorf. only x1/y1 get clamped there, so x0/y0 index src[] with no lower bound at all. the determinant guard upstream has the same shape (fabsf (det) < 1e-10f is also false for NaN), so a transform that overflowed to infinity is accepted and inv_det = 1/inf = 0 turns inf * 0 into NaN. nested PaintScale/PaintTransform reach this since hb_raster_paint_push_transform composes multiplicatively. on x86-64 (int) floorf (NaN) is INT_MIN and the index becomes 0xfffffffd80000000, a wild read of the glyph bitmap; aarch64 saturates to 0 and merely renders garbage. checking isfinite in the guard matches what evaluate_color_line, normalize_gradient_t and lookup_gradient_lut already do for gradient parameters in this file. the added test trips ubsan at hb-raster-paint.cc:59 without the fix and is clean with it; full suite green locally.