### PR TITLE
[aat] Force-inline the state-machine transition functions

### DIFF
--- a/src/hb-aat-layout-common.hh
+++ b/src/hb-aat-layout-common.hh
@@ -49,6 +49,17 @@ struct ankr;
 
 using hb_aat_class_cache_t = hb_ot_layout_mapping_cache_t;
 
+/* The state-machine subtables' transition functions are called once per
+ * transition from the drive loop, but are big enough that the compiler
+ * declines to inline them, leaving a call in the hottest loop of AAT
+ * shaping.  Forcing them inline is worth 3-10% instructions on
+ * morx/kerx-heavy fonts, for about 16KB of code. */
+#ifndef HB_OPTIMIZE_SIZE
+#define HB_AAT_TRANSITION_INLINE HB_ALWAYS_INLINE
+#else
+#define HB_AAT_TRANSITION_INLINE
+#endif
+
 struct hb_aat_scratch_t
 {
   hb_aat_scratch_t () = default;

--- a/src/hb-aat-layout-kerx-table.hh
+++ b/src/hb-aat-layout-kerx-table.hh
@@ -258,6 +258,7 @@ struct KerxSubTableFormat1
 	depth (0),
 	crossStream (table->header.coverage & table->header.CrossStream) {}
 
+    HB_AAT_TRANSITION_INLINE
     void transition (hb_buffer_t *buffer,
 		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
@@ -551,6 +552,7 @@ struct KerxSubTableFormat4
 	mark_set (false),
 	mark (0) {}
 
+    HB_AAT_TRANSITION_INLINE
     void transition (hb_buffer_t *buffer,
 		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)

--- a/src/hb-aat-layout-morx-table.hh
+++ b/src/hb-aat-layout-morx-table.hh
@@ -84,6 +84,7 @@ struct RearrangementSubtable
 	table (table_),
 	start (0), end (0) {}
 
+    HB_AAT_TRANSITION_INLINE
     void transition (hb_buffer_t *buffer,
 		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
@@ -243,6 +244,7 @@ struct ContextualSubtable
 	mark (0),
 	subs (table+table->substitutionTables) {}
 
+    HB_AAT_TRANSITION_INLINE
     void transition (hb_buffer_t *buffer,
 		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
@@ -490,6 +492,7 @@ struct LigatureSubtable
 	ligature (table+table->ligature),
 	match_length (0) {}
 
+    HB_AAT_TRANSITION_INLINE
     void transition (hb_buffer_t *buffer,
 		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)
@@ -787,6 +790,7 @@ struct InsertionSubtable
 	mark (0),
 	insertionAction (table+table->insertionAction) {}
 
+    HB_AAT_TRANSITION_INLINE
     void transition (hb_buffer_t *buffer,
 		     StateTableDriver<Types, EntryData, Flags> *driver,
 		     const Entry<EntryData> &entry)


### PR DESCRIPTION
Found while investigating why HarfRust had pulled ahead of HarfBuzz on Lucida Grande: the biggest structural difference in the drive loops was that clang declines to inline the subtables' `transition` functions (the cost model balks at their size despite the single call site per instantiation), leaving a call plus prologue per transition — 226K outlined calls per Lucida run, 13.5M instructions in `LigatureSubtable::transition` alone.

One new macro, `HB_AAT_TRANSITION_INLINE` = `HB_ALWAYS_INLINE`, defined away under `HB_OPTIMIZE_SIZE`, applied to the four morx and two kerx transition functions.

Measurements (clang -O3, instructions/cycles vs main; outputs byte-identical on the AAT corpus + PingFang/CJK; shape suite passes):

| Font | Δ instructions | Δ cycles |
|---|---|---|
| Lucida Grande/en | **−10.3%** | −5.2% |
| Menlo/en | **−6.6%** | −0.6% |
| GeezaPro/fa | **−5.6%** | −4.4% |
| Devanagari Sangam/hi | **−5.6%** | −2.2% |

Code size: **+16KB text (+0.65%)**. Staged measurement note: the ligature transition alone (+7.2KB) carries the entire Menlo/Lucida instruction win and their best cycle numbers (−8.1% Lucida); the other five buy GeezaPro/Sangam's gains at some i-cache give-back on Menlo/Lucida — the committed form takes all six behind the size gate.

*This PR was written by Claude (via Behdad's account).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)