### PR TITLE
OT: Cache first-input classes per contextual RuleSet

### DIFF
--- a/src/hb-ot-layout-gsubgpos.hh
+++ b/src/hb-ot-layout-gsubgpos.hh
@@ -1579,6 +1579,19 @@ typedef bool (*intersects_func_t) (const hb_set_t *glyphs, unsigned value, const
 typedef void (*intersected_glyphs_func_t) (const hb_set_t *glyphs, const void *data, unsigned value, hb_set_t *intersected_glyphs, void *cache);
 typedef void (*collect_glyphs_func_t) (hb_set_t *glyphs, unsigned value, const void *data);
 typedef bool (*match_func_t) (hb_glyph_info_t &info, unsigned value, const void *data);
+typedef unsigned (*get_value_func_t) (hb_glyph_info_t &info, const void *data);
+
+/* One word per RuleSet, summarizing the classes accepted at the first
+ * input position after the current glyph.  Collisions only cause extra work. */
+struct hb_ot_layout_ruleset_digest_t
+{
+  void init () { mask = 0; }
+  void set_full () { mask = (uint64_t) -1; }
+  void add (unsigned value) { mask |= (uint64_t) 1 << (value & 63); }
+  bool may_have (unsigned value) const { return mask & ((uint64_t) 1 << (value & 63)); }
+
+  uint64_t mask;
+};
 
 struct ContextClosureFuncs
 {
@@ -1782,6 +1795,11 @@ static inline bool match_class (hb_glyph_info_t &info, unsigned value, const voi
   const ClassDef &class_def = *reinterpret_cast<const ClassDef *>(data);
   return class_def.get_class (info.codepoint) == value;
 }
+static inline unsigned get_class_value (hb_glyph_info_t &info, const void *data)
+{
+  const ClassDef &class_def = *reinterpret_cast<const ClassDef *> (data);
+  return class_def.get_class (info.codepoint);
+}
 struct match_class_cache_data_t
 {
   const ClassDef *class_def;
@@ -1791,6 +1809,11 @@ static inline bool match_class_cache (hb_glyph_info_t &info, unsigned value, con
 {
   const auto &cache_data = *reinterpret_cast<const match_class_cache_data_t *> (data);
   return cache_data.class_def->get_class (info.codepoint, cache_data.cache) == value;
+}
+static inline unsigned get_class_cache_value (hb_glyph_info_t &info, const void *data)
+{
+  const auto &cache_data = *reinterpret_cast<const match_class_cache_data_t *> (data);
+  return cache_data.class_def->get_class (info.codepoint, cache_data.cache);
 }
 static inline unsigned get_class_cached (const ClassDef &class_def, hb_glyph_info_t &info)
 {
@@ -1806,6 +1829,11 @@ static inline bool match_class_cached (hb_glyph_info_t &info, unsigned value, co
 {
   const ClassDef &class_def = *reinterpret_cast<const ClassDef *>(data);
   return get_class_cached (class_def, info) == value;
+}
+static inline unsigned get_class_cached_value (hb_glyph_info_t &info, const void *data)
+{
+  const ClassDef &class_def = *reinterpret_cast<const ClassDef *> (data);
+  return get_class_cached (class_def, info);
 }
 static inline unsigned get_class_cached1 (const ClassDef &class_def, hb_glyph_info_t &info)
 {
@@ -1836,6 +1864,11 @@ static inline bool match_class_cached2 (hb_glyph_info_t &info, unsigned value, c
 {
   const ClassDef &class_def = *reinterpret_cast<const ClassDef *>(data);
   return get_class_cached2 (class_def, info) == value;
+}
+static inline unsigned get_class_cached2_value (hb_glyph_info_t &info, const void *data)
+{
+  const ClassDef &class_def = *reinterpret_cast<const ClassDef *> (data);
+  return get_class_cached2 (class_def, info);
 }
 static inline bool match_coverage (hb_glyph_info_t &info, unsigned value, const void *data)
 {
@@ -2826,6 +2859,7 @@ struct ContextApplyLookupContext
 {
   ContextApplyFuncs funcs;
   const void *match_data;
+  get_value_func_t get_value;
 };
 
 template <typename HBUINT>
@@ -3204,6 +3238,21 @@ struct RuleSet
     ;
   }
 
+  void collect_first_input_classes (hb_ot_layout_ruleset_digest_t *digest) const
+  {
+    digest->init ();
+    for (unsigned i = 0; i < rule.len; i++)
+    {
+      const Rule &r = this+rule.arrayZ[i];
+      if (r.inputCount <= 1)
+      {
+	digest->set_full ();
+	return;
+      }
+      digest->add (r.inputZ.arrayZ[0]);
+    }
+  }
+
   void depend (hb_depend_context_t *c, unsigned value, ContextDependLookupContext &lookup_context) const
   {
     + hb_iter (rule)
@@ -3265,7 +3314,8 @@ struct RuleSet
   }
 
   bool apply (hb_ot_apply_context_t *c,
-	      const ContextApplyLookupContext &lookup_context) const
+	      const ContextApplyLookupContext &lookup_context,
+	      const hb_ot_layout_ruleset_digest_t *digest = nullptr) const
   {
     TRACE_APPLY (this);
 
@@ -3313,6 +3363,13 @@ struct RuleSet
 
       first = &c->buffer->info[skippy_iter.idx];
       unsafe_to1 = skippy_iter.idx + 1;
+
+      if (digest && lookup_context.get_value &&
+	  !digest->may_have (lookup_context.get_value (*first, lookup_context.match_data)))
+	{
+	  c->buffer->unsafe_to_concat (c->buffer->idx, unsafe_to1);
+	  return_trace (false);
+	}
     }
     else
     {
@@ -3811,13 +3868,20 @@ struct ContextFormat2_5
   struct external_cache_t
   {
     hb_ot_layout_binary_cache_t coverage;
+    hb_ot_layout_ruleset_digest_t rule_sets[HB_VAR_ARRAY];
   };
   void *external_cache_create () const
   {
-    external_cache_t *cache = (external_cache_t *) hb_malloc (sizeof (external_cache_t));
+    unsigned count = ruleSet.len;
+    unsigned size = sizeof (external_cache_t) -
+		    HB_VAR_ARRAY * sizeof (hb_ot_layout_ruleset_digest_t) +
+		    count * sizeof (hb_ot_layout_ruleset_digest_t);
+    external_cache_t *cache = (external_cache_t *) hb_malloc (size);
     if (likely (cache))
     {
       cache->coverage.clear ();
+      for (unsigned i = 0; i < count; i++)
+	(this+ruleSet[i]).collect_first_input_classes (&cache->rule_sets[i]);
     }
     return cache;
   }
@@ -3838,12 +3902,18 @@ struct ContextFormat2_5
 
     struct ContextApplyLookupContext lookup_context = {
       {cached ? match_class_cached : match_class},
-      &class_def
+      &class_def,
+      cached ? get_class_cached_value : get_class_value
     };
 
     index = cached ? get_class_cached (class_def, c->buffer->cur()) : class_def.get_class (c->buffer->cur().codepoint);
     const RuleSet &rule_set = this+ruleSet[index];
-    return_trace (rule_set.apply (c, lookup_context));
+#ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+    const hb_ot_layout_ruleset_digest_t *digest = cache && index < ruleSet.len ? &cache->rule_sets[index] : nullptr;
+#else
+    const hb_ot_layout_ruleset_digest_t *digest = nullptr;
+#endif
+    return_trace (rule_set.apply (c, lookup_context, digest));
   }
 
   bool subset (hb_subset_context_t *c) const
@@ -4171,6 +4241,7 @@ struct ChainContextApplyLookupContext
 {
   ChainContextApplyFuncs funcs;
   const void *match_data[3];
+  get_value_func_t get_input_value;
 };
 
 template <typename HBUINT>
@@ -4754,6 +4825,22 @@ struct ChainRuleSet
     | hb_any
     ;
   }
+
+  void collect_first_input_classes (hb_ot_layout_ruleset_digest_t *digest) const
+  {
+    digest->init ();
+    for (unsigned i = 0; i < rule.len; i++)
+    {
+      const ChainRule &r = this+rule.arrayZ[i];
+      const auto &input = StructAfter<decltype (r.inputX)> (r.backtrack);
+      if (input.lenP1 <= 1)
+      {
+	digest->set_full ();
+	return;
+      }
+      digest->add (input.arrayZ[0]);
+    }
+  }
   void depend (hb_depend_context_t *c, unsigned value, ChainContextDependLookupContext &lookup_context) const
   {
     + hb_iter (rule)
@@ -4815,7 +4902,8 @@ struct ChainRuleSet
   }
 
   bool apply (hb_ot_apply_context_t *c,
-	      const ChainContextApplyLookupContext &lookup_context) const
+	      const ChainContextApplyLookupContext &lookup_context,
+	      const hb_ot_layout_ruleset_digest_t *digest = nullptr) const
   {
     TRACE_APPLY (this);
 
@@ -4863,6 +4951,13 @@ struct ChainRuleSet
 
       first = &c->buffer->info[skippy_iter.idx];
       unsafe_to1 = skippy_iter.idx + 1;
+
+      if (digest && lookup_context.get_input_value &&
+	  !digest->may_have (lookup_context.get_input_value (*first, lookup_context.match_data[1])))
+	{
+	  c->buffer->unsafe_to_concat (c->buffer->idx, unsafe_to1);
+	  return_trace (false);
+	}
     }
     else
     {
@@ -5413,15 +5508,22 @@ struct ChainContextFormat2_5
     hb_ot_layout_binary_cache_t coverage;
     hb_ot_layout_mapping_cache_t input_class;
     hb_ot_layout_mapping_cache_t lookahead_class;
+    hb_ot_layout_ruleset_digest_t rule_sets[HB_VAR_ARRAY];
   };
   void *external_cache_create () const
   {
-    external_cache_t *cache = (external_cache_t *) hb_malloc (sizeof (external_cache_t));
+    unsigned count = ruleSet.len;
+    unsigned size = sizeof (external_cache_t) -
+		    HB_VAR_ARRAY * sizeof (hb_ot_layout_ruleset_digest_t) +
+		    count * sizeof (hb_ot_layout_ruleset_digest_t);
+    external_cache_t *cache = (external_cache_t *) hb_malloc (size);
     if (likely (cache))
     {
       cache->coverage.clear ();
       cache->input_class.clear ();
       cache->lookahead_class.clear ();
+      for (unsigned i = 0; i < count; i++)
+	(this+ruleSet[i]).collect_first_input_classes (&cache->rule_sets[i]);
     }
     return cache;
   }
@@ -5474,14 +5576,16 @@ struct ChainContextFormat2_5
         cached ? match_class_cached1 : match_class_cache}},
       {backtrack_match_data,
        input_match_data,
-       lookahead_match_data}
+       lookahead_match_data},
+      cached ? get_class_cached2_value : get_class_cache_value
 #else
       {{cached && &backtrack_class_def == &lookahead_class_def ? match_class_cached1 : match_class,
         cached ? match_class_cached2 : match_class,
         cached ? match_class_cached1 : match_class}},
       {&backtrack_class_def,
        &input_class_def,
-       &lookahead_class_def}
+       &lookahead_class_def},
+      cached ? get_class_cached2_value : get_class_value
 #endif
     };
 
