### PR TITLE
[test/threads] Use focused shaping corpora

### DIFF
--- a/test/threads/hb-shape-threads.cc
+++ b/test/threads/hb-shape-threads.cc
@@ -23,15 +23,15 @@ struct test_input_t
 {
 
   {"perf/fonts/NotoNastaliqUrdu-Regular.ttf",
-   "perf/texts/fa-thelittleprince.txt",
+   "perf/texts/fa-paragraph.txt",
    false},
 
   {"perf/fonts/Roboto-Regular.ttf",
-   "perf/texts/en-words.txt",
+   "perf/texts/en-paragraph.txt",
    false},
 
   {SUBSET_FONT_BASE_PATH "SourceSerifVariable-Roman.ttf",
-   "perf/texts/en-thelittleprince.txt",
+   "perf/texts/en-paragraph.txt",
    true},
 };
 
@@ -128,6 +128,11 @@ static void test_backend (const char *backend,
   bool ret = hb_font_set_funcs_using (font, backend);
   if (!ret)
     abort ();
+
+  {
+    std::unique_lock<std::mutex> lk (cv_m);
+    ready = false;
+  }
 
   std::vector<std::thread> threads;
   for (unsigned i = 0; i < num_threads; i++)


### PR DESCRIPTION
## Summary

- replace full-book and word-list inputs with the existing substantial Latin and Persian paragraph corpora
- reset the worker start gate before every backend run so all combinations actually begin concurrently

## Why

`shape_threads` is a thread-safety test, but it shaped entire books and a 12,000-line word list in each worker. That created more than 150,000 tiny shaping calls across the default run and made the test behave like a benchmark.

The paragraph inputs still exercise Latin and Arabic-script shaping, every available font backend, static and variable font modes, `HB_BUFFER_FLAG_VERIFY`, and concurrent use of a shared font. Each worker now shapes a substantial 10–23KB buffer instead of thousands of individual lines.

The start condition was also left set after the first backend, so only the first combination was guaranteed to release its workers together. Resetting it strengthens the intended concurrency coverage.

## Impact

- standalone runtime: about 1.09s to 0.16s
- full-suite runtime for `shape_threads`: about 1.99s to 0.39s

## Validation

- `build/test/threads/hb-shape-threads 8 5` (8-thread, 5-repetition stress run)
- `meson test -C build --print-errorlogs`
- 270/270 tests passed