### PR TITLE
[docs] Add HarfType documentation section

### DIFF
--- a/docs/harfbuzz-docs.xml
+++ b/docs/harfbuzz-docs.xml
@@ -53,6 +53,11 @@
       <xi:include href="usermanual-integration.xml"/>
   </part>
 
+  <part id="harftype">
+    <title>HarfType</title>
+      <xi:include href="harftype-introduction.xml"/>
+  </part>
+
   <part id="reference-manual">
     <title>Reference manual</title>
       <chapter id="core-api">

--- a/docs/harfbuzz-docs.xml
+++ b/docs/harfbuzz-docs.xml
@@ -56,6 +56,7 @@
   <part id="harftype">
     <title>HarfType</title>
       <xi:include href="harftype-introduction.xml"/>
+      <xi:include href="harftype-tables.xml"/>
   </part>
 
   <part id="reference-manual">

--- a/docs/harftype-introduction.xml
+++ b/docs/harftype-introduction.xml
@@ -45,4 +45,9 @@
     remain valid for use with HarfBuzz and often with other open-source tools,
     including FreeType, FontTools, and Fontations.
   </para>
+
+  <para>
+    HarfType is released with each HarfBuzz release, using the same version
+    number.
+  </para>
 </chapter>

--- a/docs/harftype-introduction.xml
+++ b/docs/harftype-introduction.xml
@@ -15,6 +15,12 @@
   </para>
 
   <para>
+    HarfType prioritizes robust consumption by supported platforms while
+    aiming for interoperability. It does not require acceptance by every font
+    validator or proprietary platform.
+  </para>
+
+  <para>
     HarfType does not duplicate the specifications it extends. Readers should
     consult the Microsoft OpenType, Apple TrueType, and ISO Open Font Format
     specifications for table-level definitions. HarfType documents the common

--- a/docs/harftype-introduction.xml
+++ b/docs/harftype-introduction.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+               "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+<chapter id="harftype-introduction">
+  <title>Introduction</title>
+
+  <para>
+    HarfType documents, at a high level, the font format implemented by
+    HarfBuzz and HarfRust.
+  </para>
+
+  <para>
+    HarfType does not duplicate the specifications it extends. Readers should
+    consult the Microsoft OpenType, Apple TrueType, and ISO Open Font Format
+    specifications for table-level definitions. HarfType documents the common
+    model implemented by HarfBuzz and HarfRust, together with the places where
+    that model extends, relaxes, or resolves ambiguity in those specifications.
+  </para>
+
+  <para>
+    HarfType is a superset of Microsoft OpenType, Apple TrueType, and the ISO
+    Open Font Format, with small extensions and relaxed constraints. Currently,
+    HarfType adds no top-level tables to the SFNT-based font format.
+  </para>
+
+  <para>
+    HarfType remains transparent to, and supported by, transport-layer
+    transformations such as WOFF and WOFF2.
+  </para>
+
+  <para>
+    Font-validation tools might flag extensions used by HarfType as invalid,
+    although OTS is generally kept aware of HarfType extensions. Such fonts
+    remain valid for use with HarfBuzz and often with other open-source tools,
+    including FreeType, FontTools, and Fontations.
+  </para>
+</chapter>

--- a/docs/harftype-introduction.xml
+++ b/docs/harftype-introduction.xml
@@ -10,6 +10,11 @@
   </para>
 
   <para>
+    HarfBuzz behavior is normative for HarfType. HarfRust aims to match that
+    behavior.
+  </para>
+
+  <para>
     HarfType does not duplicate the specifications it extends. Readers should
     consult the Microsoft OpenType, Apple TrueType, and ISO Open Font Format
     specifications for table-level definitions. HarfType documents the common

--- a/docs/harftype-tables.xml
+++ b/docs/harftype-tables.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+               "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+<chapter id="harftype-tables">
+  <title>Tables</title>
+
+  <section id="harftype-required-tables">
+    <title>Required tables</title>
+
+    <para>
+      A HarfType font has only two required tables: <literal>head</literal> and
+      <literal>maxp</literal>.
+    </para>
+
+    <para>
+      A font file made for testing <literal>GSUB</literal>, for example, might
+      not contain any glyph-drawing tables.
+    </para>
+  </section>
+</chapter>

