### PR TITLE
[vector/raster] Bound per-session output work

### DIFF
--- a/src/hb-limits.hh
+++ b/src/hb-limits.hh
@@ -176,6 +176,12 @@
 #define HB_GPU_PAINT_MAX_WORK ((int64_t) 1 << 20)
 #endif
 
+/* One vector (SVG/PDF) draw session, in bytes of generated outline
+ * path data. */
+#ifndef HB_VECTOR_MAX_DRAW_WORK
+#define HB_VECTOR_MAX_DRAW_WORK ((int64_t) 16 << 20)
+#endif
+
 /* One vector (SVG/PDF) paint session, in bytes of generated outline
  * path and sweep-gradient patch data. */
 #ifndef HB_VECTOR_MAX_PAINT_WORK
@@ -202,6 +208,11 @@
  * budget above is charged instead. */
 #ifndef HB_RASTER_MAX_DRAW_WORK
 #define HB_RASTER_MAX_DRAW_WORK ((int64_t) 1 << 24)
+#endif
+
+/* One raster draw session, in accumulated non-horizontal edges. */
+#ifndef HB_RASTER_MAX_DRAW_EDGES
+#define HB_RASTER_MAX_DRAW_EDGES ((int64_t) 1 << 20)
 #endif
 
 

--- a/src/hb-raster-draw.cc
+++ b/src/hb-raster-draw.cc
@@ -90,6 +90,7 @@ struct hb_raster_draw_t
   int64_t *external_work = nullptr;
 
   /* Accumulated geometry */
+  int64_t edges_left = HB_RASTER_MAX_DRAW_EDGES;
   hb_vector_t<hb_raster_edge_t> edges;
 
   /* Scratch — reused across render() calls */
@@ -479,6 +480,7 @@ hb_raster_draw_clear (hb_raster_draw_t *draw)
   draw->flatten_clip_active = false;
   draw->flatten_work_left = HB_RASTER_MAX_DRAW_WORK;
   draw->external_work = nullptr;
+  draw->edges_left = HB_RASTER_MAX_DRAW_EDGES;
   draw->edges.clear ();
   draw->active_edges.clear ();
 }