@@ -5495,7 +5599,12 @@ struct ChainContextFormat2_5
           : input_class_def.get_class (c->buffer->cur().codepoint);
 #endif
     const ChainRuleSet &rule_set = this+ruleSet[index];
-    return_trace (rule_set.apply (c, lookup_context));
+#ifndef HB_NO_OT_LAYOUT_LOOKUP_CACHE
+    const hb_ot_layout_ruleset_digest_t *digest = cache && index < ruleSet.len ? &cache->rule_sets[index] : nullptr;
+#else
+    const hb_ot_layout_ruleset_digest_t *digest = nullptr;
+#endif
+    return_trace (rule_set.apply (c, lookup_context, digest));
   }
 
   bool subset (hb_subset_context_t *c) const


### PR DESCRIPTION
This ports the contextual RuleSet-summary experiment from harfbuzz/harfrust#463.

Format-2 contextual lookups select a RuleSet by the current glyph's class, but can then walk hundreds or thousands of rules whose first input class does not match the next glyph. This adds one compact 64-bit class mask per RuleSet to the subtable's existing external-cache allocation. After finding the next non-skipped glyph, a definite mask miss rejects the whole RuleSet before reading its rule offsets.

Rules without another input position force the mask open. Hash collisions only cause the normal rule walk. A rejection records the same `unsafe_to_concat` range as the existing fast path, and allocation failure falls back to the uncached path.

Performance, before to after:

| Benchmark | Time | CPU |
|---|---:|---:|
| Roboto prince | +0.75% | +0.72% |
| Roboto words | -0.02% | -0.03% |
| Source Serif | +0.65% | +0.63% |
| Noto Sans Devanagari | -0.75% | -0.76% |
| Amiri | -0.26% | -0.30% |
| Noto Nastaliq prince | **-12.58%** | **-12.64%** |
| Noto Nastaliq words | **-8.52%** | **-8.49%** |
| Gulzar prince | -2.00% | -2.03% |
| Gulzar words | -0.95% | -0.99% |
| Noto Sans Duployan | -0.92% | -0.88% |
| **Overall geomean** | **-2.55%** | **-2.57%** |

Correctness checks:

- Full Meson test suite: 274/274 passed.
- Branch and `origin/main` produced byte-identical shaping output, including glyph flags, for all ten benchmark corpora.
- C++11 compilation passed with `HB_NO_OT_LAYOUT_LOOKUP_CACHE`, `HB_NO_OT_RULESETS_FAST_PATH`, and `HB_OPTIMIZE_SIZE` configurations.
