### PR TITLE
[ft] Fix -Wdouble-promotion warnings in get_glyph_extents

### DIFF
--- a/src/hb-ft.cc
+++ b/src/hb-ft.cc
@@ -719,10 +719,10 @@ hb_ft_get_glyph_extents (hb_font_t *font,
   float x2 = x1 + x_mult *  ft_face->glyph->metrics.width;
   float y2 = y1 + y_mult * -ft_face->glyph->metrics.height;
 
-  double rx1 = roundf (x1);
-  double ry1 = roundf (y1);
-  double rx2 = roundf (x2);
-  double ry2 = roundf (y2);
+  double rx1 = (double) roundf (x1);
+  double ry1 = (double) roundf (y1);
+  double rx2 = (double) roundf (x2);
+  double ry2 = (double) roundf (y2);
 
   extents->x_bearing = hb_clamp_to<hb_position_t> (rx1);
   extents->y_bearing = hb_clamp_to<hb_position_t> (ry1);


### PR DESCRIPTION
Follow-up to #6195: `hb-ft.cc` had four more `-Wdouble-promotion` sites (the `roundf()` results assigned into `double`) that weren't covered because freetype wasn't in the scratch build. Make the widening explicit with `(double)` casts, same treatment as glyf.hh in #6195. No behavior change — the arithmetic was already in double.

Verified: `clang++ -fsyntax-only -Wdouble-promotion` on hb-ft.cc is now clean.

*This PR was written by Claude (via Behdad's account).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)