--- a/docs/harftype-todo.md
+++ b/docs/harftype-todo.md
@@ -1,0 +1,56 @@
+# HarfType review notes
+
+This is a maintainer working document for material that still needs review.
+It is tracked alongside the HarfType sources but is not linked into the public
+documentation.
+
+## Baseline corrections
+
+- Treat ISO/IEC 14496-22:2026 as baseline.
+- `VARC`, `avar` version 2, extended condition formats, and standardized
+  24-bit structures are Open Font Format features, not HarfType extensions.
+- Apple also implements `avar` version 2, although its format is not publicly
+  documented by Apple.
+- Keep specification status separate from implementation maturity. Some ISO
+  structures are still guarded by HarfBuzz experimental-build options.
+
+## Proposed table categories
+
+- Required tables
+- Glyph outlines and components
+- Character mapping
+- Metrics
+- Layout
+  - OpenType Layout
+  - Apple Advanced Typography Layout
+- Variations
+- Color glyphs
+- Compatibility and error recovery
+- Experimental extensions
+
+## Possible HarfType consumption semantics
+
+- `GSUB` MultipleSubst sequences with zero substitutes delete the input glyph.
+- Reserved `GPOS` ValueFormat bits do not add ValueRecord fields.
+- Microsoft symbol `cmap` lookup retries U+0000..U+00FF at U+F000..U+F0FF.
+- AAT `trak` uses 12pt when point size is unavailable.
+- AAT `kerx` applies cross-stream kerning in vertical text and implements the
+  reset flag described by Apple's example but not its prose.
+
+## Error recovery, not authoring permission
+
+- `avar` segment maps missing required anchors or containing duplicate input
+  coordinates.
+- `morx` data extending beyond a subtable's claimed length.
+- Unchecked SFNT checksums and search-optimization fields.
+- Invalid `head.unitsPerEm` fallback.
+- The Cambria Math constant workaround.
+
+## Scope decisions
+
+- Decide whether optional delegated formats such as Graphite are outside
+  HarfType.
+- Keep the experimental `Wasm` shaping table outside stable HarfType until it
+  graduates.
+- Distinguish conforming HarfType data, required consumption behavior, and
+  best-effort error recovery.

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -27,6 +27,7 @@ content_files = [
   'usermanual-clusters.xml',
   'usermanual-utilities.xml',
   'usermanual-integration.xml',
+  'harftype-introduction.xml',
   version_xml,
 ]
 

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -28,6 +28,7 @@ content_files = [
   'usermanual-utilities.xml',
   'usermanual-integration.xml',
   'harftype-introduction.xml',
+  'harftype-tables.xml',
   version_xml,
 ]
 


### PR DESCRIPTION
## Summary

- add HarfType as a top-level part of the public manual
- define HarfType as the high-level font format implemented by HarfBuzz and HarfRust
- establish HarfBuzz behavior as normative, with HarfRust aiming to match it
- state the goal of robust consumption and interoperability without requiring universal validator or proprietary-platform acceptance
- describe its relationship to OpenType, TrueType, and Open Font Format
- document SFNT, WOFF/WOFF2, validation, and open-source tooling compatibility
- define each HarfType release as using the same version number as its corresponding HarfBuzz release
- begin the table catalog by requiring only `head` and `maxp`, permitting purpose-built fonts without glyph-drawing tables
- track unlinked maintainer notes for proposed categories, ISO/OFF baseline corrections, compatibility semantics, and open scope decisions

## Motivation

HarfType needs a public home for documenting the common font model implemented by HarfBuzz and HarfRust, including extensions, relaxed constraints, and resolutions of ambiguities in the underlying specifications. Review-stage findings remain in an unlinked Markdown file until their wording and scope are settled.

## Impact

This is documentation-only and does not change the public API, ABI, build defaults, or runtime behavior. The review-notes file is not included in the generated public documentation.

## Validation

- `meson compile -C build docs/harfbuzz-doc:custom`
- `git diff --check`

The documentation build succeeds with existing unrelated cross-reference warnings.
