### PR TITLE
[ot-shape] Skip the post-morx digest update if not applying GPOS

### DIFF
--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -922,7 +922,10 @@ hb_ot_substitute_plan (const hb_ot_shape_context_t *c)
   {
     hb_aat_layout_substitute (c->plan, c->font, c->buffer,
 			      c->user_features, c->num_user_features);
-    c->buffer->update_digest ();
+    /* The buffer digest is only used by the OT lookup-apply loop;
+     * without GPOS ahead, nothing consumes it. */
+    if (c->plan->apply_gpos)
+      c->buffer->update_digest ();
   }
   else
 #endif


### PR DESCRIPTION
The buffer digest exists to let the OT lookup-apply loop skip lookups (`hb-ot-layout.cc` `may_intersect` gate) — that loop is its only consumer. After morx substitution, the update at the end of `hb_ot_substitute_plan` therefore only matters when GPOS positioning follows; when positioning goes through kerx/kern (Menlo, LucidaGrande, GeezaPro, …), the rebuild is pure waste.

Measured on the benchmark-shape harness: Menlo/en-thelittleprince 3.62 ms → 3.54 ms (−2%). Shaping outputs byte-identical on Menlo, LucidaGrande, GeezaPro, and Devanagari Sangam MN full texts; `test-aat-layout`/`test-shape`/`test-shape-plan` pass.

The same change is being applied to harfrust (branch `perf/shape-fixed-costs`), which inherited the unconditional update from this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)