### PR TITLE
[depend] Speed up contextual dependency collection

### DIFF
--- a/docs/harfbuzz-sections.txt
+++ b/docs/harfbuzz-sections.txt
@@ -872,6 +872,7 @@ hb_set_symmetric_difference
 hb_set_invert
 hb_set_is_inverted
 hb_set_is_equal
+hb_set_intersects
 hb_set_is_subset
 hb_set_next
 hb_set_next_range

--- a/src/OT/Layout/Common/CoverageFormat2.hh
+++ b/src/OT/Layout/Common/CoverageFormat2.hh
@@ -151,9 +151,22 @@ struct CoverageFormat2_4
       if (unlikely (range.first < last))
         break;
       last = range.last;
-      for (hb_codepoint_t g = range.first - 1;
-	   glyphs.next (&g) && g <= last;)
-	intersect_glyphs << g;
+      hb_codepoint_t cursor = range.first & -hb_bit_page_t::ELT_BITS;
+      cursor = cursor ? cursor - 1 : HB_SET_VALUE_INVALID;
+      uint64_t bits;
+      while (glyphs.next_bits (&cursor, &bits) && cursor <= last)
+      {
+	if (range.first > cursor)
+	  bits &= UINT64_MAX << (range.first - cursor);
+	unsigned int end = last - cursor;
+	if (end < hb_bit_page_t::ELT_BITS - 1)
+	  bits &= (uint64_t (1) << (end + 1)) - 1;
+	while (bits)
+	{
+	  intersect_glyphs << cursor + hb_ctz (bits);
+	  bits &= bits - 1;
+	}
+      }
     }
   }
 

--- a/src/OT/Layout/Common/CoverageFormat2.hh
+++ b/src/OT/Layout/Common/CoverageFormat2.hh
@@ -139,6 +139,19 @@ struct CoverageFormat2_4
     return false;
   }
 
+  static void add_intersected_bits (hb_set_t &set, hb_codepoint_t base, uint64_t bits)
+  { set.add_bits (base, bits); }
+
+  template <typename IterableOut>
+  static void add_intersected_bits (IterableOut&& out, hb_codepoint_t base, uint64_t bits)
+  {
+    while (bits)
+    {
+      out << base + hb_ctz (bits);
+      bits &= bits - 1;
+    }
+  }
+
   template <typename IterableOut,
 	    hb_requires (hb_is_sink_of (IterableOut, hb_codepoint_t))>
   void intersect_set (const hb_set_t &glyphs, IterableOut&& intersect_glyphs) const
@@ -161,11 +174,7 @@ struct CoverageFormat2_4
 	unsigned int end = last - cursor;
 	if (end < hb_bit_page_t::ELT_BITS - 1)
 	  bits &= (uint64_t (1) << (end + 1)) - 1;
-	while (bits)
-	{
-	  intersect_glyphs << cursor + hb_ctz (bits);
-	  bits &= bits - 1;
-	}
+	add_intersected_bits (intersect_glyphs, cursor, bits);
       }
     }
   }

--- a/src/OT/Layout/GSUB/SubstLookup.hh
+++ b/src/OT/Layout/GSUB/SubstLookup.hh
@@ -211,9 +211,9 @@ struct SubstLookup : Lookup
     return ret;
   }
 
-  static inline hb_depend_context_t::return_t depend_glyphs_recurse_func (hb_depend_context_t *c, unsigned lookup_index, hb_set_t *covered_seq_indices, unsigned seq_index, unsigned end_index);
+  static inline hb_depend_context_t::return_t depend_glyphs_recurse_func (hb_depend_context_t *c, unsigned lookup_index, hb_bit_page_t *covered_seq_indices, unsigned seq_index, unsigned end_index);
 
-  static inline hb_depend_context_t::return_t dispatch_depend_recurse_func (hb_depend_context_t *c, unsigned lookup_index, hb_set_t *covered_seq_indices, unsigned seq_index, unsigned end_index)
+  static inline hb_depend_context_t::return_t dispatch_depend_recurse_func (hb_depend_context_t *c, unsigned lookup_index, hb_bit_page_t *covered_seq_indices, unsigned seq_index, unsigned end_index)
   {
     return depend_glyphs_recurse_func (c, lookup_index, covered_seq_indices, seq_index, end_index);
   }

--- a/src/hb-bit-page.hh
+++ b/src/hb-bit-page.hh
@@ -135,7 +135,9 @@ struct hb_bit_page_t
   }
 
   void add (hb_codepoint_t g) { elt (g) |= mask (g); dirty (); }
+  void add_bits (hb_codepoint_t g, uint64_t bits) { elt (g) |= bits; dirty (); }
   void del (hb_codepoint_t g) { elt (g) &= ~mask (g); dirty (); }
+  void del_bits (hb_codepoint_t g, uint64_t bits) { elt (g) &= ~bits; dirty (); }
   void set (hb_codepoint_t g, bool value) { if (value) add (g); else del (g); }
   bool get (hb_codepoint_t g) const { return elt (g) & mask (g); }
   bool may_have (hb_codepoint_t g) const { return get (g); }

--- a/src/hb-bit-set-invertible.hh
+++ b/src/hb-bit-set-invertible.hh
@@ -205,8 +205,10 @@ struct hb_bit_set_invertible_t
 
   protected:
   template <typename Op>
-  void process (const Op& op, const hb_bit_set_invertible_t &other)
-  { s.process (op, other.s); }
+  void process (const Op& op,
+		const hb_bit_set_invertible_t &other,
+		hb_vector_t<unsigned> *workspace = nullptr)
+  { s.process (op, other.s, workspace); }
   public:
   void union_ (const hb_bit_set_invertible_t &other)
   {
@@ -228,20 +230,26 @@ struct hb_bit_set_invertible_t
       inverted = inverted || other.inverted;
   }
   void intersect (const hb_bit_set_invertible_t &other)
+  { intersect (other, nullptr); }
+  void intersect (const hb_bit_set_invertible_t &other,
+		  hb_vector_t<unsigned> &workspace)
+  { intersect (other, &workspace); }
+  void intersect (const hb_bit_set_invertible_t &other,
+		  hb_vector_t<unsigned> *workspace)
   {
     if (likely (inverted == other.inverted))
     {
       if (unlikely (inverted))
-	process (hb_bitwise_or, other);
+	process (hb_bitwise_or, other, workspace);
       else
-	process (hb_bitwise_and, other); /* Main branch. */
+	process (hb_bitwise_and, other, workspace); /* Main branch. */
     }
     else
     {
       if (unlikely (inverted))
-	process (hb_bitwise_lt, other);
+	process (hb_bitwise_lt, other, workspace);
       else
-	process (hb_bitwise_gt, other);
+	process (hb_bitwise_gt, other, workspace);
     }
     if (likely (s.successful))
       inverted = inverted && other.inverted;

--- a/src/hb-bit-set-invertible.hh
+++ b/src/hb-bit-set-invertible.hh
@@ -301,6 +301,47 @@ struct hb_bit_set_invertible_t
     *codepoint = v + 1;
     return *codepoint != INVALID;
   }
+  bool next_bits (hb_codepoint_t *codepoint, uint64_t *bits) const
+  {
+    if (likely (!inverted))
+      return s.next_bits (codepoint, bits);
+
+    hb_codepoint_t base;
+    if (unlikely (*codepoint == INVALID))
+      base = 0;
+    else
+    {
+      base = *codepoint & -hb_bit_page_t::ELT_BITS;
+      if (unlikely (base >= INVALID - hb_bit_page_t::ELT_BITS + 1))
+	goto done;
+      base += hb_bit_page_t::ELT_BITS;
+    }
+
+    while (true)
+    {
+      hb_codepoint_t cursor = base ? base - hb_bit_page_t::ELT_BITS : INVALID;
+      uint64_t excluded = 0;
+      if (!s.next_bits (&cursor, &excluded) || cursor != base)
+	excluded = 0;
+      *bits = ~excluded;
+      bool last = unlikely (base >= INVALID - hb_bit_page_t::ELT_BITS + 1);
+      if (last)
+	*bits &= UINT64_MAX >> 1;
+      if (*bits)
+      {
+	*codepoint = base;
+	return true;
+      }
+      if (unlikely (last))
+	break;
+      base += hb_bit_page_t::ELT_BITS;
+    }
+
+  done:
+    *codepoint = INVALID;
+    *bits = 0;
+    return false;
+  }
   bool previous (hb_codepoint_t *codepoint) const
   {
     if (likely (!inverted))
@@ -373,13 +414,15 @@ struct hb_bit_set_invertible_t
 
   /*
    * Iterator implementation.
+   * Mutating the set invalidates its iterators.
    */
   struct iter_t : hb_iter_with_fallback_t<iter_t, hb_codepoint_t>
   {
     static constexpr bool is_sorted_iterator = true;
     static constexpr bool has_fast_len = true;
     iter_t (const hb_bit_set_invertible_t &s_ = Null (hb_bit_set_invertible_t),
-	    bool init = true) : s (&s_), v (INVALID), l(0)
+	    bool init = true) : s (&s_), v (INVALID), l (0),
+				     base (INVALID), bits (0)
     {
       if (init)
       {
@@ -391,8 +434,33 @@ struct hb_bit_set_invertible_t
     typedef hb_codepoint_t __item_t__;
     hb_codepoint_t __item__ () const { return v; }
     bool __more__ () const { return v != INVALID; }
-    void __next__ () { s->next (&v); if (likely (l)) l--; }
-    void __prev__ () { s->previous (&v); l++; }
+    void __next__ ()
+    {
+      if (likely (bits))
+      {
+	v = base + hb_ctz (bits);
+	bits &= bits - 1;
+      }
+      else if (s->next_bits (&base, &bits))
+      {
+	v = base + hb_ctz (bits);
+	bits &= bits - 1;
+      }
+      else
+	v = INVALID;
+      if (likely (l)) l--;
+    }
+    void __prev__ ()
+    {
+      if (s->previous (&v))
+	sync ();
+      else
+      {
+	base = INVALID;
+	bits = 0;
+      }
+      l++;
+    }
     unsigned __len__ () const { return l; }
     iter_t end () const { return iter_t (*s, false); }
     bool operator != (const iter_t& o) const
@@ -402,6 +470,17 @@ struct hb_bit_set_invertible_t
     const hb_bit_set_invertible_t *s;
     hb_codepoint_t v;
     unsigned l;
+    hb_codepoint_t base;
+    uint64_t bits;
+
+    void sync ()
+    {
+      base = v & -hb_bit_page_t::ELT_BITS;
+      hb_codepoint_t cursor = base ? base - hb_bit_page_t::ELT_BITS : INVALID;
+      s->next_bits (&cursor, &bits);
+      unsigned int bit = v & (hb_bit_page_t::ELT_BITS - 1);
+      bits = bit == hb_bit_page_t::ELT_BITS - 1 ? 0 : bits >> (bit + 1) << (bit + 1);
+    }
   };
   iter_t iter () const { return iter_t (*this); }
   operator iter_t () const { return iter (); }

--- a/src/hb-bit-set-invertible.hh
+++ b/src/hb-bit-set-invertible.hh
@@ -101,6 +101,15 @@ struct hb_bit_set_invertible_t
   }
   unsigned int get_population () const
   { return inverted ? INVALID - s.get_population () : s.get_population (); }
+  bool get_singleton (hb_codepoint_t *codepoint) const
+  {
+    if (likely (!inverted))
+      return s.get_singleton (codepoint);
+    if (s.get_population () != INVALID - 1)
+      return false;
+    *codepoint = get_min ();
+    return *codepoint != INVALID;
+  }
 
 
   void add (hb_codepoint_t g) { unlikely (inverted) ? s.del (g) : s.add (g); }

--- a/src/hb-bit-set-invertible.hh
+++ b/src/hb-bit-set-invertible.hh
@@ -143,6 +143,24 @@ struct hb_bit_set_invertible_t
   bool may_intersect (const hb_bit_set_invertible_t &other) const
   { return inverted || other.inverted || s.intersects (other.s); }
 
+  bool intersects (const hb_bit_set_invertible_t &other) const
+  {
+    if (likely (!inverted))
+      return unlikely (other.inverted) ? !s.is_subset (other.s)
+				       : s.intersects (other.s);
+    if (likely (!other.inverted))
+      return !other.s.is_subset (s);
+
+    unsigned population = s.get_population ();
+    unsigned other_population = other.s.get_population ();
+    if ((uint64_t) population + other_population < INVALID)
+      return true;
+
+    return population >= other_population
+	 ? !hb_all (iter (), other.s)
+	 : !hb_all (other.iter (), s);
+  }
+
   bool intersects (hb_codepoint_t first, hb_codepoint_t last) const
   {
     hb_codepoint_t c = first - 1;

--- a/src/hb-bit-set-invertible.hh
+++ b/src/hb-bit-set-invertible.hh
@@ -113,6 +113,8 @@ struct hb_bit_set_invertible_t
 
 
   void add (hb_codepoint_t g) { unlikely (inverted) ? s.del (g) : s.add (g); }
+  void add_bits (hb_codepoint_t g, uint64_t bits)
+  { unlikely (inverted) ? s.del_bits (g, bits) : s.add_bits (g, bits); }
   bool add_range (hb_codepoint_t a, hb_codepoint_t b)
   { return unlikely (inverted) ? ((void) s.del_range (a, b), true) : s.add_range (a, b); }
 

--- a/src/hb-bit-set-invertible.hh
+++ b/src/hb-bit-set-invertible.hh
@@ -229,13 +229,8 @@ struct hb_bit_set_invertible_t
     if (likely (s.successful))
       inverted = inverted || other.inverted;
   }
-  void intersect (const hb_bit_set_invertible_t &other)
-  { intersect (other, nullptr); }
   void intersect (const hb_bit_set_invertible_t &other,
-		  hb_vector_t<unsigned> &workspace)
-  { intersect (other, &workspace); }
-  void intersect (const hb_bit_set_invertible_t &other,
-		  hb_vector_t<unsigned> *workspace)
+		  hb_vector_t<unsigned> *workspace = nullptr)
   {
     if (likely (inverted == other.inverted))
     {

--- a/src/hb-bit-set-invertible.hh
+++ b/src/hb-bit-set-invertible.hh
@@ -430,20 +430,56 @@ struct hb_bit_set_invertible_t
     static constexpr bool is_sorted_iterator = true;
     static constexpr bool has_fast_len = true;
     iter_t (const hb_bit_set_invertible_t &s_ = Null (hb_bit_set_invertible_t),
-	    bool init = true) : s (&s_), v (INVALID), l (0),
-				     base (INVALID), bits (0)
+    bool init = true) : s (&s_), v (INVALID), remaining (0),
+				     have_len (!init), base (INVALID), bits (0)
     {
       if (init)
-      {
-	l = s->get_population () + 1;
-	__next__ ();
-      }
+	advance ();
     }
 
     typedef hb_codepoint_t __item_t__;
     hb_codepoint_t __item__ () const { return v; }
     bool __more__ () const { return v != INVALID; }
     void __next__ ()
+    {
+      remaining--;
+      advance ();
+    }
+    void __prev__ ()
+    {
+      if (s->previous (&v))
+      {
+	sync ();
+	remaining++;
+      }
+      else
+      {
+	base = INVALID;
+	bits = 0;
+      }
+    }
+    unsigned __len__ () const
+    {
+      if (unlikely (!have_len))
+      {
+	remaining += s->get_population ();
+	have_len = true;
+      }
+      return remaining;
+    }
+    iter_t end () const { return iter_t (*s, false); }
+    bool operator != (const iter_t& o) const
+    { return v != o.v; }
+
+    protected:
+    const hb_bit_set_invertible_t *s;
+    hb_codepoint_t v;
+    mutable unsigned remaining;
+    mutable bool have_len;
+    hb_codepoint_t base;
+    uint64_t bits;
+
+    void advance ()
     {
       if (likely (bits))
       {
@@ -457,30 +493,7 @@ struct hb_bit_set_invertible_t
       }
       else
 	v = INVALID;
-      if (likely (l)) l--;
     }
-    void __prev__ ()
-    {
-      if (s->previous (&v))
-	sync ();
-      else
-      {
-	base = INVALID;
-	bits = 0;
-      }
-      l++;
-    }
-    unsigned __len__ () const { return l; }
-    iter_t end () const { return iter_t (*s, false); }
-    bool operator != (const iter_t& o) const
-    { return v != o.v; }
-
-    protected:
-    const hb_bit_set_invertible_t *s;
-    hb_codepoint_t v;
-    unsigned l;
-    hb_codepoint_t base;
-    uint64_t bits;
 
     void sync ()
     {

--- a/src/hb-bit-set.hh
+++ b/src/hb-bit-set.hh
@@ -942,6 +942,39 @@ struct hb_bit_set_t
     population = pop;
     return pop;
   }
+  bool get_singleton (hb_codepoint_t *codepoint) const
+  {
+    if (has_population ())
+    {
+      if (population != 1) return false;
+      *codepoint = get_min ();
+      return true;
+    }
+
+    hb_codepoint_t singleton = INVALID;
+    for (const auto &map : page_map)
+    {
+      const auto &page = pages.arrayZ[map.index];
+      for (unsigned i = 0; i < page_t::len (); i++)
+      {
+	page_t::elt_t bits = page.v[i];
+	if (!bits) continue;
+	if (singleton != INVALID || (bits & (bits - 1)))
+	  return false;
+	singleton = map.major * page_t::PAGE_BITS +
+		    i * page_t::ELT_BITS + hb_ctz (bits);
+      }
+    }
+
+    if (singleton == INVALID)
+    {
+      population = 0;
+      return false;
+    }
+    population = 1;
+    *codepoint = singleton;
+    return true;
+  }
   hb_codepoint_t get_min () const
   {
     unsigned count = pages.length;

--- a/src/hb-bit-set.hh
+++ b/src/hb-bit-set.hh
@@ -161,6 +161,14 @@ struct hb_bit_set_t
     page_t *page = page_for (g, true); if (unlikely (!page)) return;
     page->add (g);
   }
+  void add_bits (hb_codepoint_t g, uint64_t bits)
+  {
+    if (unlikely (!successful) || unlikely (!bits)) return;
+    assert (!(g & (page_t::ELT_BITS - 1)));
+    dirty ();
+    page_t *page = page_for (g, true); if (unlikely (!page)) return;
+    page->add_bits (g, bits);
+  }
   bool add_range (hb_codepoint_t a, hb_codepoint_t b)
   {
     if (unlikely (!successful)) return true; /* https://github.com/harfbuzz/harfbuzz/issues/657 */
@@ -290,6 +298,16 @@ struct hb_bit_set_t
       return;
     dirty ();
     page->del (g);
+  }
+  void del_bits (hb_codepoint_t g, uint64_t bits)
+  {
+    if (unlikely (!successful) || unlikely (!bits)) return;
+    assert (!(g & (page_t::ELT_BITS - 1)));
+    page_t *page = page_for (g);
+    if (!page)
+      return;
+    dirty ();
+    page->del_bits (g, bits);
   }
 
   private:

--- a/src/hb-bit-set.hh
+++ b/src/hb-bit-set.hh
@@ -524,7 +524,8 @@ struct hb_bit_set_t
 
   void process_ (hb_bit_page_t::vector_t (*op) (const hb_bit_page_t::vector_t &, const hb_bit_page_t::vector_t &),
 		 bool passthru_left, bool passthru_right,
-		 const hb_bit_set_t &other)
+		 const hb_bit_set_t &other,
+		 hb_vector_t<unsigned> *workspace = nullptr)
   {
     if (unlikely (!successful)) return;
 
@@ -540,8 +541,18 @@ struct hb_bit_set_t
 
     // Pre-allocate the workspace that compact() will need so we can bail on allocation failure
     // before attempting to rewrite the page map.
-    hb_vector_t<unsigned> compact_workspace;
-    if (!passthru_left && unlikely (!allocate_compact_workspace (compact_workspace))) return;
+    hb_vector_t<unsigned> local_workspace;
+    hb_vector_t<unsigned> &compact_workspace = workspace ? *workspace : local_workspace;
+    if (!passthru_left)
+    {
+      bool allocated = workspace ? compact_workspace.resize (pages.length)
+				 : allocate_compact_workspace (compact_workspace);
+      if (unlikely (!allocated))
+      {
+	successful = false;
+	return;
+      }
+    }
 
     for (; a < na && b < nb; )
     {
@@ -651,13 +662,17 @@ struct hb_bit_set_t
   op_ (const hb_bit_page_t::vector_t &a, const hb_bit_page_t::vector_t &b)
   { return Op{} (a, b); }
   template <typename Op>
-  void process (const Op& op, const hb_bit_set_t &other)
+  void process (const Op& op,
+		const hb_bit_set_t &other,
+		hb_vector_t<unsigned> *workspace = nullptr)
   {
-    process_ (op_<Op>, op (1, 0), op (0, 1), other);
+    process_ (op_<Op>, op (1, 0), op (0, 1), other, workspace);
   }
 
   void union_ (const hb_bit_set_t &other) { process (hb_bitwise_or, other); }
   void intersect (const hb_bit_set_t &other) { process (hb_bitwise_and, other); }
+  void intersect (const hb_bit_set_t &other, hb_vector_t<unsigned> &workspace)
+  { process (hb_bitwise_and, other, &workspace); }
   void subtract (const hb_bit_set_t &other) { process (hb_bitwise_gt, other); }
   void symmetric_difference (const hb_bit_set_t &other) { process (hb_bitwise_xor, other); }
 

--- a/src/hb-bit-set.hh
+++ b/src/hb-bit-set.hh
@@ -670,9 +670,9 @@ struct hb_bit_set_t
   }
 
   void union_ (const hb_bit_set_t &other) { process (hb_bitwise_or, other); }
-  void intersect (const hb_bit_set_t &other) { process (hb_bitwise_and, other); }
-  void intersect (const hb_bit_set_t &other, hb_vector_t<unsigned> &workspace)
-  { process (hb_bitwise_and, other, &workspace); }
+  void intersect (const hb_bit_set_t &other,
+		  hb_vector_t<unsigned> *workspace = nullptr)
+  { process (hb_bitwise_and, other, workspace); }
   void subtract (const hb_bit_set_t &other) { process (hb_bitwise_gt, other); }
   void symmetric_difference (const hb_bit_set_t &other) { process (hb_bitwise_xor, other); }
 

--- a/src/hb-bit-set.hh
+++ b/src/hb-bit-set.hh
@@ -723,6 +723,50 @@ struct hb_bit_set_t
     *codepoint = INVALID;
     return false;
   }
