### PR TITLE
[subset] guard scalars resize in cff2-to-cff1 blend encoder

### DIFF
--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -786,7 +786,12 @@ struct cff2_private_blend_encoder_param_t
     if (!seen_blend)
     {
       region_count = varStore->varStore.get_region_index_count (ivs);
-      scalars.resize_exact (region_count);
+      if (unlikely (!scalars.resize_exact (region_count)))
+      {
+	if (c) c->err (HB_SERIALIZE_ERROR_OTHER);
+	seen_blend = true;
+	return;
+      }
       varStore->varStore.get_region_scalars (ivs, normalized_coords.arrayZ, normalized_coords.length,
 					     &scalars[0], region_count);
       seen_blend = true;


### PR DESCRIPTION
check the scalars resize in cff2_private_blend_encoder_param_t::process_blend before get_region_scalars unconditionally writes region_count floats into it, so an allocation failure can no longer push that write past the empty vector the way the two sibling callers at hb-subset-cff2.cc:141 and hb-cff2-interp-cs.hh:154 already prevent.