### PR TITLE
[harfrust] Shape the cached Rust buffer in place

### DIFF
--- a/src/hb-harfrust.cc
+++ b/src/hb-harfrust.cc
@@ -112,7 +112,7 @@ _hb_harfrust_shape_plan_destroy_rs (void *data);
 extern "C" hb_bool_t
 _hb_harfrust_shape_rs (const void         *font_data,
 		       const void         *rs_shape_plan,
-		       const void         *rs_buffer,
+		       void               *rs_buffer,
 		       hb_font_t          *font,
 		       hb_buffer_t        *buffer,
 		       const hb_codepoint_t *pre_context,

--- a/src/rust/shape.rs
+++ b/src/rust/shape.rs
@@ -366,7 +366,7 @@ pub unsafe extern "C" fn _hb_harfrust_shape_plan_destroy_rs(data: *mut c_void) {
 pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     font_data: *const c_void,
     shape_plan: *const c_void,
-    hr_buffer_box: *const c_void,
+    hr_buffer: *mut c_void,
     font: *mut hb_font_t,
     buffer: *mut hb_buffer_t,
     pre_context: *const u32,
@@ -377,9 +377,7 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     num_features: u32,
 ) -> hb_bool_t {
     let font_data = font_data as *const HBHarfRustFontData;
-    let hr_buffer_box = hr_buffer_box as *mut harfrust::UnicodeBuffer;
-    let mut hr_buffer_box = Box::from_raw(hr_buffer_box);
-    let mut hr_buffer = *hr_buffer_box;
+    let hr_buffer = &mut *(hr_buffer as *mut harfrust::UnicodeBuffer);
     let shape_plan = (shape_plan as *const harfrust::ShapePlan).as_ref();
 
     // Set buffer properties
@@ -440,6 +438,7 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
     let infos = hb_buffer_get_glyph_infos(buffer, null_mut());
     let infos = std::slice::from_raw_parts(infos.cast(), count as usize);
     if !hr_buffer.push_glyph_infos(infos) {
+        hr_buffer.clear();
         return false as hb_bool_t;
     }
 
@@ -456,7 +455,7 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
         .point_size((*font_data).ptem)
         .features(&features)
         .font_funcs(Some(&mut font_funcs));
-    let glyphs = harfrust::shape(&(*font_data).instance, hr_buffer, options);
+    let glyphs = harfrust::shape_in_place(&(*font_data).instance, hr_buffer, options);
 
     hb_buffer_set_content_type(
         buffer,
@@ -473,10 +472,6 @@ pub unsafe extern "C" fn _hb_harfrust_shape_rs(
 
     std::ptr::copy_nonoverlapping(glyphs.glyph_infos().as_ptr().cast(), infos, count);
     std::ptr::copy_nonoverlapping(glyphs.glyph_positions().as_ptr().cast(), positions, count);
-
-    let hr_buffer = glyphs.clear();
-    *hr_buffer_box = hr_buffer; // Move the buffer back into the box
-    let _ = Box::into_raw(hr_buffer_box); // Prevent double free
 
     true as hb_bool_t
 }


### PR DESCRIPTION
Depends on harfbuzz/harfrust#448.

Borrow the reusable Rust UnicodeBuffer allocation in place for the duration of shaping. This removes the per-shape Box::from_raw / move-out / move-back / Box::into_raw sequence for the 304-byte buffer. A scoped result guard from HarfRust clears the buffer on drop, including post-shape early returns; the pre-shape import failure clears it explicitly.

The existing public shape() API remains unchanged. This change is independent of #6201 and is based directly on main after #6200.

Measured with the clang release build and hb-shape -O "" -N count, changing only the old boxed bridge versus this in-place bridge:

| benchmark | instructions |
|---|---:|
| Menlo / en-prince | -0.56% |
| Lucida Grande / en-prince | -0.41% |
| Geeza Pro / fa-prince | -0.15% |
| Devanagari Sangam / hi-words | -0.64% |
| Roboto / en-prince | -0.33% |
| Roboto / en-words | -2.19% |
| Source Serif Variable / react-dom | -0.62% |
| Noto Sans Devanagari / hi-words | -1.02% |
| Amiri / fa-prince | -0.05% |
| Noto Nastaliq Urdu / fa-prince | -0.03% |
| Noto Nastaliq Urdu / fa-words | -0.31% |

Paired cycle measurements for Roboto were -0.51% on prince and -3.94% on words. Callgrind on Roboto words attributes about 301 fewer instructions per shape, including about 236 removed from the bridge function itself and about 65 from memcpy.

No new allocation or persistent memory is added.

Validation:

- HarfBuzz HarfRust API tests: 4 subtests passed
- all eleven benchmark outputs match the OT shaper
- HarfRust: 6,271 tests and clippy with warnings denied