### PR TITLE
[directwrite] Avoid C++ allocation runtime

### DIFF
--- a/src/hb-directwrite-font.cc
+++ b/src/hb-directwrite-font.cc
@@ -244,8 +244,6 @@ public:
 	       void *draw_data)
     : font (font), drawing ({draw_funcs, draw_data}) {}
 
-  virtual ~GeometrySink() {}
-
   HRESULT STDMETHODCALLTYPE Close() override { return S_OK; }
   void STDMETHODCALLTYPE SetFillMode(D2D1_FILL_MODE) override {}
   void STDMETHODCALLTYPE SetSegmentFlags(D2D1_PATH_SEGMENT) override {}

--- a/src/hb-directwrite-shape.cc
+++ b/src/hb-directwrite-shape.cc
@@ -130,7 +130,6 @@ public:
     assert (refCount >= 0);
     if (refCount)
       return refCount;
-    delete this;
     return 0;
   }
 
@@ -164,14 +163,14 @@ public:
   {
     mRefCount.init ();
   }
-  virtual ~TextAnalysis ()
+  ~TextAnalysis ()
   {
-    // delete runs, except mRunHead which is part of the TextAnalysis object
+    // free runs, except mRunHead which is part of the TextAnalysis object
     for (Run *run = mRunHead.nextRun; run;)
     {
       Run *origRun = run;
       run = run->nextRun;
-      delete origRun;
+      hb_free (origRun);
     }
   }
 
@@ -266,10 +265,13 @@ public:
 		     DWRITE_SCRIPT_ANALYSIS const* scriptAnalysis)
   {
     SetCurrentRun (textPosition);
-    SplitCurrentRun (textPosition);
+    if (unlikely (!SplitCurrentRun (textPosition)))
+      return E_OUTOFMEMORY;
     while (textLength > 0)
     {
       Run *run = FetchNextRun (&textLength);
+      if (unlikely (!run))
+        return E_OUTOFMEMORY;
       run->mScript = *scriptAnalysis;
     }
 
@@ -302,7 +304,10 @@ protected:
     // Split the tail if needed (the length remaining is less than the
     // current run's size).
     if (*textLength < mCurrentRun->mTextLength)
-      SplitCurrentRun (mCurrentRun->mTextStart + *textLength);
+    {
+      if (unlikely (!SplitCurrentRun (mCurrentRun->mTextStart + *textLength)))
+        return nullptr;
+    }
     else
       // Just advance the current run.
       mCurrentRun = mCurrentRun->nextRun;
@@ -331,22 +336,24 @@ protected:
     assert (0); // We should always be able to find the text position in one of our runs
   }
 
-  void SplitCurrentRun (uint32_t splitPosition)
+  bool SplitCurrentRun (uint32_t splitPosition)
   {
     if (!mCurrentRun)
     {
       assert (0); // SplitCurrentRun called without current run
       // Shouldn't be calling this when no current run is set!
-      return;
+      return false;
     }
     // Split the current run.
     if (splitPosition <= mCurrentRun->mTextStart)
     {
       // No need to split, already the start of a run
       // or before it. Usually the first.
-      return;
+      return true;
     }
-    Run *newRun = new Run;
+    Run *newRun = (Run *) hb_malloc (sizeof (Run));
+    if (unlikely (!newRun))
+      return false;
 
     *newRun = *mCurrentRun;
 
@@ -360,6 +367,7 @@ protected:
     newRun->mTextLength -= splitPoint;
     mCurrentRun->mTextLength = splitPoint;
     mCurrentRun = newRun;
+    return true;
   }
 
 protected:
@@ -503,15 +511,19 @@ _hb_directwrite_shape (hb_shape_plan_t    *shape_plan,
     }
   }
 
-  uint16_t* clusterMap;
-  clusterMap = new uint16_t[textLength];
-  DWRITE_SHAPING_TEXT_PROPERTIES* textProperties;
-  textProperties = new DWRITE_SHAPING_TEXT_PROPERTIES[textLength];
+  hb_vector_t<uint16_t> clusterMap;
+  hb_vector_t<DWRITE_SHAPING_TEXT_PROPERTIES> textProperties;
+  if (unlikely (!clusterMap.resize_exact (textLength) ||
+                !textProperties.resize_exact (textLength)))
+    FAIL ("Failed to allocate shaping text data.");
+
+  hb_vector_t<uint16_t> glyphIndices;
+  hb_vector_t<DWRITE_SHAPING_GLYPH_PROPERTIES> glyphProperties;
 
 retry_getglyphs:
