### PR TITLE
[harfrust] Update to 0.13.2

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 rust-version = "1.87.0"
 
 [dependencies]
-harfrust = { version = "0.13.1", features = ["experimental_font_api"], optional = true }
+harfrust = { version = "0.13.2", features = ["experimental_font_api"], optional = true }
 # harfrust = { git = "https://github.com/harfbuzz/harfrust", optional = true }
 read-fonts = "0.43.*"
 skrifa = { version = "0.*", optional = true }


### PR DESCRIPTION
Roll the HarfRust dependency from 0.13.1 to the newly published 0.13.2 release.

Release: https://github.com/harfbuzz/harfrust/releases/tag/0.13.2

This brings in the contextual-lookup, digest, legacy-kern, AAT safe-to-break, and reusable shaping-metadata performance work from harfrust#437, #438, #439, #445, #446, and #447.

Validation:

- clang release HarfRust-enabled build succeeds
- test-shape-harfrust: 4 subtests passed