### PR TITLE
[subset] Initialize the accelerator pointers in hb_subset_plan_t

### DIFF
--- a/src/hb-subset-plan.hh
+++ b/src/hb-subset-plan.hh
@@ -181,8 +181,8 @@ struct hb_subset_plan_t
 
   os2_info_t os2_info;
 
-  const hb_subset_accelerator_t* accelerator;
-  hb_subset_accelerator_t* inprogress_accelerator;
+  const hb_subset_accelerator_t* accelerator = nullptr;
+  hb_subset_accelerator_t* inprogress_accelerator = nullptr;
 
  public:
 


### PR DESCRIPTION
Neither pointer is unconditionally assigned by the constructor: accelerator is only set inside `if (accel)`, and inprogress_accelerator is assigned after five early returns, yet the destructor tests it. Both read as null today because hb_object_create() calloc()s the storage before running the constructor via placement new, so this is hardening rather than a live bug fix.

Reported by Coverity Scan (CID 1700601), which cannot model calloc-then-placement-new:
```

  ** CID 1700601: (UNINIT_CTOR)
  hb-subset-plan.cc: 692 in hb_subset_plan_t::hb_subset_plan_t(
      hb_face_t *, const hb_subset_input_t *)

  690  #ifndef HB_NO_VAR
  691    if (!check_success (normalize_axes_location (face, this)))
  >>>  CID 1700601: (UNINIT_CTOR)
  >>>  Non-static class member "inprogress_accelerator" is not
  >>>  initialized in this constructor nor in any functions that it calls.
  692        return;
  693  #endif
```