### PR TITLE
[fontations] Use COLRv1 clip boxes for glyph extents

### DIFF
--- a/src/rust/font.rs
+++ b/src/rust/font.rs
@@ -404,15 +404,18 @@ extern "C" fn _hb_fontations_get_glyph_extents(
 
     let glyph_id = GlyphId::new(glyph);
 
-    // COLRv1 color glyphs are not supported by glyph_metrics.
     let color_glyphs = &data.color_glyphs;
-    if color_glyphs.get(glyph_id).is_some() {
-        return false as hb_bool_t;
-    };
-
-    let glyph_metrics = &data.glyph_metrics.as_ref().unwrap();
-    let Some(glyph_extents) = glyph_metrics.bounds(glyph_id) else {
-        return false as hb_bool_t;
+    let glyph_extents = if let Some(color_glyph) = color_glyphs.get(glyph_id) {
+        let Some(glyph_extents) = color_glyph.bounding_box(&data.location, data.size) else {
+            return false as hb_bool_t;
+        };
+        glyph_extents
+    } else {
+        let glyph_metrics = &data.glyph_metrics.as_ref().unwrap();
+        let Some(glyph_extents) = glyph_metrics.bounds(glyph_id) else {
+            return false as hb_bool_t;
+        };
+        glyph_extents
     };
 
     let x_bearing = (glyph_extents.x_min * data.x_mult).round() as hb_position_t;


### PR DESCRIPTION
Fontations currently declines glyph extents for every color glyph because
`GlyphMetrics` does not support COLRv1. HarfBuzz then computes painted-content
bounds, which can differ from an explicit COLRv1 ClipBox.

Use Skrifa's resolved `ColorGlyph::bounding_box()` when a clip box is present.
Returning false when it is absent preserves HarfBuzz's existing paint fallback
for COLRv0 and unbounded COLRv1 glyphs.

Tests:

- `HB_FONT_FUNCS=fontations meson test -C build --no-rebuild test-extents`
- `meson test -C build --no-rebuild` (273 passed, 1 skipped)
