### PR TITLE
[depend] Deduplicate ligature dependency data

### DIFF
--- a/src/OT/Layout/GSUB/Ligature.hh
+++ b/src/OT/Layout/GSUB/Ligature.hh
@@ -50,27 +50,26 @@ struct Ligature
       return;
     }
 
-    hb_codepoint_t ligset_idx = c->depend_data->new_ligature_set(complete_ligset);
+    bool ligset_created;
+    hb_codepoint_t ligset_idx = c->depend_data->find_or_create_set (complete_ligset,
+                                                                    &ligset_created);
     if (unlikely (ligset_idx == HB_CODEPOINT_INVALID))
       return;
 
     // Track whether any edge using this ligset_idx was actually added
     bool any_added = false;
 
-    // Now add all edges with the complete, immutable set
-    if (c->depend_data->add_gsub_lookup (first, c->lookup_index, ligGlyph, ligset_idx))
-      any_added = true;
-
-    + hb_iter (component)
-    | hb_apply ([&] (const hb_codepoint_t &gid) {
+    // Now add one edge for each glyph in the complete, immutable set
+    + hb_iter (complete_ligset)
+    | hb_apply ([&] (hb_codepoint_t gid) {
         if (c->depend_data->add_gsub_lookup (gid, c->lookup_index, ligGlyph, ligset_idx))
           any_added = true;
       })
     ;
 
-    // If no edges were added, the ligset_idx is unused - free it for reuse
-    if (!any_added)
-      c->depend_data->free_ligature_set(ligset_idx);
+    // If no edges were added, a newly allocated set is unused - free it for reuse
+    if (!any_added && ligset_created)
+      c->depend_data->discard_set (ligset_idx);
   }
 
   void collect_glyphs (hb_collect_glyphs_context_t *c) const

--- a/src/hb-depend-data.hh
+++ b/src/hb-depend-data.hh
@@ -275,7 +275,7 @@ struct hb_depend_data_t
  * Temporary state (freed on destruction):
  * - lookup_features: Lookup index to feature tag mapping
  * - seen_edges: Struct-based edge deduplication table
- * - set_to_index: Content-based context set deduplication map
+ * - set_to_index: Content-based dependency set deduplication map
  * - free_set_list: Indices of freed sets available for reuse
  * - current_context_set_index: Context requirements for current rule
  * - current_edge_flags: Flags to apply to edges being recorded
@@ -291,29 +291,21 @@ struct hb_depend_data_builder_t
   const hb_set_t *get_set_from_index (hb_codepoint_t index)
   { return data.get_set_from_index (index); }
 
-  /* Free an unused ligature set for reuse.
-   * Only called for ligature sets that were allocated but had no edges added. */
-  void free_ligature_set (hb_codepoint_t set_index)
+  /* Discard an unused set that was allocated but had no edges added. */
+  void discard_set (hb_codepoint_t set_index)
   {
     if (set_index >= data.sets.length)
     {
-      DEBUG_MSG (SUBSET, nullptr, "Attempting to free invalid set %u (max is %u)",
+      DEBUG_MSG (SUBSET, nullptr, "Attempting to discard invalid set %u (max is %u)",
                  set_index, data.sets.length - 1);
       return;
     }
+    set_to_index.del (data.sets[set_index].get ());
     data.sets[set_index]->clear ();
     check_success (free_set_list.push_or_fail (set_index));
   }
 
-  /* Allocate a new ligature set (no deduplication). */
-  hb_codepoint_t new_ligature_set (hb_codepoint_t cp)
-  {
-    hb_set_t temp_set;
-    temp_set.add (cp);
-    return new_ligature_set (temp_set);
-  }
-
-  hb_codepoint_t new_ligature_set (hb_set_t &set)
+  hb_codepoint_t new_set (const hb_set_t &set)
   {
     hb_codepoint_t set_index;
 
@@ -343,22 +335,28 @@ struct hb_depend_data_builder_t
     return set_index;
   }
 
-  /* Find existing context set with same contents, or create new one (with deduplication).
-   * Uses content-based deduplication via hb_hashmap_t with pointer keys. */
-  hb_codepoint_t find_or_create_context_set (const hb_set_t &set)
+  /* Find an existing dependency set with the same contents, or create one. */
+  hb_codepoint_t find_or_create_set (const hb_set_t &set, bool *created = nullptr)
   {
     hb_codepoint_t *existing_idx = nullptr;
     if (set_to_index.has (&set, &existing_idx))
+    {
+      if (created) *created = false;
       return *existing_idx;
+    }
 
-    hb_codepoint_t new_idx = new_ligature_set (const_cast<hb_set_t&>(set));
+    hb_codepoint_t new_idx = new_set (set);
     if (unlikely (new_idx == HB_CODEPOINT_INVALID))
       return HB_CODEPOINT_INVALID;
 
     if (unlikely (!set_to_index.set (data.sets[new_idx].get (), new_idx)))
       return fail_invalid ();
+    if (created) *created = true;
     return new_idx;
   }
+
+  hb_codepoint_t find_or_create_context_set (const hb_set_t &set)
+  { return find_or_create_set (set); }
 
   /* Build a context set from context information.
    * Encodes backtrack and lookahead requirements as a flattened set.


### PR DESCRIPTION
## Summary

- walk the already-deduplicated ligature component set instead of revisiting the raw component array
- intern equivalent ligature component sets through the existing content-based dependency-set map
- preserve the unused-set reuse path by discarding only newly interned sets

## Root cause

Dependency extraction built a complete component set for every ligature, but then ignored that set for traversal and allocated a separate copy for every ligature record. Malformed GSUB data could therefore trigger millions of redundant edge lookups and hundreds of thousands of equivalent set allocations.

## Impact

On `clusterfuzz-testcase-minimized-hb-subset-fuzzer-5845846876356608`:

- runtime: about 0.91s to 0.24s
- peak RSS: about 292MB to 80MB
- stored component sets: 210,702 to 76
- retained edges: 2,652,906 to 396,546

The dependency graph remains semantically equivalent: the API models ligature requirements as sets, so identical component sets can share one index and repeated component visits do not add information.

## Validation

- `meson test -C build --print-errorlogs`
- 270/270 tests passed, including dependency API tests, closure parity, failing-allocation fuzzing, and all dependency-fuzzer chunks