@@ -572,6 +574,9 @@ emit_segment (hb_raster_draw_t *draw,
 	      float x0, float y0,
 	      float x1, float y1)
 {
+  if (unlikely (draw->edges_left <= 0))
+    return;
+
   int32_t X0 = hb_clamp_to<int32_t> (roundf (x0 * HB_RASTER_ONE_PIXEL));
   int32_t Y0 = hb_clamp_to<int32_t> (roundf (y0 * HB_RASTER_ONE_PIXEL));
   int32_t X1 = hb_clamp_to<int32_t> (roundf (x1 * HB_RASTER_ONE_PIXEL));
@@ -588,7 +593,10 @@ emit_segment (hb_raster_draw_t *draw,
   e.slope = (((int64_t) e.xH - (int64_t) e.xL) * (int64_t) 65536) /
 	    ((int64_t) e.yH - (int64_t) e.yL);
 
-  draw->edges.push (e);
+  if (likely (draw->edges.push_or_fail (e)))
+    draw->edges_left--;
+  else
+    draw->edges_left = 0;
 }
 
 
@@ -1028,6 +1036,7 @@ hb_raster_line_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
 		   void *user_data HB_UNUSED)
 {
   hb_raster_draw_t *draw = (hb_raster_draw_t *) draw_data;
+  if (unlikely (draw->edges_left <= 0)) return;
 
   float tx0, ty0, tx1, ty1;
   transform_point (draw, st->current_x, st->current_y, tx0, ty0);
@@ -1044,6 +1053,7 @@ hb_raster_quadratic_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
 			void *user_data HB_UNUSED)
 {
   hb_raster_draw_t *draw = (hb_raster_draw_t *) draw_data;
+  if (unlikely (draw->edges_left <= 0)) return;
 
   float tx0, ty0, tx1, ty1, tx2, ty2;
   transform_point (draw, st->current_x, st->current_y, tx0, ty0);
@@ -1062,6 +1072,7 @@ hb_raster_cubic_to (hb_draw_funcs_t *dfuncs HB_UNUSED,
 		    void *user_data HB_UNUSED)
 {
   hb_raster_draw_t *draw = (hb_raster_draw_t *) draw_data;
+  if (unlikely (draw->edges_left <= 0)) return;
 
   float tx0, ty0, tx1, ty1, tx2, ty2, tx3, ty3;
   transform_point (draw, st->current_x, st->current_y, tx0, ty0);

--- a/src/hb-raster.hh
+++ b/src/hb-raster.hh
@@ -51,8 +51,9 @@ hb_raster_draw_set_clip_box (hb_raster_draw_t *draw,
 
 /* Points curve-flattening work charges at the caller's session budget
  * (one unit per Bézier subdivision) instead of the standalone
- * per-session HB_RASTER_MAX_DRAW_WORK budget.  Cleared by
- * hb_raster_draw_clear() (and hence after every render). */
+ * per-session HB_RASTER_MAX_DRAW_WORK budget.  The rasterizer's local
+ * accumulated-edge limit still applies.  Cleared by hb_raster_draw_clear()
+ * (and hence after every render). */
 HB_INTERNAL void
 hb_raster_draw_set_external_work (hb_raster_draw_t *draw,
 				  int64_t *work_left);

--- a/src/hb-vector-draw.cc
+++ b/src/hb-vector-draw.cc
@@ -49,36 +49,90 @@ hb_vector_svg_buffer_contains (const hb_vector_buf_t &buf, const char *needle)
 /* ---- SVG draw callbacks ---- */
 
 static void hb_vector_draw_svg_move_to (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, float x, float y, void *)
-{ auto *d = (hb_vector_draw_t *) dd; d->path.append_c ('M'); d->append_xy_svg (x, y); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->path.append_c ('M'); d->append_xy_svg (x, y);
+  d->end_path_command (before);
+}
 
 static void hb_vector_draw_svg_line_to (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, float x, float y, void *)
-{ auto *d = (hb_vector_draw_t *) dd; d->path.append_c ('L'); d->append_xy_svg (x, y); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->path.append_c ('L'); d->append_xy_svg (x, y);
+  d->end_path_command (before);
+}
 
 static void hb_vector_draw_svg_quadratic_to (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, float cx, float cy, float x, float y, void *)
-{ auto *d = (hb_vector_draw_t *) dd; d->path.append_c ('Q'); d->append_xy_svg (cx, cy); d->path.append_c (' '); d->append_xy_svg (x, y); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->path.append_c ('Q'); d->append_xy_svg (cx, cy); d->path.append_c (' '); d->append_xy_svg (x, y);
+  d->end_path_command (before);
+}
 
 static void hb_vector_draw_svg_cubic_to (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, float c1x, float c1y, float c2x, float c2y, float x, float y, void *)
-{ auto *d = (hb_vector_draw_t *) dd; d->path.append_c ('C'); d->append_xy_svg (c1x, c1y); d->path.append_c (' '); d->append_xy_svg (c2x, c2y); d->path.append_c (' '); d->append_xy_svg (x, y); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->path.append_c ('C'); d->append_xy_svg (c1x, c1y); d->path.append_c (' '); d->append_xy_svg (c2x, c2y); d->path.append_c (' '); d->append_xy_svg (x, y);
+  d->end_path_command (before);
+}
 
 static void hb_vector_draw_svg_close_path (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, void *)
-{ ((hb_vector_draw_t *) dd)->path.append_c ('Z'); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->path.append_c ('Z');
+  d->end_path_command (before);
+}
 
 
 /* ---- PDF draw callbacks ---- */
 
 static void hb_vector_draw_pdf_move_to (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, float x, float y, void *)
-{ auto *d = (hb_vector_draw_t *) dd; d->append_xy_pdf (x, y); d->path.append_str (" m\n"); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->append_xy_pdf (x, y); d->path.append_str (" m\n");
+  d->end_path_command (before);
+}
 
 static void hb_vector_draw_pdf_line_to (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, float x, float y, void *)
-{ auto *d = (hb_vector_draw_t *) dd; d->append_xy_pdf (x, y); d->path.append_str (" l\n"); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->append_xy_pdf (x, y); d->path.append_str (" l\n");
+  d->end_path_command (before);
+}
 
 /* No quadratic_to — null fallback auto-promotes to cubic. */
 
 static void hb_vector_draw_pdf_cubic_to (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, float c1x, float c1y, float c2x, float c2y, float x, float y, void *)
-{ auto *d = (hb_vector_draw_t *) dd; d->append_xy_pdf (c1x, c1y); d->path.append_c (' '); d->append_xy_pdf (c2x, c2y); d->path.append_c (' '); d->append_xy_pdf (x, y); d->path.append_str (" c\n"); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->append_xy_pdf (c1x, c1y); d->path.append_c (' '); d->append_xy_pdf (c2x, c2y); d->path.append_c (' '); d->append_xy_pdf (x, y); d->path.append_str (" c\n");
+  d->end_path_command (before);
+}
 
 static void hb_vector_draw_pdf_close_path (hb_draw_funcs_t *, void *dd, hb_draw_state_t *, void *)
-{ ((hb_vector_draw_t *) dd)->path.append_str ("h\n"); }
+{
+  auto *d = (hb_vector_draw_t *) dd;
+  unsigned before;
+  if (unlikely (!d->begin_path_command (&before))) return;
+  d->path.append_str ("h\n");
+  d->end_path_command (before);
+}
 
 
 /* ---- Lazy loaders ---- */
@@ -895,6 +949,7 @@ hb_vector_draw_clear (hb_vector_draw_t *draw)
   draw->defs.clear ();
   draw->body.clear ();
   draw->path.clear ();
+  draw->work_left = HB_VECTOR_MAX_DRAW_WORK;
 }
 
 /**

--- a/src/hb-vector-draw.hh
+++ b/src/hb-vector-draw.hh
@@ -54,6 +54,27 @@ struct hb_vector_draw_t
   hb_vector_buf_t pdf_extgstate_dict;
   unsigned pdf_extgstate_count = 0;
 
+  /* Cumulative output budget for the current draw session; reset by
+   * hb_vector_draw_clear().  Charge complete path commands so budget
+   * exhaustion cannot leave a syntactically partial command. */
+  int64_t work_left = HB_VECTOR_MAX_DRAW_WORK;
+
+  bool begin_path_command (unsigned *before)
+  {
+    if (unlikely (work_left <= 0 || path.in_error ()))
+      return false;
+    *before = path.length;
+    return true;
+  }
+
+  void end_path_command (unsigned before)
+  {
+    if (unlikely (path.in_error ()))
+      work_left = 0;
+    else
+      work_left -= path.length - before;
+  }
+
   void set_precision (unsigned p)
   {
     p = hb_min (p, 12u);

--- a/src/hb-vector-paint-pdf.cc
+++ b/src/hb-vector-paint-pdf.cc
@@ -345,11 +345,11 @@ hb_pdf_emit_glyph_path (hb_vector_paint_t *paint,
   if (likely (paint->work_left > 0))
   {
     hb_vector_path_sink_t sink = {&paint->path, paint->get_precision (),
-				 paint->x_scale_factor, paint->y_scale_factor};
+				 paint->x_scale_factor, paint->y_scale_factor,
+				 &paint->work_left};
     hb_font_draw_glyph (font, glyph,
 			hb_vector_pdf_path_draw_funcs_get (),
 			&sink);
-    paint->work_left -= paint->path.length;
   }
   buf->append_len (paint->path.arrayZ, paint->path.length);
   paint->path.clear ();
@@ -511,7 +511,8 @@ hb_pdf_paint_push_clip_path_start (hb_paint_funcs_t *,
    * scale_factor so they land in output space. */
   paint->clip_path_sink = {&body, paint->get_precision (),
 			   paint->x_scale_factor,
-			   paint->y_scale_factor};
+			   paint->y_scale_factor,
+			   &paint->work_left};
   *draw_data = &paint->clip_path_sink;
   return hb_vector_pdf_path_draw_funcs_get ();
 }

--- a/src/hb-vector-paint-svg.cc
+++ b/src/hb-vector-paint-svg.cc
@@ -443,9 +443,9 @@ hb_vector_paint_fill_glyph (hb_paint_funcs_t *,
   if (likely (paint->work_left > 0))
   {
     hb_vector_path_sink_t sink = {&paint->path, paint->get_precision (),
-				 paint->x_scale_factor, paint->y_scale_factor};
+				 paint->x_scale_factor, paint->y_scale_factor,
+				 &paint->work_left};
     hb_font_draw_glyph (font, glyph, hb_vector_svg_path_draw_funcs_get (), &sink);
-    paint->work_left -= paint->path.length;
   }
 
   auto &body = paint->current_body ();
@@ -476,9 +476,9 @@ hb_vector_paint_push_clip_glyph (hb_paint_funcs_t *,
   if (likely (paint->work_left > 0))
   {
     hb_vector_path_sink_t sink = {&paint->path, paint->get_precision (),
-				 paint->x_scale_factor, paint->y_scale_factor};
+				 paint->x_scale_factor, paint->y_scale_factor,
+				 &paint->work_left};
     hb_font_draw_glyph (font, glyph, hb_vector_svg_path_draw_funcs_get (), &sink);
-    paint->work_left -= paint->path.length;
   }
 
   unsigned def_id = paint->path_def_count++;
@@ -557,7 +557,8 @@ hb_vector_paint_push_clip_path_start (hb_paint_funcs_t *,
   paint->path.clear ();
   paint->clip_path_sink = {&paint->path, paint->get_precision (),
 			   paint->x_scale_factor,
-			   paint->y_scale_factor};
+			   paint->y_scale_factor,
+			   &paint->work_left};
   *draw_data = &paint->clip_path_sink;
   return hb_vector_svg_path_draw_funcs_get ();
 }

--- a/src/hb-vector-paint.hh
+++ b/src/hb-vector-paint.hh
@@ -72,7 +72,7 @@ struct hb_vector_paint_t
    * with the paint-graph traversal limits of the font tables driving
    * us (e.g. COLR). */
   int64_t work_left = HB_VECTOR_MAX_PAINT_WORK;
-  hb_vector_path_sink_t clip_path_sink = {nullptr, 0, 1.f, 1.f};
+  hb_vector_path_sink_t clip_path_sink = {nullptr, 0, 1.f, 1.f, nullptr};
   unsigned gradient_counter = 0;
   unsigned color_glyph_depth = 0;
   unsigned path_def_count = 0;

--- a/src/hb-vector-path.cc
+++ b/src/hb-vector-path.cc
@@ -48,8 +48,11 @@ hb_vector_svg_path_move_to (hb_draw_funcs_t *, void *draw_data, hb_draw_state_t 
 			     float to_x, float to_y, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   s->path->append_c ('M');
   hb_vector_svg_path_append_xy (s, to_x, to_y);
+  s->end_command (before);
 }
 
 static void
@@ -57,8 +60,11 @@ hb_vector_svg_path_line_to (hb_draw_funcs_t *, void *draw_data, hb_draw_state_t 
 			     float to_x, float to_y, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   s->path->append_c ('L');
   hb_vector_svg_path_append_xy (s, to_x, to_y);
+  s->end_command (before);
 }
 
 static void
@@ -66,10 +72,13 @@ hb_vector_svg_path_quadratic_to (hb_draw_funcs_t *, void *draw_data, hb_draw_sta
 				  float cx, float cy, float to_x, float to_y, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   s->path->append_c ('Q');
   hb_vector_svg_path_append_xy (s, cx, cy);
   s->path->append_c (' ');
   hb_vector_svg_path_append_xy (s, to_x, to_y);
+  s->end_command (before);
 }
 
 static void
@@ -78,19 +87,25 @@ hb_vector_svg_path_cubic_to (hb_draw_funcs_t *, void *draw_data, hb_draw_state_t
 			      float to_x, float to_y, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   s->path->append_c ('C');
   hb_vector_svg_path_append_xy (s, c1x, c1y);
   s->path->append_c (' ');
   hb_vector_svg_path_append_xy (s, c2x, c2y);
   s->path->append_c (' ');
   hb_vector_svg_path_append_xy (s, to_x, to_y);
+  s->end_command (before);
 }
 
 static void
 hb_vector_svg_path_close_path (hb_draw_funcs_t *, void *draw_data, hb_draw_state_t *, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   s->path->append_c ('Z');
+  s->end_command (before);
 }
 
 
@@ -109,8 +124,11 @@ hb_vector_pdf_path_move_to (hb_draw_funcs_t *, void *draw_data, hb_draw_state_t 
 			     float to_x, float to_y, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   hb_vector_pdf_path_append_xy (s, to_x, to_y);
   s->path->append_str (" m\n");
+  s->end_command (before);
 }
 
 static void
@@ -118,8 +136,11 @@ hb_vector_pdf_path_line_to (hb_draw_funcs_t *, void *draw_data, hb_draw_state_t 
 			     float to_x, float to_y, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   hb_vector_pdf_path_append_xy (s, to_x, to_y);
   s->path->append_str (" l\n");
+  s->end_command (before);
 }
 
 /* No quadratic_to — the null fallback auto-promotes to cubic. */
@@ -130,19 +151,25 @@ hb_vector_pdf_path_cubic_to (hb_draw_funcs_t *, void *draw_data, hb_draw_state_t
 			      float to_x, float to_y, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   hb_vector_pdf_path_append_xy (s, c1x, c1y);
   s->path->append_c (' ');
   hb_vector_pdf_path_append_xy (s, c2x, c2y);
   s->path->append_c (' ');
   hb_vector_pdf_path_append_xy (s, to_x, to_y);
   s->path->append_str (" c\n");
+  s->end_command (before);
 }
 
 static void
 hb_vector_pdf_path_close_path (hb_draw_funcs_t *, void *draw_data, hb_draw_state_t *, void *)
 {
   auto *s = (hb_vector_path_sink_t *) draw_data;
+  unsigned before;
+  if (unlikely (!s->begin_command (&before))) return;
   s->path->append_str ("h\n");
+  s->end_command (before);
 }
 
 

--- a/src/hb-vector-path.hh
+++ b/src/hb-vector-path.hh
@@ -44,6 +44,25 @@ struct hb_vector_path_sink_t
   unsigned precision;
   float x_scale;
   float y_scale;
+  int64_t *work_left;
+
+  bool begin_command (unsigned *before)
+  {
+    if (unlikely (path->in_error () ||
+		  (work_left && *work_left <= 0)))
+      return false;
+    *before = path->length;
+    return true;
+  }
+
+  void end_command (unsigned before)
+  {
+    if (!work_left) return;
+    if (unlikely (path->in_error ()))
+      *work_left = 0;
+    else
+      *work_left -= path->length - before;
+  }
 };
 
 HB_INTERNAL hb_draw_funcs_t *

