### PR TITLE
[raster] clamp coordinates before converting to int

### DIFF
--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -877,6 +877,18 @@ struct
 }
 HB_FUNCOBJ (hb_clamp);
 
+/* Convert a floating-point value to integer type T, saturating to T's
+ * range instead of relying on the undefined behavior of an out-of-range
+ * float-to-int conversion.  NaN saturates to the minimum of T. */
+template <typename T>
+static inline T
+hb_clamp_to (double v)
+{
+  return (T) hb_clamp (v,
+		       (double) hb_int_min (T),
+		       (double) hb_int_max (T));
+}
+
 /*
  * Bithacks.
  */

--- a/src/hb-raster-draw.cc
+++ b/src/hb-raster-draw.cc
@@ -382,10 +382,10 @@ hb_raster_draw_set_glyph_extents (hb_raster_draw_t         *draw,
     ty_max = hb_max (ty_max, ty);
   }
 
-  int ex0 = (int) floorf (tx_min);
-  int ey0 = (int) floorf (ty_min);
-  int ex1 = (int) ceilf  (tx_max);
-  int ey1 = (int) ceilf  (ty_max);
+  int32_t ex0 = hb_raster_clamp_to_int32 (floorf (tx_min));
+  int32_t ey0 = hb_raster_clamp_to_int32 (floorf (ty_min));
+  int32_t ex1 = hb_raster_clamp_to_int32 (ceilf  (tx_max));
+  int32_t ey1 = hb_raster_clamp_to_int32 (ceilf  (ty_max));
 
   if (ex1 <= ex0 || ey1 <= ey0)
   {
@@ -396,8 +396,8 @@ hb_raster_draw_set_glyph_extents (hb_raster_draw_t         *draw,
 
   draw->fixed_extents = {
     ex0, ey0,
-    (unsigned) (ex1 - ex0),
-    (unsigned) (ey1 - ey0),
+    (unsigned) ((int64_t) ex1 - ex0),
+    (unsigned) ((int64_t) ey1 - ey0),
     0
   };
   draw->has_extents = true;
@@ -483,10 +483,10 @@ emit_segment (hb_raster_draw_t *draw,
 	      float x0, float y0,
 	      float x1, float y1)
 {
-  int32_t X0 = (int32_t) roundf (x0 * HB_RASTER_ONE_PIXEL);
-  int32_t Y0 = (int32_t) roundf (y0 * HB_RASTER_ONE_PIXEL);
-  int32_t X1 = (int32_t) roundf (x1 * HB_RASTER_ONE_PIXEL);
-  int32_t Y1 = (int32_t) roundf (y1 * HB_RASTER_ONE_PIXEL);
+  int32_t X0 = hb_raster_clamp_to_int32 (roundf (x0 * HB_RASTER_ONE_PIXEL));
+  int32_t Y0 = hb_raster_clamp_to_int32 (roundf (y0 * HB_RASTER_ONE_PIXEL));
+  int32_t X1 = hb_raster_clamp_to_int32 (roundf (x1 * HB_RASTER_ONE_PIXEL));
+  int32_t Y1 = hb_raster_clamp_to_int32 (roundf (y1 * HB_RASTER_ONE_PIXEL));
 
   if (Y0 == Y1) return; /* horizontal — skip */
 

--- a/src/hb-raster-draw.cc
+++ b/src/hb-raster-draw.cc
@@ -382,10 +382,10 @@ hb_raster_draw_set_glyph_extents (hb_raster_draw_t         *draw,
     ty_max = hb_max (ty_max, ty);
   }
 
-  int32_t ex0 = hb_raster_clamp_to_int32 (floorf (tx_min));
-  int32_t ey0 = hb_raster_clamp_to_int32 (floorf (ty_min));
-  int32_t ex1 = hb_raster_clamp_to_int32 (ceilf  (tx_max));
-  int32_t ey1 = hb_raster_clamp_to_int32 (ceilf  (ty_max));
+  int32_t ex0 = hb_clamp_to<int32_t> (floorf (tx_min));
+  int32_t ey0 = hb_clamp_to<int32_t> (floorf (ty_min));
+  int32_t ex1 = hb_clamp_to<int32_t> (ceilf  (tx_max));
+  int32_t ey1 = hb_clamp_to<int32_t> (ceilf  (ty_max));
 
   if (ex1 <= ex0 || ey1 <= ey0)
   {
@@ -483,10 +483,10 @@ emit_segment (hb_raster_draw_t *draw,
 	      float x0, float y0,
 	      float x1, float y1)
 {
-  int32_t X0 = hb_raster_clamp_to_int32 (roundf (x0 * HB_RASTER_ONE_PIXEL));
-  int32_t Y0 = hb_raster_clamp_to_int32 (roundf (y0 * HB_RASTER_ONE_PIXEL));
-  int32_t X1 = hb_raster_clamp_to_int32 (roundf (x1 * HB_RASTER_ONE_PIXEL));
-  int32_t Y1 = hb_raster_clamp_to_int32 (roundf (y1 * HB_RASTER_ONE_PIXEL));
+  int32_t X0 = hb_clamp_to<int32_t> (roundf (x0 * HB_RASTER_ONE_PIXEL));
+  int32_t Y0 = hb_clamp_to<int32_t> (roundf (y0 * HB_RASTER_ONE_PIXEL));
+  int32_t X1 = hb_clamp_to<int32_t> (roundf (x1 * HB_RASTER_ONE_PIXEL));
+  int32_t Y1 = hb_clamp_to<int32_t> (roundf (y1 * HB_RASTER_ONE_PIXEL));
 
   if (Y0 == Y1) return; /* horizontal — skip */
 

--- a/src/hb-raster-paint.cc
+++ b/src/hb-raster-paint.cc
@@ -2081,10 +2081,10 @@ hb_raster_paint_set_glyph_extents (hb_raster_paint_t        *paint,
     ty_max = hb_max (ty_max, py[i]);
   }
 
-  int ex0 = (int) floorf (tx_min);
-  int ey0 = (int) floorf (ty_min);
-  int ex1 = (int) ceilf  (tx_max);
-  int ey1 = (int) ceilf  (ty_max);
+  int32_t ex0 = hb_raster_clamp_to_int32 (floorf (tx_min));
+  int32_t ey0 = hb_raster_clamp_to_int32 (floorf (ty_min));
+  int32_t ex1 = hb_raster_clamp_to_int32 (ceilf  (tx_max));
+  int32_t ey1 = hb_raster_clamp_to_int32 (ceilf  (ty_max));
 
   if (ex1 <= ex0 || ey1 <= ey0)
   {
@@ -2095,8 +2095,8 @@ hb_raster_paint_set_glyph_extents (hb_raster_paint_t        *paint,
 
   paint->fixed_extents = {
     ex0, ey0,
-    (unsigned) (ex1 - ex0),
-    (unsigned) (ey1 - ey0),
+    (unsigned) ((int64_t) ex1 - ex0),
+    (unsigned) ((int64_t) ey1 - ey0),
     0
   };
   paint->has_extents = true;

--- a/src/hb-raster-paint.cc
+++ b/src/hb-raster-paint.cc
@@ -2081,10 +2081,10 @@ hb_raster_paint_set_glyph_extents (hb_raster_paint_t        *paint,
     ty_max = hb_max (ty_max, py[i]);
   }
 
-  int32_t ex0 = hb_raster_clamp_to_int32 (floorf (tx_min));
-  int32_t ey0 = hb_raster_clamp_to_int32 (floorf (ty_min));
-  int32_t ex1 = hb_raster_clamp_to_int32 (ceilf  (tx_max));
-  int32_t ey1 = hb_raster_clamp_to_int32 (ceilf  (ty_max));
+  int32_t ex0 = hb_clamp_to<int32_t> (floorf (tx_min));
+  int32_t ey0 = hb_clamp_to<int32_t> (floorf (ty_min));
+  int32_t ex1 = hb_clamp_to<int32_t> (ceilf  (tx_max));
+  int32_t ey1 = hb_clamp_to<int32_t> (ceilf  (ty_max));
 
   if (ex1 <= ex0 || ey1 <= ey0)
   {

--- a/src/hb-raster.hh
+++ b/src/hb-raster.hh
@@ -29,6 +29,17 @@
 
 #include "hb.hh"
 
+/* Convert a coordinate to int32_t, saturating instead of relying on the
+ * undefined behavior of an out-of-range float-to-int conversion.  NaN
+ * saturates to INT32_MIN. */
+static HB_ALWAYS_INLINE int32_t
+hb_raster_clamp_to_int32 (float v)
+{
+  return (int32_t) hb_clamp ((double) v,
+			     (double) INT32_MIN,
+			     (double) INT32_MAX);
+}
+
 /* Shared pixel helpers (used by paint and image compositing). */
 
 static HB_ALWAYS_INLINE uint8_t

--- a/src/hb-raster.hh
+++ b/src/hb-raster.hh
@@ -29,17 +29,6 @@
 
 #include "hb.hh"
 
-/* Convert a coordinate to int32_t, saturating instead of relying on the
- * undefined behavior of an out-of-range float-to-int conversion.  NaN
- * saturates to INT32_MIN. */
-static HB_ALWAYS_INLINE int32_t
-hb_raster_clamp_to_int32 (float v)
-{
-  return (int32_t) hb_clamp ((double) v,
-			     (double) INT32_MIN,
-			     (double) INT32_MAX);
-}
-
 /* Shared pixel helpers (used by paint and image compositing). */
 
 static HB_ALWAYS_INLINE uint8_t

--- a/test/api/test-raster.cc
+++ b/test/api/test-raster.cc
@@ -262,6 +262,30 @@ test_image_nonfinite_transform (void)
   hb_raster_paint_destroy (paint);
 }
 
+/* ── Test 7: glyph extents that overflow the int grid ────────────── */
+
+/* Glyph extents are int32, so a transform that scales them up puts the
+ * corner coordinates far outside the int range before they are floored
+ * back to the integer pixel grid.  Exercised for the conversion itself,
+ * so this needs a sanitizer build to catch a regression. */
+static void
+test_set_glyph_extents_overflow (void)
+{
+  hb_glyph_extents_t gext = {-2000000000, 2000000000, 2000000000, -2000000000};
+
+  hb_raster_draw_t *rdr = hb_raster_draw_create_or_fail ();
+  g_assert_nonnull (rdr);
+  hb_raster_draw_set_transform (rdr, 1000.f, 0.f, 0.f, 1000.f, 0.f, 0.f);
+  hb_raster_draw_set_glyph_extents (rdr, &gext);
+  hb_raster_draw_destroy (rdr);
+
+  hb_raster_paint_t *paint = hb_raster_paint_create_or_fail ();
+  g_assert_nonnull (paint);
+  hb_raster_paint_set_transform (paint, 1000.f, 0.f, 0.f, 1000.f, 0.f, 0.f);
+  hb_raster_paint_set_glyph_extents (paint, &gext);
+  hb_raster_paint_destroy (paint);
+}
+
 /* ── main ────────────────────────────────────────────────────────── */
 
 int
@@ -275,6 +299,7 @@ main (int argc, char **argv)
   hb_test_add (test_transform);
   hb_test_add (test_set_glyph_extents_with_transform);
   hb_test_add (test_image_nonfinite_transform);
+  hb_test_add (test_set_glyph_extents_overflow);
 
   return hb_test_run ();
 }


### PR DESCRIPTION
hb_raster_draw_set_glyph_extents and hb_raster_paint_set_glyph_extents are line-for-line copies that transform the four corners of the caller's hb_glyph_extents_t and then hand the resulting floats to (int) floorf / (int) ceilf. the members are int32, so any magnifying transform or scale factor puts the corners well outside the int range, which makes the conversion undefined, and the width/height are then computed as ex1 - ex0 in int, which overflows once the saturated endpoints sit at opposite ends. emit_segment has the same shape one level down, scaling by HB_RASTER_ONE_PIXEL before the int32 cast. ubsan on test/fuzzing/fonts/clusterfuzz-testcase-minimized-harfbuzz_fuzzer-6712347260092416 reports float-cast-overflow at hb-raster-draw.cc:385-389 and :486-489 and hb-raster-paint.cc:2084-2087, plus signed-integer-overflow at hb-raster-draw.cc:399 and hb-raster-paint.cc:2098; hb_raster_draw_set_glyph_extents and hb_raster_paint_set_glyph_extents also reach them directly from the public api, which is what the added test does. saturating in double keeps INT32_MIN/INT32_MAX exact and gives NaN a defined landing spot, and it is the same shape the file already uses for the int64 cell coordinates. the remaining float-to-int conversions in the backend take values the callers already range-check (the bilinear sampler) or that are bounded by the surface (push_clip_rectangle), and none of them showed up in the ubsan run, so i left them alone.