### PR TITLE
[proof of concept] Variable axis positions within run

### DIFF
--- a/docs/wasm-shaper.md
+++ b/docs/wasm-shaper.md
@@ -420,7 +420,13 @@ wasm-bindgen = "0.2"
 harfbuzz-wasm = { path = "your-harfbuzz-source/src/wasm/rust/harfbuzz-wasm"}
 ```
 
-*
+* Harfbuzz will be providing some functions in the WASM host environment which Rust won't be able to see at link-time, so we're going to need the Rust compiler to ignore undefined symbols when linking the WASM module. We can do this by creating a `.cargo/config.toml` file:
+
+```toml
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=--import-undefined"]
+```
+
 * And now we'll create our shaper code. In `src/lib.rs`:
 
 ```rust

--- a/src/hb-buffer-serialize.cc
+++ b/src/hb-buffer-serialize.cc
@@ -177,6 +177,21 @@ _hb_buffer_serialize_glyphs_json (hb_buffer_t *buffer,
         p += hb_max (0, snprintf (p, ARRAY_LENGTH (b) - (p - b), ",\"fl\":%u", info[i].mask & HB_GLYPH_FLAG_DEFINED));
     }
 
+    if (buffer->coords_deltas && buffer->num_coords_deltas)
+    {
+      int *deltas = &buffer->coords_deltas[i * buffer->num_coords_deltas];
+      bool any_delta = false;
+      for (unsigned int j = 0; j < buffer->num_coords_deltas; j++)
+	if (deltas[j]) { any_delta = true; break; }
+      if (any_delta)
+      {
+	p += hb_max (0, snprintf (p, ARRAY_LENGTH (b) - (p - b), ",\"vd\":["));
+	for (unsigned int j = 0; j < buffer->num_coords_deltas; j++)
+	  p += hb_max (0, snprintf (p, ARRAY_LENGTH (b) - (p - b), "%s%d", j ? "," : "", deltas[j]));
+	*p++ = ']';
+      }
+    }
+
     if (flags & HB_BUFFER_SERIALIZE_FLAG_GLYPH_EXTENTS)
     {
       hb_glyph_extents_t extents;
@@ -337,6 +352,20 @@ _hb_buffer_serialize_glyphs_text (hb_buffer_t *buffer,
     {
       if (info[i].mask & HB_GLYPH_FLAG_DEFINED)
         p += hb_max (0, snprintf (p, ARRAY_LENGTH (b) - (p - b), "#%X", info[i].mask &HB_GLYPH_FLAG_DEFINED));
+    }
+
+    if (buffer->coords_deltas && buffer->num_coords_deltas)
+    {
+      int *deltas = &buffer->coords_deltas[i * buffer->num_coords_deltas];
+      bool any_delta = false;
+      for (unsigned int j = 0; j < buffer->num_coords_deltas; j++)
+	if (deltas[j]) { any_delta = true; break; }
+      if (any_delta)
+      {
+	p += hb_max (0, snprintf (p, ARRAY_LENGTH (b) - (p - b), "~"));
+	for (unsigned int j = 0; j < buffer->num_coords_deltas; j++)
+	  p += hb_max (0, snprintf (p, ARRAY_LENGTH (b) - (p - b), "%s%d", j ? "," : "", deltas[j]));
+      }
     }
 
     if (flags & HB_BUFFER_SERIALIZE_FLAG_GLYPH_EXTENTS)

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -2477,6 +2477,25 @@ hb_buffer_get_glyph_variation_delta (hb_buffer_t *buffer,
   return buffer->get_variation_delta (glyph_index, axis_index);
 }
 
+/**
+ * hb_buffer_get_variation_deltas_num_coords:
+ * @buffer: An #hb_buffer_t
+ *
+ * Returns the number of variation axes currently configured for
+ * per-glyph delta storage, or 0 if not configured.
+ *
+ * Return value: The number of variation axes
+ *
+ * Since: REPLACEME
+ **/
+unsigned int
+hb_buffer_get_variation_deltas_num_coords (hb_buffer_t *buffer)
+{
+  if (!buffer)
+    return 0;
+  return buffer->num_coords_deltas;
+}
+
 bool
 hb_buffer_t::message_impl (hb_font_t *font, const char *fmt, va_list ap)
 {

--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -170,6 +170,7 @@ hb_buffer_t::enlarge (unsigned int size)
   unsigned int new_allocated = allocated;
   hb_glyph_position_t *new_pos = nullptr;
   hb_glyph_info_t *new_info = nullptr;
+  int *new_coords_deltas = nullptr;
   bool separate_out = out_info != info;
 
   if (unlikely (hb_unsigned_mul_overflows (size, sizeof (info[0]))))
@@ -186,8 +187,15 @@ hb_buffer_t::enlarge (unsigned int size)
   new_pos = (hb_glyph_position_t *) hb_realloc (pos, new_bytes);
   new_info = (hb_glyph_info_t *) hb_realloc (info, new_bytes);
 
+  if (num_coords_deltas)
+  {
+    unsigned new_coords_bytes;
+    if (likely (!hb_unsigned_mul_overflows (new_allocated, num_coords_deltas * sizeof (int), &new_coords_bytes)))
+      new_coords_deltas = (int *) hb_realloc (coords_deltas, new_coords_bytes);
+  }
+
 done:
-  if (unlikely (!new_pos || !new_info))
+  if (unlikely (!new_pos || !new_info || (num_coords_deltas && !new_coords_deltas)))
     successful = false;
 
   if (likely (new_pos))
@@ -195,6 +203,20 @@ done:
 
   if (likely (new_info))
     info = new_info;
+
+  if (likely (new_coords_deltas || !num_coords_deltas))
+  {
+    /* Zero out newly allocated glyph slots in the deltas array. */
+    if (coords_deltas && new_coords_deltas && new_coords_deltas != coords_deltas &&
+	allocated > 0 && new_allocated > allocated)
+    {
+      unsigned int old_bytes = allocated * num_coords_deltas * sizeof (int);
+      unsigned int new_bytes = new_allocated * num_coords_deltas * sizeof (int);
+      hb_memset ((char *) new_coords_deltas + old_bytes, 0,
+		 new_bytes - old_bytes);
+    }
+    coords_deltas = new_coords_deltas;
+  }
 
   out_info = separate_out ? (hb_glyph_info_t *) pos : info;
   if (likely (successful))
@@ -235,6 +257,12 @@ hb_buffer_t::shift_forward (unsigned int count)
   }
 
   memmove (info + idx + count, info + idx, (len - idx) * sizeof (info[0]));
+  if (coords_deltas)
+  {
+    memmove (coords_deltas + (idx + count) * num_coords_deltas,
+             coords_deltas + idx * num_coords_deltas,
+             (len - idx) * num_coords_deltas * sizeof (int));
+  }
   if (idx + count > len)
   {
     /* Under memory failure we might expose this area.  At least
@@ -293,6 +321,7 @@ hb_buffer_t::reset ()
   invisible = 0;
   not_found = 0;
   not_found_variation_selector = HB_CODEPOINT_INVALID;
+  num_coords_deltas = 0;
 
   clear ();
 }
@@ -312,6 +341,13 @@ hb_buffer_t::clear ()
   len = 0;
   out_len = 0;
   out_info = info;
+
+  /* Zero variation deltas but keep the axis count. */
+  if (coords_deltas)
+  {
+    unsigned int coords_bytes = num_coords_deltas * allocated * sizeof (int);
+    hb_memset (coords_deltas, 0, coords_bytes);
+  }
 
   hb_memset (context, 0, sizeof context);
   hb_memset (context_len, 0, sizeof context_len);
@@ -485,6 +521,12 @@ hb_buffer_t::move_to (unsigned int i)
     if (unlikely (!make_room_for (count, count))) return false;
 
     memmove (out_info + out_len, info + idx, count * sizeof (out_info[0]));
+    if (coords_deltas)
+    {
+      memmove (coords_deltas + out_len * num_coords_deltas,
+               coords_deltas + idx * num_coords_deltas,
+               count * num_coords_deltas * sizeof (int));
+    }
     idx += count;
     out_len += count;
   }
@@ -507,6 +549,12 @@ hb_buffer_t::move_to (unsigned int i)
     idx -= count;
     out_len -= count;
     memmove (info + idx, out_info + out_len, count * sizeof (out_info[0]));
+    if (coords_deltas)
+    {
+      memmove (coords_deltas + idx * num_coords_deltas,
+               coords_deltas + out_len * num_coords_deltas,
+               count * num_coords_deltas * sizeof (int));
+    }
   }
 
   return true;
@@ -868,6 +916,7 @@ hb_buffer_destroy (hb_buffer_t *buffer)
 
   hb_free (buffer->info);
   hb_free (buffer->pos);
+  hb_free (buffer->coords_deltas);
 #ifndef HB_NO_BUFFER_MESSAGE
   if (buffer->message_destroy)
     buffer->message_destroy (buffer->message_data);
@@ -2059,6 +2108,11 @@ hb_buffer_append (hb_buffer_t *buffer,
   hb_memcpy (buffer->info + orig_len, source->info + start, (end - start) * sizeof (buffer->info[0]));
   if (buffer->have_positions)
     hb_memcpy (buffer->pos + orig_len, source->pos + start, (end - start) * sizeof (buffer->pos[0]));
+  if (buffer->coords_deltas && source->coords_deltas &&
+      buffer->num_coords_deltas == source->num_coords_deltas)
+    hb_memcpy (buffer->coords_deltas + orig_len * buffer->num_coords_deltas,
+               source->coords_deltas + start * source->num_coords_deltas,
+               (end - start) * source->num_coords_deltas * sizeof (int));
 
   if (source->content_type == HB_BUFFER_CONTENT_TYPE_UNICODE)
   {
@@ -2353,6 +2407,74 @@ void
 hb_buffer_changed (hb_buffer_t *buffer)
 {
   buffer->changed ();
+}
+
+/**
+ * hb_buffer_set_variation_deltas_num_coords:
+ * @buffer: An #hb_buffer_t
+ * @num_coords: Number of variation axes for per-glyph deltas
+ *
+ * Sets the number of variation axes for per-glyph delta storage.
+ * Must be called before setting per-glyph variation deltas.
+ * Pass 0 to disable per-glyph deltas and free associated storage.
+ *
+ * Since: REPLACEME
+ **/
+void
+hb_buffer_set_variation_deltas_num_coords (hb_buffer_t *buffer,
+					   unsigned int  num_coords)
+{
+  if (!buffer || !buffer->successful)
+    return;
+
+  if (unlikely (!buffer->setup_variation_deltas (num_coords)))
+    return;
+}
+
+/**
+ * hb_buffer_set_glyph_variation_delta:
+ * @buffer: An #hb_buffer_t
+ * @glyph_index: Index of the glyph in the buffer
+ * @axis_index: Index of the variation axis
+ * @delta: Normalized variation delta (2.14 fixed-point)
+ *
+ * Sets a per-glyph variation delta for a specific axis, in 2.14
+ * fixed-point format (matching hb_font_t's internal normalized
+ * coordinate representation).
+ *
+ * Since: REPLACEME
+ **/
+void
+hb_buffer_set_glyph_variation_delta (hb_buffer_t *buffer,
+				     unsigned int  glyph_index,
+				     unsigned int  axis_index,
+				     int           delta)
+{
+  if (buffer)
+    buffer->set_variation_delta (glyph_index, axis_index, delta);
+}
+
+/**
+ * hb_buffer_get_glyph_variation_delta:
+ * @buffer: An #hb_buffer_t
+ * @glyph_index: Index of the glyph in the buffer
+ * @axis_index: Index of the variation axis
+ *
+ * Gets the per-glyph variation delta for a specific axis.
+ *
+ * Return value: The normalized variation delta (2.14 fixed-point),
+ * or 0 if not set.
+ *
+ * Since: REPLACEME
+ **/
+int
+hb_buffer_get_glyph_variation_delta (hb_buffer_t *buffer,
+				     unsigned int  glyph_index,
+				     unsigned int  axis_index)
+{
+  if (!buffer)
+    return 0;
+  return buffer->get_variation_delta (glyph_index, axis_index);
 }
 
 bool

--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -873,6 +873,20 @@ hb_buffer_set_message_func (hb_buffer_t *buffer,
 HB_EXTERN void
 hb_buffer_changed (hb_buffer_t *buffer);
 
+HB_EXTERN void
+hb_buffer_set_variation_deltas_num_coords (hb_buffer_t *buffer, unsigned int num_coords);
+
+HB_EXTERN void
+hb_buffer_set_glyph_variation_delta (hb_buffer_t *buffer,
+				     unsigned int glyph_index,
+				     unsigned int axis_index,
+				     int delta);
+
+HB_EXTERN int
+hb_buffer_get_glyph_variation_delta (hb_buffer_t *buffer,
+				     unsigned int glyph_index,
+				     unsigned int axis_index);
+
 
 HB_END_DECLS
 

--- a/src/hb-buffer.h
+++ b/src/hb-buffer.h
@@ -887,6 +887,9 @@ hb_buffer_get_glyph_variation_delta (hb_buffer_t *buffer,
 				     unsigned int glyph_index,
 				     unsigned int axis_index);
 
+HB_EXTERN unsigned int
+hb_buffer_get_variation_deltas_num_coords (hb_buffer_t *buffer);
+
 
 HB_END_DECLS
 

--- a/src/hb-buffer.hh
+++ b/src/hb-buffer.hh
@@ -103,6 +103,13 @@ struct hb_buffer_t
   hb_glyph_info_t     *out_info;
   hb_glyph_position_t *pos;
 
+  /* Per-glyph normalized variation deltas (2.14 fixed-point, per OpenType spec).
+   * Sized num_coords_deltas * len, one int per axis per glyph,
+   * laid out as deltas[glyph_idx * num_coords_deltas + axis].
+   * nullptr when num_coords_deltas == 0. */
+  unsigned int num_coords_deltas;
+  int *coords_deltas;
+
   /* Text before / after the main buffer contents.
    * Always in Unicode, and ordered outward.
    * Index 0 is for "pre-context", 1 for "post-context". */
@@ -248,6 +255,19 @@ struct hb_buffer_t
     hb_array_t<hb_glyph_info_t> (info, len).reverse (start, end);
     if (have_positions)
       hb_array_t<hb_glyph_position_t> (pos, len).reverse (start, end);
+    if (coords_deltas && num_coords_deltas)
+    {
+      /* Reverse each glyph's delta block, which is num_coords_deltas ints each. */
+      int *base = coords_deltas + start * num_coords_deltas;
+      unsigned count = end - start;
+      for (unsigned i = 0; i < count / 2; i++)
+      {
+	int *a = base + i * num_coords_deltas;
+	int *b = base + (count - 1 - i) * num_coords_deltas;
+	for (unsigned j = 0; j < num_coords_deltas; j++)
+	  hb_swap (a[j], b[j]);
+      }
+    }
   }
   void reverse () { reverse_range (0, len); }
 
@@ -710,6 +730,62 @@ struct hb_buffer_t
   {
     for (unsigned int i = 0; i < len; i++)
       info[i].mask = (info[i].mask & ~HB_GLYPH_FLAG_DEFINED) | (mask & HB_GLYPH_FLAG_DEFINED);
+  }
+
+  HB_NODISCARD bool setup_variation_deltas (unsigned int num_coords)
+  {
+    if (num_coords_deltas == num_coords)
+      return true;
+
+    if (num_coords == 0)
+    {
+      num_coords_deltas = 0;
+      hb_free (coords_deltas);
+      coords_deltas = nullptr;
+      return true;
+    }
+
+    /* Ensure info/pos arrays are allocated first. */
+    if (unlikely (!ensure (len ? len : 1)))
+      return false;
+
+    /* Allocate or reallocate the deltas array. */
+    unsigned int coords_bytes = allocated * num_coords * sizeof (int);
+    int *new_deltas = (int *) hb_realloc (coords_deltas, coords_bytes);
+    if (unlikely (!new_deltas))
+    {
+      successful = false;
+      return false;
+    }
+
+    /* Zero out existing entries if we had fewer axes before. */
+    if (num_coords > num_coords_deltas && allocated > 0 && num_coords_deltas > 0)
+    {
+      /* We grew in axis count; zero the new axis columns for all rows. */
+      for (unsigned int i = 0; i < allocated; i++)
+	hb_memset (new_deltas + i * num_coords + num_coords_deltas, 0,
+		   (num_coords - num_coords_deltas) * sizeof (int));
+    }
+
+    coords_deltas = new_deltas;
+    num_coords_deltas = num_coords;
+    return true;
+  }
+
+  HB_ALWAYS_INLINE
+  int get_variation_delta (unsigned int glyph_idx, unsigned int axis) const
+  {
+    if (unlikely (!coords_deltas || axis >= num_coords_deltas || glyph_idx >= len))
+      return 0;
+    return coords_deltas[glyph_idx * num_coords_deltas + axis];
+  }
+
+  HB_ALWAYS_INLINE
+  void set_variation_delta (unsigned int glyph_idx, unsigned int axis, int delta)
+  {
+    if (unlikely (!coords_deltas || axis >= num_coords_deltas || glyph_idx >= len))
+      return;
+    coords_deltas[glyph_idx * num_coords_deltas + axis] = delta;
   }
 };
 DECLARE_NULL_INSTANCE (hb_buffer_t);

--- a/src/hb-font.cc
+++ b/src/hb-font.cc
@@ -3077,6 +3077,27 @@ hb_font_set_variations (hb_font_t            *font,
 }
 
 /**
+ * hb_font_get_variation_axis_count:
+ * @font: #hb_font_t to work upon
+ *
+ * Returns the number of variation axes in the font.
+ *
+ * Since: 1.4.2
+ */
+unsigned int
+hb_font_get_variation_axis_count (hb_font_t *font)
+{
+  if (unlikely (!font->face->table.fvar))
+    return 0;
+
+  const OT::fvar &fvar = *font->face->table.fvar;
+  auto axes = fvar.get_axes ();
+  return axes.length;
+}
+
+
+
+/**
  * hb_font_set_variation:
  * @font: #hb_font_t to work upon
  * @tag: The #hb_tag_t tag of the variation-axis name

--- a/src/hb-font.h
+++ b/src/hb-font.h
@@ -1238,6 +1238,9 @@ hb_font_set_synthetic_slant (hb_font_t *font, float slant);
 HB_EXTERN float
 hb_font_get_synthetic_slant (hb_font_t *font);
 
+HB_EXTERN unsigned int
+hb_font_get_variation_axis_count (hb_font_t *font);
+
 HB_EXTERN void
 hb_font_set_variations (hb_font_t *font,
 			const hb_variation_t *variations,

--- a/src/hb-shape.cc
+++ b/src/hb-shape.cc
@@ -142,6 +142,8 @@ hb_shape_full (hb_font_t          *font,
     hb_buffer_append (text_buffer, buffer, 0, -1);
   }
 
+	hb_buffer_set_variation_deltas_num_coords(buffer, hb_font_get_variation_axis_count(font));
+
   hb_shape_plan_t *shape_plan = hb_shape_plan_create_cached2 (font->face, &buffer->props,
 							      features, num_features,
 							      font->coords, font->num_coords,

--- a/src/hb-wasm-api-buffer.hh
+++ b/src/hb-wasm-api-buffer.hh
@@ -205,11 +205,22 @@ HB_WASM_API (void, buffer_reverse) (HB_WASM_EXEC_ENV
 }
 
 HB_WASM_API (void, buffer_reverse_clusters) (HB_WASM_EXEC_ENV
-					     ptr_d(buffer_t, buffer))
+				     ptr_d(buffer_t, buffer))
 {
   HB_REF2OBJ (buffer);
 
   hb_buffer_reverse_clusters (buffer);
+}
+
+HB_WASM_API (void, buffer_set_glyph_variation_delta) (HB_WASM_EXEC_ENV
+					     ptr_d(buffer_t, buffer),
+					     uint32_t glyph_index,
+					     uint32_t axis_index,
+					     int32_t delta)
+{
+  HB_REF2OBJ (buffer);
+
+  hb_buffer_set_glyph_variation_delta (buffer, glyph_index, axis_index, delta);
 }
 
 }}

--- a/src/hb-wasm-api-list.hh
+++ b/src/hb-wasm-api-list.hh
@@ -68,6 +68,7 @@ static NativeSymbol _hb_wasm_native_symbols[] =
   NATIVE_SYMBOL ("(i)i",	buffer_get_script),
   NATIVE_SYMBOL ("(i)",		buffer_reverse),
   NATIVE_SYMBOL ("(i)",		buffer_reverse_clusters),
+  NATIVE_SYMBOL ("(iiii)",	buffer_set_glyph_variation_delta),
 
   /* face */
   NATIVE_SYMBOL ("(ii)i",	face_create),

--- a/src/hb-wasm-api-list.hh
+++ b/src/hb-wasm-api-list.hh
@@ -93,6 +93,8 @@ static NativeSymbol _hb_wasm_native_symbols[] =
 
   /* shape */
   NATIVE_SYMBOL ("(iiii$)i",	shape_with),
+  NATIVE_SYMBOL ("(iii)i",	feature_copy_contents),
+  NATIVE_SYMBOL ("(i)",		features_free),
 
   /* debug */
 #ifdef HB_DEBUG_WASM

--- a/src/hb-wasm-api-shape.hh
+++ b/src/hb-wasm-api-shape.hh
@@ -64,6 +64,52 @@ HB_WASM_INTERFACE (bool_t, shape_with) (HB_WASM_EXEC_ENV
 			shaper_list);
 }
 
+HB_WASM_API (bool_t, feature_copy_contents) (HB_WASM_EXEC_ENV
+					       ptr_d(const feature_t, features),
+					       uint32_t num_features,
+					       ptr_d(features_t, output))
+{
+  HB_PTR_PARAM (features_t, output);
+  if (unlikely (!output))
+    return false;
+
+  unsigned bytes;
+  if (unlikely (hb_unsigned_mul_overflows (num_features, sizeof (feature_t), &bytes)))
+    return false;
+
+  if (!num_features)
+  {
+    output->length = 0;
+    output->features = nullref;
+    return true;
+  }
+
+  HB_ARRAY_PARAM (const feature_t, features, num_features);
+  if (unlikely (!features))
+    return false;
+
+  feature_t *dst = nullptr;
+  uint32_t dstref = module_malloc (bytes, (void **) &dst);
+  if (unlikely (!dstref))
+    return false;
+
+  hb_memcpy (dst, features, bytes);
+  output->length = num_features;
+  output->features = dstref;
+  return true;
+}
+
+HB_WASM_API (void, features_free) (HB_WASM_EXEC_ENV
+				    ptr_d(features_t, features))
+{
+  HB_PTR_PARAM (features_t, features);
+  if (unlikely (!features))
+    return;
+
+  module_free (features->features);
+  features->features = nullref;
+  features->length = 0;
+}
 
 }}
 

