### PR TITLE
[subset] Keep glyf table alive during serialization

### DIFF
--- a/src/OT/glyf/glyf.hh
+++ b/src/OT/glyf/glyf.hh
@@ -99,8 +99,11 @@ struct glyf
       return_trace (false);
 
     hb_vector_t<glyf_impl::SubsetGlyph> glyphs;
-    if (!_populate_subset_glyphs (c->plan, font, glyphs))
+    /* SubsetGlyphs borrow bytes from this blob until they are serialized. */
+    hb_blob_t *source_glyf = nullptr;
+    if (!_populate_subset_glyphs (c->plan, font, glyphs, &source_glyf))
     {
+      hb_blob_destroy (source_glyf);
       hb_font_destroy (font);
       return_trace (false);
     }
@@ -131,6 +134,7 @@ struct glyf
     bool result = glyf_prime->serialize (c->serializer, hb_iter (glyphs), use_short_loca, c->plan);
     if (c->plan->normalized_coords && !c->plan->pinned_at_default)
       _free_compiled_subset_glyphs (glyphs);
+    hb_blob_destroy (source_glyf);
 
     if (unlikely (!c->serializer->check_success (glyf_impl::_add_loca_and_head (c,
 						 padded_offsets.iter (),
@@ -143,7 +147,8 @@ struct glyf
   bool
   _populate_subset_glyphs (const hb_subset_plan_t   *plan,
 			   hb_font_t                *font,
-			   hb_vector_t<glyf_impl::SubsetGlyph>& glyphs /* OUT */) const;
+			   hb_vector_t<glyf_impl::SubsetGlyph>& glyphs /* OUT */,
+			   hb_blob_t               **source_glyf /* OUT */) const;
 
   hb_font_t *
   _create_font_for_instancing (const hb_subset_plan_t *plan) const;
@@ -560,6 +565,8 @@ struct glyf_accelerator_t
   }
 
   unsigned int get_num_glyphs () const { return num_glyphs; }
+  hb_blob_t *reference_glyf_table () const
+  { return hb_blob_reference (glyf_table.get_blob ()); }
 
 #ifndef HB_NO_VAR
   const gvar_accelerator_t *gvar;
@@ -584,10 +591,12 @@ struct glyf_accelerator_t
 inline bool
 glyf::_populate_subset_glyphs (const hb_subset_plan_t   *plan,
 			       hb_font_t *font,
-			       hb_vector_t<glyf_impl::SubsetGlyph>& glyphs /* OUT */) const
+			       hb_vector_t<glyf_impl::SubsetGlyph>& glyphs /* OUT */,
+			       hb_blob_t **source_glyf /* OUT */) const
 {
   OT::glyf_accelerator_t glyf (plan->source);
   if (!glyphs.alloc_exact (plan->new_to_old_gid_list.length)) return false;
+  *source_glyf = glyf.reference_glyf_table ();
 
   for (const auto &pair : plan->new_to_old_gid_list)
   {

--- a/test/api/test-subset.c
+++ b/test/api/test-subset.c
@@ -193,9 +193,12 @@ test_subset_plan (void)
 }
 
 static hb_blob_t*
-_ref_table (hb_face_t *face HB_UNUSED, hb_tag_t tag, void *user_data)
+_copy_table (hb_face_t *face HB_UNUSED, hb_tag_t tag, void *user_data)
 {
-  return hb_face_reference_table ((hb_face_t*) user_data, tag);
+  hb_blob_t *table = hb_face_reference_table ((hb_face_t*) user_data, tag);
+  hb_blob_t *copy = hb_blob_copy_writable_or_fail (table);
+  hb_blob_destroy (table);
+  return copy;
 }
 
 static void
@@ -204,7 +207,7 @@ test_subset_create_for_tables_face (void)
   hb_face_t *face_abc = hb_test_open_font_file ("fonts/Roboto-Regular.abc.ttf");
   hb_face_t *face_ac = hb_test_open_font_file ("fonts/Roboto-Regular.ac.ttf");
   hb_face_t *face_create_for_tables = hb_face_create_for_tables (
-      _ref_table,
+      _copy_table,
       face_abc,
       NULL);
 


### PR DESCRIPTION
## Summary

- retain the exact source `glyf` blob until subset glyph serialization finishes
- make the existing `hb_face_create_for_tables()` subset test return fresh table copies

`SubsetGlyph` stores borrowed byte slices into the table owned by the
function-local `glyf_accelerator_t`. When a face table callback returns a fresh
blob for each request, destroying that accelerator frees the table before the
glyphs are serialized, causing a heap use-after-free.

The regression test reproduced the UAF under ASAN before the lifetime fix.

Fixes: https://issues.chromium.org/issues/536584255

Reported by WinD39 - Huynh Dinh Vu.

## Testing

- `meson test -C build` (263/263 passed)
- `meson test -C build --suite subset` (120/120 passed)
- `meson test -C build-asan test-subset` (13/13 subtests passed)