+  bool next_bits (hb_codepoint_t *codepoint, uint64_t *bits) const
+  {
+    static_assert (page_t::ELT_BITS == 64, "");
+
+    unsigned int i = 0;
+    unsigned int elt = 0;
+    if (likely (*codepoint != INVALID))
+    {
+      hb_codepoint_t base = *codepoint & -page_t::ELT_BITS;
+      if (unlikely (base >= INVALID - page_t::ELT_BITS + 1))
+        goto done;
+      base += page_t::ELT_BITS;
+
+      unsigned int major = get_major (base);
+      i = last_page_lookup;
+      if (unlikely (i >= page_map.length || page_map.arrayZ[i].major != major))
+      {
+	page_map.bfind (major, &i, HB_NOT_FOUND_STORE_CLOSEST);
+	if (i >= page_map.length)
+	  goto done;
+      }
+      if (page_map.arrayZ[i].major == major)
+	elt = page_remainder (base) / page_t::ELT_BITS;
+    }
+
+    for (; i < page_map.length; i++, elt = 0)
+    {
+      const page_map_t &map = page_map.arrayZ[i];
+      const page_t &page = pages.arrayZ[map.index];
+      for (; elt < page_t::len (); elt++)
+	if (page.v[elt])
+	{
+	  *codepoint = major_start (map.major) + elt * page_t::ELT_BITS;
+	  *bits = page.v[elt];
+	  last_page_lookup = i;
+	  return true;
+	}
+    }
+
+  done:
+    *codepoint = INVALID;
+    *bits = 0;
+    return false;
+  }
   bool previous (hb_codepoint_t *codepoint) const
   {
     if (unlikely (*codepoint == INVALID)) {

--- a/src/hb-depend-data.hh
+++ b/src/hb-depend-data.hh
@@ -470,11 +470,8 @@ struct hb_depend_data_builder_t
     }
 
     hb_depend_edge_key_t key (target, table_tag, layout_tag, dependent, lig_set, context_set);
-    if (seen_edges.has (key))
-      return false;
-
-    if (unlikely (!seen_edges.set (key, true)))
-      return fail ();
+    if (!seen_edges.set (key, true, false))
+      return unlikely (seen_edges.in_error ()) ? fail () : false;
 
     auto &gdr = data.glyph_dependencies[target];
     if (unlikely (!gdr.dependencies.push_or_fail (table_tag, dependent, layout_tag,

--- a/src/hb-depend-data.hh
+++ b/src/hb-depend-data.hh
@@ -275,7 +275,7 @@ struct hb_depend_data_t
  * Temporary state (freed on destruction):
  * - lookup_features: Packed lookup index to feature tag mapping
  * - lookup_feature_offsets: Per-lookup offsets into lookup_features
- * - seen_edges: Struct-based edge deduplication table
+ * - edge_slots: Compact edge deduplication table
  * - set_to_index: Content-based dependency set deduplication map
  * - free_set_list: Indices of freed sets available for reuse
  * - current_context_set_index: Context requirements for current rule
@@ -456,6 +456,89 @@ struct hb_depend_data_builder_t
     return find_or_create_context_set (context_elements);
   }
 
+  static uint64_t encode_edge_ref (hb_codepoint_t source, unsigned int index)
+  { return (uint64_t (source) + 1) << 32 | index; }
+
+  static void decode_edge_ref (uint64_t ref,
+			       hb_codepoint_t *source,
+			       unsigned int *index)
+  {
+    *source = (ref >> 32) - 1;
+    *index = ref;
+  }
+
+  uint32_t edge_hash (hb_codepoint_t source, const hb_depend_edge_t &record) const
+  {
+    hb_depend_edge_key_t key (source, record.table_tag, record.layout_tag,
+			      record.dependent, record.ligature_set,
+			      record.context_set);
+    return key.hash ();
+  }
+
+  bool resize_edge_slots ()
+  {
+    unsigned int new_size = edge_slots.length ? edge_slots.length * 2 : 8;
+    if (unlikely (new_size < edge_slots.length))
+      return fail ();
+
+    hb_vector_t<uint64_t> new_slots;
+    if (unlikely (!new_slots.resize_exact (new_size)))
+      return fail ();
+
+    for (uint64_t ref : edge_slots)
+    {
+      if (!ref)
+	continue;
+
+      hb_codepoint_t source;
+      unsigned int index;
+      decode_edge_ref (ref, &source, &index);
+      const hb_depend_edge_t &record = data.glyph_dependencies[source].dependencies[index];
+      unsigned int slot = edge_hash (source, record) & (new_size - 1);
+      unsigned int step = 0;
+      while (new_slots[slot])
+	slot = (slot + ++step) & (new_size - 1);
+      new_slots[slot] = ref;
+    }
+
+    edge_slots = std::move (new_slots);
+    return true;
+  }
+
+  bool add_edge (hb_codepoint_t source, const hb_depend_edge_t &record)
+  {
+    /* Store only a source and per-glyph edge index in each bucket.  The edge
+     * itself already lives in the output vector, where it can be compared to
+     * resolve hash collisions exactly.  Adding one to the encoded source
+     * reserves zero as the empty-bucket value. */
+    if (unlikely (!edge_slots.length ||
+		  uint64_t (edge_population) * 3 / 2 >= edge_slots.length - 1))
+      if (unlikely (!resize_edge_slots ()))
+	return false;
+
+    unsigned int slot = edge_hash (source, record) & (edge_slots.length - 1);
+    unsigned int step = 0;
+    while (uint64_t ref = edge_slots[slot])
+    {
+      hb_codepoint_t existing_source;
+      unsigned int existing_index;
+      decode_edge_ref (ref, &existing_source, &existing_index);
+      if (existing_source == source &&
+	  data.glyph_dependencies[source].dependencies[existing_index] == record)
+	return false;
+      slot = (slot + ++step) & (edge_slots.length - 1);
+    }
+
+    auto &dependencies = data.glyph_dependencies[source].dependencies;
+    unsigned int index = dependencies.length;
+    if (unlikely (!dependencies.push_or_fail (record)))
+      return fail ();
+
+    edge_slots[slot] = encode_edge_ref (source, index);
+    edge_population++;
+    return true;
+  }
+
   bool add_depend_layout (hb_codepoint_t target, hb_tag_t table_tag,
                           hb_tag_t layout_tag,
                           hb_codepoint_t dependent,
@@ -469,15 +552,8 @@ struct hb_depend_data_builder_t
       return false;
     }
 
-    hb_depend_edge_key_t key (target, table_tag, layout_tag, dependent, lig_set, context_set);
-    if (!seen_edges.set (key, true, false))
-      return unlikely (seen_edges.in_error ()) ? fail () : false;
-
-    auto &gdr = data.glyph_dependencies[target];
-    if (unlikely (!gdr.dependencies.push_or_fail (table_tag, dependent, layout_tag,
-                                                  lig_set, context_set, flags)))
-      return fail ();
-    return true;
+    return add_edge (target, hb_depend_edge_t (table_tag, dependent, layout_tag,
+					      lig_set, context_set, flags));
   }
 
   bool add_gsub_lookup (hb_codepoint_t target, hb_codepoint_t lookup_index,
@@ -578,7 +654,8 @@ struct hb_depend_data_builder_t
   hb_map_t nominal_glyphs;
   hb_vector_t<uint64_t> lookup_features;
   hb_vector_t<unsigned> lookup_feature_offsets;
-  hb_hashmap_t<hb_depend_edge_key_t, bool> seen_edges;
+  hb_vector_t<uint64_t> edge_slots;
+  unsigned int edge_population = 0;
   hb_hashmap_t<const hb_set_t*, hb_codepoint_t> set_to_index;
   hb_vector_t<hb_codepoint_t> free_set_list;
   hb_codepoint_t current_context_set_index;

--- a/src/hb-depend-data.hh
+++ b/src/hb-depend-data.hh
@@ -499,6 +499,14 @@ struct hb_depend_data_builder_t
     return any_added;
   }
 
+  bool add_lookup_feature (hb_codepoint_t lookup_index, hb_tag_t feature_tag)
+  {
+    if (feature_tag == HB_SET_VALUE_INVALID)
+      return true;
+
+    return check_success (lookup_features[lookup_index].push_or_fail (feature_tag));
+  }
+
   void add_depend (hb_codepoint_t target, hb_tag_t table_tag,
                    hb_codepoint_t dependent,
                    hb_codepoint_t lig_set = HB_CODEPOINT_INVALID,
@@ -523,7 +531,7 @@ struct hb_depend_data_builder_t
   bool successful = true;
   hb_set_t unicodes;
   hb_map_t nominal_glyphs;
-  hb_vector_t<hb_set_t> lookup_features;
+  hb_vector_t<hb_vector_t<hb_tag_t>> lookup_features;
   hb_hashmap_t<hb_depend_edge_key_t, bool> seen_edges;
   hb_hashmap_t<const hb_set_t*, hb_codepoint_t> set_to_index;
   hb_vector_t<hb_codepoint_t> free_set_list;

--- a/src/hb-depend-data.hh
+++ b/src/hb-depend-data.hh
@@ -273,7 +273,8 @@ struct hb_depend_data_t
  * construction is complete, leaving only hb_depend_data_t.
  *
  * Temporary state (freed on destruction):
- * - lookup_features: Lookup index to feature tag mapping
+ * - lookup_features: Packed lookup index to feature tag mapping
+ * - lookup_feature_offsets: Per-lookup offsets into lookup_features
  * - seen_edges: Struct-based edge deduplication table
  * - set_to_index: Content-based dependency set deduplication map
  * - free_set_list: Indices of freed sets available for reuse
@@ -492,11 +493,17 @@ struct hb_depend_data_builder_t
     hb_subset_depend_edge_flags_t flags = current_edge_flags;
 
     bool any_added = false;
-    for (auto t : lookup_features[lookup_index]) {
+    for (uint64_t entry : get_lookup_features (lookup_index)) {
+      hb_tag_t t = (hb_tag_t) entry;
       if (add_depend_layout (target, HB_OT_TAG_GSUB, t, dependent, lig_set, context_set, flags))
         any_added = true;
     }
     return any_added;
+  }
+
+  bool init_lookup_features (unsigned lookup_count)
+  {
+    return check_success (lookup_feature_offsets.resize (lookup_count + 1));
   }
 
   bool add_lookup_feature (hb_codepoint_t lookup_index, hb_tag_t feature_tag)
@@ -504,7 +511,48 @@ struct hb_depend_data_builder_t
     if (feature_tag == HB_SET_VALUE_INVALID)
       return true;
 
-    return check_success (lookup_features[lookup_index].push_or_fail (feature_tag));
+    if (unlikely (!lookup_feature_offsets.length ||
+		  lookup_index >= lookup_feature_offsets.length - 1))
+      return fail ();
+
+    uint64_t entry = ((uint64_t) lookup_index << 32) | feature_tag;
+    return check_success (lookup_features.push_or_fail (entry));
+  }
+
+  bool finish_lookup_features ()
+  {
+    lookup_features.qsort ([] (uint64_t a, uint64_t b) {
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+
+    unsigned write = 0;
+    for (uint64_t entry : lookup_features)
+      if (!write || entry != lookup_features[write - 1])
+	lookup_features[write++] = entry;
+    lookup_features.shrink (write, false);
+
+    unsigned feature_index = 0;
+    unsigned lookup_count = lookup_feature_offsets.length - 1;
+    for (unsigned lookup_index = 0; lookup_index < lookup_count; lookup_index++)
+    {
+      lookup_feature_offsets[lookup_index] = feature_index;
+      while (feature_index < lookup_features.length &&
+	     lookup_features[feature_index] >> 32 == lookup_index)
+	feature_index++;
+    }
+    lookup_feature_offsets[lookup_count] = feature_index;
+    return true;
+  }
+
+  hb_array_t<const uint64_t> get_lookup_features (hb_codepoint_t lookup_index) const
+  {
+    if (unlikely (!lookup_feature_offsets.length ||
+		  lookup_index >= lookup_feature_offsets.length - 1))
+      return {};
+
+    unsigned start = lookup_feature_offsets[lookup_index];
+    unsigned end = lookup_feature_offsets[lookup_index + 1];
+    return lookup_features.as_array ().sub_array (start, end - start);
   }
 
   void add_depend (hb_codepoint_t target, hb_tag_t table_tag,
@@ -531,7 +579,8 @@ struct hb_depend_data_builder_t
   bool successful = true;
   hb_set_t unicodes;
   hb_map_t nominal_glyphs;
-  hb_vector_t<hb_vector_t<hb_tag_t>> lookup_features;
+  hb_vector_t<uint64_t> lookup_features;
+  hb_vector_t<unsigned> lookup_feature_offsets;
   hb_hashmap_t<hb_depend_edge_key_t, bool> seen_edges;
   hb_hashmap_t<const hb_set_t*, hb_codepoint_t> set_to_index;
   hb_vector_t<hb_codepoint_t> free_set_list;

--- a/src/hb-ot-layout-gsub-table.hh
+++ b/src/hb-ot-layout-gsub-table.hh
@@ -151,7 +151,8 @@ GSUB_accelerator_t::depend (hb_depend_data_builder_t *builder, hb_face_t *face) 
       this->table->get_feature (feature_index).add_lookup_indexes_to (&lookup_indexes);
 
     for (auto lookup_index : lookup_indexes)
-      builder->lookup_features[lookup_index].add (ft);
+      if (unlikely (!builder->add_lookup_feature (lookup_index, ft)))
+	return;
 
     auto &fv = this->table->get_feature_variations ();
     auto fi_count = fv.record_count ();
@@ -165,9 +166,21 @@ GSUB_accelerator_t::depend (hb_depend_data_builder_t *builder, hb_face_t *face) 
           feature_ptr->add_lookup_indexes_to (&lookup_indexes);
       }
       for (auto lookup_index : lookup_indexes)
-        if (!builder->lookup_features[lookup_index].has (ft))
-          builder->lookup_features[lookup_index].add (ft);
+        if (unlikely (!builder->add_lookup_feature (lookup_index, ft)))
+	  return;
     }
+  }
+
+  for (auto &features : builder->lookup_features)
+  {
+    features.qsort ([] (hb_tag_t a, hb_tag_t b) {
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+    unsigned write = 0;
+    for (hb_tag_t tag : features)
+      if (!write || tag != features[write - 1])
+	features[write++] = tag;
+    features.shrink (write, false);
   }
 
   hb_set_t all_glyphs;
@@ -176,10 +189,10 @@ GSUB_accelerator_t::depend (hb_depend_data_builder_t *builder, hb_face_t *face) 
   hb_depend_context_t c (builder, face, &all_glyphs);
 
   int i = -1;
-  for (auto &feature_set : builder->lookup_features)
+  for (auto &features : builder->lookup_features)
   {
     i++;
-    if (feature_set.is_empty ())
+    if (!features)
     {
       DEBUG_MSG_LEVEL (DEPEND, nullptr, 1, 0,
                        "Skipping lookup %d (no features)", i);

--- a/src/hb-ot-layout-gsub-table.hh
+++ b/src/hb-ot-layout-gsub-table.hh
@@ -66,7 +66,14 @@ template <typename context_t>
    * Mark sequence positions as covered so later lookups use the full glyph set. */
   if (l.may_have_non_1to1 ())
       hb_set_add_range (covered_seq_indices, seq_index, end_index);
-  return l.dispatch (c);
+
+  hb_depend_context_t::recurse_key_t key;
+  if (!c->get_recurse_key (lookup_index, &key))
+    return hb_empty_t ();
+
+  hb_depend_context_t::return_t ret = l.dispatch (c);
+  c->finish_recurse (key);
+  return ret;
 }
 
 template <>
@@ -181,6 +188,7 @@ GSUB_accelerator_t::depend (hb_depend_data_builder_t *builder, hb_face_t *face) 
     DEBUG_MSG_LEVEL (DEPEND, nullptr, 1, 0,
                      "Processing lookup %d with features:", i);
     c.lookup_index = i;
+    c.reset_recurse_cache ();
     c.lookups_seen.clear ();
     c.lookups_seen.add (i);  /* Seed for A→B→A cycle detection in recurse(). */
     this->table->get_lookup (i).depend (&c);

--- a/src/hb-ot-layout-gsub-table.hh
+++ b/src/hb-ot-layout-gsub-table.hh
@@ -58,14 +58,14 @@ template <typename context_t>
   return l.dispatch (c);
 }
 
-/*static*/ hb_depend_context_t::return_t SubstLookup::depend_glyphs_recurse_func (hb_depend_context_t *c, unsigned lookup_index, hb_set_t *covered_seq_indices, unsigned seq_index, unsigned end_index)
+/*static*/ hb_depend_context_t::return_t SubstLookup::depend_glyphs_recurse_func (hb_depend_context_t *c, unsigned lookup_index, hb_bit_page_t *covered_seq_indices, unsigned seq_index, unsigned end_index)
 {
   const SubstLookup &l = c->face->table.GSUB.get_relaxed ()->table->get_lookup (lookup_index);
   /* After a non-1-to-1 lookup (expansion/contraction), subsequent lookups in the same
    * contextual rule see all glyphs, not position-specific ones. This matches closure behavior.
    * Mark sequence positions as covered so later lookups use the full glyph set. */
   if (l.may_have_non_1to1 ())
-      hb_set_add_range (covered_seq_indices, seq_index, end_index);
+      covered_seq_indices->add_range (seq_index, end_index);
 
   hb_depend_context_t::recurse_key_t key;
   if (!c->get_recurse_key (lookup_index, &key))

--- a/src/hb-ot-layout-gsub-table.hh
+++ b/src/hb-ot-layout-gsub-table.hh
@@ -128,7 +128,7 @@ GSUB_accelerator_t::depend (hb_depend_data_builder_t *builder, hb_face_t *face) 
     return;
   this->table->get_feature_tags (0, &num_features, feature_tags.arrayZ);
 
-  if (!builder->check_success (builder->lookup_features.resize (num_lookups)))
+  if (!builder->init_lookup_features (num_lookups))
     return;
 
   hb_vector_t<hb_tag_t> feature_query_v;
@@ -171,35 +171,25 @@ GSUB_accelerator_t::depend (hb_depend_data_builder_t *builder, hb_face_t *face) 
     }
   }
 
-  for (auto &features : builder->lookup_features)
-  {
-    features.qsort ([] (hb_tag_t a, hb_tag_t b) {
-      return a < b ? -1 : a > b ? 1 : 0;
-    });
-    unsigned write = 0;
-    for (hb_tag_t tag : features)
-      if (!write || tag != features[write - 1])
-	features[write++] = tag;
-    features.shrink (write, false);
-  }
+  if (unlikely (!builder->finish_lookup_features ()))
+    return;
 
   hb_set_t all_glyphs;
   all_glyphs.add_range (0, face->get_num_glyphs () - 1);
 
   hb_depend_context_t c (builder, face, &all_glyphs);
 
-  int i = -1;
-  for (auto &features : builder->lookup_features)
+  for (unsigned i = 0; i < num_lookups; i++)
   {
-    i++;
+    auto features = builder->get_lookup_features (i);
     if (!features)
     {
       DEBUG_MSG_LEVEL (DEPEND, nullptr, 1, 0,
-                       "Skipping lookup %d (no features)", i);
+                       "Skipping lookup %u (no features)", i);
       continue;
     }
     DEBUG_MSG_LEVEL (DEPEND, nullptr, 1, 0,
-                     "Processing lookup %d with features:", i);
+                     "Processing lookup %u with features:", i);
     c.lookup_index = i;
     c.reset_recurse_cache ();
     c.lookups_seen.clear ();

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -451,13 +451,13 @@ struct hb_depend_context_t :
     hb_subset_depend_edge_flags_t flags = HB_SUBSET_DEPEND_EDGE_FLAG_NONE;
   };
 
-  typedef return_t (*recurse_func_t) (hb_depend_context_t *c, unsigned lookup_index, hb_set_t *covered_seq_indicies, unsigned seq_index, unsigned end_index);
+  typedef return_t (*recurse_func_t) (hb_depend_context_t *c, unsigned lookup_index, hb_bit_page_t *covered_seq_indices, unsigned seq_index, unsigned end_index);
   /* return_t is hb_empty_t — dispatch is purely for side-effects, like hb_closure_context_t. */
   template <typename T>
   return_t dispatch (const T &obj) { obj.depend (this); return hb_empty_t (); }
   static return_t default_return_value () { return hb_empty_t (); }
 
-  void recurse (unsigned lookup_idx, hb_set_t *covered_seq_indicies, unsigned seq_index, unsigned end_index)
+  void recurse (unsigned lookup_idx, hb_bit_page_t *covered_seq_indices, unsigned seq_index, unsigned end_index)
   {
     /* Cycle detection using call-stack semantics: block re-entry of a
      * lookup that is currently on the execution stack, but allow it again
@@ -478,7 +478,7 @@ struct hb_depend_context_t :
      * that indirect cycles of the form A→B→A are also caught here. */
     if (lookups_seen.has (lookup_idx)) return;
     lookups_seen.add (lookup_idx);
-    recurse_func (this, lookup_idx, covered_seq_indicies, seq_index, end_index);
+    recurse_func (this, lookup_idx, covered_seq_indices, seq_index, end_index);
     lookups_seen.del (lookup_idx);
   }
 
@@ -2148,7 +2148,8 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
    * - Sequential accumulation: Not done. We want ALL possible edges, so we don't
    *   limit later lookups based on outputs from earlier lookups in the same rule. */
 
-  hb_set_t covered_seq_indicies;
+  /* HB_MAX_CONTEXT_LENGTH positions fit in one allocation-free bit page. */
+  hb_bit_page_t covered_seq_indices;
   hb_set_t pos_glyphs;
   for (unsigned int i = 0; i < lookupCount; i++)
   {
@@ -2267,7 +2268,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 
     bool has_pos_glyphs = false;
 
-    if (!covered_seq_indicies.has (seqIndex))
+    if (!covered_seq_indices.has (seqIndex))
     {
       has_pos_glyphs = true;
       pos_glyphs.clear ();
@@ -2299,7 +2300,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
       }
     }
 
-    covered_seq_indicies.add (seqIndex);
+    covered_seq_indices.add (seqIndex);
     hb_set_t *cur_active_glyphs = c->push_cur_active_glyphs ();
     if (unlikely (!cur_active_glyphs))
     {
@@ -2317,7 +2318,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
     if (context_format == ContextFormat::CoverageBasedContext)
       endIndex += 1;
 
-    c->recurse (lookupRecord[i].lookupListIndex, &covered_seq_indicies, seqIndex, endIndex);
+    c->recurse (lookupRecord[i].lookupListIndex, &covered_seq_indices, seqIndex, endIndex);
     c->pop_cur_done_glyphs ();
 
     /* Restore outer context after this lookup, so subsequent lookups in this

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -2058,7 +2058,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
       if (unlikely (!original_set)) continue;
 
       /* Dependency context sets are never inverted. */
-      if (!original_set->s.s.intersects (position_context.s.s)) {
+      if (!original_set->intersects (position_context)) {
         /* No overlap with position_context - add full requirement */
         filtered_disjunctive_indices.add (elem);
       }
@@ -2072,7 +2072,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
     for (unsigned j = 0; j < input_position_glyphs->length; j++) {
       if (j != seqIndex && (*input_position_glyphs)[j].get_population () > 1) {
         /* Input-position sets are also never inverted. */
-        if (!(*input_position_glyphs)[j].s.s.intersects (position_context.s.s)) {
+        if (!(*input_position_glyphs)[j].intersects (position_context)) {
           /* No overlap with position_context - add full requirement */
           hb_codepoint_t idx = c->depend_data->find_or_create_context_set ((*input_position_glyphs)[j]);
           if (unlikely (idx == HB_CODEPOINT_INVALID))

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -710,6 +710,7 @@ struct hb_depend_context_t :
       backtrack_sets.clear ();
       lookahead_sets.clear ();
       input_position_glyphs.clear ();
+      cached_context_sets.clear ();
       compact_workspace.clear ();
     }
 
@@ -722,6 +723,7 @@ struct hb_depend_context_t :
     hb_vector_t<const hb_set_t *> backtrack_sets;
     hb_vector_t<const hb_set_t *> lookahead_sets;
     hb_vector_t<const hb_set_t *> input_position_glyphs;
+    hb_vector_t<hb_codepoint_t> cached_context_sets;
     hb_vector_t<unsigned> compact_workspace;
     depend_scratch_t *next = nullptr;
   };
@@ -2335,7 +2337,8 @@ context_depend_sets_are_cached (hb_depend_context_t *c,
 				const void *rule,
 				unsigned value,
 				ContextFormat context_format,
-				const void *data)
+				const void *data,
+				hb_vector_t<hb_codepoint_t> *cached_context_sets)
 {
   hb_codepoint_t active_idx = HB_CODEPOINT_INVALID;
   bool have_active_idx = false;
@@ -2353,8 +2356,11 @@ context_depend_sets_are_cached (hb_depend_context_t *c,
 
     hb_depend_context_t::context_set_cache_key_t key (
       rule, &lookup_records[i], data, active_idx, value, context_format);
-    if (!c->context_set_cache.has (key))
+    hb_codepoint_t *cached_context_set = nullptr;
+    if (!c->context_set_cache.has (key, &cached_context_set))
       return false;
+    if (unlikely (!cached_context_sets->push_or_fail (*cached_context_set)))
+      return c->depend_data->fail ();
   }
   return true;
 }
@@ -2372,6 +2378,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 					     void *cache,
 					     const hb_set_t &preliminary_context,
 					     const hb_vector_t<const hb_set_t *> *input_position_glyphs,
+					     const hb_vector_t<hb_codepoint_t> *cached_context_sets,
 					     hb_depend_context_t::depend_scratch_t *scratch)
 {
   /* For depend graph extraction, we filter active glyphs by InputCoverage constraints
@@ -2388,6 +2395,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
   hb_set_t &position_context = scratch->position_context;
   hb_set_t &disjunctive_indices = scratch->disjunctive_indices;
   hb_set_t &filtered_disjunctive_indices = scratch->filtered_disjunctive_indices;
+  unsigned cached_context_index = 0;
   for (unsigned int i = 0; i < lookupCount; i++)
   {
     unsigned seqIndex = lookupRecord[i].sequenceIndex;
@@ -2400,8 +2408,10 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
       return;
 
     hb_codepoint_t context_set_idx;
-    hb_codepoint_t *cached_context_set_idx = nullptr;
-    if (c->context_set_cache.has (context_cache_key, &cached_context_set_idx))
+    hb_codepoint_t *cached_context_set_idx;
+    if (cached_context_sets)
+      context_set_idx = (*cached_context_sets)[cached_context_index++];
+    else if (c->context_set_cache.has (context_cache_key, &cached_context_set_idx))
       context_set_idx = *cached_context_set_idx;
     else
     {
@@ -2837,7 +2847,8 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
 
   bool context_sets_cached = context_depend_sets_are_cached (
     c, inputCount, lookupCount, lookupRecord, rule, value,
-    lookup_context.context_format, lookup_context.intersects_data);
+    lookup_context.context_format, lookup_context.intersects_data,
+    &scratch->cached_context_sets);
   if (unlikely (!c->depend_data->successful))
     return;
 
@@ -2890,6 +2901,7 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
 				  lookup_context.intersected_glyphs_cache,
 				  preliminary_context,
 				  context_sets_cached ? nullptr : &input_position_glyphs,
+				  context_sets_cached ? &scratch->cached_context_sets : nullptr,
 				  scratch);
 }
 
@@ -4156,7 +4168,8 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
 
   bool context_sets_cached = context_depend_sets_are_cached (
     c, inputCount, lookupCount, lookupRecord, rule, value,
-    lookup_context.context_format, lookup_context.intersects_data[1]);
+    lookup_context.context_format, lookup_context.intersects_data[1],
+    &scratch->cached_context_sets);
   if (unlikely (!c->depend_data->successful))
     return;
 
@@ -4279,6 +4292,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
 				  lookup_context.intersected_glyphs_cache,
 				  preliminary_context,
 				  context_sets_cached ? nullptr : &input_position_glyphs,
+				  context_sets_cached ? &scratch->cached_context_sets : nullptr,
 				  scratch);
 }
 

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -569,6 +569,60 @@ struct hb_depend_context_t :
                                              glyph_set_type_t type);
   hb_codepoint_t find_or_create_cached_context_set (const hb_set_t *set);
 
+  struct depend_scratch_t
+  {
+    void clear ()
+    {
+      preliminary_context.clear ();
+      position_scratch.clear ();
+      pos_glyphs.clear ();
+      position_context.clear ();
+      disjunctive_indices.clear ();
+      filtered_disjunctive_indices.clear ();
+      backtrack_sets.clear ();
+      lookahead_sets.clear ();
+      input_position_glyphs.clear ();
+    }
+
+    hb_set_t preliminary_context;
+    hb_set_t position_scratch;
+    hb_set_t pos_glyphs;
+    hb_set_t position_context;
+    hb_set_t disjunctive_indices;
+    hb_set_t filtered_disjunctive_indices;
+    hb_vector_t<const hb_set_t *> backtrack_sets;
+    hb_vector_t<const hb_set_t *> lookahead_sets;
+    hb_vector_t<const hb_set_t *> input_position_glyphs;
+    depend_scratch_t *next = nullptr;
+  };
+
+  depend_scratch_t *acquire_depend_scratch ()
+  {
+    depend_scratch_t *scratch = depend_scratch_pool;
+    if (scratch)
+      depend_scratch_pool = scratch->next;
+    else
+    {
+      scratch = (depend_scratch_t *) hb_malloc (sizeof (depend_scratch_t));
+      if (unlikely (!scratch))
+      {
+        depend_data->fail ();
+        return nullptr;
+      }
+      new (scratch) depend_scratch_t ();
+    }
+
+    scratch->next = nullptr;
+    scratch->clear ();
+    return scratch;
+  }
+
+  void release_depend_scratch (depend_scratch_t *scratch)
+  {
+    scratch->next = depend_scratch_pool;
+    depend_scratch_pool = scratch;
+  }
+
   hb_depend_data_builder_t *depend_data;
   hb_face_t *face;
   hb_set_t *glyphs;
@@ -582,6 +636,7 @@ struct hb_depend_context_t :
   hb_vector_t<hb::unique_ptr<hb_set_t>> glyph_sets;
   hb_hashmap_t<glyph_set_cache_key_t, hb_codepoint_t> glyph_set_to_index;
   hb_hashmap_t<uintptr_t, hb_codepoint_t> cached_context_set_indices;
+  depend_scratch_t *depend_scratch_pool = nullptr;
 
   hb_depend_context_t (hb_depend_data_builder_t *depend_data_,
                        hb_face_t *face_,
@@ -590,6 +645,16 @@ struct hb_depend_context_t :
                         face(face_),
                         glyphs (glyphs_),
                         recurse_func (nullptr) {}
+  ~hb_depend_context_t ()
+  {
+    while (depend_scratch_pool)
+    {
+      depend_scratch_t *scratch = depend_scratch_pool;
+      depend_scratch_pool = scratch->next;
+      scratch->~depend_scratch_t ();
+      hb_free (scratch);
+    }
+  }
   void set_recurse_func (recurse_func_t func) { recurse_func = func; }
 };
 
@@ -2138,7 +2203,8 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 					     intersected_glyphs_func_t intersected_glyphs_func,
 					     void *cache,
 					     const hb_set_t &preliminary_context,
-					     const hb_vector_t<const hb_set_t *> *input_position_glyphs)
+					     const hb_vector_t<const hb_set_t *> *input_position_glyphs,
+					     hb_depend_context_t::depend_scratch_t *scratch)
 {
   /* For depend graph extraction, we filter active glyphs by InputCoverage constraints
    * (same as closure), but we do NOT do sequential accumulation of outputs.
@@ -2150,7 +2216,10 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 
   /* HB_MAX_CONTEXT_LENGTH positions fit in one allocation-free bit page. */
   hb_bit_page_t covered_seq_indices;
-  hb_set_t pos_glyphs;
+  hb_set_t &pos_glyphs = scratch->pos_glyphs;
+  hb_set_t &position_context = scratch->position_context;
+  hb_set_t &disjunctive_indices = scratch->disjunctive_indices;
+  hb_set_t &filtered_disjunctive_indices = scratch->filtered_disjunctive_indices;
   for (unsigned int i = 0; i < lookupCount; i++)
   {
     unsigned seqIndex = lookupRecord[i].sequenceIndex;
@@ -2158,8 +2227,9 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
       continue;
 
     /* Build position-specific context_set for this lookup */
-    hb_set_t position_context;  // Will hold direct glyphs
-    hb_set_t disjunctive_indices;  // Will hold encoded set references
+    position_context.clear ();  // Will hold direct glyphs
+    disjunctive_indices.clear ();  // Will hold encoded set references
+    filtered_disjunctive_indices.clear ();
 
     /* Process preliminary_context in one pass */
     hb_codepoint_t elem = HB_SET_VALUE_INVALID;
@@ -2182,7 +2252,6 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 
     /* Now position_context has all direct requirements.
      * Process deferred encoded sets and filter them. */
-    hb_set_t filtered_disjunctive_indices;
     elem = HB_SET_VALUE_INVALID;
     while (disjunctive_indices.next (&elem)) {
       hb_codepoint_t set_idx = elem & 0x7FFFFFFF;
@@ -2557,12 +2626,17 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
 			   lookup_context))
     return;
 
+  hb_depend_context_t::depend_scratch_t *scratch = c->acquire_depend_scratch ();
+  if (unlikely (!scratch))
+    return;
+  HB_SCOPE_GUARD (c->release_depend_scratch (scratch));
+
   /* Build preliminary_context (empty for ContextSubst - no backtrack/lookahead) */
-  hb_set_t preliminary_context;
+  hb_set_t &preliminary_context = scratch->preliminary_context;
 
   /* Build glyph sets for ALL input positions */
-  hb_set_t position_scratch;
-  hb_vector_t<const hb_set_t *> input_position_glyphs;
+  hb_set_t &position_scratch = scratch->position_scratch;
+  hb_vector_t<const hb_set_t *> &input_position_glyphs = scratch->input_position_glyphs;
 
   /* Position 0 (Coverage glyph) — must be in both the class AND the
    * coverage, so intersect with parent_active_glyphs (= coverage ∩ glyphs
@@ -2600,7 +2674,8 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
 				  lookup_context.funcs.intersected_glyphs,
 				  lookup_context.intersected_glyphs_cache,
 				  preliminary_context,
-				  &input_position_glyphs);
+				  &input_position_glyphs,
+				  scratch);
 }
 
 template <typename HBUINT>
@@ -3856,10 +3931,15 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
 				 lookup_context))
     return;
 
+  hb_depend_context_t::depend_scratch_t *scratch = c->acquire_depend_scratch ();
+  if (unlikely (!scratch))
+    return;
+  HB_SCOPE_GUARD (c->release_depend_scratch (scratch));
+
   /* Build context information - extract backtrack and lookahead glyphs */
-  hb_set_t position_scratch;
-  hb_vector_t<const hb_set_t *> backtrack_sets;
-  hb_vector_t<const hb_set_t *> lookahead_sets;
+  hb_set_t &position_scratch = scratch->position_scratch;
+  hb_vector_t<const hb_set_t *> &backtrack_sets = scratch->backtrack_sets;
+  hb_vector_t<const hb_set_t *> &lookahead_sets = scratch->lookahead_sets;
 
   /* Extract backtrack glyphs */
   for (unsigned i = 0; i < backtrackCount; i++)
@@ -3898,7 +3978,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   }
 
   /* Build preliminary_context with backtrack + lookahead encoded */
-  hb_set_t preliminary_context;
+  hb_set_t &preliminary_context = scratch->preliminary_context;
   for (const hb_set_t *back_set : backtrack_sets)
   {
     if (back_set->get_population () == 1) {
@@ -3932,7 +4012,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   }
 
   /* Build glyph sets for ALL input positions */
-  hb_vector_t<const hb_set_t *> input_position_glyphs;
+  hb_vector_t<const hb_set_t *> &input_position_glyphs = scratch->input_position_glyphs;
 
   /* Position 0 (first input coverage/class/glyph) — must be in both the
    * class AND the coverage, so intersect with parent_active_glyphs. */
@@ -3969,7 +4049,8 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
 				  lookup_context.funcs.intersected_glyphs,
 				  lookup_context.intersected_glyphs_cache,
 				  preliminary_context,
-				  &input_position_glyphs);
+				  &input_position_glyphs,
+				  scratch);
 }
 
 template <typename HBUINT>

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -412,6 +412,46 @@ struct hb_depend_context_t :
     glyph_set_type_t type = GLYPH_SET_CLASS;
   };
 
