### PR TITLE
[USE] Update the data files for Unicode 18.0

### DIFF
--- a/src/gen-use-table.py
+++ b/src/gen-use-table.py
@@ -408,7 +408,7 @@ def map_to_use(data):
 		if U in [0x11302, 0x11303, 0x114C1]: UIPC = Top
 
 		assert (UIPC in [Not_Applicable, Visual_Order_Left] or
-			U in {0x0F7F, 0x11A3A} or
+			U == 0x0F7F or
 			USE in use_positions), "%s %s %s %s %s %s %s" % (hex(U), UIPC, USE, UISC, UDI, UGC, AJT)
 
 		pos_mapping = use_positions.get(USE, None)

--- a/src/hb-ot-shaper-use-table.hh
+++ b/src/hb-ot-shaper-use-table.hh
@@ -28,6 +28,8 @@
  * # Updated for Unicode 15.0 by Andrew Glass 2022-09-16
  * # Updated for Unicode 15.1 by Andrew Glass 2023-09-14
  * # Updated for Unicode 16.0 by Andrew Glass 2024-09-11
+ * # Updated for Unicode 17.0 by Andrew Glass 2025-09-15
+ * # Updated for Unicode 18.0 by Andrew Glass 2026-09-04
  * # Override values For Indic_Positional_Category
  * # Not derivable
  * # Initial version based on Unicode 7.0 by Andrew Glass 2014-03-17
@@ -40,6 +42,8 @@
  * # Updated for Unicode 15.0 by Andrew Glass 2022-09-16
  * # Updated for Unicode 15.1 by Andrew Glass 2023-09-14
  * # Updated for Unicode 16.0 by Andrew Glass 2024-09-11
+ * # Updated for Unicode 17.0 by Andrew Glass 2025-09-15
+ * # Updated for Unicode 18.0 by Andrew Glass 2026-09-04
  * UnicodeData.txt does not have a header.
  */
 

--- a/src/ms-use/IndicPositionalCategory-Additional.txt
+++ b/src/ms-use/IndicPositionalCategory-Additional.txt
@@ -10,6 +10,8 @@
 # Updated for Unicode 15.0 by Andrew Glass 2022-09-16
 # Updated for Unicode 15.1 by Andrew Glass 2023-09-14
 # Updated for Unicode 16.0 by Andrew Glass 2024-09-11
+# Updated for Unicode 17.0 by Andrew Glass 2025-09-15
+# Updated for Unicode 18.0 by Andrew Glass 2026-09-04
 
 # ================================================
 # ================================================
@@ -54,7 +56,7 @@ AA35          ; Top     # Mn       CHAM CONSONANT SIGN
 AAB4          ; Top     # Mn       TAI VIET VOWEL U # Override: ccc controls order, USE issue #58
 1112A..1112B  ; Top     # Mn   [2] CHAKMA VOWEL SIGN U..CHAKMA VOWEL SIGN UU  # see USE issue #25
 11131..11132  ; Top     # Mn   [2] CHAKMA O MARK..CHAKMA AU MARK  # see USE issue #25
-1E4EC..1E4EF  ; Top     # Mn   [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH # 1E4EE is below, but made to for ccc 
+1E4EC..1E4EF  ; Top     # Mn   [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH # 1E4EE is below, but made to for ccc
 
 # ================================================
 
@@ -100,7 +102,7 @@ AAB4          ; Top     # Mn       TAI VIET VOWEL U # Override: ccc controls ord
 07EB..07F3    ; Top   # Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
 07FD          ; Top   # Mn       NKO DANTAYALAN # Not really top, but assigned here to allow ccc to control mark order
 1885..1886    ; Top   # Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
-1B6C          ; Top   # Mn       BALINESE MUSICAL SYMBOL COMBINING ENDEP 
+1B6C          ; Top   # Mn       BALINESE MUSICAL SYMBOL COMBINING ENDEP
 1CF8..1CF9    ; Top   # Mn   [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
 10D24..10D27  ; Top   # Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
 10EAB..10EAC  ; Top   # Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK

