### PR TITLE
[unicode] Treat U+180F FVS4 as Default_Ignorable

### DIFF
--- a/src/hb-unicode.hh
+++ b/src/hb-unicode.hh
@@ -176,7 +176,7 @@ HB_UNICODE_FUNCS_IMPLEMENT_CALLBACKS_SIMPLE
 	case 0x03: return unlikely (ch == 0x034Fu);
 	case 0x06: return unlikely (ch == 0x061Cu);
 	case 0x17: return hb_in_range<hb_codepoint_t> (ch, 0x17B4u, 0x17B5u);
-	case 0x18: return hb_in_range<hb_codepoint_t> (ch, 0x180Bu, 0x180Eu);
+	case 0x18: return hb_in_range<hb_codepoint_t> (ch, 0x180Bu, 0x180Fu);
 	case 0x20: return hb_in_ranges<hb_codepoint_t> (ch, 0x200Bu, 0x200Fu,
 					    0x202Au, 0x202Eu,
 					    0x2060u, 0x206Fu);

--- a/test/shape/data/in-house/tests/mongolian-variation-selector.tests
+++ b/test/shape/data/in-house/tests/mongolian-variation-selector.tests
@@ -4,6 +4,8 @@
 ../fonts/4d4206e30b2dbf1c1ef492a8eae1c9e7829ebad8.ttf;;U+183A,U+1823,U+182E,U+182B,U+1822,U+1826,U+180B,U+1832,U+180B,U+1827,U+1837;[uni183A1823.E971_ko.init=0+950|uni182E.E904_m.medi=2+400|uni182B1822.E8A6_pi.medi=3+1150|uni1826.E854_ue.medi1=5+1100|uni1832.E916_t.medi1=7+1000|uni1827.E85C_ee.medi=9+750|uni1837.E931_r.fina=10+750]
 ../fonts/4d4206e30b2dbf1c1ef492a8eae1c9e7829ebad8.ttf;;U+182D,U+182D,U+180B;[uni182D.E8E2_g.init=0+1000|uni182D.E8E8_g.fina1=1+1250]
 ../fonts/4d4206e30b2dbf1c1ef492a8eae1c9e7829ebad8.ttf;;U+182D,U+180C;[uni182D.EA1B_g.isol2=0+1000]
+../fonts/4d4206e30b2dbf1c1ef492a8eae1c9e7829ebad8.ttf;;U+182D,U+180F;[uni182D.E8E0_g.isol=0+950|space=0+0]
+../fonts/4d4206e30b2dbf1c1ef492a8eae1c9e7829ebad8.ttf;;U+182D,U+1810;[uni182D.E8E0_g.isol=0+950|.notdef=1+1200]
 ../fonts/4d4206e30b2dbf1c1ef492a8eae1c9e7829ebad8.ttf;;U+182D,U+180D,U+200D;[uni182D.EA1E_g.init3=0+650|space=0+0]
 ../fonts/4d4206e30b2dbf1c1ef492a8eae1c9e7829ebad8.ttf;;U+182D,U+200D,U+182D,U+180B,U+200D;[uni182D.E8E2_g.init=0+1000|space=0+0|uni182D.E8E5_g.medi1=2+800|space=2+0]
 ../fonts/4d4206e30b2dbf1c1ef492a8eae1c9e7829ebad8.ttf;;U+182D,U+180C,U+200D;[uni182D.EA1D_g.init2=0+950|space=0+0]


### PR DESCRIPTION
U+180F MONGOLIAN FREE VARIATION SELECTOR FOUR (Unicode 14.0) has
Default_Ignorable_Code_Point=Yes, but `is_default_ignorable()` covered only
U+180B..180E, so FVS4 was never hidden and leaked a `.notdef` into the output.

8c65442069 ("[Unicode 14] Handle U+180F FVS4") added the U+180F case to
`_hb_glyph_info_set_unicode_props()` and to the Arabic shaper, but that branch
sits inside `if (unicode->is_default_ignorable (u))`, so it has been unreachable
since it was written. Widening the range makes it live. U+180B..180F are all
Default_Ignorable per `DerivedCoreProperties.txt`, so it stays contiguous.

On a font with no Mongolian coverage, every other default ignorable
(U+180B..180E, U+FE00, U+200B) shapes to `[gid1=0+1114]`. Only FVS4 leaked:

    $ hb-shape test/api/fonts/Roboto-Regular.abc.ttf -u U+0061,U+180F
    [gid1=0+1114|gid0=0@-908,0+0]   # before (gid0 = .notdef)
    [gid1=0+1114]                   # after

### Verified locally

    meson setup build -Dtests=enabled
    meson compile -C build
    meson test -C build

254/254 OK, 0 failures (macOS arm64, clang).

Added two cases to `mongolian-variation-selector.tests`, which covered FVS1,
FVS2, FVS3 and MVS but not FVS4: `U+180F`, plus `U+1810` MONGOLIAN DIGIT ZERO
to pin the top of the range. Restoring U+180B..180E fails in-house 6174/6176;
widening to U+180B..1810 fails it the same way.

Not verified locally: reduced-feature and MSVC configs.
