### PR TITLE
[iter] Fix rewinding a filter at the beginning

### DIFF
--- a/src/hb-iter.hh
+++ b/src/hb-iter.hh
@@ -460,7 +460,22 @@ struct hb_filter_iter_t :
   __item_t__ __item__ () const { return *it; }
   bool __more__ () const { return bool (it); }
   void __next__ () { do ++it; while (it && !hb_has (p.get (), hb_get (f.get (), *it))); }
-  void __prev__ () { do --it; while (it && !hb_has (p.get (), hb_get (f.get (), *it))); }
+  void __prev__ ()
+  {
+    unsigned count = 0;
+    do
+    {
+      Iter old = it;
+      --it;
+      if (!(it != old))
+      {
+	it += count;
+	return;
+      }
+      count++;
+    }
+    while (!hb_has (p.get (), hb_get (f.get (), *it)));
+  }
   hb_filter_iter_t __end__ () const { return hb_filter_iter_t (it._end (), p, f); }
   bool operator != (const hb_filter_iter_t& o) const
   { return it != o.it; }

--- a/src/test-iter.cc
+++ b/src/test-iter.cc
@@ -185,6 +185,21 @@ static void test_concat ()
   hb_always_assert (it6.len () == 2);
 }
 
+static void
+test_backward_filter ()
+{
+  hb_vector_t<int> V = {2, 4, 5, 7, 8, 9, 10};
+  auto it = hb_iter (V) | hb_filter ([] (int x) { return x % 2 != 0; });
+  it += 2;
+  hb_always_assert (*it == 9);
+  --it;
+  hb_always_assert (*it == 7);
+  --it;
+  hb_always_assert (*it == 5);
+  --it;
+  hb_always_assert (*it == 5);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -377,6 +392,7 @@ main (int argc, char **argv)
   hb_always_assert (hb_range (-2, -7, -3).len () == 2);
 
   test_concat ();
+  test_backward_filter ();
 
   return 0;
 }


### PR DESCRIPTION
## Summary

- stop reverse filter iteration when the underlying iterator cannot move
- restore the last valid matching position when there is no earlier match
- exercise the decrement that previously entered an infinite loop

## Root cause

`hb_filter_iter_t::__prev__()` used the underlying iterator's forward
termination state while scanning backwards. `hb_array_t` clamps at the
beginning and remains valid for forward iteration, so a rejected first array
item caused the filter to repeatedly decrement without making progress.

## Validation

- `meson compile -C build`
- `meson test -C build --suite shape --print-errorlogs`
- `meson test -C build --print-errorlogs` (270/270 passed)
- previously crashing shape-fuzzer chunks 2, 5, and 6

Fixes #6178
