### PR TITLE
[BUG FIX] Set content_type only for the format actually being parsed

### DIFF
--- a/src/hb-buffer-serialize.cc
+++ b/src/hb-buffer-serialize.cc
@@ -796,19 +796,19 @@ hb_buffer_deserialize_glyphs (hb_buffer_t *buffer,
     return false;
   }
 
-  hb_buffer_set_content_type (buffer, HB_BUFFER_CONTENT_TYPE_GLYPHS);
-
   if (!font)
     font = hb_font_get_empty ();
 
   switch (format)
   {
     case HB_BUFFER_SERIALIZE_FORMAT_TEXT:
+      hb_buffer_set_content_type (buffer, HB_BUFFER_CONTENT_TYPE_GLYPHS);
       return _hb_buffer_deserialize_text_glyphs (buffer,
 						 buf, buf_len, end_ptr,
 						 font);
 
     case HB_BUFFER_SERIALIZE_FORMAT_JSON:
+      hb_buffer_set_content_type (buffer, HB_BUFFER_CONTENT_TYPE_GLYPHS);
       return _hb_buffer_deserialize_json (buffer,
                                           buf, buf_len, end_ptr,
                                           font);
@@ -867,18 +867,18 @@ hb_buffer_deserialize_unicode (hb_buffer_t *buffer,
     return false;
   }
 
-  hb_buffer_set_content_type (buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
-
   hb_font_t* font = hb_font_get_empty ();
 
   switch (format)
   {
     case HB_BUFFER_SERIALIZE_FORMAT_TEXT:
+      hb_buffer_set_content_type (buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
       return _hb_buffer_deserialize_text_unicode (buffer,
 						  buf, buf_len, end_ptr,
 						  font);
 
     case HB_BUFFER_SERIALIZE_FORMAT_JSON:
+      hb_buffer_set_content_type (buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
       return _hb_buffer_deserialize_json (buffer,
                                           buf, buf_len, end_ptr,
                                           font);


### PR DESCRIPTION
# Validate serialize format before mutating content_type in deserialize functions

This PR fixes issues: https://github.com/harfbuzz/harfbuzz/issues/6089 and https://github.com/harfbuzz/harfbuzz/issues/6091

## Problem Summary

`hb_buffer_deserialize_unicode()` and `hb_buffer_deserialize_glyphs()` both set the buffer's `content_type` before checking whether the caller-supplied `format` is one of the recognized values (`HB_BUFFER_SERIALIZE_FORMAT_TEXT`
/ `HB_BUFFER_SERIALIZE_FORMAT_JSON`). When `format` is invalid, each function returns `false` without rolling back that mutation, leaving the buffer in an inconsistent state (`content_type` set, `len == 0`).

A subsequent, independent call on the same buffer that relies on the `assert_glyphs()` / `assert_unicode()` invariant then aborts the process:
- A failed `hb_buffer_deserialize_unicode()` call followed by `hb_buffer_deserialize_glyphs()` aborts in `assert_glyphs()`.
- A failed `hb_buffer_deserialize_glyphs()` call followed by `hb_buffer_add_codepoints()` aborts in `assert_unicode()`.

Two separate issues were filed for these (mirror-image bugs, same root cause, different crash sites); this PR fixes both together since the fix is identical in shape.

## Changes

In `src/hb-buffer-serialize.cc`, both `hb_buffer_deserialize_unicode()` and `hb_buffer_deserialize_glyphs()` already dispatch on `format` through a `switch` whose only reachable outcomes for an unrecognized value are the
`default` / `HB_BUFFER_SERIALIZE_FORMAT_INVALID` case returning `false`. That switch is the single source of truth for which formats are supported, so rather than adding a second, separate validity check ahead of it, the `hb_buffer_set_content_type()` call is moved into the `TEXT` and `JSON` case bodies themselves. An unrecognized `format` now falls straight to the existing `default`/`INVALID` case and returns `false` without ever touching `content_type`. No change to behavior for valid `TEXT`/`JSON` formats, and no duplicated "is this format valid" logic to
keep in sync if a format is ever added or removed.
