### PR TITLE
OT: Skip lookups missing possible second glyphs

### DIFF
--- a/src/OT/Layout/GPOS/CursivePosFormat1.hh
+++ b/src/OT/Layout/GPOS/CursivePosFormat1.hh
@@ -138,6 +138,9 @@ struct CursivePosFormat1
   void collect_glyphs (hb_collect_glyphs_context_t *c) const
   { if (unlikely (!(this+coverage).collect_coverage (c->input))) return; }
 
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  { (this+coverage).collect_coverage (digest); }
+
   const Coverage &get_coverage () const { return this+coverage; }
 
   bool apply (hb_ot_apply_context_t *c) const

--- a/src/OT/Layout/GPOS/MarkBasePosFormat1.hh
+++ b/src/OT/Layout/GPOS/MarkBasePosFormat1.hh
@@ -88,6 +88,9 @@ struct MarkBasePosFormat1_2
     if (unlikely (!(this+baseCoverage).collect_coverage (c->input))) return;
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  { (this+baseCoverage).collect_coverage (digest); }
+
   const Coverage &get_coverage () const { return this+markCoverage; }
 
   static inline bool accept (hb_buffer_t *buffer, unsigned idx)

--- a/src/OT/Layout/GPOS/MarkLigPosFormat1.hh
+++ b/src/OT/Layout/GPOS/MarkLigPosFormat1.hh
@@ -90,6 +90,9 @@ struct MarkLigPosFormat1_2
     if (unlikely (!(this+ligatureCoverage).collect_coverage (c->input))) return;
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  { (this+ligatureCoverage).collect_coverage (digest); }
+
   const Coverage &get_coverage () const { return this+markCoverage; }
 
   static inline bool accept (hb_buffer_t *buffer, unsigned idx)

--- a/src/OT/Layout/GPOS/MarkMarkPosFormat1.hh
+++ b/src/OT/Layout/GPOS/MarkMarkPosFormat1.hh
@@ -90,6 +90,9 @@ struct MarkMarkPosFormat1_2
     if (unlikely (!(this+mark2Coverage).collect_coverage (c->input))) return;
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  { (this+mark2Coverage).collect_coverage (digest); }
+
   const Coverage &get_coverage () const { return this+mark1Coverage; }
 
   bool apply (hb_ot_apply_context_t *c) const

--- a/src/OT/Layout/GPOS/PairPosFormat1.hh
+++ b/src/OT/Layout/GPOS/PairPosFormat1.hh
@@ -101,6 +101,13 @@ struct PairPosFormat1_3
       (this+pairSet[i]).collect_glyphs (c, valueFormat);
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  {
+    unsigned count = pairSet.len;
+    for (unsigned i = 0; i < count; i++)
+      (this+pairSet[i]).collect_second_glyphs (digest, valueFormat);
+  }
+
   const Coverage &get_coverage () const { return this+coverage; }
 
   struct external_cache_t

--- a/src/OT/Layout/GPOS/PairSet.hh
+++ b/src/OT/Layout/GPOS/PairSet.hh
@@ -84,6 +84,15 @@ struct PairSet : ValueBase
     c->input->add_array (&record->secondGlyph, len, record_size);
   }
 
