### PR TITLE
[buffer] Charge move_to moves against max_ops

### DIFF
--- a/src/hb-buffer.cc
+++ b/src/hb-buffer.cc
@@ -484,6 +484,13 @@ hb_buffer_t::move_to (unsigned int i)
     unsigned int count = i - out_len;
     if (unlikely (!make_room_for (count, count))) return false;
 
+    max_ops -= count;
+    if (unlikely (max_ops < 0))
+    {
+      successful = false;
+      return false;
+    }
+
     memmove (out_info + out_len, info + idx, count * sizeof (out_info[0]));
     idx += count;
     out_len += count;
@@ -503,6 +510,13 @@ hb_buffer_t::move_to (unsigned int i)
     if (unlikely (idx < count && !shift_forward (count - idx))) return false;
 
     assert (idx >= count);
+
+    max_ops -= count;
+    if (unlikely (max_ops < 0))
+    {
+      successful = false;
+      return false;
+    }
 
     idx -= count;
     out_len -= count;


### PR DESCRIPTION
Fixes #6190.

`move_to()`'s two memmoves — the forward copy into `out_info` and the rewind copy-back — were not charged against `max_ops`, while `shift_forward()` already charges its moved tail. A morx insertion subtable that keeps its mark far behind the insertion point forces O(distance) rewind + re-copy per insertion action, for O(N²) total work the budget never sees.

## Approach

Charge `count` in both branches, mirroring `shift_forward()`'s exact failure pattern (charge after allocation succeeds, fail via `successful = false`). Charging only the rewind branch would also bound the quadratic, but both memmoves are attacker-drivable work and symmetric accounting is simpler to reason about; happy to reduce to rewind-only if preferred.

## Budget reasoning

`max_ops = max(len × 4096, 65536)`. For ordinary fonts, forward `move_to` advances sum to at most ~len per subtable pass and rewinds are short and cluster-local, so charges stay orders of magnitude under budget. The full test suite passes unchanged: 252/252, including all 870 text-rendering-tests and 6144 in-house shape subtests.

## Effect on MORX-36 (the one affected corpus font)

`TestMORXThirtysix.ttf` is an unbounded-recursion insertion stress font whose expansion inherently does ~quadratic buffer-move work; on current main that work is invisible to the budget and its output at larger inputs is *already* max_ops-truncated after burning the quadratic time. Timings for A×N (release build):

| N | main | patched |
|---|---|---|
| 256 | 0.041s | 0.003s |
| 1024 | 1.085s | 0.004s |
| 4096 | 12.9s | 0.007s |
| 65536 | >4.5 min (killed) | 0.074s |

**Intended behavior change:** the truncation point moves earlier, so MORX-36 output changes at all sizes — a single 'A' now expands to 359 glyphs instead of 8193 (the budget now bounds the recursion's quadratic move work, output ≈ √(4096·N) glyphs). The in-tree MORX-36 test already wildcards its output (`*`) precisely because it is limit-dependent, so the suite is unaffected. No crafted adversarial font needed for the demo — MORX-36 at N=4096 is the demonstration.

HarfRust mirrors this accounting and will port whatever lands here (harfbuzz/harfrust#423 is the constant-factor side of the same investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)