### PR TITLE
[cmake] Compile core sources individually

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Configure CMake
         run: |
           cmake -S . -B build \
+            -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_TOOLCHAIN_FILE=${DEVKITPRO}/cmake/3DS.cmake
       - name: Build
         run: make CXX_FLAGS="-w -DHB_NO_MT"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,17 @@ set (HB_VERSION_MINOR ${CMAKE_MATCH_3})
 set (HB_VERSION_MICRO ${CMAKE_MATCH_4})
 
 ## Define sources and headers of the project
-set (project_sources ${PROJECT_SOURCE_DIR}/src/harfbuzz.cc) # use amalgam source
+# Keep sources in separate archive members so duplicate internal sources in
+# dependent static libraries do not result in multiple definitions.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+             ${PROJECT_SOURCE_DIR}/src/harfbuzz.cc)
+file(STRINGS ${PROJECT_SOURCE_DIR}/src/harfbuzz.cc project_source_includes
+     REGEX "^#include \".*\\.cc\"$")
+foreach (project_source_include IN LISTS project_source_includes)
+  string(REGEX REPLACE "^#include \"(.*\\.cc)\"$" "\\1"
+         project_source ${project_source_include})
+  list(APPEND project_sources ${PROJECT_SOURCE_DIR}/src/${project_source})
+endforeach ()
 set (subset_project_sources
      ${PROJECT_SOURCE_DIR}/src/hb-number.cc
      ${PROJECT_SOURCE_DIR}/src/hb-number.hh


### PR DESCRIPTION
CMake currently builds `libharfbuzz` from the amalgamated
`harfbuzz.cc`, while auxiliary libraries compile overlapping internal
sources separately. This places all core definitions in one static
archive member. A normal link of `libharfbuzz-subset.a` followed by
`libharfbuzz.a` therefore pulls duplicate internal definitions into
the final link.

Derive the core source list from the generated `harfbuzz.cc` includes
and compile each source separately. This matches the Meson archive
layout and allows the static linker to select only the required archive
members. Changes to `harfbuzz.cc` trigger CMake reconfiguration so the
list remains synchronized.

Fixes #5683

## Testing

- Built all default CMake libraries with `BUILD_SHARED_LIBS=OFF`.
- Linked and ran a static core/subset consumer in normal dependency
  order (`libharfbuzz-subset.a libharfbuzz.a`).
- Built all default CMake libraries with `BUILD_SHARED_LIBS=ON` and
  linked and ran a shared core/subset consumer.
- Ran `meson test -C build`: 273 passed, 1 skipped, 0 failed.