+  struct context_set_cache_key_t
+  {
+    context_set_cache_key_t () = default;
+    context_set_cache_key_t (const void *rule_,
+			     const void *record_,
+			     const void *data_,
+			     hb_codepoint_t active_glyphs_,
+			     unsigned value_,
+			     unsigned format_)
+      : rule (rule_), record (record_), data (data_), active_glyphs (active_glyphs_),
+	value (value_), format (format_) {}
+
+    bool operator == (const context_set_cache_key_t &o) const
+    {
+      return rule == o.rule &&
+	     record == o.record &&
+	     data == o.data &&
+	     active_glyphs == o.active_glyphs &&
+	     value == o.value &&
+	     format == o.format;
+    }
+
+    uint32_t hash () const
+    {
+      uint32_t current = hb_hash ((uintptr_t) rule);
+      current = current * 31 + hb_hash ((uintptr_t) record);
+      current = current * 31 + hb_hash ((uintptr_t) data);
+      current = current * 31 + hb_hash (active_glyphs);
+      current = current * 31 + hb_hash (value);
+      return current * 31 + hb_hash (format);
+    }
+
+    const void *rule = nullptr;
+    const void *record = nullptr;
+    const void *data = nullptr;
+    hb_codepoint_t active_glyphs = HB_CODEPOINT_INVALID;
+    unsigned value = 0;
+    unsigned format = 0;
+  };
+
   struct recurse_key_t
   {
     recurse_key_t () = default;
@@ -554,28 +594,53 @@ struct hb_depend_context_t :
     return true;
   }
 
