### PR TITLE
[arabic] Enable Win1256 fallback on all platforms

### DIFF
--- a/src/hb-ot-shaper-arabic-fallback.hh
+++ b/src/hb-ot-shaper-arabic-fallback.hh
@@ -231,11 +231,7 @@ struct arabic_fallback_plan_t
   OT::hb_ot_layout_lookup_accelerator_t *accel_array[ARABIC_FALLBACK_MAX_LOOKUPS];
 };
 
-#if defined(_WIN32) && !defined(HB_NO_WIN1256)
-#define HB_WITH_WIN1256
-#endif
-
-#ifdef HB_WITH_WIN1256
+#ifndef HB_NO_WIN1256
 #include "hb-ot-shaper-arabic-win1256.hh"
 #endif
 
@@ -254,7 +250,7 @@ arabic_fallback_plan_init_win1256 (arabic_fallback_plan_t *fallback_plan HB_UNUS
 				   const hb_ot_shape_plan_t *plan HB_UNUSED,
 				   hb_font_t *font HB_UNUSED)
 {
-#ifdef HB_WITH_WIN1256
+#ifndef HB_NO_WIN1256
   /* Does this font look like it's Windows-1256-encoded? */
   hb_codepoint_t g;
   if (!(hb_font_get_glyph (font, 0x0627u, 0, &g) && g == 199 /* ALEF */ &&


### PR DESCRIPTION
The Win1256 fallback is a static GSUB recipe selected by a narrow glyph-ID signature; it does not call a Windows API. Enable it outside Windows too, while retaining HB_NO_WIN1256 as an explicit opt-out.

Tested: meson test -C build; build with -DHB_NO_WIN1256

Assisted-by: Codex <codex@openai.com>

behdad: I don't quite remember why we disabled it in non-Windows systems to begin with. @khaledhosny any insights?