-  uint16_t* glyphIndices = new uint16_t[maxGlyphCount];
-  DWRITE_SHAPING_GLYPH_PROPERTIES* glyphProperties;
-  glyphProperties = new DWRITE_SHAPING_GLYPH_PROPERTIES[maxGlyphCount];
+  if (unlikely (!glyphIndices.resize_exact (maxGlyphCount) ||
+                !glyphProperties.resize_exact (maxGlyphCount)))
+    FAIL ("Failed to allocate shaping glyph data.");
 
   hr = analyzer->GetGlyphs (textString,
 			    chars_len,
@@ -525,17 +537,14 @@ retry_getglyphs:
 			    range_char_counts.arrayZ,
 			    range_features.length,
 			    maxGlyphCount,
-			    clusterMap,
-			    textProperties,
-			    glyphIndices,
-			    glyphProperties,
+			    clusterMap.arrayZ,
+			    textProperties.arrayZ,
+			    glyphIndices.arrayZ,
+			    glyphProperties.arrayZ,
 			    &glyphCount);
 
   if (unlikely (hr == HRESULT_FROM_WIN32 (ERROR_INSUFFICIENT_BUFFER)))
   {
-    delete [] glyphIndices;
-    delete [] glyphProperties;
-
     maxGlyphCount *= 2;
 
     goto retry_getglyphs;
@@ -543,8 +552,11 @@ retry_getglyphs:
   if (FAILED (hr))
     FAIL ("Analyzer failed to get glyphs.");
 
-  float* glyphAdvances = new float[maxGlyphCount];
-  DWRITE_GLYPH_OFFSET* glyphOffsets = new DWRITE_GLYPH_OFFSET[maxGlyphCount];
+  hb_vector_t<float> glyphAdvances;
+  hb_vector_t<DWRITE_GLYPH_OFFSET> glyphOffsets;
+  if (unlikely (!glyphAdvances.resize_exact (maxGlyphCount) ||
+                !glyphOffsets.resize_exact (maxGlyphCount)))
+    FAIL ("Failed to allocate glyph positioning data.");
 
   /* The -2 in the following is to compensate for possible
    * alignment needed after the WORD array.  sizeof (WORD) == 2. */
@@ -564,11 +576,11 @@ retry_getglyphs:
   float y_mult = font->y_multf;
 
   hr = analyzer->GetGlyphPlacements (textString,
-				     clusterMap,
-				     textProperties,
+				     clusterMap.arrayZ,
+				     textProperties.arrayZ,
 				     chars_len,
-				     glyphIndices,
-				     glyphProperties,
+				     glyphIndices.arrayZ,
+				     glyphProperties.arrayZ,
 				     glyphCount,
 				     fontFace,
 				     fontEmSize,
@@ -579,8 +591,8 @@ retry_getglyphs:
 				     (const DWRITE_TYPOGRAPHIC_FEATURES**) range_features.arrayZ,
 				     range_char_counts.arrayZ,
 				     range_features.length,
-				     glyphAdvances,
-				     glyphOffsets);
+				     glyphAdvances.arrayZ,
+				     glyphOffsets.arrayZ);
 
   if (FAILED (hr))
     FAIL ("Analyzer failed to get glyph placements.");
@@ -640,13 +652,6 @@ retry_getglyphs:
 
   buffer->clear_glyph_flags ();
   buffer->unsafe_to_break ();
-
-  delete [] clusterMap;
-  delete [] glyphIndices;
-  delete [] textProperties;
-  delete [] glyphProperties;
-  delete [] glyphAdvances;
-  delete [] glyphOffsets;
 
   /* Wow, done! */
   return true;

--- a/src/hb-directwrite.cc
+++ b/src/hb-directwrite.cc
@@ -47,13 +47,13 @@ static struct hb_directwrite_global_lazy_loader_t : hb_lazy_loader_t<hb_directwr
 {
   static hb_directwrite_global_t * create ()
   {
-    hb_directwrite_global_t *global = new hb_directwrite_global_t;
+    hb_directwrite_global_t *global = hb_directwrite_object_create<hb_directwrite_global_t> ();
 
     if (unlikely (!global))
       return nullptr;
     if (unlikely (!global->success))
     {
-      delete global;
+      hb_directwrite_object_destroy (global);
       return nullptr;
     }
 
@@ -63,7 +63,7 @@ static struct hb_directwrite_global_lazy_loader_t : hb_lazy_loader_t<hb_directwr
   }
   static void destroy (hb_directwrite_global_t *l)
   {
-    delete l;
+    hb_directwrite_object_destroy (l);
   }
   static hb_directwrite_global_t * get_null ()
   {
@@ -116,7 +116,9 @@ dw_face_create (hb_blob_t *blob, unsigned index)
   if (unlikely (!global))
     FAIL ("Couldn't load DirectWrite!");
 
-  DWriteFontFileStream *fontFileStream = new DWriteFontFileStream (blob);
+  DWriteFontFileStream *fontFileStream = hb_directwrite_object_create<DWriteFontFileStream> (blob);
+  if (unlikely (!fontFileStream))
+    FAIL ("Failed to allocate font file stream!");
 
   IDWriteFontFile *fontFile;
   auto hr = global->dwriteFactory->CreateCustomFontFileReference (&fontFileStream->fontFileKey, sizeof (fontFileStream->fontFileKey),
@@ -168,12 +170,11 @@ _hb_directwrite_get_file_blob (IDWriteFontFace *dw_face)
   if (FAILED (dw_face->GetFiles(&file_count, NULL)))
     return nullptr;
 
-  IDWriteFontFile **files = new IDWriteFontFile*[file_count];
-  if (FAILED (dw_face->GetFiles(&file_count, files)))
-  {
-    delete [] files;
+  hb_vector_t<IDWriteFontFile *> files;
+  if (unlikely (!files.resize_exact (file_count)))
     return nullptr;
-  }
+  if (FAILED (dw_face->GetFiles(&file_count, files.arrayZ)))
+    return nullptr;
 
   hb_blob_t *blob = nullptr;
   for (UINT32 i = 0; i < file_count; i++)
@@ -209,7 +210,6 @@ _hb_directwrite_get_file_blob (IDWriteFontFace *dw_face)
     break;
   }
 
-  delete [] files;
   return blob;
 }
 

--- a/src/hb-directwrite.hh
+++ b/src/hb-directwrite.hh
@@ -69,7 +69,7 @@ hb_directwrite_object_destroy (Type *obj)
   hb_free (obj);
 }
 