+  bool get_parent_active_glyphs_index (hb_codepoint_t *active_idx)
+  {
+    if (!active_glyphs_stack_depth ||
+	active_glyphs_stack[active_glyphs_stack_depth - 1].use_root)
+    {
+      *active_idx = HB_CODEPOINT_INVALID;
+      return true;
+    }
+
+    active_glyphs_frame_t &frame = active_glyphs_stack[active_glyphs_stack_depth - 1];
+    *active_idx = frame.active_idx;
+    if (*active_idx != HB_CODEPOINT_INVALID)
+      return true;
+
+    hb_codepoint_t glyph;
+    if (frame.glyphs.get_singleton (&glyph) &&
+	likely (glyph < SINGLE_GLYPH_ACTIVE_FLAG))
+      *active_idx = glyph | SINGLE_GLYPH_ACTIVE_FLAG;
+    else if (!find_or_create_recurse_set (frame.glyphs, active_idx))
+      return false;
+
+    frame.active_idx = *active_idx;
+    return true;
+  }
+
+  bool get_context_set_cache_key (const void *rule,
+				  const void *record,
+				  const void *data,
+				  unsigned value,
+				  unsigned format,
+				  context_set_cache_key_t *key)
+  {
+    hb_codepoint_t active_idx;
+    if (!get_parent_active_glyphs_index (&active_idx))
+      return false;
+    *key = context_set_cache_key_t (rule, record, data, active_idx, value, format);
+    return true;
+  }
+
   bool get_recurse_key (unsigned lookup_idx, recurse_key_t *key)
   {
     /* The active glyphs and in-progress lookup set are part of the state.
      * Omitting the latter would make memoization incorrect for cyclic lookup
      * graphs whose available recursive paths depend on their ancestry. */
-    bool uses_root = !active_glyphs_stack_depth ||
-		     active_glyphs_stack[active_glyphs_stack_depth - 1].use_root;
-    hb_codepoint_t active_idx = HB_CODEPOINT_INVALID;
-    if (!uses_root)
-    {
-      const active_glyphs_frame_t &frame = active_glyphs_stack[active_glyphs_stack_depth - 1];
-      active_idx = frame.active_idx;
-      if (active_idx == HB_CODEPOINT_INVALID)
-      {
-	hb_codepoint_t glyph;
-	if (frame.glyphs.get_singleton (&glyph) &&
-	    likely (glyph < SINGLE_GLYPH_ACTIVE_FLAG))
-	  active_idx = glyph | SINGLE_GLYPH_ACTIVE_FLAG;
-	else if (!find_or_create_recurse_set (frame.glyphs, &active_idx))
-	  return false;
-      }
-    }
+    hb_codepoint_t active_idx;
+    if (!get_parent_active_glyphs_index (&active_idx))
+      return false;
 
     *key = recurse_key_t (lookup_idx,
                           active_idx,
@@ -591,8 +656,6 @@ struct hb_depend_context_t :
   void reset_recurse_cache ()
   {
     completed_recursions.clear ();
-    recurse_set_to_index.clear ();
-    recurse_sets.clear ();
     recurse_path_to_index.clear ();
     recurse_path = 0;
   }
@@ -706,6 +769,7 @@ struct hb_depend_context_t :
   hb_vector_t<hb::unique_ptr<hb_set_t>> glyph_sets;
   hb_hashmap_t<glyph_set_cache_key_t, hb_codepoint_t> glyph_set_to_index;
   hb_hashmap_t<uintptr_t, hb_codepoint_t> cached_context_set_indices;
+  hb_hashmap_t<context_set_cache_key_t, hb_codepoint_t> context_set_cache;
   depend_scratch_t *depend_scratch_pool = nullptr;
 
   hb_depend_context_t (hb_depend_data_builder_t *depend_data_,
@@ -2268,6 +2332,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 					     unsigned inputCount, const HBUINT input[],
 					     unsigned lookupCount,
 					     const LookupRecord lookupRecord[] /* Array of LookupRecords--in design order */,
+					     const void *rule,
 					     unsigned value,
 					     ContextFormat context_format,
 					     const void *data,
@@ -2297,84 +2362,101 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
     if (seqIndex >= inputCount)
       continue;
 
-    /* Build position-specific context_set for this lookup */
-    position_context.clear ();  // Will hold direct glyphs
-    disjunctive_indices.clear ();  // Will hold encoded set references
-    filtered_disjunctive_indices.clear ();
+    hb_depend_context_t::context_set_cache_key_t context_cache_key;
+    if (unlikely (!c->get_context_set_cache_key (rule, &lookupRecord[i], data, value,
+						 context_format, &context_cache_key)))
+      return;
 
-    /* Process preliminary_context in one pass */
-    hb_codepoint_t elem = HB_SET_VALUE_INVALID;
-    while (preliminary_context.next (&elem)) {
-      if (!(elem & HB_DEPEND_CONTEXT_SET_FLAG)) {
-        /* Direct glyph */
-        position_context.add (elem);
-      } else {
-        /* Encoded set reference - defer processing until we have all direct requirements */
-        disjunctive_indices.add (elem);
-      }
-    }
-
-    /* Add singleton glyphs from OTHER input positions */
-    for (unsigned j = 0; j < input_position_glyphs->length; j++) {
-      if (j != seqIndex && (*input_position_glyphs)[j]->get_population () == 1) {
-        position_context.add ((*input_position_glyphs)[j]->get_min ());
-      }
-    }
-
-    /* Now position_context has all direct requirements.
-     * Process deferred encoded sets and filter them. */
-    elem = HB_SET_VALUE_INVALID;
-    while (disjunctive_indices.next (&elem)) {
-      hb_codepoint_t set_idx = elem & 0x7FFFFFFF;
-      const hb_set_t *original_set = c->depend_data->get_set_from_index (set_idx);
-      if (unlikely (!original_set)) continue;
-
-      /* Dependency context sets are never inverted. */
-      if (!original_set->intersects (position_context)) {
-        /* No overlap with position_context - add full requirement */
-        filtered_disjunctive_indices.add (elem);
-      }
-      /* Otherwise: position_context intersects with original_set.
-       * Since disjunctive requirements need only ONE glyph from the set,
-       * and position_context already has a glyph from this set, the
-       * requirement is satisfied - no need to add anything. */
-    }
-
-    /* Process non-singleton input positions */
-    for (unsigned j = 0; j < input_position_glyphs->length; j++) {
-      if (j != seqIndex && (*input_position_glyphs)[j]->get_population () > 1) {
-        /* Input-position sets are also never inverted. */
-        if (!(*input_position_glyphs)[j]->intersects (position_context)) {
-          /* No overlap with position_context - add full requirement */
-          bool cached_set = context_format == ContextFormat::CoverageBasedContext ||
-                            (context_format == ContextFormat::ClassBasedContext && j != 0);
-          hb_codepoint_t idx = cached_set
-            ? c->find_or_create_cached_context_set ((*input_position_glyphs)[j])
-            : c->depend_data->find_or_create_context_set (*(*input_position_glyphs)[j]);
-          if (unlikely (idx == HB_CODEPOINT_INVALID))
-            return;
-          filtered_disjunctive_indices.add (HB_DEPEND_CONTEXT_SET_FLAG | idx);
-        }
-        /* Otherwise: position_context intersects, requirement satisfied */
-      }
-    }
-
-    /* Combine direct + disjunctive */
-    position_context.union_ (filtered_disjunctive_indices);
-    if (unlikely (position_context.in_error () ||
-                  filtered_disjunctive_indices.in_error ()))
+    hb_codepoint_t context_set_idx;
+    hb_codepoint_t *cached_context_set_idx = nullptr;
+    if (c->context_set_cache.has (context_cache_key, &cached_context_set_idx))
+      context_set_idx = *cached_context_set_idx;
+    else
     {
-      c->depend_data->fail ();
-      return;
-    }
+      /* Build position-specific context_set for this lookup. */
+      position_context.clear ();  // Will hold direct glyphs
+      disjunctive_indices.clear ();  // Will hold encoded set references
+      filtered_disjunctive_indices.clear ();
 
-    /* Allocate final context_set */
-    hb_codepoint_t context_set_idx = position_context.is_empty ()
-      ? HB_CODEPOINT_INVALID
-      : c->depend_data->find_or_create_context_set (position_context);
-    if (unlikely (!position_context.is_empty () &&
-                  context_set_idx == HB_CODEPOINT_INVALID))
-      return;
+      /* Process preliminary_context in one pass. */
+      hb_codepoint_t elem = HB_SET_VALUE_INVALID;
+      while (preliminary_context.next (&elem)) {
+	if (!(elem & HB_DEPEND_CONTEXT_SET_FLAG)) {
+	  /* Direct glyph */
+	  position_context.add (elem);
+	} else {
+	  /* Encoded set reference - defer processing until we have all direct requirements */
+	  disjunctive_indices.add (elem);
+	}
+      }
+
+      /* Add singleton glyphs from OTHER input positions. */
+      for (unsigned j = 0; j < input_position_glyphs->length; j++) {
+	if (j != seqIndex && (*input_position_glyphs)[j]->get_population () == 1) {
+	  position_context.add ((*input_position_glyphs)[j]->get_min ());
+	}
+      }
+
+      /* Now position_context has all direct requirements.
+       * Process deferred encoded sets and filter them. */
+      elem = HB_SET_VALUE_INVALID;
+      while (disjunctive_indices.next (&elem)) {
+	hb_codepoint_t set_idx = elem & 0x7FFFFFFF;
+	const hb_set_t *original_set = c->depend_data->get_set_from_index (set_idx);
+	if (unlikely (!original_set)) continue;
+
+	/* Dependency context sets are never inverted. */
+	if (!original_set->intersects (position_context)) {
+	  /* No overlap with position_context - add full requirement */
+	  filtered_disjunctive_indices.add (elem);
+	}
+	/* Otherwise: position_context intersects with original_set.
+	 * Since disjunctive requirements need only ONE glyph from the set,
+	 * and position_context already has a glyph from this set, the
+	 * requirement is satisfied - no need to add anything. */
+      }
+
+      /* Process non-singleton input positions. */
+      for (unsigned j = 0; j < input_position_glyphs->length; j++) {
+	if (j != seqIndex && (*input_position_glyphs)[j]->get_population () > 1) {
+	  /* Input-position sets are also never inverted. */
+	  if (!(*input_position_glyphs)[j]->intersects (position_context)) {
+	    /* No overlap with position_context - add full requirement */
+	    bool cached_set = context_format == ContextFormat::CoverageBasedContext ||
+			      (context_format == ContextFormat::ClassBasedContext && j != 0);
+	    hb_codepoint_t idx = cached_set
+	      ? c->find_or_create_cached_context_set ((*input_position_glyphs)[j])
+	      : c->depend_data->find_or_create_context_set (*(*input_position_glyphs)[j]);
+	    if (unlikely (idx == HB_CODEPOINT_INVALID))
+	      return;
+	    filtered_disjunctive_indices.add (HB_DEPEND_CONTEXT_SET_FLAG | idx);
+	  }
+	  /* Otherwise: position_context intersects, requirement satisfied */
+	}
+      }
+
+      /* Combine direct + disjunctive. */
+      position_context.union_ (filtered_disjunctive_indices);
+      if (unlikely (position_context.in_error () ||
+		    filtered_disjunctive_indices.in_error ()))
+      {
+	c->depend_data->fail ();
+	return;
+      }
+
+      context_set_idx = position_context.is_empty ()
+	? HB_CODEPOINT_INVALID
+	: c->depend_data->find_or_create_context_set (position_context);
+      if (unlikely (!position_context.is_empty () &&
+		    context_set_idx == HB_CODEPOINT_INVALID))
+	return;
+
+      if (unlikely (!c->context_set_cache.set (context_cache_key, context_set_idx)))
+      {
+	c->depend_data->fail ();
+	return;
+      }
+    }
 
     /* Save outer context to restore after this lookup. When a contextual lookup
      * calls another contextual lookup, we want each lookup in this rule to see
@@ -2701,6 +2783,7 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
 					  const HBUINT input[], /* Array of input values--start with second glyph */
 					  unsigned int lookupCount,
 					  const LookupRecord lookupRecord[],
+					  const void *rule,
 					  unsigned value, /* Index of first glyph in Coverage or Class value in ClassDef table */
 					  ContextDependLookupContext &lookup_context)
 {
@@ -2751,6 +2834,7 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
   context_depend_recurse_lookups (c,
 				  inputCount, input,
 				  lookupCount, lookupRecord,
+				  rule,
 				  value,
 				  lookup_context.context_format,
 				  lookup_context.intersects_data,
@@ -2867,6 +2951,7 @@ struct Rule
     context_depend_lookup (c,
 			   inputCount, inputZ.arrayZ,
 			   lookupCount, lookupRecord.arrayZ,
+			   this,
 			   value, lookup_context);
   }
 
@@ -3739,6 +3824,7 @@ struct ContextFormat3
     context_depend_lookup (c,
 			   glyphCount, (const HBUINT16 *) (coverageZ.arrayZ + 1),
 			   lookupCount, lookupRecord,
+			   this,
 			   coverageZ[0], lookup_context);
 
     c->pop_cur_done_glyphs ();
@@ -4004,6 +4090,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
 						const HBUINT lookahead[],
 						unsigned int lookupCount,
 						const LookupRecord lookupRecord[],
+						const void *rule,
 						unsigned value,
 						ChainContextDependLookupContext &lookup_context)
 {
@@ -4126,6 +4213,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   context_depend_recurse_lookups (c,
 				  inputCount, input,
 				  lookupCount, lookupRecord,
+				  rule,
 				  value,
 				  lookup_context.context_format,
 				  lookup_context.intersects_data[1],
@@ -4255,6 +4343,7 @@ struct ChainRule
 				 input.lenP1, input.arrayZ,
 				 lookahead.len, lookahead.arrayZ,
 				 lookup.len, lookup.arrayZ,
+				 this,
 				 value,
 				 lookup_context);
   }
@@ -5279,6 +5368,7 @@ struct ChainContextFormat3
 				 input.len, (const HBUINT16 *) input.arrayZ + 1,
 				 lookahead.len, (const HBUINT16 *) lookahead.arrayZ,
 				 lookup.len, lookup.arrayZ,
+				 this,
 				 input[0], lookup_context);
 
     c->pop_cur_done_glyphs ();

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -389,6 +389,8 @@ struct hb_depend_context_t :
     GLYPH_SET_SINGLE
   };
 
+  static constexpr hb_codepoint_t SINGLE_GLYPH_ACTIVE_FLAG = 0x80000000u;
+
   struct glyph_set_cache_key_t
   {
     glyph_set_cache_key_t () = default;
@@ -504,23 +506,43 @@ struct hb_depend_context_t :
     lookups_seen.del (lookup_idx);
   }
 
+  struct active_glyphs_frame_t
+  {
+    hb_set_t glyphs;
+    hb_codepoint_t active_idx = HB_CODEPOINT_INVALID;
+    bool use_root = false;
+  };
+
   const hb_set_t& parent_active_glyphs ()
   {
     if (!active_glyphs_stack_depth)
       return *glyphs;
 
-    return active_glyphs_stack[active_glyphs_stack_depth - 1];
+    const active_glyphs_frame_t &frame = active_glyphs_stack[active_glyphs_stack_depth - 1];
+    return frame.use_root ? *glyphs : frame.glyphs;
   }
 
-  hb_set_t* push_cur_active_glyphs ()
+  hb_set_t* push_cur_active_glyphs (hb_codepoint_t active_idx = HB_CODEPOINT_INVALID)
   {
     if (active_glyphs_stack_depth == active_glyphs_stack.length &&
 	unlikely (!active_glyphs_stack.push_or_fail ()))
       return nullptr;
 
-    hb_set_t *set = &active_glyphs_stack[active_glyphs_stack_depth++];
-    set->clear ();
-    return set;
+    active_glyphs_frame_t &frame = active_glyphs_stack[active_glyphs_stack_depth++];
+    frame.glyphs.clear ();
+    frame.active_idx = active_idx;
+    frame.use_root = false;
+    return &frame.glyphs;
+  }
+
+  bool push_root_active_glyphs ()
+  {
+    if (active_glyphs_stack_depth == active_glyphs_stack.length &&
+	unlikely (!active_glyphs_stack.push_or_fail ()))
+      return false;
+
+    active_glyphs_stack[active_glyphs_stack_depth++].use_root = true;
+    return true;
   }
 
   bool pop_cur_done_glyphs ()
@@ -537,9 +559,23 @@ struct hb_depend_context_t :
     /* The active glyphs and in-progress lookup set are part of the state.
      * Omitting the latter would make memoization incorrect for cyclic lookup
      * graphs whose available recursive paths depend on their ancestry. */
-    hb_codepoint_t active_idx;
-    if (!find_or_create_recurse_set (parent_active_glyphs (), &active_idx))
-      return false;
+    bool uses_root = !active_glyphs_stack_depth ||
+		     active_glyphs_stack[active_glyphs_stack_depth - 1].use_root;
+    hb_codepoint_t active_idx = HB_CODEPOINT_INVALID;
+    if (!uses_root)
+    {
+      const active_glyphs_frame_t &frame = active_glyphs_stack[active_glyphs_stack_depth - 1];
+      active_idx = frame.active_idx;
+      if (active_idx == HB_CODEPOINT_INVALID)
+      {
+	hb_codepoint_t glyph;
+	if (frame.glyphs.get_singleton (&glyph) &&
+	    likely (glyph < SINGLE_GLYPH_ACTIVE_FLAG))
+	  active_idx = glyph | SINGLE_GLYPH_ACTIVE_FLAG;
+	else if (!find_or_create_recurse_set (frame.glyphs, &active_idx))
+	  return false;
+      }
+    }
 
     *key = recurse_key_t (lookup_idx,
                           active_idx,
@@ -581,6 +617,11 @@ struct hb_depend_context_t :
     }
 
     *index = recurse_sets.length;
+    if (unlikely (*index & SINGLE_GLYPH_ACTIVE_FLAG))
+    {
+      hb_set_destroy (copy);
+      return depend_data->fail ();
+    }
     if (unlikely (!recurse_sets.push_or_fail (hb::unique_ptr<hb_set_t> {copy})))
       return depend_data->fail ();
     if (unlikely (!recurse_set_to_index.set (recurse_sets[*index].get (), *index)))
@@ -652,7 +693,7 @@ struct hb_depend_context_t :
   hb_depend_data_builder_t *depend_data;
   hb_face_t *face;
   hb_set_t *glyphs;
-  hb_vector_t<hb_set_t> active_glyphs_stack;
+  hb_vector_t<active_glyphs_frame_t> active_glyphs_stack;
   unsigned active_glyphs_stack_depth = 0;
   recurse_func_t recurse_func;
   hb_codepoint_t lookup_index = HB_CODEPOINT_INVALID;
