### PR TITLE
[limits] Restore rendering budget test runtime

### DIFF
--- a/src/hb-limits.hh
+++ b/src/hb-limits.hh
@@ -186,7 +186,7 @@
 /* The common finite default for one top-level glyph rendering session.
  * Nested outline and paint work shares the same live counter. */
 #ifndef HB_BUDGET_GLYPH
-#define HB_BUDGET_GLYPH ((int64_t) 1 << 26)
+#define HB_BUDGET_GLYPH ((int64_t) 1 << 24)
 #endif
 
 /* Precharge COST * MULT.  Callers bound COST and MULT structurally, and live
@@ -198,11 +198,14 @@ hb_budget_spend (int64_t &budget, unsigned int cost, unsigned int mult = 1)
   return budget >= 0;
 }
 
-/* One raster paint session (everything painted between two
- * render/clear calls), in pixel-op units; pixel loops charge their
- * area, consumed outline segments are charged with a fixed weight.  Its
- * default is the larger of HB_BUDGET_GLYPH and this many full-surface
- * passes, so very large surfaces still get a few full-surface operations. */
+/* The flat pixel-work floor for one raster paint session.  Pixel and
+ * outline work use separate live counters, so keep this independent of
+ * the common outline budget above. */
+#ifndef HB_BUDGET_RASTER_PIXELS
+#define HB_BUDGET_RASTER_PIXELS ((int64_t) 1 << 26)
+#endif
+
+/* Very large raster surfaces still get a few full-surface operations. */
 #ifndef HB_BUDGET_RASTER_PAINT_PASSES
 #define HB_BUDGET_RASTER_PAINT_PASSES 4
 #endif

--- a/src/hb-raster-draw.cc
+++ b/src/hb-raster-draw.cc
@@ -527,6 +527,17 @@ hb_raster_draw_set_clip_box (hb_raster_draw_t *draw,
   hb_raster_draw_update_flatten_clip (draw);
 }
 
+int64_t
+hb_raster_draw_get_pixel_work (const hb_raster_draw_t *draw,
+			       unsigned int max_rows)
+{
+  int64_t work = 0;
+  for (const auto &edge : draw->edges)
+    work += 1 + hb_min (((int64_t) edge.yH - edge.yL) >> HB_RASTER_PIXEL_BITS,
+		       (int64_t) max_rows);
+  return work;
+}
+
 /**
  * hb_raster_draw_recycle_image:
  * @draw: a rasterizer

--- a/src/hb-raster-paint.cc
+++ b/src/hb-raster-paint.cc
@@ -284,6 +284,13 @@ hb_raster_paint_finalize_path_clip (hb_raster_paint_t *c,
 				    hb_raster_image_t *surf,
 				    unsigned w, unsigned h)
 {
+  if (unlikely (!c->precharge_work (hb_raster_draw_get_pixel_work (rdr, h))))
+  {
+    hb_raster_draw_clear (rdr);
+    hb_raster_paint_push_empty_clip (c, w, h);
+    return;
+  }
+
   hb_raster_image_t *mask_img = hb_raster_draw_render (rdr);
 
   if (unlikely (!mask_img))
@@ -946,6 +953,13 @@ hb_raster_paint_fill_glyph (hb_paint_funcs_t *pfuncs HB_UNUSED,
   hb_raster_paint_glyph_clip_data_t data = {glyph, font};
   hb_raster_paint_emit_clip_glyph_mask (rdr, &data);
   hb_raster_paint_readback_budget (c, rdr);
+
+  if (unlikely (!c->precharge_work (hb_raster_draw_get_pixel_work (rdr,
+							  surf->extents.height))))
+  {
+    hb_raster_draw_clear (rdr);
+    return;
+  }
 
   hb_raster_image_t *mask_img = hb_raster_draw_render (rdr);
   if (unlikely (!mask_img)) return;

--- a/src/hb-raster-paint.hh
+++ b/src/hb-raster-paint.hh
@@ -144,13 +144,13 @@ struct hb_raster_paint_t
    *    an unlimited outline policy disables it too. */
   int64_t budget = HB_BUDGET_DEFAULT;
   int64_t budget_remaining = HB_BUDGET_GLYPH;
-  int64_t pixel_remaining = HB_BUDGET_GLYPH;
+  int64_t pixel_remaining = HB_BUDGET_RASTER_PIXELS;
 
   /* Helpers */
 
   int64_t get_default_pixel_budget () const
   {
-    return hb_max ((int64_t) HB_BUDGET_GLYPH,
+    return hb_max ((int64_t) HB_BUDGET_RASTER_PIXELS,
 		   (int64_t) HB_BUDGET_RASTER_PAINT_PASSES *
 		   fixed_extents.width * fixed_extents.height);
   }
@@ -161,7 +161,7 @@ struct hb_raster_paint_t
 		       (int64_t) HB_BUDGET_GLYPH : budget;
     pixel_remaining = budget == HB_BUDGET_UNLIMITED ? budget :
 		      (surface_stack.length ? get_default_pixel_budget () :
-					      (int64_t) HB_BUDGET_GLYPH);
+					      (int64_t) HB_BUDGET_RASTER_PIXELS);
   }
 
   /* Returns whether the pixel operation should proceed.  Allows a single
@@ -169,6 +169,18 @@ struct hb_raster_paint_t
   bool charge_work (int64_t work)
   {
     if (unlikely (pixel_remaining < 0)) return false;
+    pixel_remaining -= work;
+    return true;
+  }
+
+  /* Reject work that would exceed the remaining budget before it starts. */
+  bool precharge_work (int64_t work)
+  {
+    if (unlikely (pixel_remaining < work))
+    {
+      pixel_remaining = -1;
+      return false;
+    }
     pixel_remaining -= work;
     return true;
   }

--- a/src/hb-raster.hh
+++ b/src/hb-raster.hh
@@ -40,6 +40,12 @@ hb_raster_draw_set_clip_box (hb_raster_draw_t *draw,
 			     float x0, float y0,
 			     float x1, float y1);
 
+/* Estimated scanline work for the accumulated edges.  Raster paint uses
+ * this to precharge its separate pixel budget before rendering a mask. */
+HB_INTERNAL int64_t
+hb_raster_draw_get_pixel_work (const hb_raster_draw_t *draw,
+			       unsigned int max_rows);
+
 /* Shared pixel helpers (used by paint and image compositing). */
 
 static HB_ALWAYS_INLINE uint8_t


### PR DESCRIPTION
## Problem

The unified glyph-work budget raised the effective outline allowance for
VARC, raster, vector, and GPU rendering to `1 << 26`. Pathological fuzz
inputs consume that full allowance, increasing the full test-suite runtime
from under three seconds to about six seconds.

Separately, splitting raster outline and pixel budgets stopped charging
scanline edge work before rendering. Complex COLR masks could therefore do
expensive edge sweeps before their rendered-mask area was charged.

## Fix

- Restore the common outline budget to `1 << 24`.
- Keep the raster pixel-work floor independently at `1 << 26`.
- Precharge estimated scanline work against the pixel budget before
  rendering a raster mask.

No public API or ABI changes are involved.

## Results

- Before: 6.00-6.02s
- After: 2.82-2.83s across three consecutive full-suite runs
- Tests: 276 passed, 1 skipped