--- a/test/fuzzing/hb-raster-fuzzer.cc
+++ b/test/fuzzing/hb-raster-fuzzer.cc
@@ -32,38 +32,39 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 
   volatile unsigned counter = !glyph_count;
 
-  for (unsigned gid = 0; gid < limit; gid++)
+  if (limit)
   {
+    unsigned gid = input.text.empty () ? 0 : input.text[0] % limit;
     float x = (float) ((gid % 4) * 40);
     float y = (float) ((gid / 4) * 40);
     hb_raster_draw_set_transform (draw, 1.f, 0.f, 0.f, 1.f, x, y);
     hb_raster_draw_glyph (draw, input.font, gid);
     hb_raster_paint_set_transform (paint, 1.f, 0.f, 0.f, 1.f, x, y);
     hb_raster_paint_glyph (paint, input.font, gid);
-  }
 
-  hb_raster_image_t *draw_image = hb_raster_draw_render (draw);
-  if (draw_image)
-  {
-    hb_raster_extents_t ext;
-    hb_raster_image_get_extents (draw_image, &ext);
-    counter += ext.width + ext.height + (unsigned) (ext.x_origin != 0) + (unsigned) (ext.y_origin != 0);
-    const uint8_t *buf = hb_raster_image_get_buffer (draw_image);
-    if (buf && ext.height && ext.stride)
-      counter += buf[0];
-    hb_raster_draw_recycle_image (draw, draw_image);
-  }
+    hb_raster_image_t *draw_image = hb_raster_draw_render (draw);
+    if (draw_image)
+    {
+      hb_raster_extents_t ext;
+      hb_raster_image_get_extents (draw_image, &ext);
+      counter += ext.width + ext.height + (unsigned) (ext.x_origin != 0) + (unsigned) (ext.y_origin != 0);
+      const uint8_t *buf = hb_raster_image_get_buffer (draw_image);
+      if (buf && ext.height && ext.stride)
+	counter += buf[0];
+      hb_raster_draw_recycle_image (draw, draw_image);
+    }
 
