### PR TITLE
[ot-shape] Enable fallback mark positioning for unanchored marks in GPOS fonts

### DIFF
--- a/src/hb-ot-shape-fallback.cc
+++ b/src/hb-ot-shape-fallback.cc
@@ -30,6 +30,7 @@
 
 #include "hb-ot-shape-fallback.hh"
 #include "hb-kern.hh"
+#include "OT/Layout/GPOS/Common.hh"
 
 static unsigned int
 recategorize_combining_class (hb_codepoint_t u,
@@ -195,6 +196,9 @@ zero_mark_advances (hb_buffer_t *buffer,
   for (unsigned int i = start; i < end; i++)
     if (_hb_glyph_info_get_general_category (&info[i]) == HB_UNICODE_GENERAL_CATEGORY_NON_SPACING_MARK)
     {
+      if (buffer->pos[i].attach_type())
+	continue;
+
       if (adjust_offsets_when_zeroing)
       {
 	buffer->pos[i].x_offset = hb_saturate_sub (buffer->pos[i].x_offset,
@@ -368,6 +372,9 @@ position_around_base (const hb_ot_shape_plan_t *plan,
   for (unsigned int i = base + 1; i < end; i++)
     if (_hb_glyph_info_get_modified_combining_class (&info[i]))
     {
+      if (buffer->pos[i].attach_type())
+	continue;
+
       if (num_lig_components > 1) {
 	unsigned int this_lig_id = _hb_glyph_info_get_lig_id (&info[i]);
 	int this_lig_component = _hb_glyph_info_get_lig_comp (&info[i]) - 1;

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -203,8 +203,10 @@ hb_ot_shape_planner_t::compile (hb_ot_shape_plan_t           &plan,
 #endif
 					      );
 
-  plan.fallback_mark_positioning = plan.adjust_mark_positioning_when_zeroing &&
-				   script_fallback_position;
+  /* Fallback mark positioning should run for any unattached marks (Unicode
+   * Section 3.6 / 5.13), even if GPOS is present. Marks attached by GPOS
+   * will be skipped during fallback positioning. */
+  plan.fallback_mark_positioning = script_fallback_position;
 
 #ifndef HB_NO_AAT_SHAPE
   /* If we're using morx shaping, we cancel mark position adjustment because
@@ -899,7 +901,7 @@ hb_ot_substitute_default (const hb_ot_shape_context_t *c)
   hb_ot_shape_setup_masks (c);
 
   /* This is unfortunate to go here, but necessary... */
-  if (c->plan->fallback_mark_positioning)
+  if (c->plan->fallback_mark_positioning && c->plan->adjust_mark_positioning_when_zeroing)
     _hb_ot_shape_fallback_mark_position_recategorize_marks (c->plan, c->font, buffer);
 
   hb_ot_map_glyphs_fast (buffer);


### PR DESCRIPTION
When shaping combining character sequences where a base glyph lacks an explicit OpenType GPOS anchor (such as geometric symbols, mathematical characters, or Kaomoji like U+25E1 LOWER HALF CIRCLE with U+0308 COMBINING DIAERESIS '◡̈'), HarfBuzz previously disabled fallback mark positioning entirely whenever the font possessed a GPOS table (c->plan->apply_gpos). Because standard text fonts (such as Roboto and Noto Sans Symbols) contain GPOS tables for alphabetic glyphs but omit mark-to-base anchors for symbols, this caused unanchored combining marks to be left unpositioned, rendering detached or displaced (e.g. '◡ ¨').

Refusing implicit heuristic mark attachment when an explicit anchor is undeclared is non-compliant with the Unicode Standard:
1. Conformance Requirement C7 (Unicode Standard, Section 3.6 Combination): "A system that claims to support combining marks shall be able to apply combining marks to any base character." The standard explicitly states that combining marks are valid with any base character (including symbols) and must not be prohibited or discarded merely because a font lacks pre-declared linguistic anchors.
2. Section 5.13 (Implementation Guidelines - Rendering Nonspacing Marks): Specifies that when font tables (such as OpenType GPOS) do not define an explicit attachment point for a given base-plus-mark combination, rendering implementations are expected to apply fallback positioning heuristics (such as centering the mark over the base character's advance or bounding box) rather than leaving the mark detached or spacing.
3. Unicode Standard Annex #29 (UAX #29, Section 3): A base character followed by nonspacing marks forms an atomic Extended Grapheme Cluster (Rule GB9) that must be rendered as an integrated unit.

This change enables fallback_mark_positioning whenever the script allows it, while checking buffer->pos[i].attach_type() to guarantee that marks already positioned by GPOS remain untouched. Any unattached marks that GPOS skipped now undergo fallback heuristic centering over the base glyph.