### PR TITLE
[shape] Limit syllable length

### DIFF
--- a/src/hb-limits.hh
+++ b/src/hb-limits.hh
@@ -58,6 +58,10 @@
 #define HB_MAX_CONTEXT_LENGTH 64
 #endif
 
+#ifndef HB_MAX_SYLLABLE_LENGTH
+#define HB_MAX_SYLLABLE_LENGTH 64
+#endif
+
 #ifndef HB_CLOSURE_MAX_STAGES
 /*
  * The maximum number of times a lookup can be applied during shaping.

--- a/src/hb-ot-layout.hh
+++ b/src/hb-ot-layout.hh
@@ -159,7 +159,8 @@ static inline unsigned int
 _hb_next_syllable (hb_buffer_t *buffer, unsigned int start)
 {
   hb_glyph_info_t *info = buffer->info;
-  unsigned int count = buffer->len;
+  unsigned int count = start + hb_min (buffer->len - start,
+				       (unsigned) HB_MAX_SYLLABLE_LENGTH);
 
   unsigned int syllable = info[start].syllable();
   while (++start < count && syllable == info[start].syllable())


### PR DESCRIPTION
Unbounded syllables can make the USE and Myanmar reordering passes perform quadratic work. Process syllables in configurable chunks of at most 64 glyphs to bound the work performed by each reordering pass.

Fixes: https://github.com/harfbuzz/harfbuzz/issues/6118
Assisted-by: Codex <codex@openai.com>