### PR TITLE
[subset] Handle invalid avar2 delta-set indices

### DIFF
--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -3369,6 +3369,18 @@ struct ItemVariationStore
   }
 
   public:
+  bool has_delta_set (unsigned int index) const
+  {
+#ifdef HB_NO_VAR
+    return false;
+#endif
+
+    unsigned int outer = index >> 16;
+    unsigned int inner = index & 0xFFFF;
+    return outer < dataSets.len &&
+	   inner < (this+dataSets[outer]).get_item_count ();
+  }
+
   float get_delta (unsigned int index,
 		   const int *coords, unsigned int coord_count,
 		   hb_scalar_cache_t *cache = nullptr) const

--- a/src/hb-ot-var-avar-table.hh
+++ b/src/hb-ot-var-avar-table.hh
@@ -832,7 +832,13 @@ struct avar
     hb_vector_t<uint32_t> new_varidx_mapping;
     if (!new_varidx_mapping.resize (axisCount)) return false;
     for (unsigned i = 0; i < axisCount; i++)
-      new_varidx_mapping[i] = varidx_map.map (i);
+    {
+      uint32_t varidx = varidx_map.map (i);
+      if (varidx != HB_OT_LAYOUT_NO_VARIATIONS_INDEX &&
+	  !var_store.has_delta_set (varidx))
+	varidx = HB_OT_LAYOUT_NO_VARIATIONS_INDEX;
+      new_varidx_mapping[i] = varidx;
+    }
 
     /* 5.5. Privatize shared varIdx delta rows before adding offset
      * compensation. avar2's VarIdxMap may map several fvar axes to the SAME

--- a/src/hb-subset-plan-var.cc
+++ b/src/hb-subset-plan-var.cc
@@ -138,42 +138,38 @@
 
      double dmin = 0.0, dmax = 0.0;
      uint32_t varidx = varidx_map->map (i);
+     /* Runtime treats out-of-range delta-set indices as zero. */
+     if (varidx != HB_OT_LAYOUT_NO_VARIATIONS_INDEX &&
+	 !var_store->has_delta_set (varidx))
+       varidx = HB_OT_LAYOUT_NO_VARIATIONS_INDEX;
      if (varidx != HB_OT_LAYOUT_NO_VARIATIONS_INDEX)
      {
        unsigned outer = varidx >> 16;
        unsigned inner = varidx & 0xFFFF;
-       if (outer >= var_store->get_sub_table_count ()) return false;
-       else
+       const OT::VarData &vd = var_store->get_sub_table (outer);
+       const OT::HBUINT8 *delta_bytes = vd.get_delta_bytes ();
+       unsigned row_size = vd.get_row_size ();
+       unsigned region_count = vd.get_region_index_count ();
+       for (unsigned r = 0; r < region_count; r++)
        {
-	 const OT::VarData &vd = var_store->get_sub_table (outer);
-	 if (inner >= vd.get_item_count ()) return false;
-	 else
+	 int delta = vd.get_item_delta_fast (inner, r, delta_bytes, row_size);
+	 if (!delta) continue;
+	 unsigned region_idx = vd.get_region_index (r);
+	 if (region_idx >= regions.length) return false;
+	 double smin = 1.0, smax = 1.0;
+	 for (const auto &_ : regions[region_idx])
 	 {
-	   const OT::HBUINT8 *delta_bytes = vd.get_delta_bytes ();
-	   unsigned row_size = vd.get_row_size ();
-	   unsigned region_count = vd.get_region_index_count ();
-	   for (unsigned r = 0; r < region_count; r++)
-	   {
-	     int delta = vd.get_item_delta_fast (inner, r, delta_bytes, row_size);
-	     if (!delta) continue;
-	     unsigned region_idx = vd.get_region_index (r);
-	     if (region_idx >= regions.length) return false;
-	     double smin = 1.0, smax = 1.0;
-	     for (const auto &_ : regions[region_idx])
-	     {
-	       hb_pair_t<double, double> *input;
-	       double blo = -1.0, bhi = +1.0;
-	       if (box.has (_.first, &input)) { blo = input->first; bhi = input->second; }
-	       double tmin, tmax;
-	       _tent_value_range (_.second, blo, bhi, &tmin, &tmax);
-	       smin *= tmin;
-	       smax *= tmax;
-	       if (smax == 0.0) break;
-	     }
-	     if (delta > 0) { dmin += smin * delta; dmax += smax * delta; }
-	     else           { dmin += smax * delta; dmax += smin * delta; }
-	   }
+	   hb_pair_t<double, double> *input;
+	   double blo = -1.0, bhi = +1.0;
+	   if (box.has (_.first, &input)) { blo = input->first; bhi = input->second; }
+	   double tmin, tmax;
+	   _tent_value_range (_.second, blo, bhi, &tmin, &tmax);
+	   smin *= tmin;
+	   smax *= tmax;
+	   if (smax == 0.0) break;
 	 }
+	 if (delta > 0) { dmin += smin * delta; dmax += smax * delta; }
+	 else           { dmin += smax * delta; dmax += smin * delta; }
        }
      }
      /* A pinned axis whose delta is constant over the box is self-contained:

--- a/test/api/test-subset-avar2.c
+++ b/test/api/test-subset-avar2.c
@@ -139,6 +139,64 @@ open_original (void)
   return face;
 }
 
+static unsigned
+read_uint16_be (const unsigned char *p)
+{
+  return ((unsigned) p[0] << 8) | p[1];
+}
+
+static unsigned
+read_uint32_be (const unsigned char *p)
+{
+  return ((unsigned) p[0] << 24) | ((unsigned) p[1] << 16) |
+	 ((unsigned) p[2] << 8) | p[3];
+}
+
+/* Replace the test font's avar2 VarIdxMap with the implicit map and empty
+ * its non-NULL VarStore. The resulting implicit delta-set indices are out
+ * of range and must contribute zero, matching runtime evaluation. */
+static hb_blob_t *
+reference_table_with_empty_avar2_store (hb_face_t *face HB_UNUSED,
+					hb_tag_t tag,
+					void *user_data)
+{
+  hb_blob_t *table = hb_face_reference_table ((hb_face_t *) user_data, tag);
+  if (tag != HB_TAG ('a','v','a','r'))
+    return table;
+
+  hb_blob_t *copy = hb_blob_copy_writable_or_fail (table);
+  hb_blob_destroy (table);
+  g_assert_nonnull (copy);
+
+  unsigned length;
+  unsigned char *data = (unsigned char *) hb_blob_get_data_writable (copy, &length);
+  g_assert_nonnull (data);
+  g_assert_cmpuint (length, >=, 8);
+  g_assert_cmpuint (read_uint16_be (data), ==, 2); /* major version */
+
+  unsigned offset = 8;
+  unsigned axis_count = read_uint16_be (data + 6);
+  for (unsigned i = 0; i < axis_count; i++)
+  {
+    g_assert_cmpuint (offset + 2, <=, length);
+    unsigned map_count = read_uint16_be (data + offset);
+    g_assert_cmpuint (map_count, <=, (length - offset - 2) / 4);
+    offset += 2 + map_count * 4;
+  }
+
+  g_assert_cmpuint (offset + 8, <=, length);
+  unsigned var_store_offset = read_uint32_be (data + offset + 4);
+  g_assert_cmpuint (var_store_offset, <=, length - 8);
+  g_assert_cmpuint (read_uint16_be (data + var_store_offset), ==, 1);
+  g_assert_cmpuint (read_uint16_be (data + var_store_offset + 6), >, 0);
+
+  data[offset + 0] = data[offset + 1] = 0;
+  data[offset + 2] = data[offset + 3] = 0; /* NULL VarIdxMap: implicit map */
+  data[var_store_offset + 6] = 0;
+  data[var_store_offset + 7] = 0; /* VarDataCount = 0 */
+  return copy;
+}
+
 static hb_face_t *
 instance_n (hb_face_t *face, hb_subset_input_t *input, unsigned expected_axes)
 {
@@ -528,6 +586,27 @@ test_avar2_culling (void)
   hb_face_destroy (face);
 }
 
