### PR TITLE
[colr] clamp alpha and radius deltas before unsigned conversion

### DIFF
--- a/src/OT/Color/COLR/COLR.hh
+++ b/src/OT/Color/COLR/COLR.hh
@@ -122,7 +122,9 @@ public:
   static unsigned
   color_alpha (hb_color_t color, float alpha)
   {
-    return roundf (hb_color_get_alpha (color) * alpha);
+    /* Font-supplied alpha is F2DOT14 plus variation deltas, so it can be
+     * negative or greater than one; converting that to unsigned is UB. */
+    return roundf (hb_color_get_alpha (color) * hb_clamp (alpha, 0.f, 1.f));
   }
 
   hb_color_t get_color (unsigned int color_index, float alpha, hb_bool_t *is_foreground)
@@ -808,10 +810,10 @@ struct PaintRadialGradient
     {
       out->x0 = x0 + (int) roundf (instancer (varIdxBase, 0));
       out->y0 = y0 + (int) roundf (instancer (varIdxBase, 1));
-      out->radius0 = radius0 + (unsigned) roundf (instancer (varIdxBase, 2));
+      out->radius0 = hb_clamp ((int) radius0 + (int) roundf (instancer (varIdxBase, 2)), 0, 0xFFFF);
       out->x1 = x1 + (int) roundf (instancer (varIdxBase, 3));
       out->y1 = y1 + (int) roundf (instancer (varIdxBase, 4));
-      out->radius1 = radius1 + (unsigned) roundf (instancer (varIdxBase, 5));
+      out->radius1 = hb_clamp ((int) radius1 + (int) roundf (instancer (varIdxBase, 5)), 0, 0xFFFF);
     }
 
     if (format == 7 && c->plan->all_axes_pinned)


### PR DESCRIPTION
color_alpha in hb_paint_context_t multiplies the palette color alpha by the paint alpha and returns unsigned, but that alpha is an F2DOT14 field (PaintSolid, PaintVarSolid, ColorStop) plus a variation delta, so a font can make it negative and the conversion is undefined; patching a PaintSolid alpha to -1.0 in test/api/fonts/test_glyphs-glyf_colr_1.ttf and painting every glyph gives "COLR.hh:125: -255 is outside the range of representable values of type 'unsigned int'" under ubsan. PaintRadialGradient::subset has the same conversion for radius0/radius1 while the x/y siblings next to it already go through (int); `hb-subset --unicodes='*' --instance=GRR0=-1000 test/api/fonts/test_glyphs-glyf_colr_1_variable.ttf` reports it at COLR.hh:811 and GRR1 at :814. clamping is done in the callee since both values come straight off the wire and every caller would otherwise need the same guard; it also drops the wrap that turned an over-range alpha into a garbage byte in HB_COLOR and a negative radius delta into a 16-bit radius near 0xffff. full meson test suite passes and the three ubsan reports are gone.