@@ -2400,17 +2441,29 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
     }
 
     covered_seq_indices.add (seqIndex);
-    hb_set_t *cur_active_glyphs = c->push_cur_active_glyphs ();
-    if (unlikely (!cur_active_glyphs))
+    if (has_pos_glyphs)
+    {
+      hb_codepoint_t active_idx = HB_CODEPOINT_INVALID;
+      if (context_format == ContextFormat::SimpleContext)
+      {
+	hb_codepoint_t glyph = seqIndex ? pos_glyphs.get_min () : value;
+	if (likely (glyph < hb_depend_context_t::SINGLE_GLYPH_ACTIVE_FLAG))
+	  active_idx = glyph | hb_depend_context_t::SINGLE_GLYPH_ACTIVE_FLAG;
+      }
+      hb_set_t *cur_active_glyphs = c->push_cur_active_glyphs (active_idx);
+      if (unlikely (!cur_active_glyphs))
+      {
+	c->depend_data->current_context_set_index = saved_context_set_index;
+	c->depend_data->current_edge_flags = saved_edge_flags;
+	return;
+      }
+      *cur_active_glyphs = std::move (pos_glyphs);
+    }
+    else if (unlikely (!c->push_root_active_glyphs ()))
     {
       c->depend_data->current_context_set_index = saved_context_set_index;
       c->depend_data->current_edge_flags = saved_edge_flags;
       return;
-    }
-    if (has_pos_glyphs) {
-      *cur_active_glyphs = std::move (pos_glyphs);
-    } else {
-      *cur_active_glyphs = *c->glyphs;
     }
 
     unsigned endIndex = inputCount;

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -2096,7 +2096,7 @@ depend_position_glyphs (hb_depend_context_t *c,
 			unsigned value,
 			bool filter_class_by_parent,
 			hb_set_t *scratch,
-			hb_vector_t<unsigned> &compact_workspace)
+			hb_vector_t<unsigned> *compact_workspace = nullptr)
 {
   switch (context_format)
   {
@@ -2651,7 +2651,7 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
    * set by the ContextFormat2/3 caller). */
   const hb_set_t *pos0_glyphs = depend_position_glyphs (
     c, lookup_context.context_format, lookup_context.intersects_data, value,
-    true, &position_scratch, scratch->compact_workspace);
+    true, &position_scratch, &scratch->compact_workspace);
   if (unlikely (!pos0_glyphs ||
                 !input_position_glyphs.push_or_fail (pos0_glyphs)))
   {
@@ -2664,7 +2664,7 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
   {
     const hb_set_t *pos_glyphs = depend_position_glyphs (
       c, lookup_context.context_format, lookup_context.intersects_data,
-      input[i], false, &position_scratch, scratch->compact_workspace);
+      input[i], false, &position_scratch);
     if (unlikely (!pos_glyphs ||
                   !input_position_glyphs.push_or_fail (pos_glyphs)))
     {
@@ -3954,7 +3954,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   {
     const hb_set_t *pos_glyphs = depend_position_glyphs (
       c, lookup_context.context_format, lookup_context.intersects_data[0],
-      backtrack[i], false, &position_scratch, scratch->compact_workspace);
+      backtrack[i], false, &position_scratch);
     if (unlikely (!pos_glyphs))
       return;
     if (!pos_glyphs->is_empty ())
@@ -3972,7 +3972,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   {
     const hb_set_t *pos_glyphs = depend_position_glyphs (
       c, lookup_context.context_format, lookup_context.intersects_data[2],
-      lookahead[i], false, &position_scratch, scratch->compact_workspace);
+      lookahead[i], false, &position_scratch);
     if (unlikely (!pos_glyphs))
       return;
     if (!pos_glyphs->is_empty ())
@@ -4026,7 +4026,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
    * class AND the coverage, so intersect with parent_active_glyphs. */
   const hb_set_t *pos0_glyphs = depend_position_glyphs (
     c, lookup_context.context_format, lookup_context.intersects_data[1], value,
-    true, &position_scratch, scratch->compact_workspace);
+    true, &position_scratch, &scratch->compact_workspace);
   if (unlikely (!pos0_glyphs ||
                 !input_position_glyphs.push_or_fail (pos0_glyphs)))
   {
@@ -4039,7 +4039,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   {
     const hb_set_t *pos_glyphs = depend_position_glyphs (
       c, lookup_context.context_format, lookup_context.intersects_data[1],
-      input[i], false, &position_scratch, scratch->compact_workspace);
+      input[i], false, &position_scratch);
     if (unlikely (!pos_glyphs ||
                   !input_position_glyphs.push_or_fail (pos_glyphs)))
     {

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -484,25 +484,29 @@ struct hb_depend_context_t :
 
   const hb_set_t& parent_active_glyphs ()
   {
-    if (!active_glyphs_stack)
+    if (!active_glyphs_stack_depth)
       return *glyphs;
 
-    return active_glyphs_stack.tail ();
+    return active_glyphs_stack[active_glyphs_stack_depth - 1];
   }
 
   hb_set_t* push_cur_active_glyphs ()
   {
-    if (unlikely (!active_glyphs_stack.push_or_fail ()))
+    if (active_glyphs_stack_depth == active_glyphs_stack.length &&
+	unlikely (!active_glyphs_stack.push_or_fail ()))
       return nullptr;
-    return &active_glyphs_stack.tail ();
+
+    hb_set_t *set = &active_glyphs_stack[active_glyphs_stack_depth++];
+    set->clear ();
+    return set;
   }
 
   bool pop_cur_done_glyphs ()
   {
-    if (!active_glyphs_stack)
+    if (!active_glyphs_stack_depth)
       return false;
 
-    active_glyphs_stack.pop ();
+    active_glyphs_stack_depth--;
     return true;
   }
 
@@ -627,6 +631,7 @@ struct hb_depend_context_t :
   hb_face_t *face;
   hb_set_t *glyphs;
   hb_vector_t<hb_set_t> active_glyphs_stack;
+  unsigned active_glyphs_stack_depth = 0;
   recurse_func_t recurse_func;
   hb_codepoint_t lookup_index = HB_CODEPOINT_INVALID;
   hb_set_t lookups_seen;

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -415,12 +415,12 @@ struct hb_depend_context_t :
     recurse_key_t () = default;
     recurse_key_t (unsigned lookup_index_,
                    hb_codepoint_t active_glyphs_,
-                   hb_codepoint_t lookups_seen_,
+                   hb_codepoint_t recurse_path_,
                    hb_codepoint_t context_set_,
                    hb_subset_depend_edge_flags_t flags_)
       : lookup_index (lookup_index_),
         active_glyphs (active_glyphs_),
-        lookups_seen (lookups_seen_),
+        recurse_path (recurse_path_),
         context_set (context_set_),
         flags (flags_) {}
 
@@ -428,7 +428,7 @@ struct hb_depend_context_t :
     {
       return lookup_index == o.lookup_index &&
              active_glyphs == o.active_glyphs &&
-             lookups_seen == o.lookups_seen &&
+             recurse_path == o.recurse_path &&
              context_set == o.context_set &&
              flags == o.flags;
     }
@@ -438,7 +438,7 @@ struct hb_depend_context_t :
       uint32_t current = 0x84222325;
       current = (current ^ hb_hash (lookup_index)) * 16777619;
       current = (current ^ hb_hash (active_glyphs)) * 16777619;
-      current = (current ^ hb_hash (lookups_seen)) * 16777619;
+      current = (current ^ hb_hash (recurse_path)) * 16777619;
       current = (current ^ hb_hash (context_set)) * 16777619;
       current = (current ^ hb_hash ((unsigned) flags)) * 16777619;
       return current;
@@ -446,7 +446,7 @@ struct hb_depend_context_t :
 
     unsigned lookup_index = 0;
     hb_codepoint_t active_glyphs = 0;
-    hb_codepoint_t lookups_seen = 0;
+    hb_codepoint_t recurse_path = 0;
     hb_codepoint_t context_set = HB_CODEPOINT_INVALID;
     hb_subset_depend_edge_flags_t flags = HB_SUBSET_DEPEND_EDGE_FLAG_NONE;
   };
@@ -478,7 +478,29 @@ struct hb_depend_context_t :
      * that indirect cycles of the form A→B→A are also caught here. */
     if (lookups_seen.has (lookup_idx)) return;
     lookups_seen.add (lookup_idx);
+
+    /* Intern the ordered recursion path instead of copying and interning the
+     * lookups_seen set.  Path identity is more specific than set identity but
+     * never merges states with different cycle-detection behavior. */
+    hb_codepoint_t parent_path = recurse_path;
+    uint64_t path_key = (uint64_t) parent_path << 32 | lookup_idx;
+    hb_codepoint_t *path = nullptr;
+    hb_codepoint_t path_index;
+    if (!recurse_path_to_index.has (path_key, &path))
+    {
+      path_index = recurse_path_to_index.get_population () + 1;
+      if (unlikely (!recurse_path_to_index.set (path_key, path_index)))
+      {
+	depend_data->fail ();
+	lookups_seen.del (lookup_idx);
+	return;
+      }
+    }
+    else
+      path_index = *path;
+    recurse_path = path_index;
     recurse_func (this, lookup_idx, covered_seq_indices, seq_index, end_index);
+    recurse_path = parent_path;
     lookups_seen.del (lookup_idx);
   }
 
@@ -519,13 +541,9 @@ struct hb_depend_context_t :
     if (!find_or_create_recurse_set (parent_active_glyphs (), &active_idx))
       return false;
 
-    hb_codepoint_t seen_idx;
-    if (!find_or_create_recurse_set (lookups_seen, &seen_idx))
-      return false;
-
     *key = recurse_key_t (lookup_idx,
                           active_idx,
-                          seen_idx,
+                          recurse_path,
                           depend_data->current_context_set_index,
                           depend_data->current_edge_flags);
     return !completed_recursions.has (*key);
@@ -539,6 +557,8 @@ struct hb_depend_context_t :
     completed_recursions.clear ();
     recurse_set_to_index.clear ();
     recurse_sets.clear ();
+    recurse_path_to_index.clear ();
+    recurse_path = 0;
   }
 
   bool find_or_create_recurse_set (const hb_set_t &set, hb_codepoint_t *index)
@@ -636,9 +656,11 @@ struct hb_depend_context_t :
   unsigned active_glyphs_stack_depth = 0;
   recurse_func_t recurse_func;
   hb_codepoint_t lookup_index = HB_CODEPOINT_INVALID;
-  hb_set_t lookups_seen;
+  hb_bit_set_t lookups_seen;
   hb_vector_t<hb::unique_ptr<hb_set_t>> recurse_sets;
   hb_hashmap_t<const hb_set_t *, hb_codepoint_t> recurse_set_to_index;
+  hb_hashmap_t<uint64_t, hb_codepoint_t> recurse_path_to_index;
+  hb_codepoint_t recurse_path = 0;
   hb_hashmap_t<recurse_key_t, bool> completed_recursions;
   hb_vector_t<hb::unique_ptr<hb_set_t>> glyph_sets;
   hb_hashmap_t<glyph_set_cache_key_t, hb_codepoint_t> glyph_set_to_index;

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -586,6 +586,7 @@ struct hb_depend_context_t :
       backtrack_sets.clear ();
       lookahead_sets.clear ();
       input_position_glyphs.clear ();
+      compact_workspace.clear ();
     }
 
     hb_set_t preliminary_context;
@@ -597,6 +598,7 @@ struct hb_depend_context_t :
     hb_vector_t<const hb_set_t *> backtrack_sets;
     hb_vector_t<const hb_set_t *> lookahead_sets;
     hb_vector_t<const hb_set_t *> input_position_glyphs;
+    hb_vector_t<unsigned> compact_workspace;
     depend_scratch_t *next = nullptr;
   };
 
