### PR TITLE
Re-implement bit set's next_range()/previous_range() to utilize zero counting.

### DIFF
--- a/perf/benchmark-set.cc
+++ b/perf/benchmark-set.cc
@@ -118,6 +118,28 @@ BENCHMARK(BM_SetIteration)
         {{1 << 10, 1 << 16}, // Set Size
          {2, 512}});          // Density
 
+/* Range iteration of sets of varying sizes. */
+static void BM_SetNextRange(benchmark::State& state) {
+  unsigned set_size = state.range(0);
+  unsigned max_value = state.range(0) * state.range(1);
+
+  hb_set_t* original = hb_set_create ();
+  RandomSet(set_size, max_value, original);
+  assert(hb_set_get_population(original) == set_size);
+
+  hb_codepoint_t first = HB_SET_VALUE_INVALID;
+  hb_codepoint_t last = HB_SET_VALUE_INVALID;
+  for (auto _ : state) {
+    hb_set_next_range (original, &first, &last);
+  }
+
+  hb_set_destroy(original);
+}
+BENCHMARK(BM_SetNextRange)
+    ->Ranges(
+        {{1 << 10, 1 << 16}, // Set Size
+         {2, 512}});          // Density
+
 /* Set copy. */
 static void BM_SetCopy(benchmark::State& state) {
   unsigned set_size = state.range(0);

--- a/src/hb-bit-set.hh
+++ b/src/hb-bit-set.hh
@@ -31,7 +31,6 @@
 #include "hb.hh"
 #include "hb-bit-page.hh"
 
-
 struct hb_bit_set_t
 {
   hb_bit_set_t () = default;
@@ -827,13 +826,62 @@ struct hb_bit_set_t
       return false;
     }
 
-    /* TODO Speed up. */
     *last = *first = i;
-    while (next (&i) && i == *last + 1)
-      (*last)++;
 
-    return true;
+    const auto* page_map_array = page_map.arrayZ;
+    const auto* pages_array = pages.arrayZ;
+    unsigned int major = get_major (*last);
+    unsigned int p_index = last_page_lookup;
+
+    if (unlikely (p_index >= page_map.length || page_map_array[p_index].major != major))
+    {
+      page_map.bfind (major, &p_index, HB_NOT_FOUND_STORE_CLOSEST);
+      // The above next() call gaurantees the page we're looking for exists.
+      assert(p_index < page_map.length && page_map_array[p_index].major == major);
+      last_page_lookup = p_index;
+    }
+
+    unsigned int rem = page_remainder (*last);
+    unsigned int elt = rem / page_t::ELT_BITS;
+    unsigned int bit = rem & page_t::ELT_MASK;
+
+    const page_t *page = &pages_array[page_map_array[p_index].index];
+    unsigned int run = hb_ctz (~(page->v[elt] >> bit));
+    *last += run - 1;
+    if (run < page_t::ELT_BITS - bit)
+      return true;
+
+    elt++;
+
+    while (true)
+    {
+      for (; elt < page_t::len (); elt++)
+      {
+        uint64_t w = page->v[elt];
+        if (w == (uint64_t) -1)
+        {
+          *last += page_t::ELT_BITS;
+          continue;
+        }
+        uint64_t inv = ~w;
+        *last += hb_ctz (inv);
+        return true;
+      }
+
+      p_index++;
+
+
+      if (p_index >= page_map.length || page_map_array[p_index].major != major + 1)
+        return true;
+
+      const auto& entry = page_map_array[p_index];
+      major = entry.major;
+      last_page_lookup = p_index;
+      page = &pages_array[entry.index];
+      elt = 0;
+    }
   }
+
   bool previous_range (hb_codepoint_t *first, hb_codepoint_t *last) const
   {
     hb_codepoint_t i;
@@ -845,12 +893,62 @@ struct hb_bit_set_t
       return false;
     }
 
-    /* TODO Speed up. */
     *last = *first = i;
-    while (previous (&i) && i == *first - 1)
-      (*first)--;
 