--- a/src/ms-use/IndicSyllabicCategory-Additional.txt
+++ b/src/ms-use/IndicSyllabicCategory-Additional.txt
@@ -8,12 +8,14 @@
 # Updated for Unicode 15.0 by Andrew Glass 2022-09-16
 # Updated for Unicode 15.1 by Andrew Glass 2023-09-14
 # Updated for Unicode 16.0 by Andrew Glass 2024-09-11
+# Updated for Unicode 17.0 by Andrew Glass 2025-09-15
+# Updated for Unicode 18.0 by Andrew Glass 2026-09-04
 
 # ================================================
 # OVERRIDES TO ASSIGNED VALUES
 # ================================================
 
-# Indic_Syllabic_Category=Bindu  
+# Indic_Syllabic_Category=Bindu
 193A          ; Bindu  # Mn       LIMBU SIGN KEMPHRENG
 AA29          ; Bindu  # Mn       CHAM VOWEL SIGN AA
 10A0D         ; Bindu  # Mn       KHAROSHTHI SIGN DOUBLE RING BELOW
@@ -32,11 +34,6 @@ AA29          ; Bindu  # Mn       CHAM VOWEL SIGN AA
 
 # ================================================
 
-# Indic_Syllabic_Category=Consonant_With_Stacker
-11A3A         ; Consonant_With_Stacker # Lo   ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
-
-# ================================================
-
 # Indic_Syllabic_Category=Consonant_Subjoined
 11A3B..11A3E  ; Consonant_Subjoined # Mn [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
 
@@ -47,12 +44,12 @@ AA29          ; Bindu  # Mn       CHAM VOWEL SIGN AA
 
 # ================================================
 
-# Indic_Syllabic_Category=Gemination_Mark 
+# Indic_Syllabic_Category=Gemination_Mark
 11134         ; Gemination_Mark  # Mc      CHAKMA MAAYYAA
 
 # ================================================
 
-# Indic_Syllabic_Category=Nukta   
+# Indic_Syllabic_Category=Nukta
 0F71          ; Nukta            # Mn       TIBETAN VOWEL SIGN AA # Reassigned to get this before an above vowel, but see #22
 113CF         ; Nukta            # Mc       TULU-TIGALARI SIGN LOOPED VIRAMA
 
@@ -114,7 +111,7 @@ AABD          ; Vowel_Independent # Lo       TAI VIET VOWEL AN
 18B00..18CD5  ; Consonant # Lo  [470] KHITAN SMALL SCRIPT CHARACTER-18B00..KHITAN SMALL SCRIPT CHARACTER-18CD5
 18CFF         ; Consonant # Lo        KHITAN SMALL SCRIPT CHARACTER-18CFF
 1BC00..1BC6A  ; Consonant # Lo  [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
-1BC70..1BC7C  ; Consonant # Lo   [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK 
+1BC70..1BC7C  ; Consonant # Lo   [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
 1BC80..1BC88  ; Consonant # Lo    [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
 1BC90..1BC99  ; Consonant # Lo   [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
 1E100..1E12C  ; Consonant # Lo   [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
@@ -259,7 +256,7 @@ FE00..FE0F    ; Modifying_Letter  # Mn  [16] VARIATION SELECTOR-1..VARIATION SEL
 # ================================================
 
 # USE, Extended_Syllabic_Category=Hieroglyph_Segment_End
-13438        ; Hieroglyph_Segment_End    # Cf  EGYPTIAN HIEROGLYPH END SEGMENT 
+13438        ; Hieroglyph_Segment_End    # Cf  EGYPTIAN HIEROGLYPH END SEGMENT
 
 # ================================================
 


### PR DESCRIPTION
This uses the data files from <https://github.com/microsoft/font-tools/tree/9dcd14bcc9d9bb634b813fe06e1aaa2bc0209a7d/USE> and closes #6236. The only substantive change is the removal of U+11A3A ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA’s override to Consonant_With_Stacker, which has no practical effect on HarfBuzz because that has already been its value since Unicode 17.0.