### PR TITLE
[subset] Misc speedups

### DIFF
--- a/src/OT/Layout/Common/Coverage.hh
+++ b/src/OT/Layout/Common/Coverage.hh
@@ -189,12 +189,12 @@ struct Coverage
   bool subset (hb_subset_context_t *c) const
   {
     TRACE_SUBSET (this);
-    const hb_vector_t<hb_codepoint_t> &glyph_map = c->plan->glyph_map_gsub_flat;
+    const hb_subset_plan_t *plan = c->plan;
     auto it =
     + iter ()
-    | hb_take (c->plan->source->get_num_glyphs ())
-    | hb_map_retains_sorting ([&glyph_map] (hb_codepoint_t g) {
-	return g < glyph_map.length ? glyph_map.arrayZ[g] : HB_MAP_VALUE_INVALID;
+    | hb_take (plan->source->get_num_glyphs ())
+    | hb_map_retains_sorting ([plan] (hb_codepoint_t g) {
+	return plan->map_gsub_glyph (g);
       })
     | hb_filter ([] (hb_codepoint_t glyph) { return glyph != HB_MAP_VALUE_INVALID; })
     ;

--- a/src/OT/Layout/Common/Coverage.hh
+++ b/src/OT/Layout/Common/Coverage.hh
@@ -189,10 +189,13 @@ struct Coverage
   bool subset (hb_subset_context_t *c) const
   {
     TRACE_SUBSET (this);
+    const hb_vector_t<hb_codepoint_t> &glyph_map = c->plan->glyph_map_gsub_flat;
     auto it =
     + iter ()
     | hb_take (c->plan->source->get_num_glyphs ())
-    | hb_map_retains_sorting (c->plan->glyph_map_gsub)
+    | hb_map_retains_sorting ([&glyph_map] (hb_codepoint_t g) {
+	return g < glyph_map.length ? glyph_map.arrayZ[g] : HB_MAP_VALUE_INVALID;
+      })
     | hb_filter ([] (hb_codepoint_t glyph) { return glyph != HB_MAP_VALUE_INVALID; })
     ;
 

--- a/src/hb-ot-layout-common.hh
+++ b/src/hb-ot-layout-common.hh
@@ -1551,7 +1551,6 @@ struct ClassDefFormat1_3
                const Coverage* glyph_filter = nullptr) const
   {
     TRACE_SUBSET (this);
-    const hb_map_t &glyph_map = c->plan->glyph_map_gsub;
 
     hb_sorted_vector_t<hb_codepoint_pair_t> glyph_and_klass;
     hb_set_t orig_klasses;
@@ -1561,7 +1560,7 @@ struct ClassDefFormat1_3
 
     for (const hb_codepoint_t gid : + hb_range (start, end))
     {
-      hb_codepoint_t new_gid = glyph_map[gid];
+      hb_codepoint_t new_gid = c->plan->map_gsub_glyph (gid);
       if (new_gid == HB_MAP_VALUE_INVALID) continue;
       if (glyph_filter && !glyph_filter->has(gid)) continue;
 
@@ -1574,9 +1573,10 @@ struct ClassDefFormat1_3
 
     if (use_class_zero)
     {
+      const hb_set_t& glyphset = *c->plan->glyphset_gsub ();
       unsigned glyph_count = glyph_filter
-			     ? hb_len (hb_iter (glyph_map.keys()) | hb_filter (glyph_filter))
-			     : glyph_map.get_population ();
+			     ? hb_len (hb_iter (glyphset) | hb_filter (glyph_filter))
+			     : glyphset.get_population ();
       use_class_zero = glyph_count <= glyph_and_klass.length;
     }
     if (!ClassDef_remap_and_serialize (c->serializer,
@@ -1810,7 +1810,6 @@ struct ClassDefFormat2_4
                const Coverage* glyph_filter = nullptr) const
   {
     TRACE_SUBSET (this);
-    const hb_map_t &glyph_map = c->plan->glyph_map_gsub;
     const hb_set_t &glyph_set = *c->plan->glyphset_gsub ();
 
     hb_sorted_vector_t<hb_codepoint_pair_t> glyph_and_klass;
@@ -1823,7 +1822,7 @@ struct ClassDefFormat2_4
       {
 	unsigned klass = get_class (g);
 	if (!klass) continue;
-	hb_codepoint_t new_gid = glyph_map[g];
+	hb_codepoint_t new_gid = c->plan->map_gsub_glyph (g);
 	if (new_gid == HB_MAP_VALUE_INVALID) continue;
 	if (glyph_filter && !glyph_filter->has (g)) continue;
 	glyph_and_klass.push (hb_pair (new_gid, klass));
@@ -1841,7 +1840,7 @@ struct ClassDefFormat2_4
 	hb_codepoint_t end   = hb_min (range.last + 1, num_source_glyphs);
 	for (hb_codepoint_t g = start; g < end; g++)
 	{
-	  hb_codepoint_t new_gid = glyph_map[g];
+	  hb_codepoint_t new_gid = c->plan->map_gsub_glyph (g);
 	  if (new_gid == HB_MAP_VALUE_INVALID) continue;
 	  if (glyph_filter && !glyph_filter->has (g)) continue;
 
@@ -1854,7 +1853,7 @@ struct ClassDefFormat2_4
     const hb_set_t& glyphset = *c->plan->glyphset_gsub ();
     unsigned glyph_count = glyph_filter
                            ? hb_len (hb_iter (glyphset) | hb_filter (glyph_filter))
-                           : glyph_map.get_population ();
+                           : glyphset.get_population ();
     use_class_zero = use_class_zero && glyph_count <= glyph_and_klass.length;
     if (!ClassDef_remap_and_serialize (c->serializer,
                                        orig_klasses,

--- a/src/hb-subset-cff-common.hh
+++ b/src/hb-subset-cff-common.hh
@@ -445,29 +445,81 @@ struct parsed_cs_str_t : parsed_values_t<parsed_cs_op_t>
     parsed (false),
     hint_dropped (false),
     has_prefix_ (false),
-    has_calls_ (false)
+    has_calls_ (false),
+    coalescing_ (false)
   {
     SUPER::init ();
   }
 
+  HB_ALWAYS_INLINE
   void add_op (op_code_t op, const byte_str_ref_t& str_ref)
   {
-    if (!is_parsed ())
-      SUPER::add_op (op, str_ref);
+    if (is_parsed ()) return;
+    if (coalescing_)
+    {
+      /* Do not record individual tokens; only note their boundaries.
+       * Bytes are flushed as verbatim segments at call sites and at
+       * the end of the string.  Only enabled when per-op granularity
+       * is not needed later for hint analysis. */
+      penultimate_end_ = last_end_;
+      last_end_ = str_ref.get_offset ();
+      if (unlikely (op == OpCode_return || op == OpCode_endchar))
+	flush_segment (str_ref, last_end_);
+      return;
+    }
+    SUPER::add_op (op, str_ref);
   }
 
   void add_call_op (op_code_t op, const byte_str_ref_t& str_ref, unsigned int subr_num)
   {
-    if (!is_parsed ())
+    if (is_parsed ()) return;
+    has_calls_ = true;
+
+    if (coalescing_)
     {
-      has_calls_ = true;
-
-      /* Pop the subroutine number. */
-      values.pop ();
-
+      /* Flush bytes preceding the subroutine-number token, then skip
+       * over the number: it is re-encoded with the new bias. */
+      flush_segment (str_ref, penultimate_end_);
+      opStart = last_end_;
       SUPER::add_op (op, str_ref, {subr_num});
+      penultimate_end_ = last_end_ = str_ref.get_offset ();
+      return;
     }
+
+    /* Pop the subroutine number. */
+    values.pop ();
+
+    SUPER::add_op (op, str_ref, {subr_num});
   }
+
+  /* Flush pending bytes [opStart, end) as verbatim segment entries. */
+  void flush_segment (const byte_str_ref_t& str_ref, unsigned end)
+  {
+    unsigned start = opStart;
+    if (end <= start) return;
+    while (start < end)
+    {
+      auto arr = str_ref.sub_array (start, hb_min (end - start, 255u));
+      if (unlikely (!arr.length)) break;
+      parsed_cs_op_t *val = values.push ();
+      val->ptr = arr.arrayZ;
+      val->length = arr.length;
+      start += arr.length;
+    }
+    opStart = end;
+  }
+
+  /* For coalescing mode: flush any pending bytes through the current
+   * position; used where the string ends without an explicit
+   * return/endchar op (CFF2). */
+  void flush_coalesced (const byte_str_ref_t& str_ref)
+  {
+    if (coalescing_ && !is_parsed ())
+      flush_segment (str_ref, str_ref.get_offset ());
+  }
+
+  void enable_coalescing () { coalescing_ = true; }
+  bool is_coalescing () const { return coalescing_; }
 
   void set_prefix (const number_t &num, op_code_t op = OpCode_Invalid)
   {
@@ -532,6 +584,13 @@ struct parsed_cs_str_t : parsed_values_t<parsed_cs_op_t>
   bool    vsindex_dropped : 1;
   bool    has_prefix_ : 1;
   bool    has_calls_ : 1;
+  /* Record verbatim byte segments instead of individual tokens,
+   * making a separate compact() pass unnecessary; incompatible with
+   * hint analysis. */
+  bool    coalescing_ : 1;
+  /* End offsets of the last two tokens seen (coalescing mode). */
+  unsigned penultimate_end_ = 0;
+  unsigned last_end_ = 0;
   op_code_t	prefix_op_;
   number_t	prefix_num_;
 
@@ -612,14 +671,19 @@ struct subr_subset_param_t
 		       parsed_cs_str_vec_t *parsed_local_subrs_,
 		       hb_set_t *global_closure_,
 		       hb_set_t *local_closure_,
-		       bool drop_hints_) :
+		       bool drop_hints_,
+		       bool coalesce_ = false) :
       current_parsed_str (parsed_charstring_),
       parsed_charstring (parsed_charstring_),
       parsed_global_subrs (parsed_global_subrs_),
       parsed_local_subrs (parsed_local_subrs_),
       global_closure (global_closure_),
       local_closure (local_closure_),
-      drop_hints (drop_hints_) {}
+      drop_hints (drop_hints_),
+      coalesce (coalesce_)
+  {
+    if (coalesce) parsed_charstring->enable_coalescing ();
+  }
 
   parsed_cs_str_t *get_parsed_str_for_context (call_context_t &context)
   {
@@ -658,7 +722,10 @@ struct subr_subset_param_t
     else
     {
       if (!parsed_str->is_parsed ())
+      {
         parsed_str->alloc (env.str_ref.total_size ());
+        if (coalesce) parsed_str->enable_coalescing ();
+      }
       current_parsed_str = parsed_str;
     }
   }
@@ -671,6 +738,7 @@ struct subr_subset_param_t
   hb_set_t      *global_closure;
   hb_set_t      *local_closure;
   bool	  drop_hints;
+  bool	  coalesce;
 };
 
 struct subr_remap_t : hb_inc_bimap_t
@@ -788,6 +856,12 @@ struct subr_subsetter_t
       return false;
     }
 
+    /* When hints are not analyzed (not dropping hints, not populating
+     * the accelerator), coalesce parsed tokens as they are added,
+     * instead of a separate compact() pass. */
+    bool coalesce = !(plan->flags & HB_SUBSET_FLAGS_NO_HINTING) &&
+		    !plan->inprogress_accelerator;
+
     /* phase 1 & 2 */
     for (auto _ : plan->new_to_old_gid_list)
     {
@@ -820,7 +894,8 @@ struct subr_subsetter_t
                                   &parsed_local_subrs_storage[fd],
                                   &closures.global_closure,
                                   &closures.local_closures[fd],
-                                  plan->flags & HB_SUBSET_FLAGS_NO_HINTING);
+                                  plan->flags & HB_SUBSET_FLAGS_NO_HINTING,
+                                  coalesce);
 
       if (unlikely (!interp.interpret (param)))
         return false;
@@ -852,8 +927,11 @@ struct subr_subsetter_t
        *
        * The compacting both saves memory and makes further operations
        * faster.
+       *
+       * Not needed when tokens were coalesced during parsing.
        */
-      parsed_charstrings[new_glyph].compact ();
+      if (!coalesce)
+	parsed_charstrings[new_glyph].compact ();
     }
 
     /* Since parsed strings were loaded from accelerator, we still need

--- a/src/hb-subset-cff2.cc
+++ b/src/hb-subset-cff2.cc
@@ -714,12 +714,14 @@ struct cff2_cs_opset_subr_subset_t : cff2_cs_opset_t<cff2_cs_opset_subr_subset_t
     switch (op) {
 
       case OpCode_return:
+	param.current_parsed_str->flush_coalesced (env.str_ref);
 	param.current_parsed_str->set_parsed ();
 	env.return_from_subr ();
 	param.set_current_str (env, false);
 	break;
 
       case OpCode_endchar:
+	param.current_parsed_str->flush_coalesced (env.str_ref);
 	param.current_parsed_str->set_parsed ();
 	SUPER::process_op (op, env, param);
 	break;

--- a/src/hb-subset-plan-member-list.hh
+++ b/src/hb-subset-plan-member-list.hh
@@ -61,6 +61,11 @@ HB_SUBSET_PLAN_MEMBER (hb_set_t, drop_tables)
 // Old -> New glyph id mapping
 HB_SUBSET_PLAN_MEMBER (hb_map_t, glyph_map_gsub)
 
+// Same mapping as glyph_map_gsub, as a flat array indexed by old gid,
+// with HB_MAP_VALUE_INVALID entries for glyphs not retained.  Sized to
+// the highest retained GSUB gid plus one.
+HB_SUBSET_PLAN_MEMBER (hb_vector_t<hb_codepoint_t>, glyph_map_gsub_flat)
+
 HB_SUBSET_PLAN_MEMBER (hb_set_t, _glyphset)
 HB_SUBSET_PLAN_MEMBER (hb_set_t, _glyphset_gsub)
 HB_SUBSET_PLAN_MEMBER (hb_set_t, _glyphset_mathed)

--- a/src/hb-subset-plan.cc
+++ b/src/hb-subset-plan.cc
@@ -508,18 +508,27 @@ _populate_gids_to_retain (hb_subset_plan_t* plan,
 #endif
 }
 
-static void
+static bool
 _create_glyph_map_gsub (const hb_set_t* glyph_set_gsub,
                         const hb_map_t* glyph_map,
-                        hb_map_t* out)
+                        hb_map_t* out,
+                        hb_vector_t<hb_codepoint_t>* out_flat)
 {
+  hb_codepoint_t max_gid = HB_SET_VALUE_INVALID;
+  hb_set_previous (glyph_set_gsub, &max_gid);
+  unsigned flat_size = max_gid == HB_SET_VALUE_INVALID ? 0 : max_gid + 1;
+  if (unlikely (!out_flat->resize_dirty (flat_size)))
+    return false;
+  hb_memset (out_flat->arrayZ, 0xFF, flat_size * sizeof (hb_codepoint_t));
+
   out->alloc (glyph_set_gsub->get_population ());
-  + hb_iter (glyph_set_gsub)
-  | hb_map ([&] (hb_codepoint_t gid) {
-    return hb_codepoint_pair_t (gid, glyph_map->get (gid));
-  })
-  | hb_sink (out)
-  ;
+  for (auto gid : *glyph_set_gsub)
+  {
+    hb_codepoint_t new_gid = glyph_map->get (gid);
+    out->set (gid, new_gid);
+    out_flat->arrayZ[gid] = new_gid;
+  }
+  return !out->in_error ();
 }
 
 static bool
@@ -710,10 +719,12 @@ hb_subset_plan_t::hb_subset_plan_t (hb_face_t *face,
   }
 #endif
 
-  _create_glyph_map_gsub (
+  if (!check_success (_create_glyph_map_gsub (
       &_glyphset_gsub,
       glyph_map,
-      &glyph_map_gsub);
+      &glyph_map_gsub,
+      &glyph_map_gsub_flat)))
+    return;
 
   // Now that we have old to new gid map update the unicode to new gid list.
   for (unsigned i = 0; i < unicode_to_new_gid_list.length; i++)

--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -242,6 +242,18 @@ struct hb_subset_plan_t
   }
 
   /*
+   * Old-to-new glyph id mapping for GSUB glyphs, through the flat
+   * array; returns HB_MAP_VALUE_INVALID for glyphs not retained.
+   */
+  inline hb_codepoint_t
+  map_gsub_glyph (hb_codepoint_t old_gid) const
+  {
+    return old_gid < glyph_map_gsub_flat.length
+	 ? glyph_map_gsub_flat.arrayZ[old_gid]
+	 : HB_MAP_VALUE_INVALID;
+  }
+
+  /*
    * The total number of output glyphs in the final subset.
    */
   inline unsigned int


### PR DESCRIPTION
Profile-guided speedups for the subsetter.

Measured with interleaved A/B runs against main (cb9460bcbb) using `perf stat` task-clock, `hb-subset --unicodes='*' -n 30..100`:

| Font | main | this PR | Δ |
|---|---|---|---|
| SourceHanSans (CFF, 10K glyphs) | 806 ms | 732 ms | **−9.2%** |
| NotoNastaliqUrdu | 791 ms | 693 ms | **−12.4%** |
| Amiri | 116 ms | 104 ms | **−10.4%** |
| Mplus1p, Roboto, NotoSansDevanagari | — | — | flat (within noise) |

Commits:

- **[subset] Remap Coverage glyphs through a flat array** — `Coverage::subset` paid an `hb_map_t` hash lookup per covered glyph through `glyph_map_gsub`. The plan now also carries the same mapping as a flat old-gid-indexed array (`HB_MAP_VALUE_INVALID` holes double as the retained-glyph filter), and the lambda mapper inlines into the iterator pipeline where the `hb_map_t` mapper did not: `Coverage::iter_t::__next__` disappears from the profile entirely, and `Coverage::subset`'s share of the Nastaliq profile drops from ~18% to ~8%.

- **[subset/cff] Record byte segments instead of tokens when not analyzing hints** — the CFF subroutine subsetter recorded one `parsed_cs_op_t` per charstring token, then re-merged adjacent entries in a `compact()` pass. When hints are not analyzed (no `--no-hinting`, not populating the accelerator), only token boundaries are noted (two integer stores) and verbatim byte segments are flushed at call sites and string ends. Eliminates `compact()`, shrinks the parsed representation by ~an order of magnitude, and `add_op` inlines back into the interpreter loop. CFF2's implicit (synthesized) return/endchar get an explicit flush.

- **[subset] Remap ClassDef glyphs through the flat array** — extends the flat mapping to `ClassDefFormat1/2::subset` via a `map_gsub_glyph()` helper on the plan.

All meson tests pass on each commit, including CFF1/CFF2 golden-file subset comparisons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
