### PR TITLE
[ot-tag] guard against NULL language in hb_ot_tags_to_script_and_language

### DIFF
--- a/src/hb-ot-tag.cc
+++ b/src/hb-ot-tag.cc
@@ -668,10 +668,10 @@ hb_ot_tags_to_script_and_language (hb_tag_t       script_tag,
 					 primary_script_tag,
 					 nullptr, nullptr);
     *language = hb_ot_tag_to_language (language_tag);
-    if (script_count == 0 || primary_script_tag[0] != script_tag)
+    const char *lang_str = *language ? hb_language_to_string (*language) : nullptr;
+    if (lang_str && (script_count == 0 || primary_script_tag[0] != script_tag))
     {
       unsigned char *buf;
-      const char *lang_str = hb_language_to_string (*language);
       size_t len = strlen (lang_str);
       buf = (unsigned char *) hb_malloc (len + 16);
       if (unlikely (!buf))

--- a/test/api/test-ot-tag.c
+++ b/test/api/test-ot-tag.c
@@ -291,6 +291,9 @@ test_ot_tags_to_script_and_language (void)
   test_tags_to_script_and_language ("dev2", "MAR", "Deva", "mr-x-hbsc-64657632");
   test_tags_to_script_and_language ("dev3", "MAR", "Deva", "mr");
   test_tags_to_script_and_language ("qaa", "QTZ0", "Qaaa", "x-hbot-51545a30-hbsc-71616120");
+  /* Default language tag maps to a NULL language; the script-suffix path
+   * must not dereference it. */
+  test_tags_to_script_and_language ("DFLT", "dflt", "", NULL);
 }
 
 static void


### PR DESCRIPTION
hb_ot_tag_to_language returns NULL for HB_OT_TAG_DEFAULT_LANGUAGE, and hb_language_to_string returns NULL for that, so hb_ot_tags_to_script_and_language ran strlen on a NULL pointer whenever the primary script tag did not match the input tag. Guard the script-suffix path on a non-NULL base language string and otherwise leave the default (NULL) language untouched.

Fixes: https://github.com/harfbuzz/harfbuzz/issues/6072