-  hb_raster_image_t *paint_image = hb_raster_paint_render (paint);
-  if (paint_image)
-  {
-    hb_raster_extents_t ext;
-    hb_raster_image_get_extents (paint_image, &ext);
-    counter += ext.width + ext.height + (unsigned) (ext.x_origin != 0) + (unsigned) (ext.y_origin != 0);
-    const uint8_t *buf = hb_raster_image_get_buffer (paint_image);
-    if (buf && ext.height && ext.stride)
-      counter += buf[0];
-    hb_raster_paint_recycle_image (paint, paint_image);
+    hb_raster_image_t *paint_image = hb_raster_paint_render (paint);
+    if (paint_image)
+    {
+      hb_raster_extents_t ext;
+      hb_raster_image_get_extents (paint_image, &ext);
+      counter += ext.width + ext.height + (unsigned) (ext.x_origin != 0) + (unsigned) (ext.y_origin != 0);
+      const uint8_t *buf = hb_raster_image_get_buffer (paint_image);
+      if (buf && ext.height && ext.stride)
+	counter += buf[0];
+      hb_raster_paint_recycle_image (paint, paint_image);
+    }
   }
 
   hb_raster_draw_destroy (draw);

--- a/test/fuzzing/hb-vector-fuzzer.cc
+++ b/test/fuzzing/hb-vector-fuzzer.cc
@@ -24,36 +24,37 @@ exercise_format (const _fuzzing_shape_input_t *input,
   unsigned glyph_count = hb_face_get_glyph_count (input->face);
   unsigned limit = glyph_count > 16 ? 16 : glyph_count;
 
-  for (unsigned gid = 0; gid < limit; gid++)
+  if (limit)
   {
+    unsigned gid = input->text.empty () ? 0 : input->text[0] % limit;
     float x = (float) ((gid % 4) * 40);
     float y = (float) ((gid / 4) * 40);
     hb_vector_draw_set_transform (draw, 1.f, 0.f, 0.f, 1.f, x, y);
     hb_vector_draw_glyph  (draw,  input->font, gid, HB_VECTOR_EXTENTS_MODE_EXPAND);
     hb_vector_paint_set_transform (paint, 1.f, 0.f, 0.f, 1.f, x, y);
     hb_vector_paint_glyph (paint, input->font, gid, HB_VECTOR_EXTENTS_MODE_EXPAND);
-  }
 
-  hb_blob_t *draw_blob = hb_vector_draw_render (draw);
-  if (draw_blob)
-  {
-    unsigned length = 0;
-    const char *blob_data = hb_blob_get_data (draw_blob, &length);
-    *counter += length;
-    if (blob_data && length)
-      *counter += (unsigned char) blob_data[0];
-    hb_vector_draw_recycle_blob (draw, draw_blob);
-  }
+    hb_blob_t *draw_blob = hb_vector_draw_render (draw);
+    if (draw_blob)
+    {
+      unsigned length = 0;
+      const char *blob_data = hb_blob_get_data (draw_blob, &length);
+      *counter += length;
+      if (blob_data && length)
+	*counter += (unsigned char) blob_data[0];
+      hb_vector_draw_recycle_blob (draw, draw_blob);
+    }
 
-  hb_blob_t *paint_blob = hb_vector_paint_render (paint);
-  if (paint_blob)
-  {
-    unsigned length = 0;
-    const char *blob_data = hb_blob_get_data (paint_blob, &length);
-    *counter += length;
-    if (blob_data && length)
-      *counter += (unsigned char) blob_data[0];
-    hb_vector_paint_recycle_blob (paint, paint_blob);
+    hb_blob_t *paint_blob = hb_vector_paint_render (paint);
+    if (paint_blob)
+    {
+      unsigned length = 0;
+      const char *blob_data = hb_blob_get_data (paint_blob, &length);
+      *counter += length;
+      if (blob_data && length)
+	*counter += (unsigned char) blob_data[0];
+      hb_vector_paint_recycle_blob (paint, paint_blob);
+    }
   }
 
   hb_vector_draw_destroy (draw);


### PR DESCRIPTION
## What changed

- Make the vector and raster fuzzers select one of the first 16 glyphs and render only that glyph per input.
- Add a 16 MiB cumulative SVG/PDF path budget to vector draw and paint sessions.
- Charge complete path commands through the shared vector path sink, including glyph outlines and clip paths.
- Cap raster draw sessions at 1,048,576 accumulated non-horizontal edges.

## Why

The fuzzers accumulated 16 glyphs into one output even though these APIs generate a single glyph asset for embedding. More importantly, VARC's traversal budget could still amplify a single glyph into tens of megabytes of serialized path data or millions of raster edges. Vector paint also charged outline bytes only after the complete glyph, allowing an unbounded single-operation overshoot.

The fuzzer correction models the intended use, while the production budgets independently bound pathological single-glyph output and direct callback use. Budgets reset on render/clear and preserve complete SVG/PDF commands at the boundary.

## Impact

On the pathological VARC corpus input, raster peak RSS drops from roughly 493 MiB to 183 MiB and runtime from about 0.53 s to 0.16 s. In the full suite, raster-fuzzer-chunk-7 and vector-fuzzer-chunk-7 both complete in under one second. No public API or ABI changes.

## Validation

- `meson test -C build --suite vector --suite raster`
- parallel and serial `meson test -C build --suite fuzzing`
- `meson test -C build` (270/270 passed)
- pathological boundary SVG parsed with `xmllint --huge`
- pathological boundary PDF inspected with `pdfinfo`