### PR TITLE
[ci] Ignore unused apt repositories

### DIFF
--- a/.github/workflows/c++-versions.yml
+++ b/.github/workflows/c++-versions.yml
@@ -39,6 +39,8 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install Dependencies
       run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt install -y ${{ matrix.PACKAGES }}
     - name: Build

--- a/.github/workflows/crossbuild-mingw.yml
+++ b/.github/workflows/crossbuild-mingw.yml
@@ -33,6 +33,8 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo dpkg --add-architecture i386
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt install -y \
           zip \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ jobs:
         key: ${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
     - name: Install Dependencies
       run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install \
           gcc \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,6 +23,8 @@ jobs:
         key: ${{ github.job }}-${{ runner.os }}-${{ runner.arch }}
     - name: Install Dependencies
       run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install \
           gcc \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
           rustfmt \
           clippy \
           --toolchain nightly-x86_64-unknown-linux-gnu
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install \
           gcc \

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -46,6 +46,8 @@ jobs:
       uses: hendrikmuhs/ccache-action@f09c25b45002a07be2955cbe52e8cee55643f89d # v1.2.24
     - name: Install Dependencies
       run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt install -y \
           clang \

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,6 +20,8 @@ jobs:
       uses: hendrikmuhs/ccache-action@f09c25b45002a07be2955cbe52e8cee55643f89d # v1.2.24
     - name: Install Dependencies
       run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt install -y \
           valgrind \


### PR DESCRIPTION
GitHub's Ubuntu runner includes Chrome and Microsoft apt repositories, but the
affected workflows install all of their packages from Ubuntu. When one of the
third-party repositories is mid-publish, `apt-get update` can fail with a hash
sum mismatch and take down otherwise unrelated jobs.

Remove both unused apt sources before refreshing package indexes in all seven
affected workflows. This follows googlefonts/fontations#2120.

Validation:

- parsed all workflow YAML files with PyYAML
- verified every `apt-get update` is preceded by both source removals
- `git diff --check`

The full test suite was not run because this is a CI-only configuration change.