-class DWriteFontFileLoader : public IDWriteFontFileLoader
+class DWriteFontFileLoader final : public IDWriteFontFileLoader
 {
 private:
   hb_reference_count_t mRefCount;
@@ -141,7 +141,7 @@ public:
   }
 };
 
-class DWriteFontFileStream : public IDWriteFontFileStream
+class DWriteFontFileStream final : public IDWriteFontFileStream
 {
 private:
   hb_reference_count_t mRefCount;

--- a/src/hb-directwrite.hh
+++ b/src/hb-directwrite.hh
@@ -47,6 +47,28 @@ typedef HRESULT (WINAPI *t_DWriteCreateFactory)(
   IUnknown            **factory
 );
 
+template <typename Type, typename ...Ts>
+static Type *
+hb_directwrite_object_create (Ts&&... args)
+{
+  Type *obj = (Type *) hb_calloc (1, sizeof (Type));
+  if (unlikely (!obj))
+    return nullptr;
+
+  return new (obj) Type (std::forward<Ts> (args)...);
+}
+
+template <typename Type>
+static void
+hb_directwrite_object_destroy (Type *obj)
+{
+  if (!obj)
+    return;
+
+  obj->~Type ();
+  hb_free (obj);
+}
+
 class DWriteFontFileLoader : public IDWriteFontFileLoader
 {
 private:
@@ -91,7 +113,7 @@ public:
     assert (refCount >= 0);
     if (refCount)
       return refCount;
-    delete this;
+    hb_directwrite_object_destroy (this);
     return 0;
   }
 
@@ -112,7 +134,7 @@ public:
     return S_OK;
   }
 
-  virtual ~DWriteFontFileLoader()
+  ~DWriteFontFileLoader()
   {
     for (auto v : mFontStreams.values ())
       v->Release ();
@@ -145,7 +167,7 @@ public:
     assert (refCount >= 0);
     if (refCount)
       return refCount;
-    delete this;
+    hb_directwrite_object_destroy (this);
     return 0;
   }
 
@@ -181,7 +203,7 @@ public:
   virtual HRESULT STDMETHODCALLTYPE
   GetLastWriteTime (OUT UINT64* lastWriteTime) { return E_NOTIMPL; }
 
-  virtual ~DWriteFontFileStream();
+  ~DWriteFontFileStream();
 };
 
 struct hb_directwrite_global_t
@@ -194,8 +216,11 @@ struct hb_directwrite_global_t
     if (unlikely (hr != S_OK))
       return;
 
-    fontFileLoader = new DWriteFontFileLoader ();
-    dwriteFactory->RegisterFontFileLoader (fontFileLoader);
+    fontFileLoader = hb_directwrite_object_create<DWriteFontFileLoader> ();
+    if (unlikely (!fontFileLoader))
+      return;
+    if (unlikely (FAILED (dwriteFactory->RegisterFontFileLoader (fontFileLoader))))
+      return;
 
     success = true;
   }
@@ -208,8 +233,8 @@ struct hb_directwrite_global_t
   }
 
   bool success = false;
-  IDWriteFactory *dwriteFactory;
-  DWriteFontFileLoader *fontFileLoader;
+  IDWriteFactory *dwriteFactory = nullptr;
+  DWriteFontFileLoader *fontFileLoader = nullptr;
 };
 
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -544,8 +544,6 @@ if conf.get('HAVE_DIRECTWRITE', 0) == 1
   hb_sources += hb_directwrite_sources
   hb_headers += hb_directwrite_headers
   harfbuzz_deps += directwrite_dep
-  # hb-directwrite needs a C++ linker
-  libharfbuzz_link_language = 'cpp'
 endif
 
 if conf.get('HAVE_CORETEXT', 0) == 1


### PR DESCRIPTION
## Summary

- replace DirectWrite scalar `new`/`delete` with HarfBuzz allocation helpers
- use `hb_vector_t` for DirectWrite shaping and font-file arrays, with OOM propagation
- stop forcing the C++ linker for DirectWrite Meson builds

## Testing

- linked a MinGW DirectWrite amalgamation from a C consumer without `libstdc++`
- built MinGW DirectWrite shared libraries with Meson and CMake using the C linker
- verified DirectWrite objects have no `operator new`/`delete` references
- ran `meson test -C build --print-errorlogs` (263 passed)

Fixes #6160