### PR TITLE
[algs] Add a float overload of hb_clamp_to

### DIFF
--- a/src/OT/glyf/glyf.hh
+++ b/src/OT/glyf/glyf.hh
@@ -357,8 +357,8 @@ struct glyf_accelerator_t
 	  return;
 	}
 	{
-	  double x_bearing = roundf (min_x);
-	  double y_bearing = roundf (max_y);
+	  double x_bearing = (double) roundf (min_x);
+	  double y_bearing = (double) roundf (max_y);
 	  extents->x_bearing = hb_clamp_to<hb_position_t> (x_bearing);
 	  extents->width = hb_clamp_to<hb_position_t> ((double) roundf (max_x) - x_bearing);
 	  extents->y_bearing = hb_clamp_to<hb_position_t> (y_bearing);

--- a/src/hb-algs.hh
+++ b/src/hb-algs.hh
@@ -960,6 +960,15 @@ hb_clamp_to (double v)
 
 template <typename T>
 static HB_ALWAYS_INLINE T
+hb_clamp_to (float v)
+{
+  /* Widen explicitly: float cannot represent all integer bounds exactly,
+   * so the clamp itself is done in double. */
+  return hb_clamp_to<T> ((double) v);
+}
+
+template <typename T>
+static HB_ALWAYS_INLINE T
 hb_clamp_to (int64_t v)
 {
   static_assert (std::is_integral<T>::value && std::is_signed<T>::value, "");


### PR DESCRIPTION
Clang (21, at least) flags every `hb_clamp_to<T> (roundf (...))`-style call with `-Wdouble-promotion`: the float argument promotes implicitly to the `double` overload. Adds a `float` overload that widens **explicitly** and forwards to the double version — deliberately not clamping in float, since float cannot represent all integer bounds exactly (e.g. `INT32_MAX`), so semantics stay bit-identical. The two `glyf` extents assignments that promote outside `hb_clamp_to` get explicit casts.

Silences all 13 unique `-Wdouble-promotion` sites (glyf, COLR, sbix, CBDT, hb-raster-paint); no behavior change; draw/extents/shape tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)