### PR TITLE
[kern] Avoid rescanning skipped glyphs

### DIFF
--- a/src/hb-kern.hh
+++ b/src/hb-kern.hh
@@ -72,9 +72,9 @@ struct hb_kern_machine_t
 
       skippy_iter.reset_fast (idx);
       unsigned unsafe_to;
-      if (!skippy_iter.next (&unsafe_to))
+      if (unlikely (!skippy_iter.next (&unsafe_to)))
       {
-	idx++;
+	idx = unsafe_to;
 	continue;
       }
 


### PR DESCRIPTION
## Summary

- resume legacy `kern` processing at the skipping iterator's reported boundary
- avoid repeatedly scanning a suffix of ignored GDEF marks
- preserve later kern-enabled feature ranges and the final kern trace message

## Correctness

On a failed `next()`, `unsafe_to` is either one past a non-ignored glyph that
lacks the kern mask, or the buffer end. All intervening glyphs were ignored by
the iterator and cannot produce a kern pair before that same boundary. Moving
the outer index to `unsafe_to` therefore removes only unproductive iterations
and makes the skipping scans non-overlapping.

## Testing

- `meson compile -C build`
- `meson test -C build --suite shape --print-errorlogs` (3/3 suites; 8,936 subtests)
- `meson test -C build --print-errorlogs` (263/263 tests)
- crafted legacy `kern` + all-mark GDEF benchmark through 128k glyphs
  (1.52x–1.81x time per input doubling)
- exhaustive old/new kern-pair model comparison over 87,381 short sequences
