### PR TITLE
OT: Fuse redundant per-glyph shaping passes

### DIFF
--- a/src/hb-buffer.hh
+++ b/src/hb-buffer.hh
@@ -385,11 +385,6 @@ struct hb_buffer_t
   }
   /* Advance idx without copying to output. */
   void skip_glyph () { idx++; }
-  void reset_masks (hb_mask_t mask)
-  {
-    for (unsigned int j = 0; j < len; j++)
-      info[j].mask = mask;
-  }
   void add_masks (hb_mask_t mask)
   {
     for (unsigned int j = 0; j < len; j++)

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -265,6 +265,7 @@ OT::GDEF::is_blocklisted (hb_blob_t *blob,
   return false;
 }
 
+template <bool SetDigest>
 static void
 _hb_ot_layout_set_glyph_props (hb_font_t *font,
 			       hb_buffer_t *buffer)
@@ -276,6 +277,8 @@ _hb_ot_layout_set_glyph_props (hb_font_t *font,
   hb_glyph_info_t *info = buffer->info;
   for (unsigned int i = 0; i < count; i++)
   {
+    if (SetDigest)
+      buffer->digest.add (info[i].codepoint);
     _hb_glyph_info_set_glyph_props (&info[i], gdef.get_glyph_props (info[i].codepoint));
     _hb_glyph_info_clear_lig_props (&info[i]);
   }
@@ -1573,7 +1576,15 @@ void
 hb_ot_layout_substitute_start (hb_font_t    *font,
 			       hb_buffer_t  *buffer)
 {
-  _hb_ot_layout_set_glyph_props (font, buffer);
+  _hb_ot_layout_set_glyph_props<false> (font, buffer);
+}
+
+void
+hb_ot_layout_substitute_start_with_digest (hb_font_t    *font,
+					   hb_buffer_t  *buffer)
+{
+  buffer->digest = hb_set_digest_t ();
+  _hb_ot_layout_set_glyph_props<true> (font, buffer);
 }
 
 /**

--- a/src/hb-ot-layout.hh
+++ b/src/hb-ot-layout.hh
@@ -102,6 +102,10 @@ HB_INTERNAL void
 hb_ot_layout_substitute_start (hb_font_t    *font,
 			       hb_buffer_t  *buffer);
 
+HB_INTERNAL void
+hb_ot_layout_substitute_start_with_digest (hb_font_t    *font,
+					   hb_buffer_t  *buffer);
+
 namespace OT {
   struct hb_ot_apply_context_t;
   struct hb_ot_layout_lookup_accelerator_t;

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -905,14 +905,14 @@ hb_ot_substitute_plan (const hb_ot_shape_context_t *c)
 {
   hb_buffer_t *buffer = c->buffer;
 
-  hb_ot_layout_substitute_start (c->font, buffer);
-
-  if (c->plan->fallback_glyph_classes)
-    hb_synthesize_glyph_classes (c->buffer);
-
 #ifndef HB_NO_AAT_SHAPE
   if (unlikely (c->plan->apply_morx))
   {
+    hb_ot_layout_substitute_start (c->font, buffer);
+
+    if (c->plan->fallback_glyph_classes)
+      hb_synthesize_glyph_classes (buffer);
+
     hb_aat_layout_substitute (c->plan, c->font, c->buffer,
 			      c->user_features, c->num_user_features);
     /* The buffer digest is only used by the OT lookup-apply loop;
@@ -923,7 +923,11 @@ hb_ot_substitute_plan (const hb_ot_shape_context_t *c)
   else
 #endif
   {
-    c->buffer->update_digest ();
+    hb_ot_layout_substitute_start_with_digest (c->font, buffer);
+
+    if (c->plan->fallback_glyph_classes)
+      hb_synthesize_glyph_classes (buffer);
+
     c->plan->substitute (c->font, buffer);
   }
 }

--- a/src/hb-ot-shape.cc
+++ b/src/hb-ot-shape.cc
@@ -468,7 +468,8 @@ struct hb_ot_shape_context_t
 /* Prepare */
 
 static void
-hb_set_unicode_props (hb_buffer_t *buffer)
+hb_set_unicode_props (hb_buffer_t *buffer,
+		      hb_mask_t    global_mask)
 {
   /* Implement enough of Unicode Graphemes here that shaping
    * in reverse-direction wouldn't break graphemes.  Namely,
@@ -482,6 +483,7 @@ hb_set_unicode_props (hb_buffer_t *buffer)
   hb_glyph_info_t *info = buffer->info;
   for (unsigned int i = 0; i < count; i++)
   {
+    info[i].mask = global_mask;
     _hb_glyph_info_set_unicode_props (&info[i], buffer);
 
     if (info[i].codepoint < 0x80)
@@ -519,6 +521,7 @@ hb_set_unicode_props (hb_buffer_t *buffer)
 	  _hb_unicode_is_emoji_Extended_Pictographic (info[i + 1].codepoint))
       {
 	i++;
+	info[i].mask = global_mask;
 	_hb_glyph_info_set_unicode_props (&info[i], buffer);
 	_hb_glyph_info_set_continuation (&info[i], buffer);
       }
@@ -741,16 +744,6 @@ hb_ot_shape_setup_masks_fraction (const hb_ot_shape_context_t *c)
       i = end - 1;
     }
   }
-}
-
-static inline void
-hb_ot_shape_initialize_masks (const hb_ot_shape_context_t *c)
-{
-  hb_ot_map_t *map = &c->plan->map;
-  hb_buffer_t *buffer = c->buffer;
-
-  hb_mask_t global_mask = map->get_global_mask ();
-  buffer->reset_masks (global_mask);
 }
 
 static inline void
@@ -1178,8 +1171,7 @@ hb_ot_shape_internal (hb_ot_shape_context_t *c)
 
   _hb_buffer_allocate_unicode_vars (c->buffer);
 
-  hb_ot_shape_initialize_masks (c);
-  hb_set_unicode_props (c->buffer);
+  hb_set_unicode_props (c->buffer, c->plan->map.get_global_mask ());
   hb_insert_dotted_circle (c->buffer, c->font);
 
   hb_form_clusters (c->buffer);


### PR DESCRIPTION
## Summary

- initialize each glyph mask while computing Unicode properties
- rebuild the buffer digest while assigning GDEF glyph properties on the normal OpenType path
- preserve the existing post-morx digest rebuild and glyph-class ordering

The changes are separate commits so their performance can be measured independently. The position-buffer optimization was intentionally left out because generic HarfBuzz font callbacks do not initialize complete position records. The fast glyph-mapping path is already single-pass in HarfBuzz.

## Testing

- meson compile -C build
- meson test -C build test-buffer test-shape in-house aots --print-errorlogs
- 25 buffer, 4 shape, 800 AOTS, and 7,272 in-house subtests passed