@@ -2093,7 +2095,8 @@ depend_position_glyphs (hb_depend_context_t *c,
 			const void *data,
 			unsigned value,
 			bool filter_class_by_parent,
-			hb_set_t *scratch)
+			hb_set_t *scratch,
+			hb_vector_t<unsigned> &compact_workspace)
 {
   switch (context_format)
   {
@@ -2109,7 +2112,7 @@ depend_position_glyphs (hb_depend_context_t *c,
       if (!filter_class_by_parent)
 	return class_set;
       scratch->set (*class_set);
-      scratch->intersect (c->parent_active_glyphs ());
+      scratch->intersect (c->parent_active_glyphs (), compact_workspace);
       break;
     }
     case ContextFormat::CoverageBasedContext:
@@ -2648,7 +2651,7 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
    * set by the ContextFormat2/3 caller). */
   const hb_set_t *pos0_glyphs = depend_position_glyphs (
     c, lookup_context.context_format, lookup_context.intersects_data, value,
-    true, &position_scratch);
+    true, &position_scratch, scratch->compact_workspace);
   if (unlikely (!pos0_glyphs ||
                 !input_position_glyphs.push_or_fail (pos0_glyphs)))
   {
@@ -2661,7 +2664,7 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
   {
     const hb_set_t *pos_glyphs = depend_position_glyphs (
       c, lookup_context.context_format, lookup_context.intersects_data,
-      input[i], false, &position_scratch);
+      input[i], false, &position_scratch, scratch->compact_workspace);
     if (unlikely (!pos_glyphs ||
                   !input_position_glyphs.push_or_fail (pos_glyphs)))
     {
@@ -3951,7 +3954,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   {
     const hb_set_t *pos_glyphs = depend_position_glyphs (
       c, lookup_context.context_format, lookup_context.intersects_data[0],
-      backtrack[i], false, &position_scratch);
+      backtrack[i], false, &position_scratch, scratch->compact_workspace);
     if (unlikely (!pos_glyphs))
       return;
     if (!pos_glyphs->is_empty ())
@@ -3969,7 +3972,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   {
     const hb_set_t *pos_glyphs = depend_position_glyphs (
       c, lookup_context.context_format, lookup_context.intersects_data[2],
-      lookahead[i], false, &position_scratch);
+      lookahead[i], false, &position_scratch, scratch->compact_workspace);
     if (unlikely (!pos_glyphs))
       return;
     if (!pos_glyphs->is_empty ())
@@ -4023,7 +4026,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
    * class AND the coverage, so intersect with parent_active_glyphs. */
   const hb_set_t *pos0_glyphs = depend_position_glyphs (
     c, lookup_context.context_format, lookup_context.intersects_data[1], value,
-    true, &position_scratch);
+    true, &position_scratch, scratch->compact_workspace);
   if (unlikely (!pos0_glyphs ||
                 !input_position_glyphs.push_or_fail (pos0_glyphs)))
   {
@@ -4036,7 +4039,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   {
     const hb_set_t *pos_glyphs = depend_position_glyphs (
       c, lookup_context.context_format, lookup_context.intersects_data[1],
-      input[i], false, &position_scratch);
+      input[i], false, &position_scratch, scratch->compact_workspace);
     if (unlikely (!pos_glyphs ||
                   !input_position_glyphs.push_or_fail (pos_glyphs)))
     {

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -2362,7 +2362,9 @@ context_depend_sets_are_cached (hb_depend_context_t *c,
     if (unlikely (!cached_context_sets->push_or_fail (*cached_context_set)))
       return c->depend_data->fail ();
   }
-  return true;
+  /* A rule with no valid records has no cache entries, and its preparation
+   * can still allocate dependency sets in an observable order. */
+  return have_active_idx;
 }
 
 template <typename HBUINT>
@@ -4172,9 +4174,26 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
     &scratch->cached_context_sets);
   if (unlikely (!c->depend_data->successful))
     return;
+  if (context_sets_cached)
+  {
+    context_depend_recurse_lookups (c,
+				    inputCount, input,
+				    lookupCount, lookupRecord,
+				    rule,
+				    value,
+				    lookup_context.context_format,
+				    lookup_context.intersects_data[1],
+				    lookup_context.funcs.intersected_glyphs,
+				    lookup_context.intersected_glyphs_cache,
+				    scratch->preliminary_context,
+				    nullptr,
+				    &scratch->cached_context_sets,
+				    scratch);
+    return;
+  }
 
-  /* Keep building backtrack and lookahead sets on a label-cache hit: their
-   * interning order determines the observable dependency-set indices. */
+  /* Cache misses and rules without valid records still perform the original
+   * dependency-set interning in its observable order. */
   hb_set_t &position_scratch = scratch->position_scratch;
   hb_vector_t<const hb_set_t *> &backtrack_sets = scratch->backtrack_sets;
   hb_vector_t<const hb_set_t *> &lookahead_sets = scratch->lookahead_sets;

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -382,6 +382,34 @@ struct hb_collect_glyphs_context_t :
 struct hb_depend_context_t :
        hb_dispatch_context_t<hb_depend_context_t>
 {
+  enum glyph_set_type_t
+  {
+    GLYPH_SET_CLASS,
+    GLYPH_SET_COVERAGE,
+    GLYPH_SET_SINGLE
+  };
+
+  struct glyph_set_cache_key_t
+  {
+    glyph_set_cache_key_t () = default;
+    glyph_set_cache_key_t (const void *data_, unsigned value_, glyph_set_type_t type_)
+      : data (data_), value (value_), type (type_) {}
+
+    bool operator == (const glyph_set_cache_key_t &o) const
+    { return data == o.data && value == o.value && type == o.type; }
+
+    uint32_t hash () const
+    {
+      uint32_t current = hb_hash ((uintptr_t) data);
+      current = current * 31 + hb_hash (value);
+      return current * 31 + hb_hash ((unsigned) type);
+    }
+
+    const void *data = nullptr;
+    unsigned value = 0;
+    glyph_set_type_t type = GLYPH_SET_CLASS;
+  };
+
   struct recurse_key_t
   {
     recurse_key_t () = default;
@@ -478,12 +506,6 @@ struct hb_depend_context_t :
     return true;
   }
 
-  /* Context information for recording contextual dependencies */
-  struct context_info_t {
-    hb_vector_t<hb_set_t> backtrack_sets;  /* Sets of glyphs in backtrack positions */
-    hb_vector_t<hb_set_t> lookahead_sets;  /* Sets of glyphs in lookahead positions */
-  };
-
   bool get_recurse_key (unsigned lookup_idx, recurse_key_t *key)
   {
     /* The active glyphs and in-progress lookup set are part of the state.
@@ -542,6 +564,11 @@ struct hb_depend_context_t :
     return true;
   }
 
+  const hb_set_t *find_or_create_glyph_set (const void *data,
+                                             unsigned value,
+                                             glyph_set_type_t type);
+  hb_codepoint_t find_or_create_cached_context_set (const hb_set_t *set);
+
   hb_depend_data_builder_t *depend_data;
   hb_face_t *face;
   hb_set_t *glyphs;
@@ -552,6 +579,9 @@ struct hb_depend_context_t :
   hb_vector_t<hb::unique_ptr<hb_set_t>> recurse_sets;
   hb_hashmap_t<const hb_set_t *, hb_codepoint_t> recurse_set_to_index;
   hb_hashmap_t<recurse_key_t, bool> completed_recursions;
+  hb_vector_t<hb::unique_ptr<hb_set_t>> glyph_sets;
+  hb_hashmap_t<glyph_set_cache_key_t, hb_codepoint_t> glyph_set_to_index;
+  hb_hashmap_t<uintptr_t, hb_codepoint_t> cached_context_set_indices;
 
   hb_depend_context_t (hb_depend_data_builder_t *depend_data_,
                        hb_face_t *face_,
@@ -1440,6 +1470,69 @@ static inline void collect_coverage (hb_set_t *glyphs, unsigned value, const voi
   coverage = value;
   (data+coverage).collect_coverage (glyphs);
 }
+
+inline const hb_set_t *
+hb_depend_context_t::find_or_create_glyph_set (const void *data,
+                                                unsigned value,
+                                                glyph_set_type_t type)
+{
+  /* Class definitions and coverages are immutable for the lifetime of the
+   * context, so their expanded glyph sets can be shared across traversals. */
+  glyph_set_cache_key_t key (data, value, type);
+  hb_codepoint_t *existing = nullptr;
+  if (glyph_set_to_index.has (key, &existing))
+    return glyph_sets[*existing].get ();
+
+  hb_set_t *set = hb_object_create<hb_set_t> ();
+  if (unlikely (!set))
+  {
+    depend_data->fail ();
+    return nullptr;
+  }
+
+  if (type == GLYPH_SET_COVERAGE)
+    collect_coverage (set, value, data);
+  else if (type == GLYPH_SET_CLASS)
+    collect_class (set, value, data);
+  else
+    set->add (value);
+  if (unlikely (set->in_error ()))
+  {
+    hb_set_destroy (set);
+    depend_data->fail ();
+    return nullptr;
+  }
+
+  hb_codepoint_t index = glyph_sets.length;
+  if (unlikely (!glyph_sets.push_or_fail (hb::unique_ptr<hb_set_t> {set})))
+  {
+    depend_data->fail ();
+    return nullptr;
+  }
+  if (unlikely (!glyph_set_to_index.set (key, index)))
+  {
+    depend_data->fail ();
+    return nullptr;
+  }
+  return glyph_sets[index].get ();
+}
+
+inline hb_codepoint_t
+hb_depend_context_t::find_or_create_cached_context_set (const hb_set_t *set)
+{
+  uintptr_t key = (uintptr_t) set;
+  hb_codepoint_t *existing = nullptr;
+  if (cached_context_set_indices.has (key, &existing))
+    return *existing;
+
+  hb_codepoint_t index = depend_data->find_or_create_context_set (*set);
+  if (unlikely (index == HB_CODEPOINT_INVALID))
+    return HB_CODEPOINT_INVALID;
+  if (unlikely (!cached_context_set_indices.set (key, index)))
+    return depend_data->fail_invalid ();
+  return index;
+}
+
 template <typename HBUINT>
 static inline void collect_array (hb_collect_glyphs_context_t *c HB_UNUSED,
 				  hb_set_t *glyphs,
@@ -1924,6 +2017,44 @@ static unsigned serialize_lookuprecord_array (hb_serialize_context_t *c,
 
 enum ContextFormat { SimpleContext = 1, ClassBasedContext = 2, CoverageBasedContext = 3 };
 
+static inline const hb_set_t *
+depend_position_glyphs (hb_depend_context_t *c,
+			ContextFormat context_format,
+			const void *data,
+			unsigned value,
+			bool filter_class_by_parent,
+			hb_set_t *scratch)
+{
+  switch (context_format)
+  {
+    case ContextFormat::SimpleContext:
+      return c->find_or_create_glyph_set (nullptr, value,
+                                           hb_depend_context_t::GLYPH_SET_SINGLE);
+    case ContextFormat::ClassBasedContext:
+    {
+      const hb_set_t *class_set = c->find_or_create_glyph_set (
+        data, value, hb_depend_context_t::GLYPH_SET_CLASS);
+      if (unlikely (!class_set))
+	return nullptr;
+      if (!filter_class_by_parent)
+	return class_set;
+      scratch->set (*class_set);
+      scratch->intersect (c->parent_active_glyphs ());
+      break;
+    }
+    case ContextFormat::CoverageBasedContext:
+      return c->find_or_create_glyph_set (
+        data, value, hb_depend_context_t::GLYPH_SET_COVERAGE);
+  }
+
+  if (unlikely (scratch->in_error ()))
+  {
+    c->depend_data->fail ();
+    return nullptr;
+  }
+  return scratch;
+}
+
 template <typename HBUINT>
 static void context_closure_recurse_lookups (hb_closure_context_t *c,
 					     unsigned inputCount, const HBUINT input[],
@@ -2007,7 +2138,7 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 					     intersected_glyphs_func_t intersected_glyphs_func,
 					     void *cache,
 					     const hb_set_t &preliminary_context,
-					     const hb_vector_t<hb_set_t> *input_position_glyphs)
+					     const hb_vector_t<const hb_set_t *> *input_position_glyphs)
 {
   /* For depend graph extraction, we filter active glyphs by InputCoverage constraints
    * (same as closure), but we do NOT do sequential accumulation of outputs.
@@ -2043,8 +2174,8 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 
     /* Add singleton glyphs from OTHER input positions */
     for (unsigned j = 0; j < input_position_glyphs->length; j++) {
-      if (j != seqIndex && (*input_position_glyphs)[j].get_population () == 1) {
-        position_context.add ((*input_position_glyphs)[j].get_min ());
+      if (j != seqIndex && (*input_position_glyphs)[j]->get_population () == 1) {
+        position_context.add ((*input_position_glyphs)[j]->get_min ());
       }
     }
 
@@ -2070,11 +2201,15 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
 
     /* Process non-singleton input positions */
     for (unsigned j = 0; j < input_position_glyphs->length; j++) {
-      if (j != seqIndex && (*input_position_glyphs)[j].get_population () > 1) {
+      if (j != seqIndex && (*input_position_glyphs)[j]->get_population () > 1) {
         /* Input-position sets are also never inverted. */
-        if (!(*input_position_glyphs)[j].intersects (position_context)) {
+        if (!(*input_position_glyphs)[j]->intersects (position_context)) {
           /* No overlap with position_context - add full requirement */
-          hb_codepoint_t idx = c->depend_data->find_or_create_context_set ((*input_position_glyphs)[j]);
+          bool cached_set = context_format == ContextFormat::CoverageBasedContext ||
+                            (context_format == ContextFormat::ClassBasedContext && j != 0);
+          hb_codepoint_t idx = cached_set
+            ? c->find_or_create_cached_context_set ((*input_position_glyphs)[j])
+            : c->depend_data->find_or_create_context_set (*(*input_position_glyphs)[j]);
           if (unlikely (idx == HB_CODEPOINT_INVALID))
             return;
           filtered_disjunctive_indices.add (HB_DEPEND_CONTEXT_SET_FLAG | idx);
@@ -2425,26 +2560,17 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
   hb_set_t preliminary_context;
 
   /* Build glyph sets for ALL input positions */
-  hb_vector_t<hb_set_t> input_position_glyphs;
+  hb_set_t position_scratch;
+  hb_vector_t<const hb_set_t *> input_position_glyphs;
 
   /* Position 0 (Coverage glyph) — must be in both the class AND the
    * coverage, so intersect with parent_active_glyphs (= coverage ∩ glyphs
    * set by the ContextFormat2/3 caller). */
-  hb_set_t pos0_glyphs;
-  switch (lookup_context.context_format)
-  {
-    case ContextFormat::SimpleContext:
-      pos0_glyphs.add (value);
-      break;
-    case ContextFormat::ClassBasedContext:
-      collect_class (&pos0_glyphs, value, lookup_context.intersects_data);
-      pos0_glyphs.intersect (c->parent_active_glyphs ());
-      break;
-    case ContextFormat::CoverageBasedContext:
-      collect_coverage (&pos0_glyphs, value, lookup_context.intersects_data);
-      break;
-  }
-  if (unlikely (!input_position_glyphs.push_or_fail (pos0_glyphs)))
+  const hb_set_t *pos0_glyphs = depend_position_glyphs (
+    c, lookup_context.context_format, lookup_context.intersects_data, value,
+    true, &position_scratch);
+  if (unlikely (!pos0_glyphs ||
+                !input_position_glyphs.push_or_fail (pos0_glyphs)))
   {
     c->depend_data->fail ();
     return;
@@ -2453,20 +2579,11 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
   /* Positions 1+ (Input array) */
   for (unsigned i = 0; i < inputCount - 1; i++)
   {
-    hb_set_t pos_glyphs;
-    switch (lookup_context.context_format)
-    {
-      case ContextFormat::SimpleContext:
-        pos_glyphs.add (input[i]);
-        break;
-      case ContextFormat::ClassBasedContext:
-        collect_class (&pos_glyphs, input[i], lookup_context.intersects_data);
-        break;
-      case ContextFormat::CoverageBasedContext:
-        collect_coverage (&pos_glyphs, input[i], lookup_context.intersects_data);
-        break;
-    }
-    if (unlikely (!input_position_glyphs.push_or_fail (pos_glyphs)))
+    const hb_set_t *pos_glyphs = depend_position_glyphs (
+      c, lookup_context.context_format, lookup_context.intersects_data,
+      input[i], false, &position_scratch);
+    if (unlikely (!pos_glyphs ||
+                  !input_position_glyphs.push_or_fail (pos_glyphs)))
     {
       c->depend_data->fail ();
       return;
@@ -3739,27 +3856,21 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
     return;
 
   /* Build context information - extract backtrack and lookahead glyphs */
-  typename hb_depend_context_t::context_info_t ctx_info;
+  hb_set_t position_scratch;
+  hb_vector_t<const hb_set_t *> backtrack_sets;
+  hb_vector_t<const hb_set_t *> lookahead_sets;
 
   /* Extract backtrack glyphs */
   for (unsigned i = 0; i < backtrackCount; i++)
   {
-    hb_set_t pos_glyphs;
-    switch (lookup_context.context_format)
+    const hb_set_t *pos_glyphs = depend_position_glyphs (
+      c, lookup_context.context_format, lookup_context.intersects_data[0],
+      backtrack[i], false, &position_scratch);
+    if (unlikely (!pos_glyphs))
+      return;
+    if (!pos_glyphs->is_empty ())
     {
-      case ContextFormat::SimpleContext:
-        pos_glyphs.add (backtrack[i]);
-        break;
-      case ContextFormat::ClassBasedContext:
-        collect_class (&pos_glyphs, backtrack[i], lookup_context.intersects_data[0]);
-        break;
-      case ContextFormat::CoverageBasedContext:
-        collect_coverage (&pos_glyphs, backtrack[i], lookup_context.intersects_data[0]);
-        break;
-    }
-    if (!pos_glyphs.is_empty ())
-    {
-      if (unlikely (!ctx_info.backtrack_sets.push_or_fail (pos_glyphs)))
+      if (unlikely (!backtrack_sets.push_or_fail (pos_glyphs)))
       {
         c->depend_data->fail ();
         return;
@@ -3770,22 +3881,14 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   /* Extract lookahead glyphs */
   for (unsigned i = 0; i < lookaheadCount; i++)
   {
-    hb_set_t pos_glyphs;
-    switch (lookup_context.context_format)
+    const hb_set_t *pos_glyphs = depend_position_glyphs (
+      c, lookup_context.context_format, lookup_context.intersects_data[2],
+      lookahead[i], false, &position_scratch);
+    if (unlikely (!pos_glyphs))
+      return;
+    if (!pos_glyphs->is_empty ())
     {
-      case ContextFormat::SimpleContext:
-        pos_glyphs.add (lookahead[i]);
-        break;
-      case ContextFormat::ClassBasedContext:
-        collect_class (&pos_glyphs, lookahead[i], lookup_context.intersects_data[2]);
-        break;
-      case ContextFormat::CoverageBasedContext:
-        collect_coverage (&pos_glyphs, lookahead[i], lookup_context.intersects_data[2]);
-        break;
-    }
-    if (!pos_glyphs.is_empty ())
-    {
-      if (unlikely (!ctx_info.lookahead_sets.push_or_fail (pos_glyphs)))
+      if (unlikely (!lookahead_sets.push_or_fail (pos_glyphs)))
       {
         c->depend_data->fail ();
         return;
@@ -3795,23 +3898,27 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
 
   /* Build preliminary_context with backtrack + lookahead encoded */
   hb_set_t preliminary_context;
-  for (const auto &back_set : ctx_info.backtrack_sets)
+  for (const hb_set_t *back_set : backtrack_sets)
   {
-    if (back_set.get_population () == 1) {
-      preliminary_context.add (back_set.get_min ());  // Direct glyph
-    } else if (back_set.get_population () > 1) {
-      hb_codepoint_t set_idx = c->depend_data->find_or_create_context_set (back_set);
+    if (back_set->get_population () == 1) {
+      preliminary_context.add (back_set->get_min ());  // Direct glyph
+    } else if (back_set->get_population () > 1) {
+      hb_codepoint_t set_idx = lookup_context.context_format == ContextFormat::SimpleContext
+        ? c->depend_data->find_or_create_context_set (*back_set)
+        : c->find_or_create_cached_context_set (back_set);
       if (unlikely (set_idx == HB_CODEPOINT_INVALID))
         return;
       preliminary_context.add (HB_DEPEND_CONTEXT_SET_FLAG | set_idx);  // Encoded set reference
     }
   }
-  for (const auto &look_set : ctx_info.lookahead_sets)
+  for (const hb_set_t *look_set : lookahead_sets)
   {
-    if (look_set.get_population () == 1) {
-      preliminary_context.add (look_set.get_min ());  // Direct glyph
-    } else if (look_set.get_population () > 1) {
-      hb_codepoint_t set_idx = c->depend_data->find_or_create_context_set (look_set);
+    if (look_set->get_population () == 1) {
+      preliminary_context.add (look_set->get_min ());  // Direct glyph
+    } else if (look_set->get_population () > 1) {
+      hb_codepoint_t set_idx = lookup_context.context_format == ContextFormat::SimpleContext
+        ? c->depend_data->find_or_create_context_set (*look_set)
+        : c->find_or_create_cached_context_set (look_set);
       if (unlikely (set_idx == HB_CODEPOINT_INVALID))
         return;
       preliminary_context.add (HB_DEPEND_CONTEXT_SET_FLAG | set_idx);  // Encoded set reference
@@ -3824,25 +3931,15 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   }
 
   /* Build glyph sets for ALL input positions */
-  hb_vector_t<hb_set_t> input_position_glyphs;
+  hb_vector_t<const hb_set_t *> input_position_glyphs;
 
   /* Position 0 (first input coverage/class/glyph) — must be in both the
    * class AND the coverage, so intersect with parent_active_glyphs. */
-  hb_set_t pos0_glyphs;
-  switch (lookup_context.context_format)
-  {
-    case ContextFormat::SimpleContext:
-      pos0_glyphs.add (value);
-      break;
-    case ContextFormat::ClassBasedContext:
-      collect_class (&pos0_glyphs, value, lookup_context.intersects_data[1]);
-      pos0_glyphs.intersect (c->parent_active_glyphs ());
-      break;
-    case ContextFormat::CoverageBasedContext:
-      collect_coverage (&pos0_glyphs, value, lookup_context.intersects_data[1]);
-      break;
-  }
-  if (unlikely (!input_position_glyphs.push_or_fail (pos0_glyphs)))
+  const hb_set_t *pos0_glyphs = depend_position_glyphs (
+    c, lookup_context.context_format, lookup_context.intersects_data[1], value,
+    true, &position_scratch);
+  if (unlikely (!pos0_glyphs ||
+                !input_position_glyphs.push_or_fail (pos0_glyphs)))
   {
     c->depend_data->fail ();
     return;
@@ -3851,20 +3948,11 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   /* Positions 1+ (Input array) */
   for (unsigned i = 0; i < inputCount - 1; i++)
   {
-    hb_set_t pos_glyphs;
-    switch (lookup_context.context_format)
-    {
-      case ContextFormat::SimpleContext:
-        pos_glyphs.add (input[i]);
-        break;
-      case ContextFormat::ClassBasedContext:
-        collect_class (&pos_glyphs, input[i], lookup_context.intersects_data[1]);
-        break;
-      case ContextFormat::CoverageBasedContext:
-        collect_coverage (&pos_glyphs, input[i], lookup_context.intersects_data[1]);
-        break;
-    }
-    if (unlikely (!input_position_glyphs.push_or_fail (pos_glyphs)))
+    const hb_set_t *pos_glyphs = depend_position_glyphs (
+      c, lookup_context.context_format, lookup_context.intersects_data[1],
+      input[i], false, &position_scratch);
+    if (unlikely (!pos_glyphs ||
+                  !input_position_glyphs.push_or_fail (pos_glyphs)))
     {
       c->depend_data->fail ();
       return;

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -382,6 +382,47 @@ struct hb_collect_glyphs_context_t :
 struct hb_depend_context_t :
        hb_dispatch_context_t<hb_depend_context_t>
 {
+  struct recurse_key_t
+  {
+    recurse_key_t () = default;
+    recurse_key_t (unsigned lookup_index_,
+                   hb_codepoint_t active_glyphs_,
+                   hb_codepoint_t lookups_seen_,
+                   hb_codepoint_t context_set_,
+                   hb_subset_depend_edge_flags_t flags_)
+      : lookup_index (lookup_index_),
+        active_glyphs (active_glyphs_),
+        lookups_seen (lookups_seen_),
+        context_set (context_set_),
+        flags (flags_) {}
+
+    bool operator == (const recurse_key_t &o) const
+    {
+      return lookup_index == o.lookup_index &&
+             active_glyphs == o.active_glyphs &&
+             lookups_seen == o.lookups_seen &&
+             context_set == o.context_set &&
+             flags == o.flags;
+    }
+
+    uint32_t hash () const
+    {
+      uint32_t current = 0x84222325;
+      current = (current ^ hb_hash (lookup_index)) * 16777619;
+      current = (current ^ hb_hash (active_glyphs)) * 16777619;
+      current = (current ^ hb_hash (lookups_seen)) * 16777619;
+      current = (current ^ hb_hash (context_set)) * 16777619;
+      current = (current ^ hb_hash ((unsigned) flags)) * 16777619;
+      return current;
+    }
+
+    unsigned lookup_index = 0;
+    hb_codepoint_t active_glyphs = 0;
+    hb_codepoint_t lookups_seen = 0;
+    hb_codepoint_t context_set = HB_CODEPOINT_INVALID;
+    hb_subset_depend_edge_flags_t flags = HB_SUBSET_DEPEND_EDGE_FLAG_NONE;
+  };
+
   typedef return_t (*recurse_func_t) (hb_depend_context_t *c, unsigned lookup_index, hb_set_t *covered_seq_indicies, unsigned seq_index, unsigned end_index);
   /* return_t is hb_empty_t — dispatch is purely for side-effects, like hb_closure_context_t. */
   template <typename T>
@@ -443,30 +484,74 @@ struct hb_depend_context_t :
     hb_vector_t<hb_set_t> lookahead_sets;  /* Sets of glyphs in lookahead positions */
   };
 
-  bool push_context (context_info_t &&ctx)
+  bool get_recurse_key (unsigned lookup_idx, recurse_key_t *key)
   {
-    return depend_data->check_success (context_stack.push_or_fail (std::move (ctx)));
+    /* The active glyphs and in-progress lookup set are part of the state.
+     * Omitting the latter would make memoization incorrect for cyclic lookup
+     * graphs whose available recursive paths depend on their ancestry. */
+    hb_codepoint_t active_idx;
+    if (!find_or_create_recurse_set (parent_active_glyphs (), &active_idx))
+      return false;
+
+    hb_codepoint_t seen_idx;
+    if (!find_or_create_recurse_set (lookups_seen, &seen_idx))
+      return false;
+
+    *key = recurse_key_t (lookup_idx,
+                          active_idx,
+                          seen_idx,
+                          depend_data->current_context_set_index,
+                          depend_data->current_edge_flags);
+    return !completed_recursions.has (*key);
   }
 
-  void pop_context ()
+  void finish_recurse (const recurse_key_t &key)
+  { depend_data->check_success (completed_recursions.set (key, true)); }
+
+  void reset_recurse_cache ()
   {
-    if (context_stack.length > 0)
-      context_stack.resize (context_stack.length - 1);
+    completed_recursions.clear ();
+    recurse_set_to_index.clear ();
+    recurse_sets.clear ();
   }
 
-  const context_info_t* current_context () const
+  bool find_or_create_recurse_set (const hb_set_t &set, hb_codepoint_t *index)
   {
-    return context_stack.length > 0 ? &context_stack[context_stack.length - 1] : nullptr;
+    hb_codepoint_t *existing = nullptr;
+    if (recurse_set_to_index.has (&set, &existing))
+    {
+      *index = *existing;
+      return true;
+    }
+
+    hb_set_t *copy = hb_object_create<hb_set_t> ();
+    if (unlikely (!copy))
+      return depend_data->fail ();
+    copy->set (set);
+    if (unlikely (copy->in_error ()))
+    {
+      hb_set_destroy (copy);
+      return depend_data->fail ();
+    }
+
+    *index = recurse_sets.length;
+    if (unlikely (!recurse_sets.push_or_fail (hb::unique_ptr<hb_set_t> {copy})))
+      return depend_data->fail ();
+    if (unlikely (!recurse_set_to_index.set (recurse_sets[*index].get (), *index)))
+      return depend_data->fail ();
+    return true;
   }
 
   hb_depend_data_builder_t *depend_data;
   hb_face_t *face;
   hb_set_t *glyphs;
   hb_vector_t<hb_set_t> active_glyphs_stack;
-  hb_vector_t<context_info_t> context_stack;  /* Stack of context information */
   recurse_func_t recurse_func;
   hb_codepoint_t lookup_index = HB_CODEPOINT_INVALID;
   hb_set_t lookups_seen;
+  hb_vector_t<hb::unique_ptr<hb_set_t>> recurse_sets;
+  hb_hashmap_t<const hb_set_t *, hb_codepoint_t> recurse_set_to_index;
+  hb_hashmap_t<recurse_key_t, bool> completed_recursions;
 
   hb_depend_context_t (hb_depend_data_builder_t *depend_data_,
                        hb_face_t *face_,
@@ -1972,17 +2057,8 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
       const hb_set_t *original_set = c->depend_data->get_set_from_index (set_idx);
       if (unlikely (!original_set)) continue;
 
-      /* Make local copy and subtract direct requirements */
-      hb_set_t filtered;
-      filtered.set (*original_set);
-      filtered.subtract (position_context);
-      if (unlikely (filtered.in_error ()))
-      {
-        c->depend_data->fail ();
-        return;
-      }
-
-      if (filtered == *original_set) {
+      /* Dependency context sets are never inverted. */
+      if (!original_set->s.s.intersects (position_context.s.s)) {
         /* No overlap with position_context - add full requirement */
         filtered_disjunctive_indices.add (elem);
       }
@@ -1995,16 +2071,8 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
     /* Process non-singleton input positions */
     for (unsigned j = 0; j < input_position_glyphs->length; j++) {
       if (j != seqIndex && (*input_position_glyphs)[j].get_population () > 1) {
-        hb_set_t filtered;
-        filtered.set ((*input_position_glyphs)[j]);
-        filtered.subtract (position_context);
-        if (unlikely (filtered.in_error ()))
-        {
-          c->depend_data->fail ();
-          return;
-        }
-
-        if (filtered == (*input_position_glyphs)[j]) {
+        /* Input-position sets are also never inverted. */
+        if (!(*input_position_glyphs)[j].s.s.intersects (position_context.s.s)) {
           /* No overlap with position_context - add full requirement */
           hb_codepoint_t idx = c->depend_data->find_or_create_context_set ((*input_position_glyphs)[j]);
           if (unlikely (idx == HB_CODEPOINT_INVALID))
@@ -2405,11 +2473,6 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
     }
   }
 
-  /* Push context before recursing (for backtrack/lookahead tracking - empty for ContextSubst) */
-  typename hb_depend_context_t::context_info_t ctx_info;
-  if (unlikely (!c->push_context (std::move (ctx_info))))
-    return;
-
   context_depend_recurse_lookups (c,
 				  inputCount, input,
 				  lookupCount, lookupRecord,
@@ -2420,10 +2483,6 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
 				  lookup_context.intersected_glyphs_cache,
 				  preliminary_context,
 				  &input_position_glyphs);
-
-  /* Pop context */
-  c->pop_context ();
-  /* preliminary_context is stack-allocated and will be destroyed automatically */
 }
 
 template <typename HBUINT>
@@ -3812,10 +3871,6 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
     }
   }
 
-  /* Push context before recursing (use move to avoid copy issues) */
-  if (unlikely (!c->push_context (std::move (ctx_info))))
-    return;
-
   context_depend_recurse_lookups (c,
 				  inputCount, input,
 				  lookupCount, lookupRecord,
@@ -3826,10 +3881,6 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
 				  lookup_context.intersected_glyphs_cache,
 				  preliminary_context,
 				  &input_position_glyphs);
-
-  /* Pop context */
-  c->pop_context ();
-  /* preliminary_context is stack-allocated and will be destroyed automatically */
 }
 
 template <typename HBUINT>

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -458,21 +458,18 @@ struct hb_depend_context_t :
     recurse_key_t (unsigned lookup_index_,
                    hb_codepoint_t active_glyphs_,
                    hb_codepoint_t recurse_path_,
-                   hb_codepoint_t context_set_,
-                   hb_subset_depend_edge_flags_t flags_)
+                   hb_codepoint_t context_set_)
       : lookup_index (lookup_index_),
         active_glyphs (active_glyphs_),
         recurse_path (recurse_path_),
-        context_set (context_set_),
-        flags (flags_) {}
+        context_set (context_set_) {}
 
     bool operator == (const recurse_key_t &o) const
     {
       return lookup_index == o.lookup_index &&
              active_glyphs == o.active_glyphs &&
              recurse_path == o.recurse_path &&
-             context_set == o.context_set &&
-             flags == o.flags;
+             context_set == o.context_set;
     }
 
     uint32_t hash () const
@@ -482,7 +479,6 @@ struct hb_depend_context_t :
       current = (current ^ hb_hash (active_glyphs)) * 16777619;
       current = (current ^ hb_hash (recurse_path)) * 16777619;
       current = (current ^ hb_hash (context_set)) * 16777619;
-      current = (current ^ hb_hash ((unsigned) flags)) * 16777619;
       return current;
     }
 
@@ -490,7 +486,6 @@ struct hb_depend_context_t :
     hb_codepoint_t active_glyphs = 0;
     hb_codepoint_t recurse_path = 0;
     hb_codepoint_t context_set = HB_CODEPOINT_INVALID;
-    hb_subset_depend_edge_flags_t flags = HB_SUBSET_DEPEND_EDGE_FLAG_NONE;
   };
 
   typedef return_t (*recurse_func_t) (hb_depend_context_t *c, unsigned lookup_index, hb_bit_page_t *covered_seq_indices, unsigned seq_index, unsigned end_index);
@@ -637,7 +632,10 @@ struct hb_depend_context_t :
   {
     /* The active glyphs and in-progress lookup set are part of the state.
      * Omitting the latter would make memoization incorrect for cyclic lookup
-     * graphs whose available recursive paths depend on their ancestry. */
+     * graphs whose available recursive paths depend on their ancestry.
+     * Edge flags are not part of the state: they affect neither traversal nor
+     * edge identity, so revisiting with different flags can only find edges
+     * that the deduplication table already contains. */
     hb_codepoint_t active_idx;
     if (!get_parent_active_glyphs_index (&active_idx))
       return false;
@@ -645,8 +643,7 @@ struct hb_depend_context_t :
     *key = recurse_key_t (lookup_idx,
                           active_idx,
                           recurse_path,
-                          depend_data->current_context_set_index,
-                          depend_data->current_edge_flags);
+                          depend_data->current_context_set_index);
     return !completed_recursions.has (*key);
   }
 

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -2327,6 +2327,38 @@ static void context_closure_recurse_lookups (hb_closure_context_t *c,
   }
 }
 
+static bool
+context_depend_sets_are_cached (hb_depend_context_t *c,
+				unsigned input_count,
+				unsigned lookup_count,
+				const LookupRecord lookup_records[],
+				const void *rule,
+				unsigned value,
+				ContextFormat context_format,
+				const void *data)
+{
+  hb_codepoint_t active_idx = HB_CODEPOINT_INVALID;
+  bool have_active_idx = false;
+  for (unsigned i = 0; i < lookup_count; i++)
+  {
+    if (lookup_records[i].sequenceIndex >= input_count)
+      continue;
+
+    if (!have_active_idx)
+    {
+      if (unlikely (!c->get_parent_active_glyphs_index (&active_idx)))
+	return false;
+      have_active_idx = true;
+    }
+
+    hb_depend_context_t::context_set_cache_key_t key (
+      rule, &lookup_records[i], data, active_idx, value, context_format);
+    if (!c->context_set_cache.has (key))
+      return false;
+  }
+  return true;
+}
+
 template <typename HBUINT>
 static void context_depend_recurse_lookups (hb_depend_context_t *c,
 					     unsigned inputCount, const HBUINT input[],
@@ -2373,6 +2405,12 @@ static void context_depend_recurse_lookups (hb_depend_context_t *c,
       context_set_idx = *cached_context_set_idx;
     else
     {
+      if (unlikely (!input_position_glyphs))
+      {
+	c->depend_data->fail ();
+	return;
+      }
+
       /* Build position-specific context_set for this lookup. */
       position_context.clear ();  // Will hold direct glyphs
       disjunctive_indices.clear ();  // Will hold encoded set references
@@ -2797,6 +2835,12 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
     return;
   HB_SCOPE_GUARD (c->release_depend_scratch (scratch));
 
+  bool context_sets_cached = context_depend_sets_are_cached (
+    c, inputCount, lookupCount, lookupRecord, rule, value,
+    lookup_context.context_format, lookup_context.intersects_data);
+  if (unlikely (!c->depend_data->successful))
+    return;
+
   /* Build preliminary_context (empty for ContextSubst - no backtrack/lookahead) */
   hb_set_t &preliminary_context = scratch->preliminary_context;
 
@@ -2804,30 +2848,34 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
   hb_set_t &position_scratch = scratch->position_scratch;
   hb_vector_t<const hb_set_t *> &input_position_glyphs = scratch->input_position_glyphs;
 
-  /* Position 0 (Coverage glyph) — must be in both the class AND the
-   * coverage, so intersect with parent_active_glyphs (= coverage ∩ glyphs
-   * set by the ContextFormat2/3 caller). */
-  const hb_set_t *pos0_glyphs = depend_position_glyphs (
-    c, lookup_context.context_format, lookup_context.intersects_data, value,
-    true, &position_scratch, &scratch->compact_workspace);
-  if (unlikely (!pos0_glyphs ||
-                !input_position_glyphs.push_or_fail (pos0_glyphs)))
+  /* Cached labels no longer need the expanded input-position sets. */
+  if (!context_sets_cached)
   {
-    c->depend_data->fail ();
-    return;
-  }
-
-  /* Positions 1+ (Input array) */
-  for (unsigned i = 0; i < inputCount - 1; i++)
-  {
-    const hb_set_t *pos_glyphs = depend_position_glyphs (
-      c, lookup_context.context_format, lookup_context.intersects_data,
-      input[i], false, &position_scratch);
-    if (unlikely (!pos_glyphs ||
-                  !input_position_glyphs.push_or_fail (pos_glyphs)))
+    /* Position 0 (Coverage glyph) — must be in both the class AND the
+     * coverage, so intersect with parent_active_glyphs (= coverage ∩ glyphs
+     * set by the ContextFormat2/3 caller). */
+    const hb_set_t *pos0_glyphs = depend_position_glyphs (
+      c, lookup_context.context_format, lookup_context.intersects_data, value,
+      true, &position_scratch, &scratch->compact_workspace);
+    if (unlikely (!pos0_glyphs ||
+		  !input_position_glyphs.push_or_fail (pos0_glyphs)))
     {
       c->depend_data->fail ();
       return;
+    }
+
+    /* Positions 1+ (Input array) */
+    for (unsigned i = 0; i < inputCount - 1; i++)
+    {
+      const hb_set_t *pos_glyphs = depend_position_glyphs (
+	c, lookup_context.context_format, lookup_context.intersects_data,
+	input[i], false, &position_scratch);
+      if (unlikely (!pos_glyphs ||
+		    !input_position_glyphs.push_or_fail (pos_glyphs)))
+      {
+	c->depend_data->fail ();
+	return;
+      }
     }
   }
 
@@ -2841,7 +2889,7 @@ static inline void context_depend_lookup (hb_depend_context_t *c,
 				  lookup_context.funcs.intersected_glyphs,
 				  lookup_context.intersected_glyphs_cache,
 				  preliminary_context,
-				  &input_position_glyphs,
+				  context_sets_cached ? nullptr : &input_position_glyphs,
 				  scratch);
 }
 
@@ -4106,7 +4154,14 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
     return;
   HB_SCOPE_GUARD (c->release_depend_scratch (scratch));
 
-  /* Build context information - extract backtrack and lookahead glyphs */
+  bool context_sets_cached = context_depend_sets_are_cached (
+    c, inputCount, lookupCount, lookupRecord, rule, value,
+    lookup_context.context_format, lookup_context.intersects_data[1]);
+  if (unlikely (!c->depend_data->successful))
+    return;
+
+  /* Keep building backtrack and lookahead sets on a label-cache hit: their
+   * interning order determines the observable dependency-set indices. */
   hb_set_t &position_scratch = scratch->position_scratch;
   hb_vector_t<const hb_set_t *> &backtrack_sets = scratch->backtrack_sets;
   hb_vector_t<const hb_set_t *> &lookahead_sets = scratch->lookahead_sets;
@@ -4184,29 +4239,32 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
   /* Build glyph sets for ALL input positions */
   hb_vector_t<const hb_set_t *> &input_position_glyphs = scratch->input_position_glyphs;
 
-  /* Position 0 (first input coverage/class/glyph) — must be in both the
-   * class AND the coverage, so intersect with parent_active_glyphs. */
-  const hb_set_t *pos0_glyphs = depend_position_glyphs (
-    c, lookup_context.context_format, lookup_context.intersects_data[1], value,
-    true, &position_scratch, &scratch->compact_workspace);
-  if (unlikely (!pos0_glyphs ||
-                !input_position_glyphs.push_or_fail (pos0_glyphs)))
+  if (!context_sets_cached)
   {
-    c->depend_data->fail ();
-    return;
-  }
-
-  /* Positions 1+ (Input array) */
-  for (unsigned i = 0; i < inputCount - 1; i++)
-  {
-    const hb_set_t *pos_glyphs = depend_position_glyphs (
-      c, lookup_context.context_format, lookup_context.intersects_data[1],
-      input[i], false, &position_scratch);
-    if (unlikely (!pos_glyphs ||
-                  !input_position_glyphs.push_or_fail (pos_glyphs)))
+    /* Position 0 (first input coverage/class/glyph) — must be in both the
+     * class AND the coverage, so intersect with parent_active_glyphs. */
+    const hb_set_t *pos0_glyphs = depend_position_glyphs (
+      c, lookup_context.context_format, lookup_context.intersects_data[1], value,
+      true, &position_scratch, &scratch->compact_workspace);
+    if (unlikely (!pos0_glyphs ||
+		  !input_position_glyphs.push_or_fail (pos0_glyphs)))
     {
       c->depend_data->fail ();
       return;
+    }
+
+    /* Positions 1+ (Input array) */
+    for (unsigned i = 0; i < inputCount - 1; i++)
+    {
+      const hb_set_t *pos_glyphs = depend_position_glyphs (
+	c, lookup_context.context_format, lookup_context.intersects_data[1],
+	input[i], false, &position_scratch);
+      if (unlikely (!pos_glyphs ||
+		    !input_position_glyphs.push_or_fail (pos_glyphs)))
+      {
+	c->depend_data->fail ();
+	return;
+      }
     }
   }
 
@@ -4220,7 +4278,7 @@ static inline void chain_context_depend_lookup (hb_depend_context_t *c,
 				  lookup_context.funcs.intersected_glyphs,
 				  lookup_context.intersected_glyphs_cache,
 				  preliminary_context,
-				  &input_position_glyphs,
+				  context_sets_cached ? nullptr : &input_position_glyphs,
 				  scratch);
 }
 

--- a/src/hb-set.cc
+++ b/src/hb-set.cc
@@ -358,6 +358,24 @@ hb_set_is_equal (const hb_set_t *set,
 }
 
 /**
+ * hb_set_intersects:
+ * @set: A set
+ * @other: Another set
+ *
+ * Tests whether @set and @other have any elements in common.
+ *
+ * Return value: `true` if the two sets intersect, `false` otherwise.
+ *
+ * XSince: REPLACEME
+ **/
+hb_bool_t
+hb_set_intersects (const hb_set_t *set,
+		   const hb_set_t *other)
+{
+  return set->intersects (*other);
+}
+
+/**
  * hb_set_hash:
  * @set: A set
  *

--- a/src/hb-set.h
+++ b/src/hb-set.h
@@ -131,6 +131,10 @@ HB_EXTERN hb_bool_t
 hb_set_is_equal (const hb_set_t *set,
 		 const hb_set_t *other);
 
+HB_EXTERN hb_bool_t
+hb_set_intersects (const hb_set_t *set,
+		   const hb_set_t *other);
+
 HB_EXTERN unsigned int
 hb_set_hash (const hb_set_t *set);
 

--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -125,6 +125,9 @@ struct hb_sparseset_t
   bool may_intersect (const hb_sparseset_t &other) const
   { return s.may_intersect (other.s); }
 
+  bool intersects (const hb_sparseset_t &other) const
+  { return s.intersects (other.s); }
+
   bool intersects (hb_codepoint_t first, hb_codepoint_t last) const
   { return s.intersects (first, last); }
 

--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -140,8 +140,8 @@ struct hb_sparseset_t
   bool is_subset (const hb_sparseset_t &larger_set) const { return s.is_subset (larger_set.s); }
 
   void union_ (const hb_sparseset_t &other) { s.union_ (other.s); }
-  void intersect (const hb_sparseset_t &other) { s.intersect (other.s); }
-  void intersect (const hb_sparseset_t &other, hb_vector_t<unsigned> &workspace)
+  void intersect (const hb_sparseset_t &other,
+		  hb_vector_t<unsigned> *workspace = nullptr)
   { s.intersect (other.s, workspace); }
   void subtract (const hb_sparseset_t &other) { s.subtract (other.s); }
   void symmetric_difference (const hb_sparseset_t &other) { s.symmetric_difference (other.s); }

--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -141,6 +141,8 @@ struct hb_sparseset_t
 
   void union_ (const hb_sparseset_t &other) { s.union_ (other.s); }
   void intersect (const hb_sparseset_t &other) { s.intersect (other.s); }
+  void intersect (const hb_sparseset_t &other, hb_vector_t<unsigned> &workspace)
+  { s.intersect (other.s, workspace); }
   void subtract (const hb_sparseset_t &other) { s.subtract (other.s); }
   void symmetric_difference (const hb_sparseset_t &other) { s.symmetric_difference (other.s); }
 

--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -87,6 +87,7 @@ struct hb_sparseset_t
   uint32_t hash () const { return s.hash (); }
 
   void add (hb_codepoint_t g) { s.add (g); }
+  void add_bits (hb_codepoint_t g, uint64_t bits) { s.add_bits (g, bits); }
   bool add_range (hb_codepoint_t first, hb_codepoint_t last) { return s.add_range (first, last); }
 
   template <typename T>

--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -156,6 +156,7 @@ struct hb_sparseset_t
   { return s.next_many (codepoint, out, size); }
 
   unsigned int get_population () const { return s.get_population (); }
+  bool get_singleton (hb_codepoint_t *codepoint) const { return s.get_singleton (codepoint); }
   hb_codepoint_t get_min () const { return s.get_min (); }
   hb_codepoint_t get_max () const { return s.get_max (); }
 

--- a/src/hb-set.hh
+++ b/src/hb-set.hh
@@ -147,6 +147,8 @@ struct hb_sparseset_t
   void symmetric_difference (const hb_sparseset_t &other) { s.symmetric_difference (other.s); }
 
   bool next (hb_codepoint_t *codepoint) const { return s.next (codepoint); }
+  bool next_bits (hb_codepoint_t *codepoint, uint64_t *bits) const
+  { return s.next_bits (codepoint, bits); }
   bool previous (hb_codepoint_t *codepoint) const { return s.previous (codepoint); }
   bool next_range (hb_codepoint_t *first, hb_codepoint_t *last) const
   { return s.next_range (first, last); }

--- a/src/hb-subset-input.cc
+++ b/src/hb-subset-input.cc
@@ -806,9 +806,8 @@ _format_tag (hb_tag_t tag, hb_vector_t<char> &out)
 static void
 _format_tag_set (const hb_set_t *set, hb_vector_t<char> &out)
 {
-  hb_codepoint_t tag = HB_SET_VALUE_INVALID;
   bool first_tag = true;
-  while (hb_set_next (set, &tag))
+  for (hb_codepoint_t tag : *set)
   {
     if (!first_tag)
       out.push (',');
@@ -916,9 +915,8 @@ _format_glyph_map_arg (const hb_map_t &glyph_map,
   hb_set_t keys;
   hb_map_keys (&glyph_map, &keys);
   hb_vector_t<char> pairs;
-  hb_codepoint_t key = HB_SET_VALUE_INVALID;
   bool first = true;
-  while (hb_set_next (&keys, &key))
+  for (hb_codepoint_t key : keys)
   {
     if (!first)
       pairs.push (',');

--- a/src/test-set.cc
+++ b/src/test-set.cc
@@ -158,6 +158,26 @@ main (int argc, char **argv)
     hb_always_assert (b.intersects (c));
   }
 
+  /* Test singleton detection. */
+  {
+    hb_set_t s;
+    hb_codepoint_t singleton;
+    hb_always_assert (!s.get_singleton (&singleton));
+
+    s.add (63);
+    hb_always_assert (s.get_singleton (&singleton));
+    hb_always_assert (singleton == 63);
+
+    s.add (1024);
+    hb_always_assert (!s.get_singleton (&singleton));
+    s.del (63);
+    hb_always_assert (s.get_singleton (&singleton));
+    hb_always_assert (singleton == 1024);
+
+    s.invert ();
+    hb_always_assert (!s.get_singleton (&singleton));
+  }
+
   /* Adding HB_SET_VALUE_INVALID */
   {
     hb_set_t s;

--- a/src/test-set.cc
+++ b/src/test-set.cc
@@ -218,8 +218,10 @@ main (int argc, char **argv)
 
     auto it = s.iter ();
     hb_always_assert (*it == 0);
+    hb_always_assert (it.len () == ARRAY_LENGTH (expected));
     ++it;
     hb_always_assert (*it == 1);
+    hb_always_assert (it.len () == ARRAY_LENGTH (expected) - 1);
     --it;
     hb_always_assert (*it == 0);
     ++it;
@@ -240,6 +242,10 @@ main (int argc, char **argv)
     hb_always_assert (*it == 1024);
     ++it;
     hb_always_assert (*it == HB_SET_VALUE_INVALID - 1);
+
+    it = s.iter ();
+    it += 2;
+    hb_always_assert (it.len () == ARRAY_LENGTH (expected) - 2);
   }
 
   /* Test inverted-set iteration. */
@@ -248,6 +254,7 @@ main (int argc, char **argv)
     s.invert ();
     auto it = s.iter ();
     hb_always_assert (*it == 2);
+    hb_always_assert (it.len () == HB_SET_VALUE_INVALID - 4);
     ++it;
     hb_always_assert (*it == 3);
     --it;

--- a/src/test-set.cc
+++ b/src/test-set.cc
@@ -182,5 +182,63 @@ main (int argc, char **argv)
     hb_always_assert(s.has(2));
   }
 
+  /* Test iteration across words and pages. */
+  {
+    hb_set_t s {0, 1, 63, 64, 65, 127, 511, 512, 513, 1024,
+		HB_SET_VALUE_INVALID - 1};
+    hb_codepoint_t expected[] = {0, 1, 63, 64, 65, 127, 511, 512, 513,
+				 1024, HB_SET_VALUE_INVALID - 1};
+    unsigned int i = 0;
+    for (hb_codepoint_t v : s)
+    {
+      hb_always_assert (i < ARRAY_LENGTH (expected));
+      hb_always_assert (v == expected[i++]);
+    }
+    hb_always_assert (i == ARRAY_LENGTH (expected));
+
+    auto it = s.iter ();
+    hb_always_assert (*it == 0);
+    ++it;
+    hb_always_assert (*it == 1);
+    --it;
+    hb_always_assert (*it == 0);
+    ++it;
+    hb_always_assert (*it == 1);
+    it += 3;
+    hb_always_assert (*it == 65);
+    --it;
+    hb_always_assert (*it == 64);
+    --it;
+    hb_always_assert (*it == 63);
+    ++it;
+    hb_always_assert (*it == 64);
+
+    it = it.end ();
+    --it;
+    hb_always_assert (*it == HB_SET_VALUE_INVALID - 1);
+    --it;
+    hb_always_assert (*it == 1024);
+    ++it;
+    hb_always_assert (*it == HB_SET_VALUE_INVALID - 1);
+  }
+
+  /* Test inverted-set iteration. */
+  {
+    hb_set_t s {0, 1, 63, 64};
+    s.invert ();
+    auto it = s.iter ();
+    hb_always_assert (*it == 2);
+    ++it;
+    hb_always_assert (*it == 3);
+    --it;
+    hb_always_assert (*it == 2);
+
+    it = it.end ();
+    --it;
+    hb_always_assert (*it == HB_SET_VALUE_INVALID - 1);
+    --it;
+    hb_always_assert (*it == HB_SET_VALUE_INVALID - 2);
+  }
+
   return 0;
 }

--- a/src/test-set.cc
+++ b/src/test-set.cc
@@ -178,6 +178,20 @@ main (int argc, char **argv)
     hb_always_assert (!s.get_singleton (&singleton));
   }
 
+  /* Test word-at-a-time insertion. */
+  {
+    hb_set_t s;
+    s.add_bits (64, uint64_t (1) | (uint64_t (1) << 63));
+    hb_always_assert (s.get_population () == 2);
+    hb_always_assert (s.has (64));
+    hb_always_assert (s.has (127));
+
+    s.invert ();
+    s.add_bits (64, uint64_t (1) | (uint64_t (1) << 63));
+    hb_always_assert (s.has (64));
+    hb_always_assert (s.has (127));
+  }
+
   /* Adding HB_SET_VALUE_INVALID */
   {
     hb_set_t s;

--- a/src/test-set.cc
+++ b/src/test-set.cc
@@ -137,6 +137,27 @@ main (int argc, char **argv)
     hb_always_assert (s.has (HB_SET_VALUE_INVALID));
   }
 
+  /* Test set intersection. */
+  {
+    hb_set_t a {1, 2};
+    hb_set_t b {2, 3};
+    hb_set_t c {3, 4};
+
+    hb_always_assert (a.intersects (b));
+    hb_always_assert (!a.intersects (c));
+
+    b.invert ();
+    hb_always_assert (a.intersects (b));
+    hb_always_assert (b.intersects (a));
+
+    hb_set_t singleton {2};
+    hb_always_assert (!singleton.intersects (b));
+    hb_always_assert (!b.intersects (singleton));
+
+    c.invert ();
+    hb_always_assert (b.intersects (c));
+  }
+
   /* Adding HB_SET_VALUE_INVALID */
   {
     hb_set_t s;

--- a/test/api/test-set.c
+++ b/test/api/test-set.c
@@ -1024,6 +1024,41 @@ test_set_inverted_equality (void)
   hb_set_destroy (b);
 }
 
+static void
+test_set_intersects (void)
+{
+  hb_set_t *a = hb_set_create ();
+  hb_set_t *b = hb_set_create ();
+  hb_set_t *c = hb_set_create ();
+
+  hb_set_add (a, 1);
+  hb_set_add (a, 2);
+  hb_set_add (b, 2);
+  hb_set_add (b, 3);
+  hb_set_add (c, 3);
+  hb_set_add (c, 4);
+
+  g_assert_true (hb_set_intersects (a, b));
+  g_assert_true (hb_set_intersects (b, a));
+  g_assert_true (!hb_set_intersects (a, c));
+
+  hb_set_invert (b);
+  g_assert_true (hb_set_intersects (a, b));
+  g_assert_true (hb_set_intersects (b, a));
+
+  hb_set_clear (a);
+  hb_set_add (a, 2);
+  g_assert_true (!hb_set_intersects (a, b));
+  g_assert_true (!hb_set_intersects (b, a));
+
+  hb_set_invert (c);
+  g_assert_true (hb_set_intersects (b, c));
+
+  hb_set_destroy (a);
+  hb_set_destroy (b);
+  hb_set_destroy (c);
+}
+
 typedef enum {
   UNION = 0,
   INTERSECT,
@@ -1300,6 +1335,7 @@ main (int argc, char **argv)
   hb_test_add (test_set_inverted_iteration_next);
   hb_test_add (test_set_inverted_iteration_prev);
   hb_test_add (test_set_inverted_equality);
+  hb_test_add (test_set_intersects);
   hb_test_add (test_set_inverted_operations);
 
   hb_test_add (test_hb_set_add_sorted_array);

--- a/test/fuzzing/meson.build
+++ b/test/fuzzing/meson.build
@@ -125,7 +125,15 @@ fonts_glob = run_command(glob_cmd, meson.current_source_dir() / 'fonts', check:t
 subset_fonts_glob = run_command(glob_cmd, meson.current_source_dir() / '..' / 'subset' / 'data' / 'fonts', check:true).stdout().strip().split('\n')
 graphs_glob = run_command(glob_cmd, meson.current_source_dir() / 'graphs', check:true).stdout().strip().split('\n')
 
-depend_closure_parity_fonts_glob = subset_fonts_glob
+depend_closure_parity_fonts_glob = []
+depend_closure_parity_noto_nastaliq_fonts = []
+foreach font : subset_fonts_glob
+  if font.contains('NotoNastaliqUrdu-Bold.ttf') or font.contains('NotoNastaliqUrdu-Regular.ttf')
+    depend_closure_parity_noto_nastaliq_fonts += [font]
+  else
+    depend_closure_parity_fonts_glob += [font]
+  endif
+endforeach
 
 # Chunk the glob lists to avoid command line length limits, and for parallelization
 chunk_size = 64
@@ -242,6 +250,20 @@ if conf.get('HB_EXPERIMENTAL_API', 0) == 1
         suite: ['fuzzing'],
       )
       i += 1
+    endforeach
+
+    foreach font : depend_closure_parity_noto_nastaliq_fonts
+      font_name = 'regular'
+      if font.contains('NotoNastaliqUrdu-Bold.ttf')
+        font_name = 'bold'
+      endif
+      test('depend-closure-parity-noto-nastaliq-@0@'.format(font_name),
+        hb_depend_closure_parity_exe,
+        args: ['-s', '42', '-n', '16', font],
+        workdir: meson.current_build_dir() / '..' / '..',
+        protocol: 'tap',
+        suite: ['fuzzing'],
+      )
     endforeach
   endif
 

--- a/test/fuzzing/meson.build
+++ b/test/fuzzing/meson.build
@@ -125,14 +125,7 @@ fonts_glob = run_command(glob_cmd, meson.current_source_dir() / 'fonts', check:t
 subset_fonts_glob = run_command(glob_cmd, meson.current_source_dir() / '..' / 'subset' / 'data' / 'fonts', check:true).stdout().strip().split('\n')
 graphs_glob = run_command(glob_cmd, meson.current_source_dir() / 'graphs', check:true).stdout().strip().split('\n')
 
-depend_closure_parity_fonts_glob = []
-foreach font : subset_fonts_glob
-  # These fonts currently spend tens of seconds or more building the
-  # contextual GSUB dependency graph before the parity tests start.
-  if not font.contains('NotoNastaliqUrdu-Bold.ttf') and not font.contains('NotoNastaliqUrdu-Regular.ttf')
-    depend_closure_parity_fonts_glob += [font]
-  endif
-endforeach
+depend_closure_parity_fonts_glob = subset_fonts_glob
 
 # Chunk the glob lists to avoid command line length limits, and for parallelization
 chunk_size = 64

--- a/util/hb-subset-depend.cc
+++ b/util/hb-subset-depend.cc
@@ -38,6 +38,7 @@ struct depend_t : option_parser_t, face_options_t
   gboolean flagged_only = false;
   gboolean no_context = false;
   gboolean no_glyph_names = false;
+  gboolean quiet = false;
   char *gids_str = nullptr;
 
   void
@@ -60,6 +61,8 @@ struct depend_t : option_parser_t, face_options_t
        "Suppress context set output", nullptr},
       {"no-glyph-names", 0, 0, G_OPTION_ARG_NONE, &this->no_glyph_names,
        "Use numeric glyph IDs instead of names", nullptr},
+      {"quiet",          'q', 0, G_OPTION_ARG_NONE, &this->quiet,
+       "Build the dependency graph without printing it", nullptr},
       {nullptr}
     };
     add_group (depend_entries,
@@ -207,6 +210,12 @@ struct depend_t : option_parser_t, face_options_t
     {
       fprintf (stderr, "Failed to build dependency graph\n");
       return 1;
+    }
+
+    if (quiet)
+    {
+      hb_subset_depend_destroy (depend);
+      return 0;
     }
 
     hb_font_t *font = no_glyph_names ? nullptr : hb_font_create (face);

--- a/util/hb-subset-depend.cc
+++ b/util/hb-subset-depend.cc
@@ -38,6 +38,7 @@ struct depend_t : option_parser_t, face_options_t
   gboolean flagged_only = false;
   gboolean no_context = false;
   gboolean no_glyph_names = false;
+  gboolean compile_only = false;
   gboolean quiet = false;
   char *gids_str = nullptr;
 
@@ -61,8 +62,10 @@ struct depend_t : option_parser_t, face_options_t
        "Suppress context set output", nullptr},
       {"no-glyph-names", 0, 0, G_OPTION_ARG_NONE, &this->no_glyph_names,
        "Use numeric glyph IDs instead of names", nullptr},
+      {"compile",        0, 0, G_OPTION_ARG_NONE, &this->compile_only,
+       "Build the dependency graph without retrieving it", nullptr},
       {"quiet",          'q', 0, G_OPTION_ARG_NONE, &this->quiet,
-       "Build the dependency graph without printing it", nullptr},
+       "Retrieve the dependency graph without printing it", nullptr},
       {nullptr}
     };
     add_group (depend_entries,
@@ -212,13 +215,13 @@ struct depend_t : option_parser_t, face_options_t
       return 1;
     }
 
-    if (quiet)
+    if (compile_only)
     {
       hb_subset_depend_destroy (depend);
       return 0;
     }
 
-    hb_font_t *font = no_glyph_names ? nullptr : hb_font_create (face);
+    hb_font_t *font = no_glyph_names || quiet ? nullptr : hb_font_create (face);
 
     std::set<unsigned> gid_filter;
     bool filter_gids = gids_str != nullptr;
@@ -249,7 +252,7 @@ struct depend_t : option_parser_t, face_options_t
         entries.push_back (entry);
       }
 
-      if (entries.empty ()) continue;
+      if (entries.empty () || quiet) continue;
 
       if (printed_any) printf ("\n");
       printed_any = true;


### PR DESCRIPTION
## What changed

- add `--compile` for construction-only profiling, `-q` / `--quiet` for retrieval without printing, and `--no-glyph-names` for numeric output
- memoize completed contextual GSUB lookup-recursion states per top-level lookup
- include the active glyph set, ordered recursion ancestry, and context set in the cache key; omit edge flags because they affect neither traversal nor edge identity
- encode the common root and single-active-glyph states directly in the memoization key
- intern ordered recursion paths directly from parent-path and lookup IDs instead of hashing and copying ancestry sets
- cache position-specific contextual edge labels by rule, lookup record, and stable active-glyph identity
- skip side-effect-free input-position expansion when every record label is already cached
- skip chained-context backtrack, lookahead, and input-position preparation when a nonempty rule's record labels are already cached
- reuse context-set indices resolved by the all-cached precheck instead of probing the cache twice
- retain content-interned active-glyph identities across top-level lookups
- combine edge deduplication lookup and insertion, then store exact edge locations in a compact dedicated table
- cache contextual position glyph sets, keep the bounded covered-position bitmap inline, and recycle scratch sets and vectors by active recursion depth
- retain active-glyph set storage and reuse set-intersection compaction workspace
- store lookup feature tags in one compact owned vector with per-lookup offsets, sorting and deduplicating once after collection
- add an inversion-aware exact set-intersection helper and use it to avoid allocation-heavy temporary set subtraction
- expose the helper as the public `hb_set_intersects()` API
- consume stable `hb_set_t` iteration 64 bitmap bits at a time while preserving scalar and inverted-set behavior
- compute iterator length lazily when a consumer actually requests it
- intersect coverage-format-2 ranges and insert `hb_set_t` results one 64-bit bitmap word at a time
- remove unused contextual stack bookkeeping
- run each Noto Nastaliq dependency closure-parity fixture as its own named one-font test

## Why

Complex contextual lookup graphs can reach the same completed subgraph through many parent paths. The existing active-stack set prevents cycles but forgets states after unwinding, so Noto Nastaliq repeatedly expands equivalent recursion states. Memoization removes that repeated traversal.

After memoization, retained scratch storage, compact lookup-feature storage, bitmap-word set operations, and compact edge deduplication reduce the remaining allocation and bookkeeping cost. Contextual rules also rebuilt the same position-specific edge label on nearly every visit; caching that label by its exact stable inputs avoids repeated set scans, intersections, and content hashing without changing traversal or label semantics.

## Performance

On the full 529,108-byte `NotoNastaliqUrdu-Regular.ttf`:

- old implementation with full graph output: 7:44.77 wall, 462.58s user
- new construction path, measured over 30 runs: 103.53ms task-clock, 105.64ms elapsed, and 1.208 billion instructions
- new implementation with full graph output, measured over 10 runs: 575.80ms task-clock and 578.30ms elapsed
- new peak RSS: about 30MB

Construction is about 4,400x faster than the original end-to-end baseline. The apples-to-apples full-output run is about 804x faster. The full formatted graph is 150,835,628 bytes. Old and new stdout are byte-for-byte identical with SHA-256 `cb59827fa48f3efa96e3275b249b671aa5546779d39bfc6c2dff49075bc3d2dc`; stderr is empty for both.

The follow-up storage changes reduced allocation/reallocation calls from 5.26 million to 95,308 and cumulative allocated bytes from 480MB to about 51.7MB. Context-label caching, lazy input expansion, cached chained-context preparation, and flag-independent memoization reduced construction from about 209ms and 2.77 billion instructions to about 106ms and 1.21 billion instructions. From the first memoized implementation, construction fell from 374ms and 4.71 billion instructions to about 106ms and 1.21 billion instructions.

The internal 64-bit set iterator provides a smaller general benefit without adding public API. Ten-iteration full-Unicode subset runs improved by about 1.0% on Noto Nastaliq, 1.4% on Amiri, 1.9% on Source Serif Variable, and 2.7% on Noto COLRv1. A trial conversion of very sparse contextual sets regressed and was discarded.

## Validation

- full Meson suite: 272/272 passed
- public and internal exact set-intersection coverage for regular and inverted pairs
- word-at-a-time set insertion coverage for regular and inverted sets
- all dependency fuzzer chunks passed
- Clang 18 ASan/UBSan dependency fuzzer chunks: 9/9 passed after flattening lookup-feature storage
- `depend-closure-parity-noto-nastaliq-bold` and `depend-closure-parity-noto-nastaliq-regular` each pass as independent one-font tests
- remaining graph-vs-legacy closure fixtures pass in two balanced chunks
- exact old-vs-new graph output across 513 fuzz fonts, 99 subset fixtures that completed with the old implementation, and representative production fonts
- byte-identical graph output for Noto Nastaliq, Noto Sans Duployan, Gulzar, IranNastaliq, Noto-COLRv1, Amiri, and SourceSerifVariable-Roman
- byte-identical full-Unicode subset output before/after the iterator change for Noto Nastaliq, Amiri, Source Serif Variable, and Noto COLRv1
- an independent adversarial audit found the memoization key complete and no successful-construction correctness counterexample; OOM allocation timing changes but failure remains safe
