### PR TITLE
Add hb_malloc2/hb_realloc2 for overflow-checked array allocation

### DIFF
--- a/src/OT/glyf/glyf-helpers.hh
+++ b/src/OT/glyf/glyf-helpers.hh
@@ -94,7 +94,7 @@ _add_loca_and_head (hb_subset_context_t *c,
   unsigned num_offsets = c->plan->num_output_glyphs () + 1;
   unsigned entry_size = use_short_loca ? 2 : 4;
 
-  char *loca_prime_data = (char *) hb_malloc (entry_size * num_offsets);
+  char *loca_prime_data = (char *) hb_malloc2 (num_offsets, entry_size);
 
   if (unlikely (!loca_prime_data)) return false;
 

--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -39,6 +39,19 @@
 #include <functional>
 #include <new>
 
+static HB_ALWAYS_INLINE void *
+hb_malloc2 (size_t nmemb, size_t size)
+{
+  if (size && nmemb > SIZE_MAX / size) return nullptr;
+  return hb_malloc (nmemb * size);
+}
+static HB_ALWAYS_INLINE void *
+hb_realloc2 (void *ptr, size_t nmemb, size_t size)
+{
+  if (size && nmemb > SIZE_MAX / size) return nullptr;
+  return hb_realloc (ptr, nmemb * size);
+}
+
 /*
  * Flags
  */

--- a/src/hb-cairo-utils.cc
+++ b/src/hb-cairo-utils.cc
@@ -237,7 +237,7 @@ _hb_cairo_get_color_stops (hb_cairo_context_t *c,
     return false;
   if (len > *count)
   {
-    *stops = (hb_color_stop_t *) hb_malloc (len * sizeof (hb_color_stop_t));
+    *stops = (hb_color_stop_t *) hb_malloc2 (len, sizeof (hb_color_stop_t));
     if (unlikely (!*stops))
       return false;
     allocated = true;

--- a/src/hb-gpu-paint.cc
+++ b/src/hb-gpu-paint.cc
@@ -877,7 +877,7 @@ hb_gpu_paint_emit_sweep (hb_gpu_paint_t  *c,
   hb_color_stop_t *heap_stops = nullptr;
   if (count > 16)
   {
-    heap_stops = (hb_color_stop_t *) hb_malloc (count * sizeof (hb_color_stop_t));
+    heap_stops = (hb_color_stop_t *) hb_malloc2 (count, sizeof (hb_color_stop_t));
     if (unlikely (!heap_stops)) { c->unsupported = true; return; }
     stops = heap_stops;
   }

--- a/src/hb-map.hh
+++ b/src/hb-map.hh
@@ -204,7 +204,7 @@ struct hb_hashmap_t
 
     unsigned int power = hb_bit_storage (hb_max (hb_max ((unsigned) population, new_population) * 2, 4u));
     unsigned int new_size = 1u << power;
-    item_t *new_items = (item_t *) hb_malloc ((size_t) new_size * sizeof (item_t));
+    item_t *new_items = (item_t *) hb_malloc2 ((size_t) new_size, sizeof (item_t));
     if (unlikely (!new_items))
     {
       successful = false;

--- a/src/hb-ot-post-table.hh
+++ b/src/hb-ot-post-table.hh
@@ -188,7 +188,7 @@ struct post
 
       if (unlikely (!gids))
       {
-	gids = (uint16_t *) hb_malloc (count * sizeof (gids[0]));
+	gids = (uint16_t *) hb_malloc2 (count, sizeof (gids[0]));
 	if (unlikely (!gids))
 	  return false; /* Anything better?! */
 

--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -316,7 +316,7 @@ hb_shape_justify (hb_font_t          *font,
 
   /* Copy buffer text as we need it so we can shape multiple times. */
   unsigned text_len = buffer->len;
-  auto *text_info = (hb_glyph_info_t *) hb_malloc (text_len * sizeof (buffer->info[0]));
+  auto *text_info = (hb_glyph_info_t *) hb_malloc2 (text_len, sizeof (buffer->info[0]));
   if (unlikely (text_len && !text_info))
     return false;
   hb_memcpy (text_info, buffer->info, text_len * sizeof (buffer->info[0]));


### PR DESCRIPTION
Add `hb_malloc2(nmemb, size)` and `hb_realloc2(ptr, nmemb, size)` that check for multiplication overflow before allocating, without paying the cost of zero-initialization.

**Changes:**

- Add `hb_malloc2` / `hb_realloc2` to the public API (`hb-common.h` / `hb-common.cc`)
- Convert all `hb_malloc(count * sizeof(T))` sites to `hb_malloc2(count, sizeof(T))` (12 files)
- Convert `hb_realloc(ptr, count * sizeof(T))` to `hb_realloc2` in `hb-vector.hh` and `hb-buffer.cc`
- Clean up now-redundant manual `hb_unsigned_mul_overflows` checks in `hb-vector.hh` and `hb-buffer.cc`
- Fix raw `malloc`/`free` → `hb_malloc2`/`hb_free` in `main.cc` and `wasm/graphite/shape.cc`