### PR TITLE
Respect HB_NO_AAT_SHAPE in KernSubTable::collect_glyphs

### DIFF
--- a/src/hb-ot-kern-table.hh
+++ b/src/hb-ot-kern-table.hh
@@ -162,9 +162,13 @@ struct KernSubTable
     unsigned int subtable_type = get_type ();
     switch (subtable_type) {
     case 0:	hb_barrier (); u.format0.collect_glyphs (left_set, right_set, num_glyphs); return;
+#ifndef HB_NO_AAT_SHAPE
     case 1:	hb_barrier (); u.format1.collect_glyphs (left_set, right_set, num_glyphs); return;
+#endif
     case 2:	hb_barrier (); u.format2.collect_glyphs (left_set, right_set, num_glyphs); return;
+#ifndef HB_NO_AAT_SHAPE
     case 3:	hb_barrier (); u.format3.collect_glyphs (left_set, right_set, num_glyphs); return;
+#endif
     default:	return;
     }
   }
@@ -184,9 +188,13 @@ struct KernSubTable
   union {
   KernSubTableHeader				header;
   AAT::KerxSubTableFormat0<KernSubTableHeader>	format0;
+#ifndef HB_NO_AAT_SHAPE
   AAT::KerxSubTableFormat1<KernSubTableHeader>	format1;
+#endif
   AAT::KerxSubTableFormat2<KernSubTableHeader>	format2;
+#ifndef HB_NO_AAT_SHAPE
   KernSubTableFormat3<KernSubTableHeader>	format3;
+#endif
   } u;
   public:
   DEFINE_SIZE_MIN (KernSubTableHeader::static_size);


### PR DESCRIPTION
Sanitize is skipped for subtable 1 and 3 when HB_NO_AAT_SHAPE is set, so it's not safe to run collect_glyphs in this case. This mirrors dispatch().