### PR TITLE
[harfrust] Store shape-plan data directly

### DIFF
--- a/src/hb-harfrust.cc
+++ b/src/hb-harfrust.cc
@@ -100,7 +100,6 @@ _hb_harfrust_shape_plan_create_rs (const void *font_data,
 				   const hb_feature_t *features,
 				   unsigned int        num_features);
 
-
 extern "C" void
 _hb_harfrust_shape_plan_destroy_rs (void *data);
 
@@ -122,7 +121,7 @@ _hb_harfrust_shape_rs (const void         *font_data,
 		       const hb_feature_t *features,
 		       unsigned int        num_features);
 
-static hb_user_data_key_t hb_object_key = {0};
+static hb_user_data_key_t hb_buffer_key = {0};
 
 hb_bool_t
 _hb_harfrust_shape (hb_shape_plan_t    *shape_plan,
@@ -134,7 +133,7 @@ _hb_harfrust_shape (hb_shape_plan_t    *shape_plan,
   const hb_harfrust_font_data_t *font_data = font->data.harfrust;
 
 retry_buffer:
-  void *hr_buffer = hb_buffer_get_user_data (buffer, &hb_object_key);
+  void *hr_buffer = hb_buffer_get_user_data (buffer, &hb_buffer_key);
   if (unlikely (!hr_buffer))
   {
     hr_buffer = _hb_harfrust_buffer_create_rs ();
@@ -142,7 +141,7 @@ retry_buffer:
       return false;
 
     if (!hb_buffer_set_user_data (buffer,
-				  &hb_object_key,
+				  &hb_buffer_key,
 				  hr_buffer,
 				  _hb_harfrust_buffer_destroy_rs,
 				  false))
@@ -155,7 +154,7 @@ retry_buffer:
   void *hr_shape_plan = nullptr;
 
 retry_shape_plan:
-  hr_shape_plan = hb_shape_plan_get_user_data (shape_plan, &hb_object_key);
+  hr_shape_plan = shape_plan->harfrust_data.get_acquire ();
   if (unlikely (!hr_shape_plan))
   {
     hr_shape_plan = _hb_harfrust_shape_plan_create_rs (font_data,
@@ -164,11 +163,7 @@ retry_shape_plan:
 						       shape_plan->key.props.direction,
 						       features, num_features);
     if (hr_shape_plan &&
-	!hb_shape_plan_set_user_data (shape_plan,
-				     &hb_object_key,
-				     hr_shape_plan,
-				     _hb_harfrust_shape_plan_destroy_rs,
-				     false))
+	!shape_plan->harfrust_data.cmpexch (nullptr, hr_shape_plan))
     {
       _hb_harfrust_shape_plan_destroy_rs (hr_shape_plan);
       goto retry_shape_plan;

--- a/src/hb-shape-plan.cc
+++ b/src/hb-shape-plan.cc
@@ -52,6 +52,20 @@
  * Most client programs will not need to deal with shape plans directly.
  **/
 
+#ifdef HAVE_HARFRUST
+extern "C" void _hb_harfrust_shape_plan_destroy_rs (void *data);
+#endif
+
+hb_shape_plan_t::~hb_shape_plan_t ()
+{
+#ifdef HAVE_HARFRUST
+  void *data = harfrust_data.get_relaxed ();
+  if (data)
+    _hb_harfrust_shape_plan_destroy_rs (data);
+#endif
+  key.fini ();
+}
+
 
 /*
  * hb_shape_plan_key_t
@@ -115,6 +129,7 @@ hb_shape_plan_key_t::init (bool                           copy,
       else if (0 == strcmp (*shaper_list, #shaper)) \
 	HB_SHAPER_PLAN (shaper);
 #include "hb-shaper-list.hh"
+
 #undef HB_SHAPER_IMPLEMENT
   }
   else

--- a/src/hb-shape-plan.hh
+++ b/src/hb-shape-plan.hh
@@ -31,7 +31,6 @@
 #include "hb-shaper.hh"
 #include "hb-ot-shape.hh"
 
-
 struct hb_shape_plan_key_t
 {
   hb_segment_properties_t  props;
@@ -64,12 +63,15 @@ struct hb_shape_plan_key_t
 
 struct hb_shape_plan_t
 {
-  ~hb_shape_plan_t () { key.fini (); }
+  HB_INTERNAL ~hb_shape_plan_t ();
   hb_object_header_t header;
   hb_face_t *face_unsafe; /* We don't carry a reference to face. */
   hb_shape_plan_key_t key;
 #ifndef HB_NO_OT_SHAPE
   hb_ot_shape_plan_t ot;
+#endif
+#ifdef HAVE_HARFRUST
+  hb_atomic_t<void *> harfrust_data;
 #endif
 };
 


### PR DESCRIPTION
Store the HarfRust plan directly on `hb_shape_plan_t`, like the existing OT plan data, instead of putting it in generic user data.

The data is created lazily because construction needs the font instance, published atomically for shared plans, and destroyed with the shape plan. This removes one mutex-backed user-data lookup per shape.

There is no HarfRust-specific field on `hb_buffer_t`; the reusable Rust buffer remains owned by generic user data.

Memory cost: 8 bytes per shape plan when HarfRust is enabled, with one fewer user-data allocation for plans.

Measured against current `main` with the clang release build and `hb-shape -O "" -n 10 --shaper harfrust`:

| Font / text | Instructions | Cycles |
|---|---:|---:|
| Roboto / en-prince | -0.11% | -0.29% |
| Roboto / en-words | -0.73% | -1.75% |

Cycle results are noisier than retired instructions.

Validation:

- `test-shape-harfrust`: 4 subtests pass
- HarfRust and OT output hashes match on the benchmark corpus
- `git diff --check`