+  template <typename set_t>
+  void collect_second_glyphs (set_t *glyphs,
+			      const ValueFormat *valueFormats) const
+  {
+    unsigned record_size = get_size (valueFormats);
+    const PairValueRecord *record = &firstPairValueRecord;
+    glyphs->add_array (&record->secondGlyph, len, record_size);
+  }
+
   void collect_variation_indices (hb_collect_variation_indices_context_t *c,
                                   const ValueFormat *valueFormats) const
   {

--- a/src/OT/Layout/GSUB/LigatureSubstFormat1.hh
+++ b/src/OT/Layout/GSUB/LigatureSubstFormat1.hh
@@ -79,6 +79,14 @@ struct LigatureSubstFormat1_2
     ;
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  {
+    + hb_iter (ligatureSet)
+    | hb_map (hb_add (this))
+    | hb_apply ([digest] (const LigatureSet<Types> &_) { _.collect_seconds (*digest); })
+    ;
+  }
+
   const Coverage &get_coverage () const { return this+coverage; }
 
   bool would_apply (hb_would_apply_context_t *c) const

--- a/src/OT/Layout/types.hh
+++ b/src/OT/Layout/types.hh
@@ -35,9 +35,6 @@ static_assert (sizeof (hb_ot_layout_mapping_cache_t) == 512, "");
 using hb_ot_layout_binary_cache_t = hb_cache_t<14, 1, 8>;
 static_assert (sizeof (hb_ot_layout_binary_cache_t) == 256, "");
 
-using hb_ot_layout_subtable_index_cache_t = hb_cache_t<12, 3, 7>;
-static_assert (sizeof (hb_ot_layout_subtable_index_cache_t) == 128, "");
-
 namespace OT {
 namespace Layout {
 

--- a/src/OT/Layout/types.hh
+++ b/src/OT/Layout/types.hh
@@ -35,6 +35,9 @@ static_assert (sizeof (hb_ot_layout_mapping_cache_t) == 512, "");
 using hb_ot_layout_binary_cache_t = hb_cache_t<14, 1, 8>;
 static_assert (sizeof (hb_ot_layout_binary_cache_t) == 256, "");
 
+using hb_ot_layout_subtable_index_cache_t = hb_cache_t<12, 3, 7>;
+static_assert (sizeof (hb_ot_layout_subtable_index_cache_t) == 128, "");
+
 namespace OT {
 namespace Layout {
 

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -5870,44 +5870,57 @@ struct hb_ot_layout_lookup_accelerator_t
   bool may_have (hb_codepoint_t g) const
   { return digest.may_have (g); }
 
-#ifndef HB_OPTIMIZE_SIZE
-  HB_ALWAYS_INLINE
-#endif
-  bool apply (hb_ot_apply_context_t *c, bool use_cache) const
+  typedef bool (*apply_func_t) (const hb_ot_layout_lookup_accelerator_t *accel,
+				hb_ot_apply_context_t                   *c);
+
+  static bool apply_one (const hb_ot_layout_lookup_accelerator_t *accel,
+			 hb_ot_apply_context_t                   *c)
   {
-    if (count == 1)
-    {
-      /* The accelerator digest is the union of the subtable digests, so
-       * for a single subtable it equals that subtable's digest, which the
-       * caller has already tested; skip the redundant retest. Zeroed
-       * invalid entries were trimmed at create time, so the subtable is
-       * always valid here. */
+    /* The accelerator digest is the union of the subtable digests, so
+     * for a single subtable it equals that subtable's digest, which the
+     * caller has already tested; skip the redundant retest. Zeroed
+     * invalid entries were trimmed at create time, so the subtable is
+     * always valid here. */
+    return accel->subtables[0].apply_no_digest (c);
+  }
+
+  static bool apply_many (const hb_ot_layout_lookup_accelerator_t *accel,
+			  hb_ot_apply_context_t                   *c)
+  {
+    return
+    + hb_iter (hb_iter (accel->subtables, accel->count))
+    | hb_map ([&c] (const hb_accelerate_subtables_context_t::hb_applicable_t &_) { return _.apply (c); })
+    | hb_any
+    ;
+  }
+
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
-      if (use_cache)
-	return subtables[0].apply_cached_no_digest (c);
+  static bool apply_cached_one (const hb_ot_layout_lookup_accelerator_t *accel,
+				hb_ot_apply_context_t                   *c)
+  { return accel->subtables[0].apply_cached_no_digest (c); }
+
+  static bool apply_cached_many (const hb_ot_layout_lookup_accelerator_t *accel,
+				 hb_ot_apply_context_t                   *c)
+  {
+    return
+    + hb_iter (hb_iter (accel->subtables, accel->count))
+    | hb_map ([&c] (const hb_accelerate_subtables_context_t::hb_applicable_t &_) { return _.apply_cached (c); })
+    | hb_any
+    ;
+  }
 #endif
-      return subtables[0].apply_no_digest (c);
-    }
+
+  apply_func_t get_apply_func (bool use_cache HB_UNUSED) const
+  {
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
     if (use_cache)
-    {
-      return
-      + hb_iter (hb_iter (subtables, count))
-      | hb_map ([&c] (const hb_accelerate_subtables_context_t::hb_applicable_t &_) { return _.apply_cached (c); })
-      | hb_any
-      ;
-    }
-    else
+      return count == 1 ? apply_cached_one : apply_cached_many;
 #endif
-    {
-      return
-      + hb_iter (hb_iter (subtables, count))
-      | hb_map ([&c] (const hb_accelerate_subtables_context_t::hb_applicable_t &_) { return _.apply (c); })
-      | hb_any
-      ;
-    }
-    return false;
+    return count == 1 ? apply_one : apply_many;
   }
+
+  bool apply (hb_ot_apply_context_t *c, bool use_cache) const
+  { return get_apply_func (use_cache) (this, c); }
 
   bool cache_enter (hb_ot_apply_context_t *c) const
   {

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -5870,57 +5870,44 @@ struct hb_ot_layout_lookup_accelerator_t
   bool may_have (hb_codepoint_t g) const
   { return digest.may_have (g); }
 
-  typedef bool (*apply_func_t) (const hb_ot_layout_lookup_accelerator_t *accel,
-				hb_ot_apply_context_t                   *c);
-
-  static bool apply_one (const hb_ot_layout_lookup_accelerator_t *accel,
-			 hb_ot_apply_context_t                   *c)
-  {
-    /* The accelerator digest is the union of the subtable digests, so
-     * for a single subtable it equals that subtable's digest, which the
-     * caller has already tested; skip the redundant retest. Zeroed
-     * invalid entries were trimmed at create time, so the subtable is
-     * always valid here. */
-    return accel->subtables[0].apply_no_digest (c);
-  }
-
-  static bool apply_many (const hb_ot_layout_lookup_accelerator_t *accel,
-			  hb_ot_apply_context_t                   *c)
-  {
-    return
-    + hb_iter (hb_iter (accel->subtables, accel->count))
-    | hb_map ([&c] (const hb_accelerate_subtables_context_t::hb_applicable_t &_) { return _.apply (c); })
-    | hb_any
-    ;
-  }
-
-#ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
-  static bool apply_cached_one (const hb_ot_layout_lookup_accelerator_t *accel,
-				hb_ot_apply_context_t                   *c)
-  { return accel->subtables[0].apply_cached_no_digest (c); }
-
-  static bool apply_cached_many (const hb_ot_layout_lookup_accelerator_t *accel,
-				 hb_ot_apply_context_t                   *c)
-  {
-    return
-    + hb_iter (hb_iter (accel->subtables, accel->count))
-    | hb_map ([&c] (const hb_accelerate_subtables_context_t::hb_applicable_t &_) { return _.apply_cached (c); })
-    | hb_any
-    ;
-  }
+#ifndef HB_OPTIMIZE_SIZE
+  HB_ALWAYS_INLINE
 #endif
-
-  apply_func_t get_apply_func (bool use_cache HB_UNUSED) const
+  bool apply (hb_ot_apply_context_t *c, bool use_cache) const
   {
+    if (count == 1)
+    {
+      /* The accelerator digest is the union of the subtable digests, so
+       * for a single subtable it equals that subtable's digest, which the
+       * caller has already tested; skip the redundant retest. Zeroed
+       * invalid entries were trimmed at create time, so the subtable is
+       * always valid here. */
+#ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+      if (use_cache)
+	return subtables[0].apply_cached_no_digest (c);
+#endif
+      return subtables[0].apply_no_digest (c);
+    }
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
     if (use_cache)
-      return count == 1 ? apply_cached_one : apply_cached_many;
+    {
+      return
+      + hb_iter (hb_iter (subtables, count))
+      | hb_map ([&c] (const hb_accelerate_subtables_context_t::hb_applicable_t &_) { return _.apply_cached (c); })
+      | hb_any
+      ;
+    }
+    else
 #endif
-    return count == 1 ? apply_one : apply_many;
+    {
+      return
+      + hb_iter (hb_iter (subtables, count))
+      | hb_map ([&c] (const hb_accelerate_subtables_context_t::hb_applicable_t &_) { return _.apply (c); })
+      | hb_any
+      ;
+    }
+    return false;
   }
-
-  bool apply (hb_ot_apply_context_t *c, bool use_cache) const
-  { return get_apply_func (use_cache) (this, c); }
 
   bool cache_enter (hb_ot_apply_context_t *c) const
   {

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -5873,9 +5873,6 @@ struct hb_ot_layout_lookup_accelerator_t
   typedef bool (*apply_func_t) (const hb_ot_layout_lookup_accelerator_t *accel,
 				hb_ot_apply_context_t                   *c);
 
-#ifndef HB_OPTIMIZE_SIZE
-  HB_ALWAYS_INLINE
-#endif
   static bool apply_one (const hb_ot_layout_lookup_accelerator_t *accel,
 			 hb_ot_apply_context_t                   *c)
   {
@@ -5887,9 +5884,6 @@ struct hb_ot_layout_lookup_accelerator_t
     return accel->subtables[0].apply_no_digest (c);
   }
 
-#ifndef HB_OPTIMIZE_SIZE
-  HB_ALWAYS_INLINE
-#endif
   static bool apply_many (const hb_ot_layout_lookup_accelerator_t *accel,
 			  hb_ot_apply_context_t                   *c)
   {
@@ -5901,16 +5895,10 @@ struct hb_ot_layout_lookup_accelerator_t
   }
 
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
-#ifndef HB_OPTIMIZE_SIZE
-  HB_ALWAYS_INLINE
-#endif
   static bool apply_cached_one (const hb_ot_layout_lookup_accelerator_t *accel,
 				hb_ot_apply_context_t                   *c)
   { return accel->subtables[0].apply_cached_no_digest (c); }
 
-#ifndef HB_OPTIMIZE_SIZE
-  HB_ALWAYS_INLINE
-#endif
   static bool apply_cached_many (const hb_ot_layout_lookup_accelerator_t *accel,
 				 hb_ot_apply_context_t                   *c)
   {

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -1378,6 +1378,16 @@ struct hb_accelerate_subtables_context_t :
        hb_dispatch_context_t<hb_accelerate_subtables_context_t>
 {
   template <typename T>
+  static inline auto collect_second_glyphs_ (const T &obj,
+					     hb_set_digest_t *digest,
+					     hb_priority<1>) HB_RETURN (void, obj.collect_second_glyphs (digest) )
+  template <typename T>
+  static inline void collect_second_glyphs_ (const T &obj HB_UNUSED,
+					     hb_set_digest_t *digest,
+					     hb_priority<0>)
+  { *digest = hb_set_digest_t::full (); }
+
+  template <typename T>
   static inline auto apply_ (const T *obj, hb_ot_apply_context_t *c, void *external_cache, hb_priority<1>) HB_RETURN (bool, obj->apply (c, external_cache) )
   template <typename T>
   static inline auto apply_ (const T *obj, hb_ot_apply_context_t *c, void *external_cache, hb_priority<0>) HB_RETURN (bool, obj->apply (c) )
@@ -1511,6 +1521,8 @@ struct hb_accelerate_subtables_context_t :
   template <typename T>
   return_t dispatch (const T &obj)
   {
+    collect_second_glyphs_ (obj, &digest_second, hb_prioritize);
+
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
     void *external_cache = nullptr;
     if (i < 8)
@@ -1554,6 +1566,7 @@ struct hb_accelerate_subtables_context_t :
 
   hb_applicable_t *array;
   unsigned i = 0;
+  hb_set_digest_t digest_second;
 
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
   unsigned subtable_cache_user_idx = (unsigned) -1;
@@ -3064,6 +3077,24 @@ struct Rule
 				   lookup_context);
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest,
+			      const ClassDef *class_def = nullptr) const
+  {
+    if (inputCount <= 1)
+    {
+      *digest = hb_set_digest_t::full ();
+      return;
+    }
+
+    unsigned second = inputZ.arrayZ[0];
+    if (!class_def)
+      digest->add (second);
+    else if (!second)
+      *digest = hb_set_digest_t::full ();
+    else
+      class_def->collect_class (digest, second);
+  }
+
   bool would_apply (hb_would_apply_context_t *c,
 		    const ContextApplyLookupContext &lookup_context) const
   {
@@ -3200,6 +3231,15 @@ struct RuleSet
     + hb_iter (rule)
     | hb_map (hb_add (this))
     | hb_apply ([&] (const Rule &_) { _.collect_glyphs (c, lookup_context); })
+    ;
+  }
+
+  void collect_second_glyphs (hb_set_digest_t *digest,
+			      const ClassDef *class_def = nullptr) const
+  {
+    + hb_iter (rule)
+    | hb_map (hb_add (this))
+    | hb_apply ([=] (const Rule &_) { _.collect_second_glyphs (digest, class_def); })
     ;
   }
 
@@ -3492,6 +3532,14 @@ struct ContextFormat1_4
     ;
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  {
+    + hb_iter (ruleSet)
+    | hb_map (hb_add (this))
+    | hb_apply ([digest] (const RuleSet &_) { _.collect_second_glyphs (digest); })
+    ;
+  }
+
   bool would_apply (hb_would_apply_context_t *c) const
   {
     const RuleSet &rule_set = this+ruleSet[(this+coverage).get_coverage (c->glyphs[0])];
@@ -3715,6 +3763,15 @@ struct ContextFormat2_5
     + hb_iter (ruleSet)
     | hb_map (hb_add (this))
     | hb_apply ([&] (const RuleSet &_) { _.collect_glyphs (c, lookup_context); })
+    ;
+  }
+
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  {
+    const ClassDef &class_def = this+classDef;
+    + hb_iter (ruleSet)
+    | hb_map (hb_add (this))
+    | hb_apply ([=, &class_def] (const RuleSet &_) { _.collect_second_glyphs (digest, &class_def); })
     ;
   }
 
@@ -3953,6 +4010,14 @@ struct ContextFormat3
 				   glyphCount, (const HBUINT16 *) (coverageZ.arrayZ + 1),
 				   lookupCount, lookupRecord,
 				   lookup_context);
+  }
+
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  {
+    if (glyphCount <= 1)
+      *digest = hb_set_digest_t::full ();
+    else
+      (this+coverageZ[1]).collect_coverage (digest);
   }
 
   bool would_apply (hb_would_apply_context_t *c) const
@@ -4495,6 +4560,39 @@ struct ChainRule
 					 lookup_context);
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest,
+			      const ClassDef *input_class_def = nullptr,
+			      const ClassDef *lookahead_class_def = nullptr) const
+  {
+    const auto &input = StructAfter<decltype (inputX)> (backtrack);
+    const auto &lookahead = StructAfter<decltype (lookaheadX)> (input);
+
+    unsigned second;
+    const ClassDef *class_def;
+    if (input.lenP1 > 1)
+    {
+      second = input.arrayZ[0];
+      class_def = input_class_def;
+    }
+    else if (lookahead.len)
+    {
+      second = lookahead.arrayZ[0];
+      class_def = lookahead_class_def;
+    }
+    else
+    {
+      *digest = hb_set_digest_t::full ();
+      return;
+    }
+
+    if (!class_def)
+      digest->add (second);
+    else if (!second)
+      *digest = hb_set_digest_t::full ();
+    else
+      class_def->collect_class (digest, second);
+  }
+
   bool would_apply (hb_would_apply_context_t *c,
 		    const ChainContextApplyLookupContext &lookup_context) const
   {
@@ -4681,6 +4779,17 @@ struct ChainRuleSet
     + hb_iter (rule)
     | hb_map (hb_add (this))
     | hb_apply ([&] (const ChainRule &_) { _.collect_glyphs (c, lookup_context); })
+    ;
+  }
+
+  void collect_second_glyphs (hb_set_digest_t *digest,
+			      const ClassDef *input_class_def = nullptr,
+			      const ClassDef *lookahead_class_def = nullptr) const
+  {
+    + hb_iter (rule)
+    | hb_map (hb_add (this))
+    | hb_apply ([=] (const ChainRule &_)
+		{ _.collect_second_glyphs (digest, input_class_def, lookahead_class_def); })
     ;
   }
 
@@ -4997,6 +5106,14 @@ struct ChainContextFormat1_4
     ;
   }
 
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  {
+    + hb_iter (ruleSet)
+    | hb_map (hb_add (this))
+    | hb_apply ([digest] (const ChainRuleSet &_) { _.collect_second_glyphs (digest); })
+    ;
+  }
+
   bool would_apply (hb_would_apply_context_t *c) const
   {
     const ChainRuleSet &rule_set = this+ruleSet[(this+coverage).get_coverage (c->glyphs[0])];
@@ -5239,6 +5356,17 @@ struct ChainContextFormat2_5
     + hb_iter (ruleSet)
     | hb_map (hb_add (this))
     | hb_apply ([&] (const ChainRuleSet &_) { _.collect_glyphs (c, lookup_context); })
+    ;
+  }
+
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  {
+    const ClassDef &input_class_def = this+inputClassDef;
+    const ClassDef &lookahead_class_def = this+lookaheadClassDef;
+    + hb_iter (ruleSet)
+    | hb_map (hb_add (this))
+    | hb_apply ([digest, &input_class_def, &lookahead_class_def] (const ChainRuleSet &_)
+		{ _.collect_second_glyphs (digest, &input_class_def, &lookahead_class_def); })
     ;
   }
 
@@ -5540,6 +5668,18 @@ struct ChainContextFormat3
 					 lookahead.len, (const HBUINT16 *) lookahead.arrayZ,
 					 lookup.len, lookup.arrayZ,
 					 lookup_context);
+  }
+
+  void collect_second_glyphs (hb_set_digest_t *digest) const
+  {
+    const auto &input = StructAfter<decltype (inputX)> (backtrack);
+    const auto &lookahead = StructAfter<decltype (lookaheadX)> (input);
+    if (input.len > 1)
+      (this+input[1]).collect_coverage (digest);
+    else if (lookahead.len)
+      (this+lookahead[0]).collect_coverage (digest);
+    else
+      *digest = hb_set_digest_t::full ();
   }
 
   bool would_apply (hb_would_apply_context_t *c) const
@@ -5845,6 +5985,7 @@ struct hb_ot_layout_lookup_accelerator_t
     thiz->digest.init ();
     for (auto& subtable : hb_iter (thiz->subtables, count))
       thiz->digest.union_ (subtable.digest);
+    thiz->digest_second = c_accelerate_subtables.digest_second;
 
     thiz->count = count;
 
@@ -5927,6 +6068,7 @@ struct hb_ot_layout_lookup_accelerator_t
 
 
   hb_set_digest_t digest;
+  hb_set_digest_t digest_second;
   private:
   unsigned count = 0; /* Number of subtables in the array. */
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -1129,7 +1129,6 @@ struct hb_ot_apply_context_t :
   recurse_func_t recurse_func = nullptr;
   const GDEF &gdef;
   const GDEF::accelerator_t &gdef_accel;
-  const hb_ot_layout_lookup_accelerator_t *lookup_accel = nullptr;
   const ItemVariationStore &var_store;
   hb_scalar_cache_t *var_store_cache;
 
@@ -5876,7 +5875,6 @@ struct hb_ot_layout_lookup_accelerator_t
 #endif
   bool apply (hb_ot_apply_context_t *c, bool use_cache) const
   {
-    c->lookup_accel = this;
     if (count == 1)
     {
       /* The accelerator digest is the union of the subtable digests, so

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -5849,14 +5849,6 @@ struct hb_ot_layout_lookup_accelerator_t
     thiz->count = count;
 
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
-    if (count > 4)
-    {
-      thiz->subtable_index_cache = (hb_ot_layout_subtable_index_cache_t *)
-				   hb_malloc (sizeof (hb_ot_layout_subtable_index_cache_t));
-      if (likely (thiz->subtable_index_cache))
-	new (thiz->subtable_index_cache) hb_ot_layout_subtable_index_cache_t ();
-    }
-
     thiz->subtable_cache_user_idx = c_accelerate_subtables.subtable_cache_user_idx;
 
     for (unsigned i = 0; i < count; i++)
@@ -5870,7 +5862,6 @@ struct hb_ot_layout_lookup_accelerator_t
   void fini ()
   {
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
-    hb_free (subtable_index_cache);
     for (unsigned i = 0; i < count; i++)
       hb_free (subtables[i].external_cache);
 #endif
@@ -5897,49 +5888,6 @@ struct hb_ot_layout_lookup_accelerator_t
 #endif
       return subtables[0].apply_no_digest (c);
     }
-#ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
-    if (subtable_index_cache)
-    {
-      hb_codepoint_t glyph = c->buffer->cur().codepoint;
-      unsigned cached_index;
-      if (subtable_index_cache->get (glyph, &cached_index) &&
-	  cached_index < count)
-      {
-	if (use_cache ? subtables[cached_index].apply_cached_no_digest (c) :
-			subtables[cached_index].apply_no_digest (c))
-	  return true;
-
-	/* The cached subtable was the first whose digest admitted this glyph,
-	 * so no earlier subtable can apply. */
-	for (unsigned i = cached_index + 1; i < count; i++)
-	  if (use_cache ? subtables[i].apply_cached (c) : subtables[i].apply (c))
-	    return true;
-	return false;
-      }
-
-      /* Only cache a successful subtable if all earlier subtable digests
-	 * reject the glyph.  This preserves lookup order when contextual
-	 * subtables have overlapping first-glyph coverages. */
-      unsigned i = 0;
-      while (i < count && !subtables[i].digest.may_have (glyph))
-	i++;
-      if (i < count)
-      {
-	if (use_cache ? subtables[i].apply_cached_no_digest (c) :
-			subtables[i].apply_no_digest (c))
-	{
-	  subtable_index_cache->set (glyph, i);
-	  return true;
-	}
-	i++;
-      }
-      for (; i < count; i++)
-	if (use_cache ? subtables[i].apply_cached (c) : subtables[i].apply (c))
-	  return true;
-      return false;
-    }
-#endif
-
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
     if (use_cache)
     {
@@ -5982,7 +5930,6 @@ struct hb_ot_layout_lookup_accelerator_t
   private:
   unsigned count = 0; /* Number of subtables in the array. */
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
-  hb_ot_layout_subtable_index_cache_t *subtable_index_cache = nullptr;
   unsigned subtable_cache_user_idx = (unsigned) -1;
 #endif
   hb_accelerate_subtables_context_t::hb_applicable_t subtables[HB_VAR_ARRAY];

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -5873,6 +5873,9 @@ struct hb_ot_layout_lookup_accelerator_t
   typedef bool (*apply_func_t) (const hb_ot_layout_lookup_accelerator_t *accel,
 				hb_ot_apply_context_t                   *c);
 
+#ifndef HB_OPTIMIZE_SIZE
+  HB_ALWAYS_INLINE
+#endif
   static bool apply_one (const hb_ot_layout_lookup_accelerator_t *accel,
 			 hb_ot_apply_context_t                   *c)
   {
@@ -5884,6 +5887,9 @@ struct hb_ot_layout_lookup_accelerator_t
     return accel->subtables[0].apply_no_digest (c);
   }
 
+#ifndef HB_OPTIMIZE_SIZE
+  HB_ALWAYS_INLINE
+#endif
   static bool apply_many (const hb_ot_layout_lookup_accelerator_t *accel,
 			  hb_ot_apply_context_t                   *c)
   {
@@ -5895,10 +5901,16 @@ struct hb_ot_layout_lookup_accelerator_t
   }
 
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+#ifndef HB_OPTIMIZE_SIZE
+  HB_ALWAYS_INLINE
+#endif
   static bool apply_cached_one (const hb_ot_layout_lookup_accelerator_t *accel,
 				hb_ot_apply_context_t                   *c)
   { return accel->subtables[0].apply_cached_no_digest (c); }
 
+#ifndef HB_OPTIMIZE_SIZE
+  HB_ALWAYS_INLINE
+#endif
   static bool apply_cached_many (const hb_ot_layout_lookup_accelerator_t *accel,
 				 hb_ot_apply_context_t                   *c)
   {

--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -5849,6 +5849,14 @@ struct hb_ot_layout_lookup_accelerator_t
     thiz->count = count;
 
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+    if (count > 4)
+    {
+      thiz->subtable_index_cache = (hb_ot_layout_subtable_index_cache_t *)
+				   hb_malloc (sizeof (hb_ot_layout_subtable_index_cache_t));
+      if (likely (thiz->subtable_index_cache))
+	new (thiz->subtable_index_cache) hb_ot_layout_subtable_index_cache_t ();
+    }
+
     thiz->subtable_cache_user_idx = c_accelerate_subtables.subtable_cache_user_idx;
 
     for (unsigned i = 0; i < count; i++)
@@ -5862,6 +5870,7 @@ struct hb_ot_layout_lookup_accelerator_t
   void fini ()
   {
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+    hb_free (subtable_index_cache);
     for (unsigned i = 0; i < count; i++)
       hb_free (subtables[i].external_cache);
 #endif
@@ -5888,6 +5897,49 @@ struct hb_ot_layout_lookup_accelerator_t
 #endif
       return subtables[0].apply_no_digest (c);
     }
+#ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+    if (subtable_index_cache)
+    {
+      hb_codepoint_t glyph = c->buffer->cur().codepoint;
+      unsigned cached_index;
+      if (subtable_index_cache->get (glyph, &cached_index) &&
+	  cached_index < count)
+      {
+	if (use_cache ? subtables[cached_index].apply_cached_no_digest (c) :
+			subtables[cached_index].apply_no_digest (c))
+	  return true;
+
+	/* The cached subtable was the first whose digest admitted this glyph,
+	 * so no earlier subtable can apply. */
+	for (unsigned i = cached_index + 1; i < count; i++)
+	  if (use_cache ? subtables[i].apply_cached (c) : subtables[i].apply (c))
+	    return true;
+	return false;
+      }
+
+      /* Only cache a successful subtable if all earlier subtable digests
+	 * reject the glyph.  This preserves lookup order when contextual
+	 * subtables have overlapping first-glyph coverages. */
+      unsigned i = 0;
+      while (i < count && !subtables[i].digest.may_have (glyph))
+	i++;
+      if (i < count)
+      {
+	if (use_cache ? subtables[i].apply_cached_no_digest (c) :
+			subtables[i].apply_no_digest (c))
+	{
+	  subtable_index_cache->set (glyph, i);
+	  return true;
+	}
+	i++;
+      }
+      for (; i < count; i++)
+	if (use_cache ? subtables[i].apply_cached (c) : subtables[i].apply (c))
+	  return true;
+      return false;
+    }
+#endif
+
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
     if (use_cache)
     {
@@ -5930,6 +5982,7 @@ struct hb_ot_layout_lookup_accelerator_t
   private:
   unsigned count = 0; /* Number of subtables in the array. */
 #ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+  hb_ot_layout_subtable_index_cache_t *subtable_index_cache = nullptr;
   unsigned subtable_cache_user_idx = (unsigned) -1;
 #endif
   hb_accelerate_subtables_context_t::hb_applicable_t subtables[HB_VAR_ARRAY];

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1924,13 +1924,12 @@ struct GPOSProxy
 };
 
 
-static inline bool
-apply_forward (OT::hb_ot_apply_context_t *c,
-	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
+template <OT::hb_ot_layout_lookup_accelerator_t::apply_func_t Apply>
+HB_NEVER_INLINE
+static bool
+apply_forward_impl (OT::hb_ot_apply_context_t *c,
+		    const OT::hb_ot_layout_lookup_accelerator_t &accel)
 {
-  bool use_hot_subtable_cache = accel.cache_enter (c);
-  auto apply_func = accel.get_apply_func (use_hot_subtable_cache);
-
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
   while (buffer->successful)
@@ -1947,11 +1946,44 @@ apply_forward (OT::hb_ot_apply_context_t *c,
     if (buffer->idx >= buffer->len)
       break;
 
-    if (apply_func (&accel, c))
+    if (Apply (&accel, c))
       ret = true;
     else
       (void) buffer->next_glyph ();
   }
+
+  return ret;
+}
+
+static inline bool
+apply_forward (OT::hb_ot_apply_context_t *c,
+	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
+{
+  using accelerator_t = OT::hb_ot_layout_lookup_accelerator_t;
+
+  bool use_hot_subtable_cache = accel.cache_enter (c);
+  auto apply_func = accel.get_apply_func (use_hot_subtable_cache);
+
+  bool ret;
+  if (apply_func == accelerator_t::apply_one)
+    ret = apply_forward_impl<accelerator_t::apply_one> (c, accel);
+#ifdef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+  else
+  {
+    assert (apply_func == accelerator_t::apply_many);
+    ret = apply_forward_impl<accelerator_t::apply_many> (c, accel);
+  }
+#else
+  else if (apply_func == accelerator_t::apply_many)
+    ret = apply_forward_impl<accelerator_t::apply_many> (c, accel);
+  else if (apply_func == accelerator_t::apply_cached_one)
+    ret = apply_forward_impl<accelerator_t::apply_cached_one> (c, accel);
+  else
+  {
+    assert (apply_func == accelerator_t::apply_cached_many);
+    ret = apply_forward_impl<accelerator_t::apply_cached_many> (c, accel);
+  }
+#endif
 
   if (use_hot_subtable_cache)
     accel.cache_leave (c);
@@ -1959,12 +1991,12 @@ apply_forward (OT::hb_ot_apply_context_t *c,
   return ret;
 }
 
-static inline bool
-apply_backward (OT::hb_ot_apply_context_t *c,
-	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
+template <OT::hb_ot_layout_lookup_accelerator_t::apply_func_t Apply>
+HB_NEVER_INLINE
+static bool
+apply_backward_impl (OT::hb_ot_apply_context_t *c,
+		     const OT::hb_ot_layout_lookup_accelerator_t &accel)
 {
-  auto apply_func = accel.get_apply_func (false);
-
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
   do
@@ -1973,13 +2005,27 @@ apply_backward (OT::hb_ot_apply_context_t *c,
     if (accel.digest.may_have (cur.codepoint) &&
 	(cur.mask & c->lookup_mask) &&
 	c->check_glyph_property (&cur, c->lookup_props))
-      ret |= apply_func (&accel, c);
+      ret |= Apply (&accel, c);
 
     /* The reverse lookup doesn't "advance" cursor (for good reason). */
     buffer->idx--;
   }
   while ((int) buffer->idx >= 0);
   return ret;
+}
+
+static inline bool
+apply_backward (OT::hb_ot_apply_context_t *c,
+		const OT::hb_ot_layout_lookup_accelerator_t &accel)
+{
+  using accelerator_t = OT::hb_ot_layout_lookup_accelerator_t;
+
+  auto apply_func = accel.get_apply_func (false);
+  if (apply_func == accelerator_t::apply_one)
+    return apply_backward_impl<accelerator_t::apply_one> (c, accel);
+
+  assert (apply_func == accelerator_t::apply_many);
+  return apply_backward_impl<accelerator_t::apply_many> (c, accel);
 }
 
 template <typename Proxy>

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1929,7 +1929,6 @@ apply_forward (OT::hb_ot_apply_context_t *c,
 	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
 {
   bool use_hot_subtable_cache = accel.cache_enter (c);
-  auto apply_func = accel.get_apply_func (use_hot_subtable_cache);
 
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
@@ -1947,7 +1946,7 @@ apply_forward (OT::hb_ot_apply_context_t *c,
     if (buffer->idx >= buffer->len)
       break;
 
-    if (apply_func (&accel, c))
+    if (accel.apply (c, use_hot_subtable_cache))
       ret = true;
     else
       (void) buffer->next_glyph ();
@@ -1963,8 +1962,6 @@ static inline bool
 apply_backward (OT::hb_ot_apply_context_t *c,
 	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
 {
-  auto apply_func = accel.get_apply_func (false);
-
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
   do
@@ -1973,7 +1970,7 @@ apply_backward (OT::hb_ot_apply_context_t *c,
     if (accel.digest.may_have (cur.codepoint) &&
 	(cur.mask & c->lookup_mask) &&
 	c->check_glyph_property (&cur, c->lookup_props))
-      ret |= apply_func (&accel, c);
+      ret |= accel.apply (c, false);
 
     /* The reverse lookup doesn't "advance" cursor (for good reason). */
     buffer->idx--;

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1929,6 +1929,7 @@ apply_forward (OT::hb_ot_apply_context_t *c,
 	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
 {
   bool use_hot_subtable_cache = accel.cache_enter (c);
+  auto apply_func = accel.get_apply_func (use_hot_subtable_cache);
 
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
@@ -1946,7 +1947,7 @@ apply_forward (OT::hb_ot_apply_context_t *c,
     if (buffer->idx >= buffer->len)
       break;
 
-    if (accel.apply (c, use_hot_subtable_cache))
+    if (apply_func (&accel, c))
       ret = true;
     else
       (void) buffer->next_glyph ();
@@ -1962,6 +1963,8 @@ static inline bool
 apply_backward (OT::hb_ot_apply_context_t *c,
 	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
 {
+  auto apply_func = accel.get_apply_func (false);
+
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
   do
@@ -1970,7 +1973,7 @@ apply_backward (OT::hb_ot_apply_context_t *c,
     if (accel.digest.may_have (cur.codepoint) &&
 	(cur.mask & c->lookup_mask) &&
 	c->check_glyph_property (&cur, c->lookup_props))
-      ret |= accel.apply (c, false);
+      ret |= apply_func (&accel, c);
 
     /* The reverse lookup doesn't "advance" cursor (for good reason). */
     buffer->idx--;

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -1924,12 +1924,13 @@ struct GPOSProxy
 };
 
 
-template <OT::hb_ot_layout_lookup_accelerator_t::apply_func_t Apply>
-HB_NEVER_INLINE
-static bool
-apply_forward_impl (OT::hb_ot_apply_context_t *c,
-		    const OT::hb_ot_layout_lookup_accelerator_t &accel)
+static inline bool
+apply_forward (OT::hb_ot_apply_context_t *c,
+	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
 {
+  bool use_hot_subtable_cache = accel.cache_enter (c);
+  auto apply_func = accel.get_apply_func (use_hot_subtable_cache);
+
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
   while (buffer->successful)
@@ -1946,44 +1947,11 @@ apply_forward_impl (OT::hb_ot_apply_context_t *c,
     if (buffer->idx >= buffer->len)
       break;
 
-    if (Apply (&accel, c))
+    if (apply_func (&accel, c))
       ret = true;
     else
       (void) buffer->next_glyph ();
   }
-
-  return ret;
-}
-
-static inline bool
-apply_forward (OT::hb_ot_apply_context_t *c,
-	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
-{
-  using accelerator_t = OT::hb_ot_layout_lookup_accelerator_t;
-
-  bool use_hot_subtable_cache = accel.cache_enter (c);
-  auto apply_func = accel.get_apply_func (use_hot_subtable_cache);
-
-  bool ret;
-  if (apply_func == accelerator_t::apply_one)
-    ret = apply_forward_impl<accelerator_t::apply_one> (c, accel);
-#ifdef HB_NO_OT_LAYOUT_LOOKUP_CACHE
-  else
-  {
-    assert (apply_func == accelerator_t::apply_many);
-    ret = apply_forward_impl<accelerator_t::apply_many> (c, accel);
-  }
-#else
-  else if (apply_func == accelerator_t::apply_many)
-    ret = apply_forward_impl<accelerator_t::apply_many> (c, accel);
-  else if (apply_func == accelerator_t::apply_cached_one)
-    ret = apply_forward_impl<accelerator_t::apply_cached_one> (c, accel);
-  else
-  {
-    assert (apply_func == accelerator_t::apply_cached_many);
-    ret = apply_forward_impl<accelerator_t::apply_cached_many> (c, accel);
-  }
-#endif
 
   if (use_hot_subtable_cache)
     accel.cache_leave (c);
@@ -1991,12 +1959,12 @@ apply_forward (OT::hb_ot_apply_context_t *c,
   return ret;
 }
 
-template <OT::hb_ot_layout_lookup_accelerator_t::apply_func_t Apply>
-HB_NEVER_INLINE
-static bool
-apply_backward_impl (OT::hb_ot_apply_context_t *c,
-		     const OT::hb_ot_layout_lookup_accelerator_t &accel)
+static inline bool
+apply_backward (OT::hb_ot_apply_context_t *c,
+	       const OT::hb_ot_layout_lookup_accelerator_t &accel)
 {
+  auto apply_func = accel.get_apply_func (false);
+
   bool ret = false;
   hb_buffer_t *buffer = c->buffer;
   do
@@ -2005,27 +1973,13 @@ apply_backward_impl (OT::hb_ot_apply_context_t *c,
     if (accel.digest.may_have (cur.codepoint) &&
 	(cur.mask & c->lookup_mask) &&
 	c->check_glyph_property (&cur, c->lookup_props))
-      ret |= Apply (&accel, c);
+      ret |= apply_func (&accel, c);
 
     /* The reverse lookup doesn't "advance" cursor (for good reason). */
     buffer->idx--;
   }
   while ((int) buffer->idx >= 0);
   return ret;
-}
-
-static inline bool
-apply_backward (OT::hb_ot_apply_context_t *c,
-		const OT::hb_ot_layout_lookup_accelerator_t &accel)
-{
-  using accelerator_t = OT::hb_ot_layout_lookup_accelerator_t;
-
-  auto apply_func = accel.get_apply_func (false);
-  if (apply_func == accelerator_t::apply_one)
-    return apply_backward_impl<accelerator_t::apply_one> (c, accel);
-
-  assert (apply_func == accelerator_t::apply_many);
-  return apply_backward_impl<accelerator_t::apply_many> (c, accel);
 }
 
 template <typename Proxy>

--- a/src/hb-ot-layout.cc
+++ b/src/hb-ot-layout.cc
@@ -2048,7 +2048,9 @@ inline void hb_ot_map_t::apply (const Proxy &proxy,
 	  !buffer->message (font, "start lookup %u feature '%c%c%c%c'", lookup_index, HB_UNTAG (lookup.feature_tag))) continue;
 
       /* Only try applying the lookup if there is any overlap. */
-      if (accel->digest.may_intersect (buffer->digest))
+      if (accel->digest.may_intersect (buffer->digest) &&
+	  ((buffer->flags & HB_BUFFER_FLAG_PRODUCE_UNSAFE_TO_CONCAT) ||
+	   accel->digest_second.may_intersect (buffer->digest)))
       {
 	c.set_lookup_index (lookup_index);
 	c.set_lookup_mask (lookup.mask, false);


### PR DESCRIPTION
## Summary

This follows up on the optimization ideas explored in [HarfRust PR #463](https://github.com/harfbuzz/harfrust/pull/463).

Add a conservative `digest_second` to each GSUB/GPOS lookup accelerator. It summarizes glyphs that can occupy the lookup's second constrained position: for mark positioning these are the possible bases, and for pair/context/ligature lookups they are the next relevant input. Before scanning a lookup, reject it if either its existing first-glyph digest or its second-glyph digest cannot intersect the buffer digest.

Formats without a useful second-glyph constraint use a full digest. The new rejection is disabled under `HB_BUFFER_FLAG_PRODUCE_UNSAFE_TO_CONCAT`, since skipping the lookup would otherwise suppress observable unsafe-to-concat marking. The existing first-glyph rejection remains active.

The PR also removes an unused `lookup_accel` field exposed while testing the alternatives.

## Experiments

The experiments came from the HarfRust PR #463 review:

- The two applicable non-lookup pass fusions were handled separately and merged in [PR #6231](https://github.com/harfbuzz/harfbuzz/pull/6231).
- Hoisting `count == 1` / `use_cache` selection into a per-lookup apply function was a net slowdown and was reverted.
- Template-specializing forward/backward traversal by apply function did not justify its performance and binary-size cost and was reverted.
- Caching the applicable subtable index with `hb_cache_t<12, 3, 7>`, tested for multi-subtable lookups and for `count > 4`, regressed performance and was reverted.
- `digest_second` was the only lookup optimization that paid off, so it is the only one retained.

The reverted experiment commits remain in the branch history for reference; the final diff contains none of their code.

## Performance

User-supplied before/after shaping benchmarks showed an overall geomean change of **-9.23% wall time / -9.25% CPU time**. The strongest cases improved by 20–30%; a few complex Arabic cases were neutral or regressed by up to 2.6%.

## Testing

- `meson compile -C build harfbuzz`
- `meson test -C build test-buffer test-shape in-house aots --print-errorlogs`
  - 25 buffer, 4 shape, 800 AOTS, and 7,272 in-house subtests passed
- Re-ran the AOTS and in-house corpora without the harness-injected `--unsafe-to-concat`, exercising the new rejection path; no failures
