### PR TITLE
[rust] Batch nominal-glyph lookups in the harfrust bridge

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 rust-version = "1.87.0"
 
 [dependencies]
-harfrust = { version = "0.13.0", features = ["experimental_font_api"], optional = true }
+harfrust = { version = "0.13.1", features = ["experimental_font_api"], optional = true }
 # harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
 read-fonts = "0.43.*"
 skrifa = { version = "0.*", optional = true }

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use harfrust::{
     font::{
         AdvanceWidthBatch, BuiltinFontFuncs, Font, FontBlob, FontFuncs, FontInstance,
-        FontTableFunction,
+        FontTableFunction, NominalGlyphBatch,
     },
     GlyphExtents, GlyphFlags as HRGlyphFlags, GlyphId, GlyphInfo as HRGlyphInfo,
     GlyphPosition as HRGlyphPosition, NormalizedCoord, ShapeOptions, Tag,
@@ -175,6 +175,24 @@ impl FontFuncs for HBHarfBuzzFontFuncs {
                 raw.advances,
                 raw.advance_stride as u32,
             );
+        }
+    }
+
+    fn populate_nominal_glyphs(
+        &mut self,
+        _: &BuiltinFontFuncs,
+        batch: NominalGlyphBatch<'_>,
+    ) -> usize {
+        let raw = batch.into_raw();
+        unsafe {
+            hb_font_get_nominal_glyphs(
+                self.font,
+                raw.len as u32,
+                raw.codepoints,
+                raw.codepoint_stride as u32,
+                raw.glyphs,
+                raw.glyph_stride as u32,
+            ) as usize
         }
     }
 


### PR DESCRIPTION
Implements harfrust's `FontFuncs::populate_nominal_glyphs` callback (harfbuzz/harfrust#434, released in harfrust 0.13.1) with a single `hb_font_get_nominal_glyphs` call per run, replacing one FFI round-trip per character during the normalizer's short-circuit prefill. The batch contract is identical to the plural API's (map consecutive codepoints, stop at first miss, return count), so this is a straight passthrough; the harfrust requirement is bumped to 0.13.1.

Parity-harness numbers for the harfrust shaper: **Menlo −6.2%** (4.18 → 3.92 ms), **LucidaGrande −4.6%** (5.38 → 5.13 ms) on en-thelittleprince; GeezaPro −2%, Devanagari Sangam MN −1%. Verified to build against the published 0.13.1 crate (no path overrides) with shaping outputs byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)