### PR TITLE
[gpu] handle NaN in clamp_i16 before int16 cast

### DIFF
--- a/src/hb-gpu-paint.cc
+++ b/src/hb-gpu-paint.cc
@@ -291,6 +291,7 @@ clamp_i16 (float v)
 {
   if (v <= -32768.f) return -32768;
   if (v >=  32767.f) return  32767;
+  if (unlikely (std::isnan (v))) return 0;
   return (int16_t) v;
 }
 

--- a/test/api/test-gpu.cc
+++ b/test/api/test-gpu.cc
@@ -667,6 +667,75 @@ test_paint_clip_path_depth_overflow (void)
   hb_gpu_paint_destroy (p);
 }
 
+static unsigned
+repro_color_stops (hb_color_line_t *cl HB_UNUSED, void *cl_data HB_UNUSED,
+		   unsigned start, unsigned *count,
+		   hb_color_stop_t *stops, void *user_data HB_UNUSED)
+{
+  static const hb_color_stop_t all[2] = {
+    { 0.f, 0, HB_COLOR (255, 0, 0, 255) },
+    { 1.f, 0, HB_COLOR (0, 0, 255, 255) },
+  };
+  if (count)
+  {
+    unsigned n = 0;
+    for (unsigned i = start; i < 2 && n < *count; i++)
+      stops[n++] = all[i];
+    *count = n;
+  }
+  return 2;
+}
+
+static hb_paint_extend_t
+repro_color_extend (hb_color_line_t *cl HB_UNUSED, void *cl_data HB_UNUSED,
+		    void *user_data HB_UNUSED)
+{
+  return HB_PAINT_EXTEND_PAD;
+}
+
+static void
+test_paint_gradient_overflow_transform (void)
+{
+  /* A COLRv1 paint tree can nest PaintScale/PaintTransform, which the
+   * GPU paint encoder composes multiplicatively into cur_transform.
+   * Deep enough nesting overflows the matrix entries to +inf.  When a
+   * gradient encoder inverts that transform (linv_q10), a 1/inf
+   * determinant gives inv==0 and inf*0==NaN, which clamp_i16 then cast
+   * straight to int16 -- float-cast-overflow UB that aborts the
+   * asan-ubsan CI job (halt_on_error). */
+  hb_gpu_paint_t *p = hb_gpu_paint_create_or_fail ();
+  g_assert_nonnull (p);
+  hb_gpu_paint_set_scale (p, 1000, 1000);
+
+  hb_paint_funcs_t *pf = hb_gpu_paint_get_funcs (p);
+
+  /* A clip must be on the stack before a gradient is emitted. */
+  void *draw_data = nullptr;
+  hb_draw_funcs_t *df = hb_paint_push_clip_path_start (pf, p, &draw_data);
+  g_assert_nonnull (df);
+  hb_draw_state_t st = HB_DRAW_STATE_DEFAULT;
+  hb_draw_move_to (df, draw_data, &st, 0.f, 0.f);
+  hb_draw_line_to (df, draw_data, &st, 100.f, 0.f);
+  hb_draw_line_to (df, draw_data, &st, 100.f, 100.f);
+  hb_draw_close_path (df, draw_data, &st);
+  hb_paint_push_clip_path_end (pf, p);
+
+  /* Compose large scales until the transform overflows to inf. */
+  for (unsigned i = 0; i < 4; i++)
+    hb_paint_push_transform (pf, p, 1e19f, 0.f, 0.f, 1e19f, 0.f, 0.f);
+
+  hb_color_line_t cl = {};
+  cl.get_color_stops = repro_color_stops;
+  cl.get_extend = repro_color_extend;
+
+  hb_paint_linear_gradient (pf, p, &cl, 0.f, 0.f, 1.f, 0.f, 0.f, 1.f);
+
+  hb_blob_t *blob = hb_gpu_paint_encode (p, nullptr);
+  hb_blob_destroy (blob);
+
+  hb_gpu_paint_destroy (p);
+}
+
 
 static void
 test_shapes (void)
@@ -784,6 +853,7 @@ main (int argc, char **argv)
   hb_test_add (test_paint_reset);
   hb_test_add (test_paint_recycle_blob);
   hb_test_add (test_paint_clip_path_depth_overflow);
+  hb_test_add (test_paint_gradient_overflow_transform);
 
   return hb_test_run ();
 }


### PR DESCRIPTION
the gpu paint encoder composes nested colrv1 painttransform/paintscale into cur_transform by repeated float multiply in hb_gpu_paint_push_transform, so deep enough nesting overflows the 2x2 matrix entries to inf. when the gradient encoders invert that transform, linv_q10 sets inv = 1/det = 0 for the inf determinant and t.xx * inv then evaluates inf*0 = nan, which clamp_i16 casts straight to int16. clamp_i16 already saturates +-inf through its ordered compares but nan fails both, so the cast is (int16_t) nan, a float-cast-overflow that aborts the asan-ubsan job under halt_on_error. reachable from a font via hb_gpu_paint on a colrv1 glyph carrying a gradient under an overflowing transform. the guard maps nan to 0 to match the degenerate-determinant branch that already yields a zero inverse, so fixing the one shared helper covers the linear, radial and sweep encoders at once. the added test drives the public paint funcs and aborts without the fix.