### PR TITLE
[subset] don't return early on null offset in BASE table

### DIFF
--- a/src/hb-ot-layout-base-table.hh
+++ b/src/hb-ot-layout-base-table.hh
@@ -79,8 +79,12 @@ struct BaseCoordFormat2
     auto *out = c->serializer->embed (*this);
     if (unlikely (!out)) return_trace (false);
 
+    hb_codepoint_t *new_gid;
+    if (!c->plan->glyph_map->has (referenceGlyph, &new_gid))
+      return_trace (false);
+
     return_trace (c->serializer->check_assign (out->referenceGlyph,
-                                               c->plan->glyph_map->get (referenceGlyph),
+                                               *new_gid,
                                                HB_SERIALIZE_ERROR_INT_OVERFLOW));
   }
 
@@ -139,10 +143,12 @@ struct BaseCoordFormat3
           return_trace (false);
       }
     }
-    return_trace (out->deviceTable.serialize_copy (c->serializer, deviceTable,
-                                                   this, 0,
-                                                   hb_serialize_context_t::Head,
-                                                   &c->plan->base_variation_idx_map));
+    
+    out->deviceTable.serialize_copy (c->serializer, deviceTable,
+                                     this, 0,
+                                     hb_serialize_context_t::Head,
+                                     &c->plan->base_variation_idx_map);
+    return_trace (true);
   }
 
   bool sanitize (hb_sanitize_context_t *c) const
@@ -255,10 +261,10 @@ struct FeatMinMaxRecord
     TRACE_SUBSET (this);
     auto *out = c->serializer->embed (*this);
     if (unlikely (!out)) return_trace (false);
-    if (!(out->minCoord.serialize_subset (c, minCoord, base)))
-      return_trace (false);
 
-    return_trace (out->maxCoord.serialize_subset (c, maxCoord, base));
+    bool ret = out->minCoord.serialize_subset (c, minCoord, base);
+    ret |= out->maxCoord.serialize_subset (c, maxCoord, base);
+    return_trace (ret);
   }
 
   bool sanitize (hb_sanitize_context_t *c, const void *base) const
@@ -315,9 +321,8 @@ struct MinMax
     auto *out = c->serializer->start_embed (*this);
     if (unlikely (!out || !c->serializer->extend_min (out))) return_trace (false);
 
-    if (!(out->minCoord.serialize_subset (c, minCoord, this)) ||
-        !(out->maxCoord.serialize_subset (c, maxCoord, this)))
-      return_trace (false);
+    bool ret = out->minCoord.serialize_subset (c, minCoord, this);
+    ret |= out->maxCoord.serialize_subset (c, maxCoord, this);
 
     unsigned len = 0;
     for (const FeatMinMaxRecord& _ : featMinMaxRecords)
@@ -326,9 +331,13 @@ struct MinMax
       if (!c->plan->layout_features.has (feature_tag))
         continue;
 
-      if (!_.subset (c, this)) return false;
-      len++;
+      auto snap = c->serializer->snapshot ();
+      if (!_.subset (c, this)) c->serializer->revert (snap);
+      else len++;
     }
+
+    if (len > 0) ret = true;
+    if (!ret) return_trace (false);
     return_trace (c->serializer->check_assign (out->featMinMaxRecords.len, len,
                                                HB_SERIALIZE_ERROR_INT_OVERFLOW));
   }
@@ -380,11 +389,15 @@ struct BaseValues
     if (unlikely (!out || !c->serializer->extend_min (out))) return_trace (false);
     out->defaultIndex = defaultIndex;
 
+    bool ret = false;
     for (const auto& _ : baseCoords)
-      if (!subset_offset_array (c, out->baseCoords, this) (_))
-        return_trace (false);
+    {
+      auto *o = out->baseCoords.serialize_append (c->serializer);
+      if (unlikely (!o)) return_trace (false);
+       ret |= o->serialize_subset (c, _, this);
+    }
 
-    return_trace (bool (out->baseCoords));
+    return_trace (ret);
   }
 
   bool sanitize (hb_sanitize_context_t *c) const
@@ -478,16 +491,22 @@ struct BaseScript
     auto *out = c->serializer->start_embed (*this);
     if (unlikely (!out || !c->serializer->extend_min (out))) return_trace (false);
 
-    if (baseValues && !out->baseValues.serialize_subset (c, baseValues, this))
-      return_trace (false);
+    bool ret = out->baseValues.serialize_subset (c, baseValues, this);
+    ret |= out->defaultMinMax.serialize_subset (c, defaultMinMax, this);
 
-    if (defaultMinMax && !out->defaultMinMax.serialize_subset (c, defaultMinMax, this))
-      return_trace (false);
-
+    unsigned len = 0;
     for (const auto& _ : baseLangSysRecords)
-      if (!_.subset (c, this)) return_trace (false);
+    {
+      auto snap = c->serializer->snapshot ();
+      if (_.subset (c, this)) {
+        ret = true;
+        len++;
+      }
+      else c->serializer->revert (snap);
+    }
 
-    return_trace (c->serializer->check_assign (out->baseLangSysRecords.len, baseLangSysRecords.len,
+    if (!ret) return_trace (false);
+    return_trace (c->serializer->check_assign (out->baseLangSysRecords.len, len,
                                                HB_SERIALIZE_ERROR_INT_OVERFLOW));
   }
 
@@ -594,9 +613,12 @@ struct BaseScriptList
       if (!c->plan->layout_scripts.has (script_tag))
         continue;
 
-      if (!_.subset (c, this)) return false;
-      len++;
+      auto snap = c->serializer->snapshot ();
+      if (!_.subset (c, this)) c->serializer->revert (snap);
+      else len++;
     }
+
+    if (!len) return_trace (false);
     return_trace (c->serializer->check_assign (out->baseScriptRecords.len, len,
                                                HB_SERIALIZE_ERROR_INT_OVERFLOW));
   }
@@ -672,8 +694,9 @@ struct Axis
     auto *out = c->serializer->embed (*this);
     if (unlikely (!out)) return_trace (false);
 
-    out->baseTagList.serialize_copy (c->serializer, baseTagList, this);
-    return_trace (out->baseScriptList.serialize_subset (c, baseScriptList, this));
+    bool ret = out->baseTagList.serialize_copy (c->serializer, baseTagList, this);
+    ret |= out->baseScriptList.serialize_subset (c, baseScriptList, this);
+    return_trace (ret);
   }
 
   bool sanitize (hb_sanitize_context_t *c) const
@@ -770,13 +793,10 @@ struct BASE
     if (has_var_store () && !subset_varstore (c, out))
         return_trace (false);
 
-    if (hAxis && !out->hAxis.serialize_subset (c, hAxis, this))
-      return_trace (false);
+    bool ret = out->hAxis.serialize_subset (c, hAxis, this);
+    ret |= out->vAxis.serialize_subset (c, vAxis, this);
 
-    if (vAxis && !out->vAxis.serialize_subset (c, vAxis, this))
-      return_trace (false);
-
-    return_trace (true);
+    return_trace (ret);
   }
 
   bool get_baseline (hb_font_t      *font,


### PR DESCRIPTION
I noticed this issue while fixing empty VariationDevice in Skera(https://github.com/googlefonts/fontations/pull/2057). `serialize_subset() `call would return false if the offset is null. Spec says these offsets "may be NULL".  
No testcase for this issue.