+static void
+test_avar2_empty_varstore (void)
+{
+  hb_face_t *source = open_original ();
+  hb_face_t *face = hb_face_create_for_tables (reference_table_with_empty_avar2_store,
+					       source, NULL);
+  hb_subset_input_t *input = create_input ();
+  g_assert_true (hb_subset_input_set_axis_range (input, face, WGHT, 300.f, 500.f, 400.f));
+  hb_face_t *inst = instance (face, input);
+
+  for (unsigned i = 0; i < 9; i++)
+  {
+    hb_variation_t vars[1] = {{WGHT, lerp (300.f, 500.f, i, 9)}};
+    check_same_coords (face, inst, vars, 1, 2);
+  }
+
+  hb_face_destroy (inst);
+  hb_face_destroy (face);
+  hb_face_destroy (source);
+}
+
 /* Move opsz's default from near the axis minimum (14) far up the axis:
  * the retained negative-side avar v1 segment becomes very steep in the
  * new space and offset compensation is quantization-limited. The
@@ -569,6 +648,7 @@ main (int argc, char **argv)
   hb_test_add (test_avar2_self_contained_plus_range);
   hb_test_add (test_avar2_restrict_both_shared);
   hb_test_add (test_avar2_culling);
+  hb_test_add (test_avar2_empty_varstore);
   hb_test_add (test_avar2_restrict_steep);
   hb_test_add (test_avar2_restrict_steep_no_varidx);
 


### PR DESCRIPTION
## Summary

- treat out-of-range avar2 delta-set indices as zero during subset planning and rewriting, matching runtime evaluation
- normalize invalid output mappings to `NO_VARIATION_INDEX`
- add an end-to-end regression for an empty non-NULL VarStore with an implicit index map

This ports the applicable invalid-index behavior identified in https://github.com/fonttools/fonttools/pull/4150. HarfBuzz already handles the other culling-bound cases there through conservative interval bounds, F2Dot14 padding, and symmetric endpoint clamping.

## Testing

- `meson test -C build` (263/263 passed)
- `meson test -C build --suite subset` (120/120 passed)
- `HB_TINY` amalgamation compile
