### PR TITLE
[util] parse numeric options in the C locale

### DIFF
--- a/util/options.hh
+++ b/util/options.hh
@@ -285,6 +285,12 @@ inline bool
 option_parser_t::parse (int *argc, char ***argv, bool ignore_error)
 {
   setlocale (LC_ALL, "");
+  /* Parse numbers with a '.' radix regardless of the environment's
+   * LC_NUMERIC. Options like --font-size, --margin and --font-extents
+   * read floats with sscanf("%lf"), which otherwise mis-parses e.g.
+   * "10.5" as 10 under a comma-radix locale. This matches the ascii
+   * number handling already used for --width via g_ascii_strtod. */
+  setlocale (LC_NUMERIC, "C");
 
   add_exit_code (RETURN_VALUE_SUCCESS, "Success.");
   add_exit_code (RETURN_VALUE_OPTION_PARSING_FAILED, "Option parsing failed.");


### PR DESCRIPTION
The util tools call setlocale(LC_ALL, "") and then read floating point options like --font-size, --margin and --font-extents with sscanf("%lf"), so under a comma-radix locale such as de_DE or fr_FR an argument like 300.9 is parsed as 300 and the fractional part is silently dropped (hb-view --font-size=300.9 renders a 332x332 image instead of 333x333). Forcing LC_NUMERIC to C right after the environment locale is applied makes these options parse with a '.' radix everywhere, matching the g_ascii_strtod already used for the --width spec.