--- a/src/hb-wasm-api.h
+++ b/src/hb-wasm-api.h
@@ -303,6 +303,21 @@ typedef struct
 #define FEATURE_GLOBAL_START	0
 #define FEATURE_GLOBAL_END	((uint32_t) -1)
 
+typedef struct
+{
+  uint32_t length;
+  ptr_t(feature_t) features;
+} features_t;
+#define FEATURES_INIT {0, 0}
+
+HB_WASM_API (bool_t, feature_copy_contents) (HB_WASM_EXEC_ENV
+					       ptr_d(const feature_t, features),
+					       uint32_t num_features,
+					       ptr_d(features_t, output));
+
+HB_WASM_API (void, features_free) (HB_WASM_EXEC_ENV
+				     ptr_d(features_t, features));
+
 HB_WASM_API (bool_t, shape_with) (HB_WASM_EXEC_ENV
 				  ptr_d(font_t, font),
 				  ptr_d(buffer_t, buffer),

--- a/src/hb-wasm-api.h
+++ b/src/hb-wasm-api.h
@@ -173,6 +173,12 @@ HB_WASM_API (void, buffer_reverse) (HB_WASM_EXEC_ENV
 HB_WASM_API (void, buffer_reverse_clusters) (HB_WASM_EXEC_ENV
 					     ptr_d(buffer_t, buffer));
 
+HB_WASM_API (void, buffer_set_glyph_variation_delta) (HB_WASM_EXEC_ENV
+						       ptr_d(buffer_t, buffer),
+						       uint32_t glyph_index,
+						       uint32_t axis_index,
+						       int32_t delta);
+
 /* face */
 
 typedef struct face_t face_t;

--- a/src/wasm/rust/harfbuzz-wasm/src/lib.rs
+++ b/src/wasm/rust/harfbuzz-wasm/src/lib.rs
@@ -45,6 +45,7 @@ extern "C" {
     fn face_copy_table(font: u32, tag: u32, blob: *mut Blob) -> bool;
     fn buffer_copy_contents(buffer: u32, cbuffer: *mut CBufferContents) -> bool;
     fn buffer_set_contents(buffer: u32, cbuffer: &CBufferContents) -> bool;
+    fn buffer_set_glyph_variation_delta(buffer: u32, glyph_index: u32, axis_index: u32, delta: i32);
     fn debugprint(s: *const u8);
     fn shape_with(
         font: u32,
@@ -288,6 +289,20 @@ impl<T: BufferItem> Buffer<T> {
                 .map(|(i, p)| T::from_c(i, p))
                 .collect(),
             _ptr: ptr,
+        }
+    }
+
+    /// Set a per-glyph variation delta for a specific axis.
+    ///
+    /// The delta is a normalized 2.14 fixed-point value (per the
+    /// OpenType specification) that will be added to the font's
+    /// variation coordinate for that axis when rendering this glyph.
+    /// You must have previously called
+    /// `hb_buffer_set_variation_deltas_num_coords` (in C) to set
+    /// the number of variation axes.
+    pub fn set_glyph_variation_delta(&self, glyph_index: u32, axis_index: u32, delta: i32) {
+        unsafe {
+            buffer_set_glyph_variation_delta(self._ptr, glyph_index, axis_index, delta);
         }
     }
 }

--- a/src/wasm/rust/harfbuzz-wasm/src/lib.rs
+++ b/src/wasm/rust/harfbuzz-wasm/src/lib.rs
@@ -46,6 +46,8 @@ extern "C" {
     fn buffer_copy_contents(buffer: u32, cbuffer: *mut CBufferContents) -> bool;
     fn buffer_set_contents(buffer: u32, cbuffer: &CBufferContents) -> bool;
     fn buffer_set_glyph_variation_delta(buffer: u32, glyph_index: u32, axis_index: u32, delta: i32);
+    fn feature_copy_contents(features: u32, num_features: u32, output: *mut CFFeatures) -> bool;
+    fn features_free(features: *mut CFFeatures);
     fn debugprint(s: *const u8);
     fn shape_with(
         font: u32,
@@ -378,12 +380,46 @@ pub struct CGlyphExtents {
     pub height: i32,
 }
 
+/// An OpenType feature passed to the shaper.
+#[derive(Debug, Clone, Copy)]
+pub struct Feature {
+    /// The feature tag (e.g. `TAG(b'k', b'e', b'r', b'n')`)
+    pub tag: [u8; 4],
+    /// The feature value (0 = off, 1 = on, etc.)
+    pub value: u32,
+    /// Start index of the feature range, or `FEATURE_GLOBAL_START`
+    pub start: u32,
+    /// End index of the feature range, or `FEATURE_GLOBAL_END`
+    pub end: u32,
+}
+
+/// Start index for features that apply globally.
+pub const FEATURE_GLOBAL_START: u32 = 0;
+/// End index for features that apply globally.
+pub const FEATURE_GLOBAL_END: u32 = u32::MAX;
+
 #[derive(Debug)]
 #[repr(C)]
 struct CBufferContents {
     length: u32,
     info: *mut CGlyphInfo,
     position: *mut CGlyphPosition,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+struct CFFeatures {
+    length: u32,
+    features: *mut CFeature,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct CFeature {
+    tag: u32,
+    value: u32,
+    start: u32,
+    end: u32,
 }
 
 /// Ergonomic representation of a Harfbuzz buffer item
@@ -469,6 +505,78 @@ struct CGlyphOutline {
 
 /// Our default buffer item struct. See also [`Glyph`].
 pub type GlyphBuffer = Buffer<Glyph>;
+
+/// A collection of OpenType features passed to the shaper.
+#[derive(Debug)]
+pub struct Features {
+    features: Vec<Feature>,
+}
+
+fn u32_to_tag(tag: u32) -> [u8; 4] {
+    [
+        ((tag >> 24) & 0xFF) as u8,
+        ((tag >> 16) & 0xFF) as u8,
+        ((tag >> 8) & 0xFF) as u8,
+        (tag & 0xFF) as u8,
+    ]
+}
+
+impl Features {
+    /// Construct a `Features` from the raw pointer and count
+    /// passed to the `shape` function by the WASM host.
+    pub fn from_raw(ptr: u32, count: u32) -> Self {
+        let mut c_features = CFFeatures {
+            length: 0,
+            features: std::ptr::null_mut(),
+        };
+        if count > 0 {
+            unsafe {
+                feature_copy_contents(ptr, count, &mut c_features);
+            }
+        }
+        let slice =
+            unsafe { std::slice::from_raw_parts(c_features.features, c_features.length as usize) };
+        let features: Vec<Feature> = slice
+            .iter()
+            .map(|f| Feature {
+                tag: u32_to_tag(f.tag),
+                value: f.value,
+                start: f.start,
+                end: f.end,
+            })
+            .collect();
+        Features { features }
+    }
+
+    /// Returns the number of features.
+    pub fn len(&self) -> usize {
+        self.features.len()
+    }
+
+    /// Returns true if there are no features.
+    pub fn is_empty(&self) -> bool {
+        self.features.is_empty()
+    }
+
+    /// Returns a slice of all features.
+    pub fn as_slice(&self) -> &[Feature] {
+        &self.features
+    }
+
+    /// Iterate over the features.
+    pub fn iter(&self) -> impl Iterator<Item = &Feature> {
+        self.features.iter()
+    }
+}
+
+impl Drop for Features {
+    fn drop(&mut self) {
+        // CFFeatures is stack-allocated but it points to WASM memory.
+        // We don't need to free since feature_copy_contents allocates
+        // in WASM heap and we copied values out. The WASM module
+        // frees its heap on deinstantiation.
+    }
+}
 
 /// Write a string to the Harfbuzz debug log.
 pub fn debug(s: &str) {

--- a/util/raster-output.hh
+++ b/util/raster-output.hh
@@ -167,11 +167,27 @@ struct raster_output_t : output_options_t<true>, view_options_t
     line.glyphs.reserve (line.glyphs.size () + count);
     for (unsigned i = 0; i < count; i++)
     {
-      line.glyphs.push_back ({
+      glyph_instance_t g = {
 	infos[i].codepoint,
 	(float) (pen_x + positions[i].x_offset),
 	(float) (pen_y + positions[i].y_offset),
-      });
+      };
+      unsigned num_delta_axes = hb_buffer_get_variation_deltas_num_coords (buffer);
+      if (num_delta_axes)
+      {
+	/* Check if any delta is non-zero before copying the row. */
+	for (unsigned j = 0; j < num_delta_axes; j++)
+	{
+	  if (hb_buffer_get_glyph_variation_delta (buffer, i, j))
+	  {
+	    g.coords_deltas.resize (num_delta_axes);
+	    for (unsigned k = 0; k < num_delta_axes; k++)
+	      g.coords_deltas[k] = hb_buffer_get_glyph_variation_delta (buffer, i, k);
+	    break;
+	  }
+	}
+      }
+      line.glyphs.push_back (std::move (g));
       pen_x += positions[i].x_advance;
       pen_y += positions[i].y_advance;
     }
@@ -249,15 +265,17 @@ struct raster_output_t : output_options_t<true>, view_options_t
 	    float pen_x = g.x + off_x;
 	    float pen_y = g.y + off_y;
 	    hb_raster_draw_set_transform (rdr, 1.f, 0.f, 0.f, 1.f, pen_x, pen_y);
-	    hb_raster_draw_glyph (rdr, font, g.gid);
-	    if (show_extents)
-	    {
-	      hb_glyph_extents_t ge;
-	      if (hb_font_get_glyph_extents (font, g.gid, &ge))
-		util_emit_extents_overlay_into_draw (
-		  hb_raster_draw_get_funcs (rdr), rdr,
-		  &ge, pen_x, pen_y, extents_stroke_width ());
-	    }
+	    with_glyph_coords (g, [&] () {
+	      hb_raster_draw_glyph (rdr, font, g.gid);
+	      if (show_extents)
+	      {
+		hb_glyph_extents_t ge;
+		if (hb_font_get_glyph_extents (font, g.gid, &ge))
+		  util_emit_extents_overlay_into_draw (
+		    hb_raster_draw_get_funcs (rdr), rdr,
+		    &ge, pen_x, pen_y, extents_stroke_width ());
+	      }
+	    });
 	  }
 	}
 
@@ -276,12 +294,45 @@ struct raster_output_t : output_options_t<true>, view_options_t
 
   private:
 
-  struct glyph_instance_t { hb_codepoint_t gid; float x, y; };
+  struct glyph_instance_t { hb_codepoint_t gid; float x, y; std::vector<int> coords_deltas; };
   struct line_t
   {
     float advance_x = 0.f, advance_y = 0.f;
     std::vector<glyph_instance_t> glyphs;
   };
+
+  /* Apply per-glyph variation deltas (if any) while rendering a glyph,
+   * then restore the font's original coords. */
+  template <typename F>
+  void with_glyph_coords (const glyph_instance_t &g, F &&render)
+  {
+    if (g.coords_deltas.empty ()) { render (); return; }
+
+    unsigned nc;
+    const int *base = hb_font_get_var_coords_normalized (font, &nc);
+    if (!base || !nc) { render (); return; }
+
+    /* Save a copy — hb_font_set_var_coords_normalized frees the old array. */
+    std::vector<int> saved (base, base + nc);
+
+    unsigned n = hb_min (nc, (unsigned) g.coords_deltas.size ());
+    std::vector<int> modified (n);
+    bool any_delta = false;
+    for (unsigned j = 0; j < n; j++)
+    {
+      modified[j] = base[j] + g.coords_deltas[j];
+      if (g.coords_deltas[j]) any_delta = true;
+    }
+    /* Fill remaining axes (if font has more) from saved coords. */
+    if (n < nc)
+      modified.insert (modified.end (), saved.begin () + n, saved.end ());
+
+    if (!any_delta) { render (); return; }
+
+    hb_font_set_var_coords_normalized (font, modified.data (), nc);
+    render ();
+    hb_font_set_var_coords_normalized (font, saved.data (), nc);
+  }
 
   float extents_stroke_width () const
   {
@@ -332,16 +383,18 @@ struct raster_output_t : output_options_t<true>, view_options_t
 	  hb_raster_paint_set_palette (pnt, palette);
 	  hb_raster_paint_set_foreground (pnt, glyph_fg);
 
-	  hb_raster_paint_glyph (pnt, font, g.gid);
+	  with_glyph_coords (g, [&] () {
+	    hb_raster_paint_glyph (pnt, font, g.gid);
 
-	  if (show_extents)
-	  {
-	    hb_glyph_extents_t ge;
-	    if (hb_font_get_glyph_extents (font, g.gid, &ge))
-	      util_emit_extents_overlay_into_paint (
-		hb_raster_paint_get_funcs (pnt), pnt,
-		&ge, pen_x, pen_y, extents_stroke_width ());
-	  }
+	    if (show_extents)
+	    {
+	      hb_glyph_extents_t ge;
+	      if (hb_font_get_glyph_extents (font, g.gid, &ge))
+		util_emit_extents_overlay_into_paint (
+		  hb_raster_paint_get_funcs (pnt), pnt,
+		  &ge, pen_x, pen_y, extents_stroke_width ());
+	    }
+	  });
 
 	  hb_raster_image_t *img = hb_raster_paint_render (pnt);
 	  if (img)
@@ -424,15 +477,17 @@ struct raster_output_t : output_options_t<true>, view_options_t
 					       scalbnf (1.f, (int) subpixel_bits));
 	  hb_raster_draw_set_extents (rdr, &ext);
 	  hb_raster_draw_set_transform (rdr, 1.f, 0.f, 0.f, 1.f, g.x + off_x, g.y + off_y);
-	  hb_raster_draw_glyph (rdr, font, g.gid);
-	  if (show_extents)
-	  {
-	    hb_glyph_extents_t ge;
-	    if (hb_font_get_glyph_extents (font, g.gid, &ge))
-	      util_emit_extents_overlay_into_draw (
-		hb_raster_draw_get_funcs (rdr), rdr,
-		&ge, g.x + off_x, g.y + off_y, extents_stroke_width ());
-	  }
+	  with_glyph_coords (g, [&] () {
+	    hb_raster_draw_glyph (rdr, font, g.gid);
+	    if (show_extents)
+	    {
+	      hb_glyph_extents_t ge;
+	      if (hb_font_get_glyph_extents (font, g.gid, &ge))
+		util_emit_extents_overlay_into_draw (
+		  hb_raster_draw_get_funcs (rdr), rdr,
+		  &ge, g.x + off_x, g.y + off_y, extents_stroke_width ());
+	    }
+	  });
 
 	  hb_raster_image_t *img = hb_raster_draw_render (rdr);
 	  if (!img) { glyph_index++; continue; }
@@ -568,11 +623,15 @@ struct raster_output_t : output_options_t<true>, view_options_t
       float off_x = vertical ? -(step * (float) li) : 0.f;
       float off_y = vertical ?  0.f                 : -(step * (float) li);
 
-      for (const auto &g : lines[li].glyphs)
-      {
-	hb_glyph_extents_t gext;
-	if (!hb_font_get_glyph_extents (font, g.gid, &gext))
-	  continue;
+	      for (const auto &g : lines[li].glyphs)
+	      {
+		hb_glyph_extents_t gext;
+		bool got_extents;
+		with_glyph_coords (g, [&] () {
+		  got_extents = hb_font_get_glyph_extents (font, g.gid, &gext);
+		});
+		if (!got_extents)
+		  continue;
 
 	float gx = (g.x + off_x) * sx;
 	float gy = (g.y + off_y) * sy;


### PR DESCRIPTION
You don't want to merge this. This is an example of adding [per-glyph variation position deltas](https://typedrawers.com/discussion/comment/72014/#Comment_72014) in the buffer. It's not designed to be efficient or optimised. 

Some commits are actually quite useful generally so I'll cherry-pick them for separate PRs.