-    return true;
+    const auto* page_map_array = page_map.arrayZ;
+    const auto* pages_array = pages.arrayZ;
+    unsigned int major = get_major (*first);
+    unsigned int p_index = last_page_lookup;
+
+    if (unlikely (p_index >= page_map.length || page_map_array[p_index].major != major))
+    {
+      page_map.bfind (major, &p_index, HB_NOT_FOUND_STORE_CLOSEST);
+      // The above previous() call gaurantees the page we're looking for exists.
+      assert(p_index < page_map.length && page_map_array[p_index].major == major);
+      last_page_lookup = p_index;
+    }
+
+    unsigned int rem = page_remainder (*first);
+    int elt = rem / page_t::ELT_BITS;
+    unsigned int bit = rem & page_t::ELT_MASK;
+
+    const page_t *page = &pages_array[page_map_array[p_index].index];
+    uint64_t inv = ~(page->v[elt] << (63 - bit));
+    unsigned int run = hb_bit_storage (inv) ? (page_t::ELT_BITS - hb_bit_storage (inv)) : page_t::ELT_BITS;
+    *first -= run - 1;
+    if (run < bit + 1)
+      return true;
+
+    elt--;
+
+    while (true)
+    {
+      for (; elt >= 0; elt--)
+      {
+        uint64_t w = page->v[elt];
+        if (w == (uint64_t) -1)
+        {
+          *first -= page_t::ELT_BITS;
+          continue;
+        }
+        uint64_t inv = ~w;
+        unsigned int zeros = hb_bit_storage (inv) ? (page_t::ELT_BITS - hb_bit_storage (inv)) : page_t::ELT_BITS;
+        *first -= zeros;
+        return true;
+      }
+
+
+      if (p_index == 0 || page_map_array[p_index - 1].major != major - 1)
+        return true;
+
+      p_index--;
+      const auto& entry = page_map_array[p_index];
+
+      major = entry.major;
+      last_page_lookup = p_index;
+      page = &pages_array[entry.index];
+      elt = page_t::len () - 1;
+    }
   }
 
   unsigned int next_many (hb_codepoint_t  codepoint,

--- a/test/api/test-set.c
+++ b/test/api/test-set.c
@@ -1312,12 +1312,85 @@ test_set_next_many_out_of_order_pages (void) {
   hb_set_destroy(set);
 }
 
+static void
+test_set_next_previous_range (void)
+{
+  hb_set_t *s = hb_set_create ();
+
+  /* Test with ranges covering:
+   * - 0..0 (single element at 0)
+   * - 2..3 (small range within word 0)
+   * - 60..70 (spans 64-bit word boundary 0 -> 1)
+   * - 127..127 (single element at word boundary)
+   * - 129..130 (starts after word boundary)
+   * - 500..525 (spans 512-bit page boundary 0 -> 1)
+   * - 1000..3000 (spans multiple full pages)
+   * - 50000..50000 (isolated high codepoint)
+   */
+  hb_set_add (s, 0);
+  /* gap: 1 */
+  hb_set_add_range (s, 2, 3);
+  /* gap: 4..59 */
+  hb_set_add_range (s, 60, 70);
+  /* gap: 71..126 */
+  hb_set_add (s, 127);
+  /* gap: 128 */
+  hb_set_add_range (s, 129, 130);
+  /* gap: 131..499 */
+  hb_set_add_range (s, 500, 525);
+  /* gap: 526..999 */
+  hb_set_add_range (s, 1000, 3000);
+  /* gap: 3001..49999 */
+  hb_set_add (s, 50000);
+
+  struct { hb_codepoint_t first, last; } expected[] = {
+    {0, 0},
+    {2, 3},
+    {60, 70},
+    {127, 127},
+    {129, 130},
+    {500, 525},
+    {1000, 3000},
+    {50000, 50000}
+  };
+  unsigned int num_expected = sizeof (expected) / sizeof (expected[0]);
+
+  /* Forward iteration */
+  hb_codepoint_t first = HB_SET_VALUE_INVALID;
+  hb_codepoint_t last = HB_SET_VALUE_INVALID;
+  for (unsigned int idx = 0; idx < num_expected; idx++)
+  {
+    g_assert_true (hb_set_next_range (s, &first, &last));
+    g_assert_cmpint (first, ==, expected[idx].first);
+    g_assert_cmpint (last, ==, expected[idx].last);
+  }
+  g_assert_true (!hb_set_next_range (s, &first, &last));
+  g_assert_cmpint (first, ==, HB_SET_VALUE_INVALID);
+  g_assert_cmpint (last, ==, HB_SET_VALUE_INVALID);
+
+  /* Backward iteration */
+  first = HB_SET_VALUE_INVALID;
+  last = HB_SET_VALUE_INVALID;
+  for (int idx = (int) num_expected - 1; idx >= 0; idx--)
+  {
+    g_assert_true (hb_set_previous_range (s, &first, &last));
+    g_assert_cmpint (first, ==, expected[idx].first);
+    g_assert_cmpint (last, ==, expected[idx].last);
+  }
+  g_assert_true (!hb_set_previous_range (s, &first, &last));
+  g_assert_cmpint (first, ==, HB_SET_VALUE_INVALID);
+  g_assert_cmpint (last, ==, HB_SET_VALUE_INVALID);
+
+  hb_set_destroy (s);
+}
+
 int
 main (int argc, char **argv)
 {
   hb_test_init (&argc, &argv);
 
   hb_test_add (test_set_basic);
+  hb_test_add (test_set_next_previous_range);
   hb_test_add (test_set_subsets);
   hb_test_add (test_set_subsets_empty_pages);
   hb_test_add (test_set_subsets_inverted);


### PR DESCRIPTION
Prior implementation was checking each bit manually. This improves efficiency by checking ranges of bits in one go using zero counting.

Added a benchmark for next_range() which shows significant speedups for most cases . Subset benchmarks are neutral.

```
BM_SetNextRange/1024/2_median                   -0.3310         -0.3308            23            15            23            15
BM_SetNextRange/4096/2_median                   -0.4719         -0.4715            29            15            29            15
BM_SetNextRange/32768/2_median                  -0.5245         -0.5245            33            16            33            16
BM_SetNextRange/65536/2_median                  -0.5309         -0.5307            33            16            33            16
BM_SetNextRange/1024/8_median                   +0.0577         +0.0579            15            16            15            16
BM_SetNextRange/4096/8_median                   -0.0252         -0.0246            17            17            17            16
BM_SetNextRange/32768/8_median                  -0.0893         -0.0888            18            17            18            17
BM_SetNextRange/65536/8_median                  -0.0853         -0.0847            18            17            18            17
BM_SetNextRange/1024/64_median                  -0.2658         -0.2653            20            14            20            14
BM_SetNextRange/4096/64_median                  -0.3178         -0.3174            32            22            32            22
BM_SetNextRange/32768/64_median                 -0.2883         -0.2879            36            26            36            26
BM_SetNextRange/65536/64_median                 -0.2885         -0.2879            37            26            37            26
BM_SetNextRange/1024/512_median                 -0.7106         -0.7105            56            16            55            16
BM_SetNextRange/4096/512_median                 -0.6429         -0.6425            84            30            84            30
BM_SetNextRange/32768/512_median                -0.5837         -0.5831            96            40            96            40
BM_SetNextRange/65536/512_median                -0.5896         -0.5892           100            41           100            41
```

Assisted by Gemini