### PR TITLE
[util/gpu] Avoid use-after-free on current_text in rebuild_buffer

### DIFF
--- a/util/gpu/web/hb-gpu-web-webgpu.cc
+++ b/util/gpu/web/hb-gpu-web-webgpu.cc
@@ -289,10 +289,16 @@ static const char *arg_font = nullptr;
 static void
 rebuild_buffer (const char *text)
 {
-  /* strdup first -- text may alias current_text. */
-  char *new_text = strdup (text);
-  free (current_text);
-  current_text = new_text;
+  if (!text)
+    text = default_text_en;
+
+  if (text != current_text)
+  {
+    /* strdup first -- text may alias current_text. */
+    char *new_text = strdup (text);
+    free (current_text);
+    current_text = new_text;
+  }
 
   demo_font_clear_cache (current_demo_font);
   atlas_clear_cb (&atlas);
@@ -300,7 +306,8 @@ rebuild_buffer (const char *text)
   demo_buffer_clear (buffer);
   demo_point_t top_left = {0, 0};
   demo_buffer_move_to (buffer, &top_left);
-  demo_buffer_add_text (buffer, text, current_demo_font, 1);
+  if (current_text)
+    demo_buffer_add_text (buffer, current_text, current_demo_font, 1);
 
   atlas.dirty = true;
   demo_view_reset (vu);

--- a/util/gpu/web/hb-gpu-web.cc
+++ b/util/gpu/web/hb-gpu-web.cc
@@ -68,10 +68,16 @@ static bool custom_text;
 static void
 rebuild_buffer (const char *text)
 {
-  /* strdup first -- text may alias current_text. */
-  char *new_text = strdup (text);
-  free (current_text);
-  current_text = new_text;
+  if (!text)
+    text = default_text_en;
+
+  if (text != current_text)
+  {
+    /* strdup first -- text may alias current_text. */
+    char *new_text = strdup (text);
+    free (current_text);
+    current_text = new_text;
+  }
 
   demo_font_clear_cache (current_demo_font);
   demo_atlas_clear (renderer->get_atlas ());
@@ -79,7 +85,8 @@ rebuild_buffer (const char *text)
   demo_buffer_clear (buffer);
   demo_point_t top_left = {0, 0};
   demo_buffer_move_to (buffer, &top_left);
-  demo_buffer_add_text (buffer, text, current_demo_font, 1);
+  if (current_text)
+    demo_buffer_add_text (buffer, current_text, current_demo_font, 1);
   demo_view_reset (vu);
   /* Don't call demo_view_display here: it may run from a
    * microtask (e.g. the font-fetch .then() callback) where the


### PR DESCRIPTION
In hb-gpu-web and hb-gpu-web-webgpu, rebuild_buffer() frees current_text after duplicating the input text, but then passes the original text pointer to demo_buffer_add_text(). When called from web_load_font(), web_set_variations(), web_set_features(), or web_set_palette() with custom text active, text aliases current_text, resulting in a use-after-free read of recently freed heap memory.

Fix this by:
1. Skipping redundant reallocation when text already equals current_text.
2. Passing current_text to demo_buffer_add_text().
3. Handling a null text input safely with a default fallback.

Assisted-by: Gemini